### PR TITLE
Remove `@frozen` attributes

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
@@ -24,7 +24,6 @@ let lookupTable = ArrayExprSyntax(leftSquare: .leftSquareBracketToken(trailingTr
 let keywordFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
-    @frozen  // FIXME: Not actually stable, works around a miscompile
     public enum Keyword: UInt8, Hashable
     """
   ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -48,7 +48,6 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       for (name, choices) in enums {
         try EnumDeclSyntax(
           """
-          @frozen // FIXME: Not actually stable, works around a miscompile
           public enum \(raw: name): RawSyntaxNodeProtocol
           """
         ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -54,7 +54,6 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       if let collectionElementChoices = node.collectionElementChoices, !collectionElementChoices.isEmpty {
         try EnumDeclSyntax(
           """
-          @frozen // FIXME: Not actually stable, works around a miscompile
           public enum Element: SyntaxChildChoices
           """
         ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxEnumFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxEnumFile.swift
@@ -19,7 +19,6 @@ let syntaxEnumFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
     /// Enum to exhaustively switch over all different syntax nodes.
-    @frozen // FIXME: Not actually stable, works around a miscompile
     public enum SyntaxEnum
     """
   ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxKindFile.swift
@@ -19,7 +19,6 @@ let syntaxKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
     /// Enumerates the known kinds of Syntax represented in the Syntax tree.
-    @frozen // FIXME: Not actually stable, works around a miscompile
     public enum SyntaxKind
     """
   ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -19,7 +19,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
     /// Enumerates the kinds of tokens in the Swift language.
-    @frozen // FIXME: Not actually stable, works around a miscompile
     public enum TokenKind: Hashable
     """
   ) {

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@frozen  // FIXME: Not actually stable, works around a miscompile
 public enum Keyword: UInt8, Hashable {
   case __consuming
   case __owned

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -448,7 +448,6 @@ extension ArrayElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `attribute`(AttributeSyntax)
     case `ifConfigDecl`(IfConfigDeclSyntax)
@@ -7585,7 +7584,6 @@ extension PatternBindingListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `precedenceGroupRelation`(PrecedenceGroupRelationSyntax)
     case `precedenceGroupAssignment`(PrecedenceGroupAssignmentSyntax)
@@ -8264,7 +8262,6 @@ extension PrimaryAssociatedTypeListSyntax: BidirectionalCollection {
 
 /// A collection of arguments for the `@_specialize` attribute
 public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `labeledSpecializeEntry`(LabeledSpecializeEntrySyntax)
     case `availabilityEntry`(AvailabilityEntrySyntax)
@@ -8541,7 +8538,6 @@ extension SpecializeAttributeSpecListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `stringSegment`(StringSegmentSyntax)
     case `expressionSegment`(ExpressionSegmentSyntax)
@@ -8793,7 +8789,6 @@ extension StringLiteralSegmentsSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `switchCase`(SwitchCaseSyntax)
     case `ifConfigDecl`(IfConfigDeclSyntax)

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 /// Enum to exhaustively switch over all different syntax nodes.
-@frozen // FIXME: Not actually stable, works around a miscompile
 public enum SyntaxEnum {
   case token(TokenSyntax)
   case accessorBlock(AccessorBlockSyntax)

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
-@frozen // FIXME: Not actually stable, works around a miscompile
 public enum SyntaxKind {
   case token
   case accessorBlock

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the kinds of tokens in the Swift language.
-@frozen // FIXME: Not actually stable, works around a miscompile
 public enum TokenKind: Hashable {
   case eof
   case arrow

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -1209,7 +1209,6 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `attribute`(RawAttributeSyntax)
     case `ifConfigDecl`(RawIfConfigDeclSyntax)
@@ -1290,7 +1289,6 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Argument: RawSyntaxNodeProtocol {
     case `argumentList`(RawTupleExprElementListSyntax)
     case `token`(RawTokenSyntax)
@@ -1635,7 +1633,6 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Entry: RawSyntaxNodeProtocol {
     case `token`(RawTokenSyntax)
     case `availabilityVersionRestriction`(RawAvailabilityVersionRestrictionSyntax)
@@ -1931,7 +1928,6 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Value: RawSyntaxNodeProtocol {
     case `string`(RawStringLiteralExprSyntax)
     case `version`(RawVersionTupleSyntax)
@@ -4308,7 +4304,6 @@ public struct RawClosureParameterSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Input: RawSyntaxNodeProtocol {
     case `simpleInput`(RawClosureParamListSyntax)
     case `input`(RawClosureParameterClauseSyntax)
@@ -4507,7 +4502,6 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Item: RawSyntaxNodeProtocol {
     case `decl`(RawDeclSyntax)
     case `stmt`(RawStmtSyntax)
@@ -4925,7 +4919,6 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Condition: RawSyntaxNodeProtocol {
     case `expression`(RawExprSyntax)
     case `availability`(RawAvailabilityConditionSyntax)
@@ -6471,7 +6464,6 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Content: RawSyntaxNodeProtocol {
     case `colon`(RawTokenSyntax)
     case `elements`(RawDictionaryElementListSyntax)
@@ -6810,7 +6802,6 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Parameters: RawSyntaxNodeProtocol {
     case `parameter`(RawDifferentiabilityParamSyntax)
     case `parameterList`(RawDifferentiabilityParamsSyntax)
@@ -7321,7 +7312,6 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Value: RawSyntaxNodeProtocol {
     case `token`(RawTokenSyntax)
     case `string`(RawStringLiteralExprSyntax)
@@ -10497,7 +10487,6 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Body: RawSyntaxNodeProtocol {
     case `sameTypeRequirement`(RawSameTypeRequirementSyntax)
     case `conformanceRequirement`(RawConformanceRequirementSyntax)
@@ -10947,7 +10936,6 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Elements: RawSyntaxNodeProtocol {
     case `statements`(RawCodeBlockItemListSyntax)
     case `switchCases`(RawSwitchCaseListSyntax)
@@ -11151,7 +11139,6 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum ElseBody: RawSyntaxNodeProtocol {
     case `ifExpr`(RawIfExprSyntax)
     case `codeBlock`(RawCodeBlockSyntax)
@@ -12422,7 +12409,6 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Component: RawSyntaxNodeProtocol {
     case `property`(RawKeyPathPropertyComponentSyntax)
     case `subscript`(RawKeyPathSubscriptComponentSyntax)
@@ -16038,7 +16024,6 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Accessor: RawSyntaxNodeProtocol {
     case `accessors`(RawAccessorBlockSyntax)
     case `getter`(RawCodeBlockSyntax)
@@ -16742,7 +16727,6 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `precedenceGroupRelation`(RawPrecedenceGroupRelationSyntax)
     case `precedenceGroupAssignment`(RawPrecedenceGroupAssignmentSyntax)
@@ -18290,7 +18274,6 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `labeledSpecializeEntry`(RawLabeledSpecializeEntrySyntax)
     case `availabilityEntry`(RawAvailabilityEntrySyntax)
@@ -18600,7 +18583,6 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `stringSegment`(RawStringSegmentSyntax)
     case `expressionSegment`(RawExpressionSegmentSyntax)
@@ -18881,7 +18863,6 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Accessor: RawSyntaxNodeProtocol {
     case `accessors`(RawAccessorBlockSyntax)
     case `getter`(RawCodeBlockSyntax)
@@ -19382,7 +19363,6 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `switchCase`(RawSwitchCaseSyntax)
     case `ifConfigDecl`(RawIfConfigDeclSyntax)
@@ -19463,7 +19443,6 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Label: RawSyntaxNodeProtocol {
     case `default`(RawSwitchDefaultLabelSyntax)
     case `case`(RawSwitchCaseLabelSyntax)
@@ -22597,7 +22576,6 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Yields: RawSyntaxNodeProtocol {
     case `yieldList`(RawYieldListSyntax)
     case `simpleYield`(RawExprSyntax)


### PR DESCRIPTION
These only existed to work around a miscompile in Swift 5.5. Since we no longer support it, we can remove the workaround.