### PR TITLE
[5.9] Package.swift: make package name consistent with repo name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ if ProcessInfo.processInfo.environment["SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTRO
 }
 
 let package = Package(
-  name: "SwiftSyntax",
+  name: "swift-syntax",
   platforms: [
     .macOS(.v10_15),
     .iOS(.v13),

--- a/Tests/SwiftParserTest/LinkageTests.swift
+++ b/Tests/SwiftParserTest/LinkageTests.swift
@@ -200,9 +200,9 @@ extension LinkageTest {
       let name = try XCTUnwrap(_dyld_get_image_name(i))
       let path = String(cString: name)
       // We can wind up in SwiftParserTest.xctest when built via the IDE or
-      // in SwiftSyntaxPackageTests.xctest when built at the command line
+      // in swift-syntaxPackageTests.xctest when built at the command line
       // via the package manager.
-      guard path.hasSuffix("SwiftParserTest") || path.hasSuffix("SwiftSyntaxPackageTests") else {
+      guard path.hasSuffix("SwiftParserTest") || path.hasSuffix("swift-syntaxPackageTests") else {
         continue
       }
 

--- a/build-script.py
+++ b/build-script.py
@@ -439,7 +439,7 @@ def run_xctests(
     if verbose:
         swiftpm_call.extend(["--verbose"])
 
-    swiftpm_call.extend(["--test-product", "SwiftSyntaxPackageTests"])
+    swiftpm_call.extend(["--test-product", "swift-syntaxPackageTests"])
 
     env = dict(os.environ)
     env["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] = "1"


### PR DESCRIPTION
Rest of SwiftPM packages provided by Apple follow a dash-case naming scheme consistent with repository name, usually with `swift-` prefix.

This shouldn't have an impact on SwiftSyntax clients. For example `swift-format` already uses `package: "swift-syntax"` argument in its `Package.swift` for specifying the dependency.