### PR TITLE
Created an Examples-all target to include all the example targets, and updated build_script.py.

### DIFF
--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -40,3 +40,19 @@ let package = Package(
     ),
   ]
 )
+
+// This is a fake target that depends on all targets in the package.
+// We need to define it manually because the `Examples-Package` target doesn't exist for `swift build`.
+
+package.targets.append(
+  .target(
+    name: "Examples-all",
+    dependencies: package.targets.compactMap {
+      if $0.type == .test {
+        return nil
+      } else {
+        return .byName(name: $0.name)
+      }
+    }
+  )
+)

--- a/Examples/Sources/Examples-all/empty.swift
+++ b/Examples/Sources/Examples-all/empty.swift
@@ -1,0 +1,2 @@
+// This is a fake target that depends on all targets in the package.
+// We need to define it manually because the `Examples-Package` target doesn't exist for `swift build`.

--- a/build-script.py
+++ b/build-script.py
@@ -218,9 +218,9 @@ class Builder(object):
         print("** Building product " + product_name + " **")
         self.__build(PACKAGE_DIR, product_name, is_product=True)
 
-    def buildTarget(self, target_name: str) -> None:
+    def buildTarget(self, package_dir: str, target_name: str) -> None:
         print("** Building target " + target_name + " **")
-        self.__build(PACKAGE_DIR, target_name, is_product=False)
+        self.__build(package_dir, target_name, is_product=False)
 
     def buildExample(self, example_name: str) -> None:
         print("** Building example " + example_name + " **")
@@ -504,11 +504,8 @@ def build_command(args: argparse.Namespace) -> None:
             verbose=args.verbose,
             disable_sandbox=args.disable_sandbox,
         )
-        builder.buildTarget("SwiftSyntax-all")
-
-        # Build examples
-        builder.buildExample("AddOneToIntegerLiterals")
-        builder.buildExample("CodeGenerationUsingSwiftSyntaxBuilder")
+        builder.buildTarget(PACKAGE_DIR, "SwiftSyntax-all")
+        builder.buildTarget(EXAMPLES_DIR, "Examples-all")
     except subprocess.CalledProcessError as e:
         fail_for_called_process_error("Building SwiftSyntax failed", e)
 


### PR DESCRIPTION
Resolve #1655 

Created the Examples-all target in the same way as SwiftSyntax-all and modified build_script.py to build all the targets in the Examples package with it.

The command to build only the ExamplePlugin in the test command was left in because I think the ExamplePlugin is being used in Swift-syntax's compiler_plugin_basic.swift, but I'll delete it if it's not needed.

https://github.com/apple/swift-syntax/blob/d14176d74bff98aa877bbf284a8bccd4bb02c833/build-script.py#L516-L545

https://github.com/apple/swift-syntax/blob/d14176d74bff98aa877bbf284a8bccd4bb02c833/lit_tests/compiler_plugin_basic.swift#L14-L18