### PR TITLE
[Parser] Emit diagnostics for `@ AttributeName` and `@\nAttributeName`

### DIFF
--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -171,6 +171,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var invalidWhitespaceAfterPeriod: Self {
     .init("extraneous whitespace after '.' is not permitted")
   }
+  public static var invalidWhitespaceBetweenAttributeAtSignAndIdentifier: Self {
+    .init("extraneous whitespace after '@' is not permitted")
+  }
   public static var joinConditionsUsingComma: Self {
     .init("expected ',' joining parts of a multi-clause condition")
   }

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -293,7 +293,8 @@ extension RawSyntax {
   /// - Parameters:
   ///   - leadingTrivia: The trivia to attach.
   ///   - arena: SyntaxArena to the result node data resides.
-  func withLeadingTrivia(_ leadingTrivia: Trivia, arena: SyntaxArena) -> RawSyntax? {
+  @_spi(RawSyntax)
+  public func withLeadingTrivia(_ leadingTrivia: Trivia, arena: SyntaxArena) -> RawSyntax? {
     switch view {
     case .token(let tokenView):
       return .makeMaterializedToken(
@@ -319,7 +320,8 @@ extension RawSyntax {
   /// - Parameters:
   ///   - trailingTrivia: The trivia to attach.
   ///   - arena: SyntaxArena to the result node data resides.
-  func withTrailingTrivia(_ trailingTrivia: Trivia, arena: SyntaxArena) -> RawSyntax? {
+  @_spi(RawSyntax)
+  public func withTrailingTrivia(_ trailingTrivia: Trivia, arena: SyntaxArena) -> RawSyntax? {
     switch view {
     case .token(let tokenView):
       return .makeMaterializedToken(

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -631,4 +631,43 @@ final class AttributeTests: XCTestCase {
       """
     )
   }
+
+  func testInvalidWhitespaceBetweenAtSignAndIdenfifierIsDiagnosed() {
+    assertParse(
+      """
+      @1️⃣ MyAttribute
+      func foo() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "extraneous whitespace after '@' is not permitted",
+          fixIts: ["remove whitespace"]
+        )
+      ],
+      fixedSource: """
+        @MyAttribute
+        func foo() {}
+        """
+    )
+  }
+
+  func testInvalidNewlineBetweenAtSignAndIdenfifierIsDiagnosed() {
+    assertParse(
+      """
+      @1️⃣
+      MyAttribute
+      func foo() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "extraneous whitespace after '@' is not permitted",
+          fixIts: ["remove whitespace"]
+        )
+      ],
+      fixedSource: """
+        @MyAttribute
+        func foo() {}
+        """
+    )
+  }
 }


### PR DESCRIPTION
# Goal

To fix the second part of issue https://github.com/apple/swift-syntax/issues/1395. The first one (for unexpected whitespace in between the macro declaration), is being fixed by https://github.com/apple/swift-syntax/issues/1395.

## Notes

There are some `TODOs` I've placed to seek assistance from reviewers. Specifically, I don't know how I would synthesize a `RawTypeSyntax`, as I didn't find an easy way to access its text (without the leading trivia). Any help is appreciated. Thank you.