### PR TITLE
Migrate generics to opaque parameter types where possible

### DIFF
--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -160,7 +160,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in an optional depending on whether `isOptional` is true.
-  public func optionalWrapped<TypeNode: TypeSyntaxProtocol>(type: TypeNode) -> TypeSyntax {
+  public func optionalWrapped(type: some TypeSyntaxProtocol) -> TypeSyntax {
     if isOptional {
       return TypeSyntax(OptionalTypeSyntax(wrappedType: type))
     } else {
@@ -169,7 +169,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in an optional chaining depending on whether `isOptional` is true.
-  public func optionalChained<ExprNode: ExprSyntaxProtocol>(expr: ExprNode) -> ExprSyntax {
+  public func optionalChained(expr: some ExprSyntaxProtocol) -> ExprSyntax {
     if isOptional {
       return ExprSyntax(OptionalChainingExprSyntax(expression: expr))
     } else {
@@ -178,7 +178,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in a force unwrap expression depending on whether `isOptional` is true.
-  public func forceUnwrappedIfNeeded<ExprNode: ExprSyntaxProtocol>(expr: ExprNode) -> ExprSyntax {
+  public func forceUnwrappedIfNeeded(expr: some ExprSyntaxProtocol) -> ExprSyntax {
     if isOptional {
       return ExprSyntax(ForcedValueExprSyntax(expression: expr))
     } else {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -72,7 +72,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           }
 
-          try InitializerDeclSyntax("public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol") {
+          try InitializerDeclSyntax("public init?(_ other: some RawSyntaxNodeProtocol)") {
             for (swiftName, typeName) in choices {
               StmtSyntax(
                 """
@@ -145,7 +145,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
       DeclSyntax(
         """
-        public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+        public init?(_ other: some RawSyntaxNodeProtocol) {
           guard Self.isKindOf(other.raw) else { return nil }
           self.init(unchecked: other.raw)
         }
@@ -155,7 +155,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       if node.isBase {
         DeclSyntax(
           """
-          public init<Node: Raw\(raw: node.name)NodeProtocol>(_ other: Node) {
+          public init(_ other: some Raw\(raw: node.name)NodeProtocol) {
             self.init(unchecked: other.raw)
           }
           """

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -63,7 +63,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Create a `\(raw: node.name)` node from a specialized syntax node.
-        public init<S: \(raw: node.name)Protocol>(_ syntax: S) {
+        public init(_ syntax: some \(raw: node.name)Protocol) {
           // We know this cast is going to succeed. Go through init(_: SyntaxData)
           // to do a sanity check and verify the kind matches in debug builds and get
           // maximum performance in release builds.
@@ -75,7 +75,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Create a `\(raw: node.name)` node from a specialized optional syntax node.
-        public init?<S: \(raw: node.name)Protocol>(_ syntax: S?) {
+        public init?(_ syntax: (some \(raw: node.name)Protocol)?) {
           guard let syntax = syntax else { return nil }
           self.init(syntax)
         }
@@ -103,7 +103,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         """
       )
 
-      try InitializerDeclSyntax("public init?<S: SyntaxProtocol>(_ node: S)") {
+      try InitializerDeclSyntax("public init?(_ node: some SyntaxProtocol)") {
         try SwitchExprSyntax("switch node.raw.kind") {
           SwitchCaseListSyntax {
             SwitchCaseSyntax(

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -81,7 +81,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             if choiceNode.isBase {
               DeclSyntax(
                 """
-                public init<Node: \(raw: choiceNode.name)Protocol>(_ node: Node) {
+                public init(_ node: some \(raw: choiceNode.name)Protocol) {
                   self = .\(raw: choiceNode.swiftSyntaxKind)(\(raw: choiceNode.name)(node))
                 }
                 """
@@ -98,7 +98,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           }
 
-          try InitializerDeclSyntax("public init?<S: SyntaxProtocol>(_ node: S)") {
+          try InitializerDeclSyntax("public init?(_ node: some SyntaxProtocol)") {
             for choiceName in node.collectionElementChoices ?? [] {
               let choiceNode = SYNTAX_NODE_MAP[choiceName]!
               StmtSyntax(
@@ -144,7 +144,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
       DeclSyntax(
         """
-        public init?<S: SyntaxProtocol>(_ node: S) {
+        public init?(_ node: some SyntaxProtocol) {
           guard node.raw.kind == .\(raw: node.swiftSyntaxKind) else { return nil }
           self._syntaxNode = node._syntaxNode
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTransformFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTransformFile.swift
@@ -96,7 +96,7 @@ let syntaxTransformFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      public func visit<T: SyntaxChildChoices>(_ node: T) -> ResultType {
+      public func visit(_ node: some SyntaxChildChoices) -> ResultType {
         return visit(Syntax(node))
       }
       """
@@ -104,7 +104,7 @@ let syntaxTransformFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      public func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) -> [ResultType] {
+      public func visitChildren(_ node: some SyntaxProtocol) -> [ResultType] {
         let syntaxNode = Syntax(node)
         return NonNilRawSyntaxChildren(syntaxNode, viewMode: .sourceAccurate).map { rawChild in
           let child = Syntax(SyntaxData(rawChild, parent: syntaxNode))

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxVisitorFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxVisitorFile.swift
@@ -44,7 +44,7 @@ let syntaxVisitorFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       /// Walk all nodes of the given syntax tree, calling the corresponding `visit`
       /// function for every node that is being visited.
-      public func walk<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+      public func walk(_ node: some SyntaxProtocol) {
         visit(node.data)
       }
       """
@@ -135,7 +135,7 @@ let syntaxVisitorFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      private func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+      private func visitChildren(_ node: some SyntaxProtocol) {
         let syntaxNode = Syntax(node)
         for childRaw in NonNilRawSyntaxChildren(syntaxNode, viewMode: viewMode) {
           let childData = SyntaxData(childRaw, parent: syntaxNode)

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TriviaPiecesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TriviaPiecesFile.swift
@@ -55,7 +55,7 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// Prints the provided trivia as they would be written in a source file.
       ///
       /// - Parameter stream: The stream to which to print the trivia.
-      public func write<Target>(to target: inout Target) where Target: TextOutputStream
+      public func write(to target: inout some TextOutputStream)
       """
     ) {
       DeclSyntax(

--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -139,7 +139,7 @@ open class BasicFormat: SyntaxRewriter {
   // MARK: - Customization points
 
   /// Whether a leading newline on `token` should be added.
-  open func requiresIndent<T: SyntaxProtocol>(_ node: T) -> Bool {
+  open func requiresIndent(_ node: some SyntaxProtocol) -> Bool {
     return node.requiresIndent
   }
 

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -46,21 +46,21 @@ extension CompilerPluginMessageHandler {
 
       switch macroDefinition {
       case let exprMacroDef as ExpressionMacro.Type:
-        func _expand<Node: FreestandingMacroExpansionSyntax>(node: Node) throws -> ExprSyntax {
+        func _expand(node: some FreestandingMacroExpansionSyntax) throws -> ExprSyntax {
           try exprMacroDef.expansion(of: node, in: context)
         }
         let rewritten = try _openExistential(macroSyntax, do: _expand)
         expandedSource = rewritten.formattedExpansion(macroDefinition.formatMode)
 
       case let declMacroDef as DeclarationMacro.Type:
-        func _expand<Node: FreestandingMacroExpansionSyntax>(node: Node) throws -> [DeclSyntax] {
+        func _expand(node: some FreestandingMacroExpansionSyntax) throws -> [DeclSyntax] {
           try declMacroDef.expansion(of: node, in: context)
         }
         let rewritten = try _openExistential(macroSyntax, do: _expand)
         expandedSource = CodeBlockItemListSyntax(rewritten.map { CodeBlockItemSyntax(item: .decl($0)) }).formattedExpansion(macroDefinition.formatMode)
 
       case let codeItemMacroDef as CodeItemMacro.Type:
-        func _expand<Node: FreestandingMacroExpansionSyntax>(node: Node) throws -> [CodeBlockItemSyntax] {
+        func _expand(node: some FreestandingMacroExpansionSyntax) throws -> [CodeBlockItemSyntax] {
           try codeItemMacroDef.expansion(of: node, in: context)
         }
         let rewritten = try _openExistential(macroSyntax, do: _expand)
@@ -128,8 +128,8 @@ extension CompilerPluginMessageHandler {
 
         // Local function to expand a member atribute macro once we've opened up
         // the existential.
-        func expandMemberAttributeMacro<Node: DeclGroupSyntax>(
-          _ node: Node
+        func expandMemberAttributeMacro(
+          _ node: some DeclGroupSyntax
         ) throws -> [AttributeSyntax] {
           return try attachedMacro.expansion(
             of: attributeNode,
@@ -158,8 +158,8 @@ extension CompilerPluginMessageHandler {
 
         // Local function to expand a member macro once we've opened up
         // the existential.
-        func expandMemberMacro<Node: DeclGroupSyntax>(
-          _ node: Node
+        func expandMemberMacro(
+          _ node: some DeclGroupSyntax
         ) throws -> [DeclSyntax] {
           return try attachedMacro.expansion(
             of: attributeNode,
@@ -196,8 +196,8 @@ extension CompilerPluginMessageHandler {
 
         // Local function to expand a conformance macro once we've opened up
         // the existential.
-        func expandConformanceMacro<Node: DeclGroupSyntax>(
-          _ node: Node
+        func expandConformanceMacro(
+          _ node: some DeclGroupSyntax
         ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
           return try attachedMacro.expansion(
             of: attributeNode,

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -242,8 +242,8 @@ extension PluginMacroExpansionContext: MacroExpansionContext {
     diagnostics.append(diagnostic)
   }
 
-  public func location<Node: SyntaxProtocol>(
-    of node: Node,
+  public func location(
+    of node: some SyntaxProtocol,
     at positionMode: PositionInSyntaxNode,
     filePathMode: SourceLocationFilePathMode
   ) -> AbstractSourceLocation? {

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -81,8 +81,8 @@ public struct DiagnosticsFormatter {
     self.colorize = colorize
   }
 
-  public static func annotatedSource<SyntaxType: SyntaxProtocol>(
-    tree: SyntaxType,
+  public static func annotatedSource(
+    tree: some SyntaxProtocol,
     diags: [Diagnostic],
     contextSize: Int = 2,
     colorize: Bool = false
@@ -92,10 +92,10 @@ public struct DiagnosticsFormatter {
   }
 
   /// Colorize the given source line by applying highlights from diagnostics.
-  private func colorizeSourceLine<SyntaxType: SyntaxProtocol>(
+  private func colorizeSourceLine(
     _ annotatedLine: AnnotatedSourceLine,
     lineNumber: Int,
-    tree: SyntaxType,
+    tree: some SyntaxProtocol,
     sourceLocationConverter slc: SourceLocationConverter
   ) -> String {
     guard colorize, !annotatedLine.diagnostics.isEmpty else {
@@ -181,9 +181,9 @@ public struct DiagnosticsFormatter {
   /// - Parameters:
   ///   - suffixTexts: suffix text to be printed at the given absolute
   ///                  locations within the source file.
-  func annotatedSource<SyntaxType: SyntaxProtocol>(
+  func annotatedSource(
     fileName: String?,
-    tree: SyntaxType,
+    tree: some SyntaxProtocol,
     diags: [Diagnostic],
     indentString: String,
     suffixTexts: [AbsolutePosition: String],
@@ -313,8 +313,8 @@ public struct DiagnosticsFormatter {
   }
 
   /// Print given diagnostics for a given syntax tree on the command line
-  public func annotatedSource<SyntaxType: SyntaxProtocol>(
-    tree: SyntaxType,
+  public func annotatedSource(
+    tree: some SyntaxProtocol,
     diags: [Diagnostic]
   ) -> String {
     return annotatedSource(

--- a/Sources/SwiftOperators/OperatorTable+Folding.swift
+++ b/Sources/SwiftOperators/OperatorTable+Folding.swift
@@ -529,8 +529,8 @@ extension OperatorTable {
   /// function, a throwing error handler will end up being called twice with
   /// the first error that causes it to be thrown. The first call will stop
   /// the operation, then the second must also throw.
-  public func foldAll<Node: SyntaxProtocol>(
-    _ node: Node,
+  public func foldAll(
+    _ node: some SyntaxProtocol,
     errorHandler: OperatorErrorHandler = { throw $0 }
   ) rethrows -> Syntax {
     return try withoutActuallyEscaping(errorHandler) { errorHandler in

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1130,7 +1130,7 @@ extension Parser {
 
 extension Parser {
   /// If a `throws` keyword appears right in front of the `arrow`, it is returned as `misplacedThrowsKeyword` so it can be synthesized in front of the arrow.
-  mutating func parseFunctionReturnClause<S: RawEffectSpecifiersTrait>(effectSpecifiers: inout S?, allowNamedOpaqueResultType: Bool) -> RawReturnClauseSyntax {
+  mutating func parseFunctionReturnClause(effectSpecifiers: inout (some RawEffectSpecifiersTrait)?, allowNamedOpaqueResultType: Bool) -> RawReturnClauseSyntax {
     let (unexpectedBeforeArrow, arrow) = self.expect(.arrow)
     let unexpectedBeforeReturnType = self.parseMisplacedEffectSpecifiers(&effectSpecifiers)
     let result: RawTypeSyntax

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -614,7 +614,7 @@ extension Parser {
   }
 
   @_spi(RawSyntax)
-  public mutating func parseDottedExpressionSuffix<R: RawSyntaxNodeProtocol>(previousNode: R?) -> (
+  public mutating func parseDottedExpressionSuffix(previousNode: (some RawSyntaxNodeProtocol)?) -> (
     unexpectedPeriod: RawUnexpectedNodesSyntax?,
     period: RawTokenSyntax,
     name: RawTokenSyntax,

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -264,8 +264,7 @@ extension Lexer {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
     }
 
-    public func starts<PossiblePrefix>(with possiblePrefix: PossiblePrefix) -> Bool
-    where PossiblePrefix: Sequence, PossiblePrefix.Element == UInt8 {
+    public func starts(with possiblePrefix: some Sequence<UInt8>) -> Bool {
       return self.input.starts(with: possiblePrefix)
     }
 

--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -226,7 +226,7 @@ extension Unicode.Scalar {
   }
 
   /// Returns the first unicode scalar in `byteSequence`, which may span multiple bytes.
-  public static func lexing<S: Collection>(from byteSequence: S) -> Self? where S.Element == UInt8 {
+  public static func lexing(from byteSequence: some Collection<UInt8>) -> Self? {
     var index = byteSequence.startIndex
     let peek = { () -> UInt8? in
       if index < byteSequence.endIndex {

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -602,7 +602,7 @@ extension Parser {
   ///     unexpected period (with the extraneous whitespace) and a missing
   ///     period. If there is a newline also set `skipMember` to inform
   ///     callers to not parse any futher member names.
-  mutating func consumeMemberPeriod<R: RawSyntaxNodeProtocol>(previousNode: R?) -> (unexpected: RawUnexpectedNodesSyntax?, period: RawTokenSyntax, skipMemberName: Bool) {
+  mutating func consumeMemberPeriod(previousNode: (some RawSyntaxNodeProtocol)?) -> (unexpected: RawUnexpectedNodesSyntax?, period: RawTokenSyntax, skipMemberName: Bool) {
     precondition(self.at(.period))
 
     let beforePeriodWhitespace = previousNode?.raw.trailingTriviaByteLength ?? 0 > 0 || self.currentToken.leadingTriviaByteLength > 0

--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -73,11 +73,11 @@ extension RawTokenSyntax: UnexpectedNodesCombinable {
 extension RawUnexpectedNodesSyntax: UnexpectedNodesCombinable {}
 
 extension RawUnexpectedNodesSyntax {
-  init?<T1: UnexpectedNodesCombinable, T2: UnexpectedNodesCombinable>(combining syntax1: T1, _ syntax2: T2, arena: __shared SyntaxArena) {
+  init?(combining syntax1: some UnexpectedNodesCombinable, _ syntax2: some UnexpectedNodesCombinable, arena: __shared SyntaxArena) {
     self.init(syntax1.elements + syntax2.elements, arena: arena)
   }
 
-  init?<T1: UnexpectedNodesCombinable, T2: UnexpectedNodesCombinable, T3: UnexpectedNodesCombinable>(combining syntax1: T1, _ syntax2: T2, _ syntax3: T3, arena: __shared SyntaxArena) {
+  init?(combining syntax1: some UnexpectedNodesCombinable, _ syntax2: some UnexpectedNodesCombinable, _ syntax3: some UnexpectedNodesCombinable, arena: __shared SyntaxArena) {
     self.init(syntax1.elements + syntax2.elements + syntax3.elements, arena: arena)
   }
 }

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -89,7 +89,7 @@ extension FixIt.MultiNodeChange {
 
   /// If `transferTrivia` is `true`, the leading and trailing trivia of the
   /// removed node will be transferred to the trailing trivia of the previous token.
-  static func makeMissing<SyntaxType: SyntaxProtocol>(_ node: SyntaxType?, transferTrivia: Bool = true) -> Self {
+  static func makeMissing(_ node: (some SyntaxProtocol)?, transferTrivia: Bool = true) -> Self {
     guard let node = node else {
       return FixIt.MultiNodeChange(primitiveChanges: [])
     }
@@ -104,7 +104,7 @@ extension FixIt.MultiNodeChange {
   /// While doing this, it tries to be smart, merging trivia where it makes sense
   /// and refusing to add e.g. a space after punctuation, where it usually
   /// doesn't make sense.
-  private static func transferTriviaAtSides<SyntaxType: SyntaxProtocol>(from nodes: [SyntaxType]) -> Self {
+  private static func transferTriviaAtSides(from nodes: [some SyntaxProtocol]) -> Self {
     let removedTriviaAtSides = (nodes.first?.leadingTrivia ?? []).merging(nodes.last?.trailingTrivia ?? [])
     if !removedTriviaAtSides.isEmpty, let previousToken = nodes.first?.previousToken(viewMode: .sourceAccurate) {
       let mergedTrivia = previousToken.trailingTrivia.merging(removedTriviaAtSides)
@@ -133,8 +133,8 @@ class MissingNodesBasicFormatter: BasicFormat {
 extension FixIt.MultiNodeChange {
   /// Make a node present. If `leadingTrivia` or `trailingTrivia` is specified,
   /// override the default leading/trailing trivia inferred from `BasicFormat`.
-  static func makePresent<T: SyntaxProtocol>(
-    _ node: T,
+  static func makePresent(
+    _ node: some SyntaxProtocol,
     leadingTrivia: Trivia? = nil,
     trailingTrivia: Trivia? = nil
   ) -> Self {

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -66,7 +66,7 @@ fileprivate enum NodesDescriptionPart {
     }
   }
 
-  static func descriptionParts<S: Sequence>(for nodes: S) -> [NodesDescriptionPart] where S.Element == Syntax {
+  static func descriptionParts(for nodes: some Sequence<Syntax>) -> [NodesDescriptionPart] {
     var parts: [NodesDescriptionPart] = []
     for missingNode in nodes {
       if let token = missingNode.as(TokenSyntax.self) {
@@ -110,12 +110,12 @@ fileprivate enum NodesDescriptionPart {
 /// Returns a string that describes `missingNodes`.
 /// If `commonParent` is not `nil`, `missingNodes` are expected to all be children of `commonParent`.
 /// If `format` is `true`, `BasicFormat` will be used to format the tokens prior to printing. This is useful if the nodes have been synthesized.
-func nodesDescription<SyntaxType: SyntaxProtocol>(_ nodes: [SyntaxType], format: Bool) -> String {
+func nodesDescription(_ nodes: [some SyntaxProtocol], format: Bool) -> String {
   return nodesDescriptionAndCommonParent(nodes, format: format).description
 }
 
 /// Same as `nodesDescription` but if a common ancestor was used to describe `missingNodes`, also return that `commonAncestor`
-func nodesDescriptionAndCommonParent<SyntaxType: SyntaxProtocol>(_ nodes: [SyntaxType], format: Bool) -> (commonAncestor: Syntax?, description: String) {
+func nodesDescriptionAndCommonParent(_ nodes: [some SyntaxProtocol], format: Bool) -> (commonAncestor: Syntax?, description: String) {
   let missingSyntaxNodes = nodes.map(Syntax.init)
 
   let isOnlyTokenWithNonMissingText: Bool
@@ -329,8 +329,8 @@ public struct InsertTokenFixIt: ParserFixIt {
 // MARK: - Generate Error
 
 extension ParseDiagnosticsGenerator {
-  func handleMissingSyntax<T: SyntaxProtocol>(
-    _ node: T,
+  func handleMissingSyntax(
+    _ node: some SyntaxProtocol,
     overridePosition: AbsolutePosition? = nil,
     additionalChanges: [FixIt.MultiNodeChange] = [],
     additionalHandledNodes: [SyntaxIdentifier] = []

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -648,11 +648,11 @@ public struct RemoveRedundantFixIt: ParserFixIt {
 public struct RemoveNodesFixIt: ParserFixIt {
   public let nodesToRemove: [Syntax]
 
-  init<SyntaxType: SyntaxProtocol>(_ nodesToRemove: [SyntaxType]) {
+  init(_ nodesToRemove: [some SyntaxProtocol]) {
     self.nodesToRemove = nodesToRemove.map(Syntax.init)
   }
 
-  init<SyntaxType: SyntaxProtocol>(_ nodeToRemove: SyntaxType) {
+  init(_ nodeToRemove: some SyntaxProtocol) {
     self.nodesToRemove = [Syntax(nodeToRemove)]
   }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -797,13 +797,13 @@ extension RawSyntax {
     )
   }
 
-  static func makeLayout<C: Collection>(
+  static func makeLayout(
     kind: SyntaxKind,
-    from collection: C,
+    from collection: some Collection<RawSyntax?>,
     arena: __shared SyntaxArena,
     leadingTrivia: Trivia? = nil,
     trailingTrivia: Trivia? = nil
-  ) -> RawSyntax where C.Element == RawSyntax? {
+  ) -> RawSyntax {
     if leadingTrivia != nil || trailingTrivia != nil {
       var layout = Array(collection)
       if let leadingTrivia = leadingTrivia,
@@ -829,7 +829,7 @@ extension RawSyntax {
 
 extension RawSyntax: CustomDebugStringConvertible {
 
-  private func debugWrite<Target: TextOutputStream>(to target: inout Target, indent: Int, withChildren: Bool = false) {
+  private func debugWrite(to target: inout some TextOutputStream, indent: Int, withChildren: Bool = false) {
     let childIndent = indent + 2
     switch rawData.payload {
     case .parsedToken(let dat):

--- a/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
@@ -55,10 +55,10 @@ public struct RawSyntaxLayoutView {
 
   /// Creates a new node of the same kind but with children replaced by `elements`.
   @_spi(RawSyntax)
-  public func replacingLayout<C: Collection>(
-    with elements: C,
+  public func replacingLayout(
+    with elements: some Collection<RawSyntax?>,
     arena: SyntaxArena
-  ) -> RawSyntax where C.Element == RawSyntax? {
+  ) -> RawSyntax {
     return .makeLayout(
       kind: raw.kind,
       uninitializedCount: elements.count,
@@ -124,11 +124,11 @@ public struct RawSyntaxLayoutView {
   }
 
   @_spi(RawSyntax)
-  public func replacingChildSubrange<C: Collection>(
+  public func replacingChildSubrange(
     _ range: Range<Int>,
-    with elements: C,
+    with elements: some Collection<RawSyntax?>,
     arena: SyntaxArena
-  ) -> RawSyntax where C.Element == RawSyntax? {
+  ) -> RawSyntax {
     precondition(!raw.isToken)
     let newCount = children.count - range.count + elements.count
     return .makeLayout(

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -21,7 +21,7 @@ public protocol RawSyntaxNodeProtocol: CustomStringConvertible, TextOutputStream
   var raw: RawSyntax { get }
 
   /// Create the typed raw syntax if `other` can be cast to `Self`
-  init?<T: RawSyntaxNodeProtocol>(_ other: T)
+  init?(_ other: some RawSyntaxNodeProtocol)
 }
 
 public extension RawSyntaxNodeProtocol {
@@ -39,7 +39,7 @@ public extension RawSyntaxNodeProtocol {
     raw.description
   }
 
-  func write<Target>(to target: inout Target) where Target: TextOutputStream {
+  func write(to target: inout some TextOutputStream) {
     raw.write(to: &target)
   }
 
@@ -67,7 +67,7 @@ extension RawSyntax: RawSyntaxNodeProtocol {
     self = raw
   }
 
-  public init<T: RawSyntaxNodeProtocol>(_ other: T) {
+  public init(_ other: some RawSyntaxNodeProtocol) {
     self.init(raw: other.raw)
   }
 }
@@ -112,7 +112,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
 
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else { return nil }
     self.init(unchecked: other.raw)
   }

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -73,7 +73,7 @@ public final class SourceLocationConverter {
   /// - Parameters:
   ///   - file: The file path associated with the syntax tree.
   ///   - tree: The root of the syntax tree to convert positions to line/columns for.
-  public init<SyntaxType: SyntaxProtocol>(file: String, tree: SyntaxType) {
+  public init(file: String, tree: some SyntaxProtocol) {
     precondition(tree.parent == nil, "SourceLocationConverter must be passed the root of the syntax tree")
     self.file = file
     self.source = tree.syntaxTextBytes

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -68,7 +68,7 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// Create a `Syntax` node from a specialized syntax node.
-  public init<S: SyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some SyntaxProtocol) {
     self = syntax._syntaxNode
   }
 
@@ -158,7 +158,7 @@ public protocol SyntaxProtocol: CustomStringConvertible,
 
   /// Converts the given specialized node to this type. Returns `nil` if the
   /// conversion is not possible.
-  init?<S: SyntaxProtocol>(_ node: S)
+  init?(_ node: some SyntaxProtocol)
 
   /// The statically allowed structure of the syntax node.
   static var structure: SyntaxNodeStructure { get }

--- a/Sources/SwiftSyntax/Trivia.swift
+++ b/Sources/SwiftSyntax/Trivia.swift
@@ -21,7 +21,7 @@ public struct Trivia {
   public let pieces: [TriviaPiece]
 
   /// Creates Trivia with the provided underlying pieces.
-  public init<S: Sequence>(pieces: S) where S.Element == TriviaPiece {
+  public init(pieces: some Sequence<TriviaPiece>) {
     self.pieces = Array(pieces)
   }
 
@@ -69,7 +69,7 @@ public struct Trivia {
   /// Creates a new `Trivia` by merging the leading and trailing `Trivia`
   /// of `triviaOf` into the end of `self`. Only includes one copy of any
   /// common prefixes.
-  public func merging<T: SyntaxProtocol>(triviaOf node: T) -> Trivia {
+  public func merging(triviaOf node: some SyntaxProtocol) -> Trivia {
     return merging(node.leadingTrivia).merging(node.trailingTrivia)
   }
 
@@ -115,8 +115,7 @@ extension Trivia: TextOutputStreamable {
   /// Prints the provided trivia as they would be written in a source file.
   ///
   /// - Parameter stream: The stream to which to print the trivia.
-  public func write<Target>(to target: inout Target)
-  where Target: TextOutputStream {
+  public func write(to target: inout some TextOutputStream) {
     for piece in pieces {
       piece.write(to: &target)
     }
@@ -173,7 +172,7 @@ extension Trivia {
 }
 
 extension RawTriviaPiece: TextOutputStreamable {
-  public func write<Target: TextOutputStream>(to target: inout Target) {
+  public func write(to target: inout some TextOutputStream) {
     TriviaPiece(raw: self).write(to: &target)
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -39,7 +39,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `DeclSyntax` node from a specialized syntax node.
-  public init<S: DeclSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some DeclSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -47,7 +47,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `DeclSyntax` node from a specialized optional syntax node.
-  public init?<S: DeclSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some DeclSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -69,7 +69,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .accessorDecl, .actorDecl, .associatedtypeDecl, .classDecl, .deinitializerDecl, .editorPlaceholderDecl, .enumCaseDecl, .enumDecl, .extensionDecl, .functionDecl, .ifConfigDecl, .importDecl, .initializerDecl, .macroDecl, .macroExpansionDecl, .missingDecl, .operatorDecl, .poundSourceLocation, .precedenceGroupDecl, .protocolDecl, .structDecl, .subscriptDecl, .typealiasDecl, .variableDecl:
       self._syntaxNode = node._syntaxNode
@@ -174,7 +174,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `ExprSyntax` node from a specialized syntax node.
-  public init<S: ExprSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some ExprSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -182,7 +182,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `ExprSyntax` node from a specialized optional syntax node.
-  public init?<S: ExprSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some ExprSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -204,7 +204,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .canImportExpr, .canImportVersionInfo, .closureExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forcedValueExpr, .functionCallExpr, .identifierExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .moveExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .postfixIfConfigExpr, .postfixUnaryExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .specializeExpr, .stringLiteralExpr, .subscriptExpr, .superRefExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedPatternExpr, .unresolvedTernaryExpr:
       self._syntaxNode = node._syntaxNode
@@ -335,7 +335,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `PatternSyntax` node from a specialized syntax node.
-  public init<S: PatternSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some PatternSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -343,7 +343,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `PatternSyntax` node from a specialized optional syntax node.
-  public init?<S: PatternSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some PatternSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -365,7 +365,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .expressionPattern, .identifierPattern, .isTypePattern, .missingPattern, .tuplePattern, .valueBindingPattern, .wildcardPattern:
       self._syntaxNode = node._syntaxNode
@@ -453,7 +453,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `StmtSyntax` node from a specialized syntax node.
-  public init<S: StmtSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some StmtSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -461,7 +461,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `StmtSyntax` node from a specialized optional syntax node.
-  public init?<S: StmtSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some StmtSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -483,7 +483,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
       self._syntaxNode = node._syntaxNode
@@ -580,7 +580,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `TypeSyntax` node from a specialized syntax node.
-  public init<S: TypeSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some TypeSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -588,7 +588,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `TypeSyntax` node from a specialized optional syntax node.
-  public init?<S: TypeSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some TypeSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -610,7 +610,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .arrayType, .attributedType, .classRestrictionType, .compositionType, .constrainedSugarType, .dictionaryType, .functionType, .implicitlyUnwrappedOptionalType, .memberTypeIdentifier, .metatypeType, .missingType, .namedOpaqueReturnType, .optionalType, .packExpansionType, .packReferenceType, .simpleTypeIdentifier, .suppressedType, .tupleType:
       self._syntaxNode = node._syntaxNode

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -38,7 +38,7 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorList else {
       return nil
     }
@@ -247,7 +247,7 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrayElementList else {
       return nil
     }
@@ -474,7 +474,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
       self = .ifConfigDecl(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(AttributeSyntax.self) {
         self = .attribute(node)
         return
@@ -499,7 +499,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .attributeList else {
       return nil
     }
@@ -708,7 +708,7 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilitySpecList else {
       return nil
     }
@@ -917,7 +917,7 @@ public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, Syntax
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityVersionRestrictionList else {
       return nil
     }
@@ -1126,7 +1126,7 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .caseItemList else {
       return nil
     }
@@ -1335,7 +1335,7 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .catchClauseList else {
       return nil
     }
@@ -1544,7 +1544,7 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .catchItemList else {
       return nil
     }
@@ -1753,7 +1753,7 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureItemList else {
       return nil
     }
@@ -1962,7 +1962,7 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParamList else {
       return nil
     }
@@ -2171,7 +2171,7 @@ public struct ClosureParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParameterList else {
       return nil
     }
@@ -2380,7 +2380,7 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .codeBlockItemList else {
       return nil
     }
@@ -2589,7 +2589,7 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .compositionTypeElementList else {
       return nil
     }
@@ -2798,7 +2798,7 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conditionElementList else {
       return nil
     }
@@ -3007,7 +3007,7 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declNameArgumentList else {
       return nil
     }
@@ -3216,7 +3216,7 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .designatedTypeList else {
       return nil
     }
@@ -3425,7 +3425,7 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryElementList else {
       return nil
     }
@@ -3634,7 +3634,7 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityParamList else {
       return nil
     }
@@ -3840,7 +3840,7 @@ public struct DocumentationAttributeArgumentsSyntax: SyntaxCollection, SyntaxHas
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .documentationAttributeArguments else {
       return nil
     }
@@ -4046,7 +4046,7 @@ public struct EffectsArgumentsSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .effectsArguments else {
       return nil
     }
@@ -4252,7 +4252,7 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseElementList else {
       return nil
     }
@@ -4461,7 +4461,7 @@ public struct EnumCaseParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseParameterList else {
       return nil
     }
@@ -4667,7 +4667,7 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .exprList else {
       return nil
     }
@@ -4876,7 +4876,7 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionParameterList else {
       return nil
     }
@@ -5085,7 +5085,7 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericArgumentList else {
       return nil
     }
@@ -5294,7 +5294,7 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericParameterList else {
       return nil
     }
@@ -5503,7 +5503,7 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericRequirementList else {
       return nil
     }
@@ -5712,7 +5712,7 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ifConfigClauseList else {
       return nil
     }
@@ -5921,7 +5921,7 @@ public struct ImportPathSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .importPath else {
       return nil
     }
@@ -6130,7 +6130,7 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .inheritedTypeList else {
       return nil
     }
@@ -6339,7 +6339,7 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathComponentList else {
       return nil
     }
@@ -6548,7 +6548,7 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberDeclList else {
       return nil
     }
@@ -6757,7 +6757,7 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .modifierList else {
       return nil
     }
@@ -6966,7 +6966,7 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .multipleTrailingClosureElementList else {
       return nil
     }
@@ -7175,7 +7175,7 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .objCSelector else {
       return nil
     }
@@ -7384,7 +7384,7 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .patternBindingList else {
       return nil
     }
@@ -7618,7 +7618,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
       self = .precedenceGroupAssociativity(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(PrecedenceGroupRelationSyntax.self) {
         self = .precedenceGroupRelation(node)
         return
@@ -7648,7 +7648,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupAttributeList else {
       return nil
     }
@@ -7857,7 +7857,7 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupNameList else {
       return nil
     }
@@ -8066,7 +8066,7 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .primaryAssociatedTypeList else {
       return nil
     }
@@ -8304,7 +8304,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
       self = .genericWhereClause(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(LabeledSpecializeEntrySyntax.self) {
         self = .labeledSpecializeEntry(node)
         return
@@ -8340,7 +8340,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .specializeAttributeSpecList else {
       return nil
     }
@@ -8567,7 +8567,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
       self = .expressionSegment(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(StringSegmentSyntax.self) {
         self = .stringSegment(node)
         return
@@ -8592,7 +8592,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .stringLiteralSegments else {
       return nil
     }
@@ -8819,7 +8819,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
       self = .ifConfigDecl(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(SwitchCaseSyntax.self) {
         self = .switchCase(node)
         return
@@ -8844,7 +8844,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchCaseList else {
       return nil
     }
@@ -9053,7 +9053,7 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleExprElementList else {
       return nil
     }
@@ -9262,7 +9262,7 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tuplePatternElementList else {
       return nil
     }
@@ -9471,7 +9471,7 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleTypeElementList else {
       return nil
     }
@@ -9677,7 +9677,7 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unexpectedNodes else {
       return nil
     }
@@ -9886,7 +9886,7 @@ public struct VersionComponentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .versionComponentList else {
       return nil
     }
@@ -10095,7 +10095,7 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .yieldExprList else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -3866,11 +3866,11 @@ extension SyntaxTransformVisitor {
     visit(Syntax(node))
   }
   
-  public func visit<T: SyntaxChildChoices>(_ node: T) -> ResultType {
+  public func visit(_ node: some SyntaxChildChoices) -> ResultType {
     return visit(Syntax(node))
   }
   
-  public func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) -> [ResultType] {
+  public func visitChildren(_ node: some SyntaxProtocol) -> [ResultType] {
     let syntaxNode = Syntax(node)
     return NonNilRawSyntaxChildren(syntaxNode, viewMode: .sourceAccurate).map { rawChild in
       let child = Syntax(SyntaxData(rawChild, parent: syntaxNode))

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -30,7 +30,7 @@ open class SyntaxVisitor {
   
   /// Walk all nodes of the given syntax tree, calling the corresponding `visit`
   /// function for every node that is being visited.
-  public func walk<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+  public func walk(_ node: some SyntaxProtocol) {
     visit(node.data)
   }
   
@@ -6881,7 +6881,7 @@ open class SyntaxVisitor {
     }
   }
   
-  private func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+  private func visitChildren(_ node: some SyntaxProtocol) {
     let syntaxNode = Syntax(node)
     for childRaw in NonNilRawSyntaxChildren(syntaxNode, viewMode: viewMode) {
       let childData = SyntaxData(childRaw, parent: syntaxNode)

--- a/Sources/SwiftSyntax/generated/TriviaPieces.swift
+++ b/Sources/SwiftSyntax/generated/TriviaPieces.swift
@@ -57,7 +57,7 @@ extension TriviaPiece: TextOutputStreamable {
   /// Prints the provided trivia as they would be written in a source file.
   ///
   /// - Parameter stream: The stream to which to print the trivia.
-  public func write<Target>(to target: inout Target) where Target: TextOutputStream {
+  public func write(to target: inout some TextOutputStream) {
     func printRepeated(_ character: String, count: Int) {
       for _ in 0 ..< count {
         target.write(character)

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -49,7 +49,7 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -131,7 +131,7 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -249,7 +249,7 @@ public struct RawAccessorEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -319,7 +319,7 @@ public struct RawAccessorListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -369,7 +369,7 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -451,7 +451,7 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -593,7 +593,7 @@ public struct RawArrayElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -643,7 +643,7 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -713,7 +713,7 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -795,7 +795,7 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -877,7 +877,7 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -947,7 +947,7 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1041,7 +1041,7 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1099,7 +1099,7 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1227,7 +1227,7 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawAttributeSyntax(other) {
         self = .attribute(node)
         return
@@ -1260,7 +1260,7 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1362,7 +1362,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawTupleExprElementListSyntax(other) {
         self = .argumentList(node)
         return
@@ -1467,7 +1467,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1573,7 +1573,7 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1656,7 +1656,7 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawTokenSyntax(other) {
         self = .token(node)
         return
@@ -1693,7 +1693,7 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1763,7 +1763,7 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1857,7 +1857,7 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1949,7 +1949,7 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawStringLiteralExprSyntax(other) {
         self = .string(node)
         return
@@ -1982,7 +1982,7 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2064,7 +2064,7 @@ public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2114,7 +2114,7 @@ public struct RawAvailabilityVersionRestrictionListEntrySyntax: RawSyntaxNodePro
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2184,7 +2184,7 @@ public struct RawAvailabilityVersionRestrictionListSyntax: RawSyntaxNodeProtocol
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2234,7 +2234,7 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2304,7 +2304,7 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2374,7 +2374,7 @@ public struct RawBackDeployedAttributeSpecListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2456,7 +2456,7 @@ public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2514,7 +2514,7 @@ public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2572,7 +2572,7 @@ public struct RawBorrowExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2642,7 +2642,7 @@ public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2712,7 +2712,7 @@ public struct RawCanImportExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2818,7 +2818,7 @@ public struct RawCanImportVersionInfoSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2912,7 +2912,7 @@ public struct RawCaseItemListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2962,7 +2962,7 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3044,7 +3044,7 @@ public struct RawCatchClauseListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3094,7 +3094,7 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3176,7 +3176,7 @@ public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3226,7 +3226,7 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3308,7 +3308,7 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3450,7 +3450,7 @@ public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3508,7 +3508,7 @@ public struct RawClosureCaptureItemListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3558,7 +3558,7 @@ public struct RawClosureCaptureItemSpecifierSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3652,7 +3652,7 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3758,7 +3758,7 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3840,7 +3840,7 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3934,7 +3934,7 @@ public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3984,7 +3984,7 @@ public struct RawClosureParamSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4054,7 +4054,7 @@ public struct RawClosureParameterClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4136,7 +4136,7 @@ public struct RawClosureParameterListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4186,7 +4186,7 @@ public struct RawClosureParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4326,7 +4326,7 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawClosureParamListSyntax(other) {
         self = .simpleInput(node)
         return
@@ -4359,7 +4359,7 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4477,7 +4477,7 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4528,7 +4528,7 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawDeclSyntax(other) {
         self = .decl(node)
         return
@@ -4565,7 +4565,7 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4635,7 +4635,7 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4717,7 +4717,7 @@ public struct RawCompositionTypeElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4767,7 +4767,7 @@ public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4837,7 +4837,7 @@ public struct RawCompositionTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4895,7 +4895,7 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4949,7 +4949,7 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawExprSyntax(other) {
         self = .expression(node)
         return
@@ -4990,7 +4990,7 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5060,7 +5060,7 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5142,7 +5142,7 @@ public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5212,7 +5212,7 @@ public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5282,7 +5282,7 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5388,7 +5388,7 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5470,7 +5470,7 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5552,7 +5552,7 @@ public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5622,7 +5622,7 @@ public struct RawDeclNameArgumentListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5672,7 +5672,7 @@ public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5742,7 +5742,7 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5824,7 +5824,7 @@ public struct RawDeclNameSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5899,14 +5899,14 @@ public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawDeclSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawDeclSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -5933,7 +5933,7 @@ public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6003,7 +6003,7 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6097,7 +6097,7 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6227,7 +6227,7 @@ public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6297,7 +6297,7 @@ public struct RawDesignatedTypeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6347,7 +6347,7 @@ public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6397,7 +6397,7 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6489,7 +6489,7 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawTokenSyntax(other) {
         self = .colon(node)
         return
@@ -6522,7 +6522,7 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6604,7 +6604,7 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6710,7 +6710,7 @@ public struct RawDifferentiabilityParamListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6760,7 +6760,7 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6828,7 +6828,7 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawDifferentiabilityParamSyntax(other) {
         self = .parameter(node)
         return
@@ -6861,7 +6861,7 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6943,7 +6943,7 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7025,7 +7025,7 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7131,7 +7131,7 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7189,7 +7189,7 @@ public struct RawDiscardStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7259,7 +7259,7 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7339,7 +7339,7 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawTokenSyntax(other) {
         self = .token(node)
         return
@@ -7372,7 +7372,7 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7466,7 +7466,7 @@ public struct RawDocumentationAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7516,7 +7516,7 @@ public struct RawDynamicReplacementArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7598,7 +7598,7 @@ public struct RawEditorPlaceholderDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7656,7 +7656,7 @@ public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7714,7 +7714,7 @@ public struct RawEffectsArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7764,7 +7764,7 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7858,7 +7858,7 @@ public struct RawEnumCaseElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7908,7 +7908,7 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8002,7 +8002,7 @@ public struct RawEnumCaseParameterClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8084,7 +8084,7 @@ public struct RawEnumCaseParameterListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8134,7 +8134,7 @@ public struct RawEnumCaseParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8264,7 +8264,7 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8406,7 +8406,7 @@ public struct RawExposeAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8488,7 +8488,7 @@ public struct RawExprListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8543,14 +8543,14 @@ public struct RawExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawExprSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawExprSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -8577,7 +8577,7 @@ public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8635,7 +8635,7 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8741,7 +8741,7 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8799,7 +8799,7 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8929,7 +8929,7 @@ public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8987,7 +8987,7 @@ public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9045,7 +9045,7 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9211,7 +9211,7 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9281,7 +9281,7 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9399,7 +9399,7 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9541,7 +9541,7 @@ public struct RawFunctionEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9611,7 +9611,7 @@ public struct RawFunctionParameterListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9661,7 +9661,7 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9815,7 +9815,7 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9897,7 +9897,7 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10003,7 +10003,7 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10085,7 +10085,7 @@ public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10135,7 +10135,7 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10205,7 +10205,7 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10299,7 +10299,7 @@ public struct RawGenericParameterListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10349,7 +10349,7 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10467,7 +10467,7 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10518,7 +10518,7 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawSameTypeRequirementSyntax(other) {
         self = .sameTypeRequirement(node)
         return
@@ -10555,7 +10555,7 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10625,7 +10625,7 @@ public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10695,7 +10695,7 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10789,7 +10789,7 @@ public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10859,7 +10859,7 @@ public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10917,7 +10917,7 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10974,7 +10974,7 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawCodeBlockItemListSyntax(other) {
         self = .statements(node)
         return
@@ -11019,7 +11019,7 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11101,7 +11101,7 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11169,7 +11169,7 @@ public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawIfExprSyntax(other) {
         self = .ifExpr(node)
         return
@@ -11202,7 +11202,7 @@ public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11308,7 +11308,7 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11402,7 +11402,7 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11472,7 +11472,7 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11578,7 +11578,7 @@ public struct RawImportPathComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11648,7 +11648,7 @@ public struct RawImportPathSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11698,7 +11698,7 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11768,7 +11768,7 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11850,7 +11850,7 @@ public struct RawInheritedTypeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11900,7 +11900,7 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11970,7 +11970,7 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12040,7 +12040,7 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12182,7 +12182,7 @@ public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12240,7 +12240,7 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12322,7 +12322,7 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12392,7 +12392,7 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12443,7 +12443,7 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawKeyPathPropertyComponentSyntax(other) {
         self = .property(node)
         return
@@ -12480,7 +12480,7 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12550,7 +12550,7 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12632,7 +12632,7 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12690,7 +12690,7 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12772,7 +12772,7 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12854,7 +12854,7 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12948,7 +12948,7 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13030,7 +13030,7 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13172,7 +13172,7 @@ public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13314,7 +13314,7 @@ public struct RawMacroExpansionDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13456,7 +13456,7 @@ public struct RawMacroExpansionExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13598,7 +13598,7 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13692,7 +13692,7 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13786,7 +13786,7 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13868,7 +13868,7 @@ public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13938,7 +13938,7 @@ public struct RawMemberDeclListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13988,7 +13988,7 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14082,7 +14082,7 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14164,7 +14164,7 @@ public struct RawMissingDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14246,7 +14246,7 @@ public struct RawMissingExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14304,7 +14304,7 @@ public struct RawMissingPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14362,7 +14362,7 @@ public struct RawMissingStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14420,7 +14420,7 @@ public struct RawMissingSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14478,7 +14478,7 @@ public struct RawMissingTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14536,7 +14536,7 @@ public struct RawModifierListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14586,7 +14586,7 @@ public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14656,7 +14656,7 @@ public struct RawMultipleTrailingClosureElementListSyntax: RawSyntaxNodeProtocol
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14706,7 +14706,7 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14788,7 +14788,7 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14858,7 +14858,7 @@ public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14916,7 +14916,7 @@ public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14986,7 +14986,7 @@ public struct RawObjCSelectorSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15036,7 +15036,7 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15118,7 +15118,7 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15224,7 +15224,7 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15306,7 +15306,7 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15400,7 +15400,7 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15470,7 +15470,7 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15540,7 +15540,7 @@ public struct RawOriginallyDefinedInArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15646,7 +15646,7 @@ public struct RawPackElementExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15716,7 +15716,7 @@ public struct RawPackExpansionExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15786,7 +15786,7 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15856,7 +15856,7 @@ public struct RawPackReferenceTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15926,7 +15926,7 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16008,7 +16008,7 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16056,7 +16056,7 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawAccessorBlockSyntax(other) {
         self = .accessors(node)
         return
@@ -16089,7 +16089,7 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16200,14 +16200,14 @@ public struct RawPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawPatternSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawPatternSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -16234,7 +16234,7 @@ public struct RawPostfixIfConfigExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16304,7 +16304,7 @@ public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16374,7 +16374,7 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16504,7 +16504,7 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16598,7 +16598,7 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16680,7 +16680,7 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16763,7 +16763,7 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawPrecedenceGroupRelationSyntax(other) {
         self = .precedenceGroupRelation(node)
         return
@@ -16800,7 +16800,7 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16850,7 +16850,7 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16980,7 +16980,7 @@ public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17050,7 +17050,7 @@ public struct RawPrecedenceGroupNameListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17100,7 +17100,7 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17182,7 +17182,7 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17252,7 +17252,7 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17334,7 +17334,7 @@ public struct RawPrimaryAssociatedTypeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17384,7 +17384,7 @@ public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17454,7 +17454,7 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17596,7 +17596,7 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17690,7 +17690,7 @@ public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17796,7 +17796,7 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17890,7 +17890,7 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17960,7 +17960,7 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18030,7 +18030,7 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18112,7 +18112,7 @@ public struct RawSequenceExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18170,7 +18170,7 @@ public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18240,7 +18240,7 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18314,7 +18314,7 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawLabeledSpecializeEntrySyntax(other) {
         self = .labeledSpecializeEntry(node)
         return
@@ -18355,7 +18355,7 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18405,7 +18405,7 @@ public struct RawSpecializeExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18480,14 +18480,14 @@ public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawStmtSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawStmtSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -18514,7 +18514,7 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18618,7 +18618,7 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawStringSegmentSyntax(other) {
         self = .stringSegment(node)
         return
@@ -18651,7 +18651,7 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18701,7 +18701,7 @@ public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18759,7 +18759,7 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18899,7 +18899,7 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawAccessorBlockSyntax(other) {
         self = .accessors(node)
         return
@@ -18932,7 +18932,7 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19074,7 +19074,7 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19192,7 +19192,7 @@ public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19250,7 +19250,7 @@ public struct RawSuppressedTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19320,7 +19320,7 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19400,7 +19400,7 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawSwitchCaseSyntax(other) {
         self = .switchCase(node)
         return
@@ -19433,7 +19433,7 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19481,7 +19481,7 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawSwitchDefaultLabelSyntax(other) {
         self = .default(node)
         return
@@ -19514,7 +19514,7 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19596,7 +19596,7 @@ public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19666,7 +19666,7 @@ public struct RawSwitchExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19772,7 +19772,7 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19866,7 +19866,7 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19972,7 +19972,7 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20042,7 +20042,7 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20124,7 +20124,7 @@ public struct RawTupleExprElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20174,7 +20174,7 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20268,7 +20268,7 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20350,7 +20350,7 @@ public struct RawTuplePatternElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20400,7 +20400,7 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20494,7 +20494,7 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20576,7 +20576,7 @@ public struct RawTupleTypeElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20626,7 +20626,7 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20768,7 +20768,7 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20850,7 +20850,7 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20920,7 +20920,7 @@ public struct RawTypeEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20990,7 +20990,7 @@ public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21048,7 +21048,7 @@ public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21118,7 +21118,7 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21193,14 +21193,14 @@ public struct RawTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawTypeSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawTypeSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -21227,7 +21227,7 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21357,7 +21357,7 @@ public struct RawUnavailableFromAsyncArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21439,7 +21439,7 @@ public struct RawUnderscorePrivateAttributeArgumentsSyntax: RawSyntaxNodeProtoco
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21521,7 +21521,7 @@ public struct RawUnexpectedNodesSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21571,7 +21571,7 @@ public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21641,7 +21641,7 @@ public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21699,7 +21699,7 @@ public struct RawUnresolvedPatternExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21757,7 +21757,7 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21839,7 +21839,7 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21909,7 +21909,7 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22003,7 +22003,7 @@ public struct RawVersionComponentListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22053,7 +22053,7 @@ public struct RawVersionComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22123,7 +22123,7 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22193,7 +22193,7 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22263,7 +22263,7 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22345,7 +22345,7 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22415,7 +22415,7 @@ public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22485,7 +22485,7 @@ public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22535,7 +22535,7 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22615,7 +22615,7 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawYieldListSyntax(other) {
         self = .yieldList(node)
         return
@@ -22648,7 +22648,7 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -18,7 +18,7 @@
 public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorDecl else {
       return nil
     }
@@ -257,7 +257,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .actorDecl else {
       return nil
     }
@@ -589,7 +589,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .associatedtypeDecl else {
       return nil
     }
@@ -900,7 +900,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .classDecl else {
       return nil
     }
@@ -1223,7 +1223,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .deinitializerDecl else {
       return nil
     }
@@ -1433,7 +1433,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .editorPlaceholderDecl else {
       return nil
     }
@@ -1511,7 +1511,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseDecl else {
       return nil
     }
@@ -1740,7 +1740,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumDecl else {
       return nil
     }
@@ -2058,7 +2058,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .extensionDecl else {
       return nil
     }
@@ -2073,7 +2073,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
@@ -2082,7 +2082,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodesSyntax? = nil,
       extensionKeyword: TokenSyntax = .keyword(.extension),
       _ unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodesSyntax? = nil,
-      extendedType: E,
+      extendedType: some TypeSyntaxProtocol,
       _ unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodesSyntax? = nil,
       inheritanceClause: TypeInheritanceClauseSyntax? = nil,
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
@@ -2342,7 +2342,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionDecl else {
       return nil
     }
@@ -2652,7 +2652,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ifConfigDecl else {
       return nil
     }
@@ -2791,7 +2791,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .importDecl else {
       return nil
     }
@@ -3054,7 +3054,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .initializerDecl else {
       return nil
     }
@@ -3372,7 +3372,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .macroDecl else {
       return nil
     }
@@ -3682,7 +3682,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .macroExpansionDecl else {
       return nil
     }
@@ -3993,7 +3993,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingDecl else {
       return nil
     }
@@ -4176,7 +4176,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .operatorDecl else {
       return nil
     }
@@ -4411,7 +4411,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .poundSourceLocation else {
       return nil
     }
@@ -4579,7 +4579,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupDecl else {
       return nil
     }
@@ -4892,7 +4892,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .protocolDecl else {
       return nil
     }
@@ -5264,7 +5264,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .structDecl else {
       return nil
     }
@@ -5605,7 +5605,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       self = .getter(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(AccessorBlockSyntax.self) {
         self = .accessors(node)
         return
@@ -5624,7 +5624,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .subscriptDecl else {
       return nil
     }
@@ -5934,7 +5934,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typealiasDecl else {
       return nil
     }
@@ -6218,7 +6218,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .variableDecl else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -18,7 +18,7 @@
 public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrayExpr else {
       return nil
     }
@@ -179,7 +179,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrowExpr else {
       return nil
     }
@@ -295,7 +295,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .asExpr else {
       return nil
     }
@@ -310,16 +310,16 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol, T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndAsTok: UnexpectedNodesSyntax? = nil,
       asTok: TokenSyntax = .keyword(.as),
       _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
       questionOrExclamationMark: TokenSyntax? = nil,
       _ unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodesSyntax? = nil,
-      typeName: T,
+      typeName: some TypeSyntaxProtocol,
       _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -463,7 +463,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .assignmentExpr else {
       return nil
     }
@@ -541,7 +541,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .awaitExpr else {
       return nil
     }
@@ -556,12 +556,12 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAwaitKeyword: UnexpectedNodesSyntax? = nil,
       awaitKeyword: TokenSyntax = .keyword(.await),
       _ unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -657,7 +657,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .binaryOperatorExpr else {
       return nil
     }
@@ -735,7 +735,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .booleanLiteralExpr else {
       return nil
     }
@@ -813,7 +813,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .borrowExpr else {
       return nil
     }
@@ -828,12 +828,12 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBorrowKeyword: UnexpectedNodesSyntax? = nil,
       borrowKeyword: TokenSyntax = .keyword(._borrow),
       _ unexpectedBetweenBorrowKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -929,7 +929,7 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .canImportExpr else {
       return nil
     }
@@ -1123,7 +1123,7 @@ public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .canImportVersionInfo else {
       return nil
     }
@@ -1291,7 +1291,7 @@ public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureExpr else {
       return nil
     }
@@ -1501,7 +1501,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       self = .elements(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(TokenSyntax.self) {
         self = .colon(node)
         return
@@ -1520,7 +1520,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryExpr else {
       return nil
     }
@@ -1662,7 +1662,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .discardAssignmentExpr else {
       return nil
     }
@@ -1740,7 +1740,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .editorPlaceholderExpr else {
       return nil
     }
@@ -1818,7 +1818,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .floatLiteralExpr else {
       return nil
     }
@@ -1896,7 +1896,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .forcedValueExpr else {
       return nil
     }
@@ -1911,10 +1911,10 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodesSyntax? = nil,
       exclamationMark: TokenSyntax = .exclamationMarkToken(),
       _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil,
@@ -2012,7 +2012,7 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionCallExpr else {
       return nil
     }
@@ -2027,10 +2027,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil,
-      calledExpression: C,
+      calledExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodesSyntax? = nil,
       leftParen: TokenSyntax? = nil,
       _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil,
@@ -2270,7 +2270,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .identifierExpr else {
       return nil
     }
@@ -2409,7 +2409,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       self = .codeBlock(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(IfExprSyntax.self) {
         self = .ifExpr(node)
         return
@@ -2428,7 +2428,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ifExpr else {
       return nil
     }
@@ -2641,7 +2641,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .inOutExpr else {
       return nil
     }
@@ -2656,12 +2656,12 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAmpersand: UnexpectedNodesSyntax? = nil,
       ampersand: TokenSyntax = .prefixAmpersandToken(),
       _ unexpectedBetweenAmpersandAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -2757,7 +2757,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .infixOperatorExpr else {
       return nil
     }
@@ -2772,14 +2772,14 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<L: ExprSyntaxProtocol, O: ExprSyntaxProtocol, R: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftOperand: UnexpectedNodesSyntax? = nil,
-      leftOperand: L,
+      leftOperand: some ExprSyntaxProtocol,
       _ unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodesSyntax? = nil,
-      operatorOperand: O,
+      operatorOperand: some ExprSyntaxProtocol,
       _ unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodesSyntax? = nil,
-      rightOperand: R,
+      rightOperand: some ExprSyntaxProtocol,
       _ unexpectedAfterRightOperand: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -2899,7 +2899,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .integerLiteralExpr else {
       return nil
     }
@@ -2983,7 +2983,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .isExpr else {
       return nil
     }
@@ -2998,14 +2998,14 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol, T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndIsTok: UnexpectedNodesSyntax? = nil,
       isTok: TokenSyntax = .keyword(.is),
       _ unexpectedBetweenIsTokAndTypeName: UnexpectedNodesSyntax? = nil,
-      typeName: T,
+      typeName: some TypeSyntaxProtocol,
       _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -3128,7 +3128,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathExpr else {
       return nil
     }
@@ -3143,12 +3143,12 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<R: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil,
       backslash: TokenSyntax = .backslashToken(),
       _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil,
-      root: R? = nil,
+      root: (some TypeSyntaxProtocol)? = nil,
       _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil,
       components: KeyPathComponentListSyntax,
       _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil,
@@ -3324,7 +3324,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .macroExpansionExpr else {
       return nil
     }
@@ -3635,7 +3635,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberAccessExpr else {
       return nil
     }
@@ -3650,10 +3650,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-      base: B? = nil,
+      base: (some ExprSyntaxProtocol)? = nil,
       _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil,
       dot: TokenSyntax = .periodToken(),
       _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
@@ -3842,7 +3842,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingExpr else {
       return nil
     }
@@ -3921,7 +3921,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .moveExpr else {
       return nil
     }
@@ -3936,12 +3936,12 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? = nil,
       moveKeyword: TokenSyntax,
       _ unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -4037,7 +4037,7 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .nilLiteralExpr else {
       return nil
     }
@@ -4115,7 +4115,7 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .optionalChainingExpr else {
       return nil
     }
@@ -4130,10 +4130,10 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil,
       questionMark: TokenSyntax = .postfixQuestionMarkToken(),
       _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil,
@@ -4231,7 +4231,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .packElementExpr else {
       return nil
     }
@@ -4246,12 +4246,12 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil,
       eachKeyword: TokenSyntax = .keyword(.each),
       _ unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodesSyntax? = nil,
-      packRefExpr: P,
+      packRefExpr: some ExprSyntaxProtocol,
       _ unexpectedAfterPackRefExpr: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -4347,7 +4347,7 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .packExpansionExpr else {
       return nil
     }
@@ -4362,12 +4362,12 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil,
       repeatKeyword: TokenSyntax = .keyword(.repeat),
       _ unexpectedBetweenRepeatKeywordAndPatternExpr: UnexpectedNodesSyntax? = nil,
-      patternExpr: P,
+      patternExpr: some ExprSyntaxProtocol,
       _ unexpectedAfterPatternExpr: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -4463,7 +4463,7 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .postfixIfConfigExpr else {
       return nil
     }
@@ -4478,10 +4478,10 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-      base: B? = nil,
+      base: (some ExprSyntaxProtocol)? = nil,
       _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil,
       config: IfConfigDeclSyntax,
       _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil,
@@ -4610,7 +4610,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .postfixUnaryExpr else {
       return nil
     }
@@ -4625,10 +4625,10 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodesSyntax? = nil,
       operatorToken: TokenSyntax,
       _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil,
@@ -4726,7 +4726,7 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .prefixOperatorExpr else {
       return nil
     }
@@ -4741,12 +4741,12 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil,
       operatorToken: TokenSyntax? = nil,
       _ unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodesSyntax? = nil,
-      postfixExpression: P,
+      postfixExpression: some ExprSyntaxProtocol,
       _ unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -4842,7 +4842,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .regexLiteralExpr else {
       return nil
     }
@@ -5036,7 +5036,7 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .sequenceExpr else {
       return nil
     }
@@ -5133,7 +5133,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .specializeExpr else {
       return nil
     }
@@ -5148,10 +5148,10 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
       genericArgumentClause: GenericArgumentClauseSyntax,
       _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
@@ -5249,7 +5249,7 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .stringLiteralExpr else {
       return nil
     }
@@ -5462,7 +5462,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .subscriptExpr else {
       return nil
     }
@@ -5477,10 +5477,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil,
-      calledExpression: C,
+      calledExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodesSyntax? = nil,
       leftBracket: TokenSyntax = .leftSquareBracketToken(),
       _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil,
@@ -5720,7 +5720,7 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .superRefExpr else {
       return nil
     }
@@ -5798,7 +5798,7 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchExpr else {
       return nil
     }
@@ -5813,12 +5813,12 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeSwitchKeyword: UnexpectedNodesSyntax? = nil,
       switchKeyword: TokenSyntax = .keyword(.switch),
       _ unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodesSyntax? = nil,
       leftBrace: TokenSyntax = .leftBraceToken(),
       _ unexpectedBetweenLeftBraceAndCases: UnexpectedNodesSyntax? = nil,
@@ -6011,7 +6011,7 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ternaryExpr else {
       return nil
     }
@@ -6026,18 +6026,18 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol, F: ExprSyntaxProtocol, S: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeConditionExpression: UnexpectedNodesSyntax? = nil,
-      conditionExpression: C,
+      conditionExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil,
       questionMark: TokenSyntax = .infixQuestionMarkToken(),
       _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil,
-      firstChoice: F,
+      firstChoice: some ExprSyntaxProtocol,
       _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil,
       colonMark: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodesSyntax? = nil,
-      secondChoice: S,
+      secondChoice: some ExprSyntaxProtocol,
       _ unexpectedAfterSecondChoice: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -6205,7 +6205,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tryExpr else {
       return nil
     }
@@ -6220,14 +6220,14 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeTryKeyword: UnexpectedNodesSyntax? = nil,
       tryKeyword: TokenSyntax = .keyword(.try),
       _ unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
       questionOrExclamationMark: TokenSyntax? = nil,
       _ unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -6347,7 +6347,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleExpr else {
       return nil
     }
@@ -6508,7 +6508,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeExpr else {
       return nil
     }
@@ -6523,10 +6523,10 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -6586,7 +6586,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedAsExpr else {
       return nil
     }
@@ -6702,7 +6702,7 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedIsExpr else {
       return nil
     }
@@ -6780,7 +6780,7 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedPatternExpr else {
       return nil
     }
@@ -6795,10 +6795,10 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedAfterPattern: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -6858,7 +6858,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedTernaryExpr else {
       return nil
     }
@@ -6873,12 +6873,12 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<F: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeQuestionMark: UnexpectedNodesSyntax? = nil,
       questionMark: TokenSyntax = .infixQuestionMarkToken(),
       _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil,
-      firstChoice: F,
+      firstChoice: some ExprSyntaxProtocol,
       _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil,
       colonMark: TokenSyntax = .colonToken(),
       _ unexpectedAfterColonMark: UnexpectedNodesSyntax? = nil,

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -18,7 +18,7 @@
 public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorBlock else {
       return nil
     }
@@ -179,7 +179,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
 public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorEffectSpecifiers else {
       return nil
     }
@@ -295,7 +295,7 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorParameter else {
       return nil
     }
@@ -437,7 +437,7 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrayElement else {
       return nil
     }
@@ -452,10 +452,10 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -702,7 +702,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       self = .documentationArguments(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(TupleExprElementListSyntax.self) {
         self = .argumentList(node)
         return
@@ -814,7 +814,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .attribute else {
       return nil
     }
@@ -829,12 +829,12 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<A: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? = nil,
       atSignToken: TokenSyntax = .atSignToken(),
       _ unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? = nil,
-      attributeName: A,
+      attributeName: some TypeSyntaxProtocol,
       _ unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? = nil,
       leftParen: TokenSyntax? = nil,
       _ unexpectedBetweenLeftParenAndArgument: UnexpectedNodesSyntax? = nil,
@@ -1043,7 +1043,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       self = .availabilityLabeledArgument(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(TokenSyntax.self) {
         self = .token(node)
         return
@@ -1066,7 +1066,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityArgument else {
       return nil
     }
@@ -1184,7 +1184,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityCondition else {
       return nil
     }
@@ -1371,7 +1371,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityEntry else {
       return nil
     }
@@ -1583,7 +1583,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       self = .version(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(StringLiteralExprSyntax.self) {
         self = .string(node)
         return
@@ -1602,7 +1602,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityLabeledArgument else {
       return nil
     }
@@ -1747,7 +1747,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityVersionRestrictionListEntry else {
       return nil
     }
@@ -1864,7 +1864,7 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
 public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityVersionRestriction else {
       return nil
     }
@@ -1981,7 +1981,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
 public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .backDeployedAttributeSpecList else {
       return nil
     }
@@ -2145,7 +2145,7 @@ public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashabl
 public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .caseItem else {
       return nil
     }
@@ -2160,10 +2160,10 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil,
       whereClause: WhereClauseSyntax? = nil,
       _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -2287,7 +2287,7 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .catchClause else {
       return nil
     }
@@ -2448,7 +2448,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .catchItem else {
       return nil
     }
@@ -2463,10 +2463,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: P? = nil,
+      pattern: (some PatternSyntaxProtocol)? = nil,
       _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil,
       whereClause: WhereClauseSyntax? = nil,
       _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -2625,7 +2625,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureItemSpecifier else {
       return nil
     }
@@ -2793,7 +2793,7 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
 public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureItem else {
       return nil
     }
@@ -2808,7 +2808,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil,
       specifier: ClosureCaptureItemSpecifierSyntax? = nil,
@@ -2817,7 +2817,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenNameAndAssignToken: UnexpectedNodesSyntax? = nil,
       assignToken: TokenSyntax? = nil,
       _ unexpectedBetweenAssignTokenAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -2987,7 +2987,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureSignature else {
       return nil
     }
@@ -3148,7 +3148,7 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParam else {
       return nil
     }
@@ -3264,7 +3264,7 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParameterClause else {
       return nil
     }
@@ -3428,7 +3428,7 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParameter else {
       return nil
     }
@@ -3443,7 +3443,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
@@ -3456,7 +3456,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T? = nil,
+      type: (some TypeSyntaxProtocol)? = nil,
       _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
       ellipsis: TokenSyntax? = nil,
       _ unexpectedBetweenEllipsisAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -3822,7 +3822,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       self = .input(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(ClosureParamListSyntax.self) {
         self = .simpleInput(node)
         return
@@ -3841,7 +3841,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureSignature else {
       return nil
     }
@@ -4098,19 +4098,19 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
       self.init(Syntax(data))!
     }
     
-    public init<Node: DeclSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some DeclSyntaxProtocol) {
       self = .decl(DeclSyntax(node))
     }
     
-    public init<Node: StmtSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some StmtSyntaxProtocol) {
       self = .stmt(StmtSyntax(node))
     }
     
-    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some ExprSyntaxProtocol) {
       self = .expr(ExprSyntax(node))
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(DeclSyntax.self) {
         self = .decl(node)
         return
@@ -4133,7 +4133,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .codeBlockItem else {
       return nil
     }
@@ -4251,7 +4251,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .codeBlock else {
       return nil
     }
@@ -4412,7 +4412,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
 public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .compositionTypeElement else {
       return nil
     }
@@ -4427,10 +4427,10 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndAmpersand: UnexpectedNodesSyntax? = nil,
       ampersand: TokenSyntax? = nil,
       _ unexpectedAfterAmpersand: UnexpectedNodesSyntax? = nil,
@@ -4549,7 +4549,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       self.init(Syntax(data))!
     }
     
-    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some ExprSyntaxProtocol) {
       self = .expression(ExprSyntax(node))
     }
     
@@ -4565,7 +4565,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       self = .optionalBinding(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(ExprSyntax.self) {
         self = .expression(node)
         return
@@ -4597,7 +4597,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conditionElement else {
       return nil
     }
@@ -4713,7 +4713,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conformanceRequirement else {
       return nil
     }
@@ -4728,14 +4728,14 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<L: TypeSyntaxProtocol, R: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      leftTypeIdentifier: L,
+      leftTypeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      rightTypeIdentifier: R,
+      rightTypeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -4855,7 +4855,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conventionAttributeArguments else {
       return nil
     }
@@ -5050,7 +5050,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conventionWitnessMethodAttributeArguments else {
       return nil
     }
@@ -5192,7 +5192,7 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
 public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declModifierDetail else {
       return nil
     }
@@ -5334,7 +5334,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declModifier else {
       return nil
     }
@@ -5450,7 +5450,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declNameArgument else {
       return nil
     }
@@ -5566,7 +5566,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declNameArguments else {
       return nil
     }
@@ -5727,7 +5727,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declName else {
       return nil
     }
@@ -5845,7 +5845,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .derivativeRegistrationAttributeArguments else {
       return nil
     }
@@ -6096,7 +6096,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
 public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .designatedTypeElement else {
       return nil
     }
@@ -6212,7 +6212,7 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryElement else {
       return nil
     }
@@ -6227,14 +6227,14 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<K: ExprSyntaxProtocol, V: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeKeyExpression: UnexpectedNodesSyntax? = nil,
-      keyExpression: K,
+      keyExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenKeyExpressionAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndValueExpression: UnexpectedNodesSyntax? = nil,
-      valueExpression: V,
+      valueExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenValueExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -6380,7 +6380,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityParam else {
       return nil
     }
@@ -6519,7 +6519,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       self = .parameterList(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(DifferentiabilityParamSyntax.self) {
         self = .parameter(node)
         return
@@ -6538,7 +6538,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityParamsClause else {
       return nil
     }
@@ -6682,7 +6682,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
 public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityParams else {
       return nil
     }
@@ -6844,7 +6844,7 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiableAttributeArguments else {
       return nil
     }
@@ -7063,7 +7063,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       self = .string(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(TokenSyntax.self) {
         self = .token(node)
         return
@@ -7082,7 +7082,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .documentationAttributeArgument else {
       return nil
     }
@@ -7251,7 +7251,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
 public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dynamicReplacementArguments else {
       return nil
     }
@@ -7393,7 +7393,7 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
 public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseElement else {
       return nil
     }
@@ -7565,7 +7565,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseParameterClause else {
       return nil
     }
@@ -7729,7 +7729,7 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseParameter else {
       return nil
     }
@@ -7744,7 +7744,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeModifiers: UnexpectedNodesSyntax? = nil,
       modifiers: ModifierListSyntax? = nil,
@@ -7755,7 +7755,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndDefaultArgument: UnexpectedNodesSyntax? = nil,
       defaultArgument: InitializerClauseSyntax? = nil,
       _ unexpectedBetweenDefaultArgumentAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -7998,7 +7998,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .exposeAttributeArguments else {
       return nil
     }
@@ -8140,7 +8140,7 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .expressionSegment else {
       return nil
     }
@@ -8353,7 +8353,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionEffectSpecifiers else {
       return nil
     }
@@ -8469,7 +8469,7 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionParameter else {
       return nil
     }
@@ -8484,7 +8484,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
@@ -8497,7 +8497,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
       ellipsis: TokenSyntax? = nil,
       _ unexpectedBetweenEllipsisAndDefaultArgument: UnexpectedNodesSyntax? = nil,
@@ -8805,7 +8805,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
 public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionSignature else {
       return nil
     }
@@ -8947,7 +8947,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericArgumentClause else {
       return nil
     }
@@ -9108,7 +9108,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericArgument else {
       return nil
     }
@@ -9123,10 +9123,10 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<A: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeArgumentType: UnexpectedNodesSyntax? = nil,
-      argumentType: A,
+      argumentType: some TypeSyntaxProtocol,
       _ unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -9224,7 +9224,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericParameterClause else {
       return nil
     }
@@ -9411,7 +9411,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericParameter else {
       return nil
     }
@@ -9426,7 +9426,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<I: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
@@ -9437,7 +9437,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? = nil,
-      inheritedType: I? = nil,
+      inheritedType: (some TypeSyntaxProtocol)? = nil,
       _ unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -9727,7 +9727,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       self = .layoutRequirement(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(SameTypeRequirementSyntax.self) {
         self = .sameTypeRequirement(node)
         return
@@ -9750,7 +9750,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericRequirement else {
       return nil
     }
@@ -9866,7 +9866,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericWhereClause else {
       return nil
     }
@@ -10037,7 +10037,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       self = .decls(node)
     }
     
-    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some ExprSyntaxProtocol) {
       self = .postfixExpression(ExprSyntax(node))
     }
     
@@ -10045,7 +10045,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       self = .attributes(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(CodeBlockItemListSyntax.self) {
         self = .statements(node)
         return
@@ -10082,7 +10082,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ifConfigClause else {
       return nil
     }
@@ -10097,12 +10097,12 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePoundKeyword: UnexpectedNodesSyntax? = nil,
       poundKeyword: TokenSyntax,
       _ unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? = nil,
-      condition: C? = nil,
+      condition: (some ExprSyntaxProtocol)? = nil,
       _ unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? = nil,
       elements: Elements? = nil,
       _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
@@ -10259,7 +10259,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .implementsAttributeArguments else {
       return nil
     }
@@ -10274,10 +10274,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? = nil,
       comma: TokenSyntax = .commaToken(),
       _ unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? = nil,
@@ -10431,7 +10431,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .importPathComponent else {
       return nil
     }
@@ -10547,7 +10547,7 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .inheritedType else {
       return nil
     }
@@ -10562,10 +10562,10 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeTypeName: UnexpectedNodesSyntax? = nil,
-      typeName: T,
+      typeName: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -10663,7 +10663,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .initializerClause else {
       return nil
     }
@@ -10678,12 +10678,12 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<V: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil,
       equal: TokenSyntax = .equalToken(),
       _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil,
-      value: V,
+      value: some ExprSyntaxProtocol,
       _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -10809,7 +10809,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       self = .optional(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(KeyPathPropertyComponentSyntax.self) {
         self = .property(node)
         return
@@ -10832,7 +10832,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathComponent else {
       return nil
     }
@@ -10948,7 +10948,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathOptionalComponent else {
       return nil
     }
@@ -11026,7 +11026,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathPropertyComponent else {
       return nil
     }
@@ -11168,7 +11168,7 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathSubscriptComponent else {
       return nil
     }
@@ -11329,7 +11329,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .labeledSpecializeEntry else {
       return nil
     }
@@ -11501,7 +11501,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
 public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .layoutRequirement else {
       return nil
     }
@@ -11516,10 +11516,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      typeIdentifier: T,
+      typeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodesSyntax? = nil,
@@ -11773,7 +11773,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .matchingPatternCondition else {
       return nil
     }
@@ -11788,12 +11788,12 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? = nil,
       caseKeyword: TokenSyntax = .keyword(.case),
       _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
       typeAnnotation: TypeAnnotationSyntax? = nil,
       _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil,
@@ -11941,7 +11941,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberDeclBlock else {
       return nil
     }
@@ -12102,7 +12102,7 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberDeclListItem else {
       return nil
     }
@@ -12117,10 +12117,10 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<D: DeclSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeDecl: UnexpectedNodesSyntax? = nil,
-      decl: D,
+      decl: some DeclSyntaxProtocol,
       _ unexpectedBetweenDeclAndSemicolon: UnexpectedNodesSyntax? = nil,
       semicolon: TokenSyntax? = nil,
       _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil,
@@ -12220,7 +12220,7 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missing else {
       return nil
     }
@@ -12299,7 +12299,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .multipleTrailingClosureElement else {
       return nil
     }
@@ -12441,7 +12441,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
 public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .objCSelectorPiece else {
       return nil
     }
@@ -12557,7 +12557,7 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
 public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .opaqueReturnTypeOfAttributeArguments else {
       return nil
     }
@@ -12701,7 +12701,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
 public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .operatorPrecedenceAndTypes else {
       return nil
     }
@@ -12864,7 +12864,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
 public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .optionalBindingCondition else {
       return nil
     }
@@ -12879,12 +12879,12 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBindingKeyword: UnexpectedNodesSyntax? = nil,
       bindingKeyword: TokenSyntax,
       _ unexpectedBetweenBindingKeywordAndPattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
       typeAnnotation: TypeAnnotationSyntax? = nil,
       _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil,
@@ -13032,7 +13032,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
 public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .originallyDefinedInArguments else {
       return nil
     }
@@ -13245,7 +13245,7 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .parameterClause else {
       return nil
     }
@@ -13429,7 +13429,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       self = .getter(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(AccessorBlockSyntax.self) {
         self = .accessors(node)
         return
@@ -13448,7 +13448,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .patternBinding else {
       return nil
     }
@@ -13463,10 +13463,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
       typeAnnotation: TypeAnnotationSyntax? = nil,
       _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil,
@@ -13642,7 +13642,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .poundSourceLocationArgs else {
       return nil
     }
@@ -13888,7 +13888,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupAssignment else {
       return nil
     }
@@ -14031,7 +14031,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupAssociativity else {
       return nil
     }
@@ -14174,7 +14174,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupNameElement else {
       return nil
     }
@@ -14290,7 +14290,7 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupRelation else {
       return nil
     }
@@ -14453,7 +14453,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .primaryAssociatedTypeClause else {
       return nil
     }
@@ -14614,7 +14614,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
 public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .primaryAssociatedType else {
       return nil
     }
@@ -14730,7 +14730,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .qualifiedDeclName else {
       return nil
     }
@@ -14745,10 +14745,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B? = nil,
+      baseType: (some TypeSyntaxProtocol)? = nil,
       _ unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? = nil,
       dot: TokenSyntax? = nil,
       _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
@@ -14940,7 +14940,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .returnClause else {
       return nil
     }
@@ -14955,12 +14955,12 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<R: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeArrow: UnexpectedNodesSyntax? = nil,
       arrow: TokenSyntax = .arrowToken(),
       _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil,
-      returnType: R,
+      returnType: some TypeSyntaxProtocol,
       _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -15056,7 +15056,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .sameTypeRequirement else {
       return nil
     }
@@ -15071,14 +15071,14 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<L: TypeSyntaxProtocol, R: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      leftTypeIdentifier: L,
+      leftTypeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodesSyntax? = nil,
       equalityToken: TokenSyntax,
       _ unexpectedBetweenEqualityTokenAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      rightTypeIdentifier: R,
+      rightTypeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -15198,7 +15198,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .sourceFile else {
       return nil
     }
@@ -15333,7 +15333,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
 public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .stringSegment else {
       return nil
     }
@@ -15411,7 +15411,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchCaseLabel else {
       return nil
     }
@@ -15595,7 +15595,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       self = .case(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(SwitchDefaultLabelSyntax.self) {
         self = .default(node)
         return
@@ -15614,7 +15614,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchCase else {
       return nil
     }
@@ -15775,7 +15775,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchDefaultLabel else {
       return nil
     }
@@ -15891,7 +15891,7 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .targetFunctionEntry else {
       return nil
     }
@@ -16063,7 +16063,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
 public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleExprElement else {
       return nil
     }
@@ -16078,14 +16078,14 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil,
       label: TokenSyntax? = nil,
       _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -16231,7 +16231,7 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tuplePatternElement else {
       return nil
     }
@@ -16246,14 +16246,14 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil,
       labelName: TokenSyntax? = nil,
       _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil,
       labelColon: TokenSyntax? = nil,
       _ unexpectedBetweenLabelColonAndPattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -16399,7 +16399,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleTypeElement else {
       return nil
     }
@@ -16414,7 +16414,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeInOut: UnexpectedNodesSyntax? = nil,
       inOut: TokenSyntax? = nil,
@@ -16425,7 +16425,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
       ellipsis: TokenSyntax? = nil,
       _ unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? = nil,
@@ -16671,7 +16671,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeAnnotation else {
       return nil
     }
@@ -16686,12 +16686,12 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -16787,7 +16787,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeEffectSpecifiers else {
       return nil
     }
@@ -16903,7 +16903,7 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeInheritanceClause else {
       return nil
     }
@@ -17038,7 +17038,7 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeInitializerClause else {
       return nil
     }
@@ -17053,12 +17053,12 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<V: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil,
       equal: TokenSyntax = .equalToken(),
       _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil,
-      value: V,
+      value: some TypeSyntaxProtocol,
       _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -17154,7 +17154,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unavailableFromAsyncArguments else {
       return nil
     }
@@ -17296,7 +17296,7 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
 public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .underscorePrivateAttributeArguments else {
       return nil
     }
@@ -17438,7 +17438,7 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
 public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .versionComponent else {
       return nil
     }
@@ -17556,7 +17556,7 @@ public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .versionTuple else {
       return nil
     }
@@ -17693,7 +17693,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .whereClause else {
       return nil
     }
@@ -17708,12 +17708,12 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<G: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil,
       whereKeyword: TokenSyntax = .keyword(.where),
       _ unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodesSyntax? = nil,
-      guardResult: G,
+      guardResult: some ExprSyntaxProtocol,
       _ unexpectedAfterGuardResult: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -17809,7 +17809,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .yieldExprListElement else {
       return nil
     }
@@ -17824,10 +17824,10 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? = nil,
       comma: TokenSyntax? = nil,
       _ unexpectedAfterComma: UnexpectedNodesSyntax? = nil,
@@ -17925,7 +17925,7 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .yieldList else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -18,7 +18,7 @@
 public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .expressionPattern else {
       return nil
     }
@@ -33,10 +33,10 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -96,7 +96,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .identifierPattern else {
       return nil
     }
@@ -174,7 +174,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .isTypePattern else {
       return nil
     }
@@ -189,12 +189,12 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeIsKeyword: UnexpectedNodesSyntax? = nil,
       isKeyword: TokenSyntax = .keyword(.is),
       _ unexpectedBetweenIsKeywordAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -290,7 +290,7 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingPattern else {
       return nil
     }
@@ -369,7 +369,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tuplePattern else {
       return nil
     }
@@ -530,7 +530,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .valueBindingPattern else {
       return nil
     }
@@ -545,12 +545,12 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<V: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBindingKeyword: UnexpectedNodesSyntax? = nil,
       bindingKeyword: TokenSyntax,
       _ unexpectedBetweenBindingKeywordAndValuePattern: UnexpectedNodesSyntax? = nil,
-      valuePattern: V,
+      valuePattern: some PatternSyntaxProtocol,
       _ unexpectedAfterValuePattern: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -646,7 +646,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .wildcardPattern else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -18,7 +18,7 @@
 public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .breakStmt else {
       return nil
     }
@@ -134,7 +134,7 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .continueStmt else {
       return nil
     }
@@ -250,7 +250,7 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .deferStmt else {
       return nil
     }
@@ -366,7 +366,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .discardStmt else {
       return nil
     }
@@ -381,12 +381,12 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeDiscardKeyword: UnexpectedNodesSyntax? = nil,
       discardKeyword: TokenSyntax,
       _ unexpectedBetweenDiscardKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -482,7 +482,7 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .doStmt else {
       return nil
     }
@@ -643,7 +643,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .expressionStmt else {
       return nil
     }
@@ -658,10 +658,10 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -721,7 +721,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .fallthroughStmt else {
       return nil
     }
@@ -799,7 +799,7 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .forInStmt else {
       return nil
     }
@@ -814,7 +814,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol, S: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeForKeyword: UnexpectedNodesSyntax? = nil,
       forKeyword: TokenSyntax = .keyword(.for),
@@ -825,13 +825,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodesSyntax? = nil,
       caseKeyword: TokenSyntax? = nil,
       _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
       typeAnnotation: TypeAnnotationSyntax? = nil,
       _ unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodesSyntax? = nil,
       inKeyword: TokenSyntax = .keyword(.in),
       _ unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodesSyntax? = nil,
-      sequenceExpr: S,
+      sequenceExpr: some ExprSyntaxProtocol,
       _ unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodesSyntax? = nil,
       whereClause: WhereClauseSyntax? = nil,
       _ unexpectedBetweenWhereClauseAndBody: UnexpectedNodesSyntax? = nil,
@@ -1123,7 +1123,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .guardStmt else {
       return nil
     }
@@ -1310,7 +1310,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .labeledStmt else {
       return nil
     }
@@ -1325,14 +1325,14 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<S: StmtSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil,
       labelName: TokenSyntax,
       _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil,
       labelColon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? = nil,
-      statement: S,
+      statement: some StmtSyntaxProtocol,
       _ unexpectedAfterStatement: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1452,7 +1452,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingStmt else {
       return nil
     }
@@ -1531,7 +1531,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .repeatWhileStmt else {
       return nil
     }
@@ -1546,7 +1546,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil,
       repeatKeyword: TokenSyntax = .keyword(.repeat),
@@ -1555,7 +1555,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodesSyntax? = nil,
       whileKeyword: TokenSyntax = .keyword(.while),
       _ unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodesSyntax? = nil,
-      condition: C,
+      condition: some ExprSyntaxProtocol,
       _ unexpectedAfterCondition: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1699,7 +1699,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .returnStmt else {
       return nil
     }
@@ -1714,12 +1714,12 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil,
       returnKeyword: TokenSyntax = .keyword(.return),
       _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E? = nil,
+      expression: (some ExprSyntaxProtocol)? = nil,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1846,7 +1846,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .throwStmt else {
       return nil
     }
@@ -1861,12 +1861,12 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeThrowKeyword: UnexpectedNodesSyntax? = nil,
       throwKeyword: TokenSyntax = .keyword(.throw),
       _ unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1962,7 +1962,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .whileStmt else {
       return nil
     }
@@ -2142,11 +2142,11 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       self = .yieldList(node)
     }
     
-    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some ExprSyntaxProtocol) {
       self = .simpleYield(ExprSyntax(node))
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(YieldListSyntax.self) {
         self = .yieldList(node)
         return
@@ -2165,7 +2165,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .yieldStmt else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -18,7 +18,7 @@
 public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrayType else {
       return nil
     }
@@ -33,12 +33,12 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil,
       leftSquareBracket: TokenSyntax = .leftSquareBracketToken(),
       _ unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodesSyntax? = nil,
-      elementType: E,
+      elementType: some TypeSyntaxProtocol,
       _ unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil,
       rightSquareBracket: TokenSyntax = .rightSquareBracketToken(),
       _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil,
@@ -160,7 +160,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .attributedType else {
       return nil
     }
@@ -175,14 +175,14 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil,
       specifier: TokenSyntax? = nil,
       _ unexpectedBetweenSpecifierAndAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
       _ unexpectedBetweenAttributesAndBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -321,7 +321,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .classRestrictionType else {
       return nil
     }
@@ -399,7 +399,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .compositionType else {
       return nil
     }
@@ -496,7 +496,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .constrainedSugarType else {
       return nil
     }
@@ -511,12 +511,12 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodesSyntax? = nil,
       someOrAnySpecifier: TokenSyntax,
       _ unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -612,7 +612,7 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryType else {
       return nil
     }
@@ -627,16 +627,16 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<K: TypeSyntaxProtocol, V: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil,
       leftSquareBracket: TokenSyntax = .leftSquareBracketToken(),
       _ unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodesSyntax? = nil,
-      keyType: K,
+      keyType: some TypeSyntaxProtocol,
       _ unexpectedBetweenKeyTypeAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndValueType: UnexpectedNodesSyntax? = nil,
-      valueType: V,
+      valueType: some TypeSyntaxProtocol,
       _ unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil,
       rightSquareBracket: TokenSyntax = .rightSquareBracketToken(),
       _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil,
@@ -806,7 +806,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionType else {
       return nil
     }
@@ -1019,7 +1019,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .implicitlyUnwrappedOptionalType else {
       return nil
     }
@@ -1034,10 +1034,10 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     self._syntaxNode = Syntax(data)
   }
   
-  public init<W: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil,
-      wrappedType: W,
+      wrappedType: some TypeSyntaxProtocol,
       _ unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodesSyntax? = nil,
       exclamationMark: TokenSyntax = .exclamationMarkToken(),
       _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil,
@@ -1135,7 +1135,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberTypeIdentifier else {
       return nil
     }
@@ -1150,10 +1150,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil,
       period: TokenSyntax = .periodToken(),
       _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil,
@@ -1303,7 +1303,7 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .metatypeType else {
       return nil
     }
@@ -1318,10 +1318,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil,
       period: TokenSyntax = .periodToken(),
       _ unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodesSyntax? = nil,
@@ -1445,7 +1445,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingType else {
       return nil
     }
@@ -1524,7 +1524,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .namedOpaqueReturnType else {
       return nil
     }
@@ -1539,12 +1539,12 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? = nil,
       genericParameters: GenericParameterClauseSyntax,
       _ unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1640,7 +1640,7 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .optionalType else {
       return nil
     }
@@ -1655,10 +1655,10 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<W: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil,
-      wrappedType: W,
+      wrappedType: some TypeSyntaxProtocol,
       _ unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodesSyntax? = nil,
       questionMark: TokenSyntax = .postfixQuestionMarkToken(),
       _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil,
@@ -1756,7 +1756,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .packExpansionType else {
       return nil
     }
@@ -1771,12 +1771,12 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil,
       repeatKeyword: TokenSyntax = .keyword(.repeat),
       _ unexpectedBetweenRepeatKeywordAndPatternType: UnexpectedNodesSyntax? = nil,
-      patternType: P,
+      patternType: some TypeSyntaxProtocol,
       _ unexpectedAfterPatternType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1872,7 +1872,7 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .packReferenceType else {
       return nil
     }
@@ -1887,12 +1887,12 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil,
       eachKeyword: TokenSyntax = .keyword(.each),
       _ unexpectedBetweenEachKeywordAndPackType: UnexpectedNodesSyntax? = nil,
-      packType: P,
+      packType: some TypeSyntaxProtocol,
       _ unexpectedAfterPackType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1988,7 +1988,7 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .simpleTypeIdentifier else {
       return nil
     }
@@ -2104,7 +2104,7 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .suppressedType else {
       return nil
     }
@@ -2119,12 +2119,12 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeWithoutTilde: UnexpectedNodesSyntax? = nil,
       withoutTilde: TokenSyntax,
       _ unexpectedBetweenWithoutTildeAndPatternType: UnexpectedNodesSyntax? = nil,
-      patternType: P,
+      patternType: some TypeSyntaxProtocol,
       _ unexpectedAfterPatternType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -2220,7 +2220,7 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleType else {
       return nil
     }

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -121,7 +121,7 @@ extension ExprSyntax {
   /// to produce a literal as the outermost syntax node, or even to have a
   /// literal anywhere in its syntax tree. Use a convenience initializer on a
   /// specific type if you need that exact type in the syntax tree.
-  public init<Literal: ExpressibleByLiteralSyntax>(literal: Literal) {
+  public init(literal: some ExpressibleByLiteralSyntax) {
     self.init(literal.makeLiteralSyntax())
   }
 }
@@ -144,8 +144,8 @@ extension FunctionCallExprSyntax {
   /// A convenience initializer that allows passing in arguments using a result builder
   /// instead of having to wrap them in a `TupleExprElementList`.
   /// The presence of the parenthesis will be inferred based on the presence of arguments and the trailing closure.
-  public init<C: ExprSyntaxProtocol>(
-    callee: C,
+  public init(
+    callee: some ExprSyntaxProtocol,
     trailingClosure: ClosureExprSyntax? = nil,
     additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? = nil,
     @TupleExprElementListBuilder argumentList: () -> TupleExprElementListSyntax = { [] }
@@ -303,7 +303,7 @@ extension StringLiteralExprSyntax {
 extension TupleExprElementSyntax {
   /// A convenience initializer that allows passing in label as an optional string.
   /// The presence of the colon will be inferred based on the presence of the label.
-  public init<E: ExprSyntaxProtocol>(label: String? = nil, expression: E) {
+  public init(label: String? = nil, expression: some ExprSyntaxProtocol) {
     self.init(
       label: label.map { .identifier($0) },
       colon: label == nil ? nil : .colonToken(),

--- a/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
+++ b/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
@@ -13,21 +13,21 @@
 import SwiftSyntax
 
 extension CodeBlockItemListBuilder {
-  public static func buildExpression<ExprType: ExprSyntaxProtocol>(_ expression: ExprType) -> Component {
+  public static func buildExpression(_ expression: some ExprSyntaxProtocol) -> Component {
     return buildExpression(CodeBlockItemSyntax(item: .expr(ExprSyntax(expression))))
   }
 
-  public static func buildExpression<StmtType: StmtSyntaxProtocol>(_ expression: StmtType) -> Component {
+  public static func buildExpression(_ expression: some StmtSyntaxProtocol) -> Component {
     return buildExpression(CodeBlockItemSyntax(item: .stmt(StmtSyntax(expression))))
   }
 
-  public static func buildExpression<DeclType: DeclSyntaxProtocol>(_ expression: DeclType) -> Component {
+  public static func buildExpression(_ expression: some DeclSyntaxProtocol) -> Component {
     return buildExpression(CodeBlockItemSyntax(item: .decl(DeclSyntax(expression))))
   }
 }
 
 extension ConditionElementListBuilder {
-  public static func buildExpression<ExprType: ExprSyntaxProtocol>(_ expression: ExprType) -> Component {
+  public static func buildExpression(_ expression: some ExprSyntaxProtocol) -> Component {
     return buildExpression(ConditionElementSyntax(condition: .expression(ExprSyntax(expression))))
   }
 
@@ -45,7 +45,7 @@ extension ConditionElementListBuilder {
 }
 
 extension MemberDeclListBuilder {
-  public static func buildExpression<DeclType: DeclSyntaxProtocol>(_ expression: DeclType) -> Component {
+  public static func buildExpression(_ expression: some DeclSyntaxProtocol) -> Component {
     return buildExpression(MemberDeclListItemSyntax(decl: expression))
   }
 }

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -97,8 +97,8 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
     self.lastIndentation = nil
   }
 
-  public mutating func appendInterpolation<Buildable: SyntaxProtocol>(
-    _ buildable: Buildable,
+  public mutating func appendInterpolation(
+    _ buildable: some SyntaxProtocol,
     format: BasicFormat = BasicFormat()
   ) {
     self.appendInterpolation(buildable.formatted(using: format))
@@ -107,8 +107,8 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
   /// Interpolates a literal or similar expression syntax equivalent to `value`.
   ///
   /// - SeeAlso: ``Expr/init(literal:)``
-  public mutating func appendInterpolation<Literal: ExpressibleByLiteralSyntax>(
-    literal value: Literal,
+  public mutating func appendInterpolation(
+    literal value: some ExpressibleByLiteralSyntax,
     format: BasicFormat = BasicFormat()
   ) {
     self.appendInterpolation(ExprSyntax(literal: value), format: format)

--- a/Sources/SwiftSyntaxMacros/BasicMacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/BasicMacroExpansionContext.swift
@@ -70,8 +70,8 @@ public class BasicMacroExpansionContext {
 extension BasicMacroExpansionContext {
   /// Note that the given node that was at the given position in the provided
   /// source file has been disconnected and is now a new root.
-  private func addDisconnected<Node: SyntaxProtocol>(
-    _ node: Node,
+  private func addDisconnected(
+    _ node: some SyntaxProtocol,
     at offset: AbsolutePosition,
     in sourceFile: SourceFileSyntax
   ) {
@@ -135,8 +135,8 @@ extension BasicMacroExpansionContext: MacroExpansionContext {
     diagnostics.append(diagnostic)
   }
 
-  public func location<Node: SyntaxProtocol>(
-    of node: Node,
+  public func location(
+    of node: some SyntaxProtocol,
     at position: PositionInSyntaxNode,
     filePathMode: SourceLocationFilePathMode
   ) -> AbstractSourceLocation? {

--- a/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
@@ -42,8 +42,8 @@ public protocol MacroExpansionContext: AnyObject {
   /// - Returns: the source location within the given node, or `nil` if the
   ///   given syntax node is not rooted in a source file that the macro
   ///   expansion context knows about.
-  func location<Node: SyntaxProtocol>(
-    of node: Node,
+  func location(
+    of node: some SyntaxProtocol,
     at position: PositionInSyntaxNode,
     filePathMode: SourceLocationFilePathMode
   ) -> AbstractSourceLocation?
@@ -59,8 +59,8 @@ extension MacroExpansionContext {
   /// - Returns: the source location within the given node, or `nil` if the
   ///   given syntax node is not rooted in a source file that the macro
   ///   expansion context knows about.
-  public func location<Node: SyntaxProtocol>(
-    of node: Node
+  public func location(
+    of node: some SyntaxProtocol
   ) -> AbstractSourceLocation? {
     return location(of: node, at: .afterLeadingTrivia, filePathMode: .fileID)
   }
@@ -79,7 +79,7 @@ private struct ThrownErrorDiagnostic: DiagnosticMessage {
 
 extension MacroExpansionContext {
   /// Add diagnostics from the error thrown during macro expansion.
-  public func addDiagnostics<S: SyntaxProtocol>(from error: Error, node: S) {
+  public func addDiagnostics(from error: Error, node: some SyntaxProtocol) {
     // Inspect the error to form an appropriate set of diagnostics.
     var diagnostics: [Diagnostic]
     if let diagnosticsError = error as? DiagnosticsError {

--- a/Sources/SwiftSyntaxMacros/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacros/MacroReplacement.swift
@@ -271,8 +271,8 @@ extension MacroDeclSyntax {
   /// Given a freestanding macro expansion syntax node that references this
   /// macro declaration, expand the macro by substituting the arguments from
   /// the macro expansion into the parameters that are used in the definition.
-  public func expand<Node: FreestandingMacroExpansionSyntax>(
-    _ node: Node,
+  public func expand(
+    _ node: some FreestandingMacroExpansionSyntax,
     definition: MacroExpansionExprSyntax,
     replacements: [MacroDefinition.Replacement]
   ) -> ExprSyntax {

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -442,7 +442,7 @@ extension MacroApplication {
       do {
         let typedDecl = decl.asProtocol(DeclGroupSyntax.self)!
 
-        func expand<Decl: DeclGroupSyntax>(_ decl: Decl) throws -> [AttributeSyntax] {
+        func expand(_ decl: some DeclGroupSyntax) throws -> [AttributeSyntax] {
           return try attributeMacro.expansion(
             of: attribute,
             attachedTo: decl,
@@ -471,9 +471,9 @@ extension MacroApplication {
 extension SyntaxProtocol {
   /// Expand all uses of the given set of macros within this syntax
   /// node.
-  public func expand<Context: MacroExpansionContext>(
+  public func expand(
     macros: [String: Macro.Type],
-    in context: Context
+    in context: some MacroExpansionContext
   ) -> Syntax {
     // Build the macro system.
     var system = MacroSystem()

--- a/Sources/SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
+++ b/Sources/SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
@@ -28,9 +28,9 @@ extension SyntaxProtocol {
 extension MacroExpansionExprSyntax {
   /// Evaluate the given macro for this syntax node, producing the expanded
   /// result and (possibly) some diagnostics.
-  func evaluateMacro<Context: MacroExpansionContext>(
+  func evaluateMacro(
     _ macro: Macro.Type,
-    in context: Context
+    in context: some MacroExpansionContext
   ) -> ExprSyntax {
     guard let exprMacro = macro as? ExpressionMacro.Type else {
       return ExprSyntax(self)
@@ -49,9 +49,9 @@ extension MacroExpansionExprSyntax {
 extension MacroExpansionDeclSyntax {
   /// Evaluate the given macro for this syntax node, producing the expanded
   /// result and (possibly) some diagnostics.
-  func evaluateMacro<Context: MacroExpansionContext>(
+  func evaluateMacro(
     _ macro: Macro.Type,
-    in context: Context
+    in context: some MacroExpansionContext
   ) -> Syntax {
     // TODO: declaration/statement macros
 
@@ -82,9 +82,9 @@ extension Syntax {
   /// This operation only makes sense when `evaluatedMacroName` produces a
   /// non-nil value, indicating that this syntax node is a macro evaluation of
   /// some kind.
-  func evaluateMacro<Context: MacroExpansionContext>(
+  func evaluateMacro(
     with macroSystem: MacroSystem,
-    context: Context
+    context: some MacroExpansionContext
   ) -> Syntax {
     // If this isn't a macro evaluation node, do nothing.
     guard let macroName = evaluatedMacroName else {

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -58,9 +58,9 @@ public struct NoteSpec {
   }
 }
 
-func assertNote<T: SyntaxProtocol>(
+func assertNote(
   _ note: Note,
-  in tree: T,
+  in tree: some SyntaxProtocol,
   expected spec: NoteSpec
 ) {
   assertStringsEqualWithDiff(note.message, spec.message, "message of note does not match", file: spec.originatorFile, line: spec.originatorLine)
@@ -177,9 +177,9 @@ public struct DiagnosticSpec {
   }
 }
 
-func assertDiagnostic<T: SyntaxProtocol>(
+func assertDiagnostic(
   _ diag: Diagnostic,
-  in tree: T,
+  in tree: some SyntaxProtocol,
   expected spec: DiagnosticSpec
 ) {
   if let id = spec.id {

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
@@ -32,8 +32,7 @@ public struct TreeDifference {
   public let baseline: Syntax
   public let reason: DifferenceReason
 
-  public init<Difference, Baseline>(node: Difference, baseline: Baseline, reason: DifferenceReason)
-  where Difference: SyntaxProtocol, Baseline: SyntaxProtocol {
+  public init(node: some SyntaxProtocol, baseline: some SyntaxProtocol, reason: DifferenceReason) {
     self.node = Syntax(node)
     self.baseline = Syntax(baseline)
     self.reason = reason
@@ -90,7 +89,7 @@ extension TreeDifference: CustomDebugStringConvertible {
 public extension SyntaxProtocol {
   /// Compares the current tree against a `baseline`, returning the first
   /// difference it finds.
-  func findFirstDifference<Tree: SyntaxProtocol>(baseline: Tree, includeTrivia: Bool = false) -> TreeDifference? {
+  func findFirstDifference(baseline: some SyntaxProtocol, includeTrivia: Bool = false) -> TreeDifference? {
     if let reason = isDifferent(baseline: baseline, includeTrivia: includeTrivia) {
       return TreeDifference(node: self, baseline: baseline, reason: reason)
     }
@@ -113,7 +112,7 @@ public extension SyntaxProtocol {
     return nil
   }
 
-  private func isDifferent<Tree: SyntaxProtocol>(baseline: Tree, includeTrivia: Bool = false) -> DifferenceReason? {
+  private func isDifferent(baseline: some SyntaxProtocol, includeTrivia: Bool = false) -> DifferenceReason? {
     if syntaxNodeType != baseline.syntaxNodeType {
       return .nodeType
     }


### PR DESCRIPTION
Now that we no longer need to support Swift <5.7, we can use opaque parameter types.