### PR TITLE
Fix newline parsing at trailing trivia

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -320,8 +320,8 @@ extension Lexer {
     /// If `tokenKind` is `.keyword`, the kind of keyword produced, otherwise
     /// `nil`.
     let keywordKind: Keyword?
-    /// Indicates whether the lexed token text contains a newline.
-    let newlinePresence: Lexer.Cursor.NewlinePresence
+    /// Indicates whether the end of the lexed token text contains a newline.
+    let trailingNewlinePresence: Lexer.Cursor.NewlinePresence
 
     private init(
       _ tokenKind: RawTokenKind,
@@ -330,7 +330,7 @@ extension Lexer {
       stateTransition: StateTransition?,
       trailingTriviaLexingMode: Lexer.Cursor.TriviaLexingMode?,
       keywordKind: Keyword?,
-      newlinePresence: Lexer.Cursor.NewlinePresence
+      trailingNewlinePresence: Lexer.Cursor.NewlinePresence
     ) {
       self.tokenKind = tokenKind
       self.flags = flags
@@ -338,7 +338,7 @@ extension Lexer {
       self.stateTransition = stateTransition
       self.trailingTriviaLexingMode = trailingTriviaLexingMode
       self.keywordKind = keywordKind
-      self.newlinePresence = newlinePresence
+      self.trailingNewlinePresence = trailingNewlinePresence
     }
 
     /// Create a lexer result. Note that keywords should use `Result.keyword`
@@ -349,7 +349,7 @@ extension Lexer {
       error: Cursor.LexingDiagnostic? = nil,
       stateTransition: StateTransition? = nil,
       trailingTriviaLexingMode: Lexer.Cursor.TriviaLexingMode? = nil,
-      newlinePresence: Lexer.Cursor.NewlinePresence = .absent
+      trailingNewlinePresence: Lexer.Cursor.NewlinePresence = .absent
     ) {
       precondition(tokenKind != .keyword, "Use Result.keyword instead")
       self.init(
@@ -359,7 +359,7 @@ extension Lexer {
         stateTransition: stateTransition,
         trailingTriviaLexingMode: trailingTriviaLexingMode,
         keywordKind: nil,
-        newlinePresence: newlinePresence
+        trailingNewlinePresence: trailingNewlinePresence
       )
     }
 
@@ -372,7 +372,7 @@ extension Lexer {
         stateTransition: nil,
         trailingTriviaLexingMode: nil,
         keywordKind: kind,
-        newlinePresence: .absent
+        trailingNewlinePresence: .absent
       )
     }
   }
@@ -448,7 +448,7 @@ extension Lexer.Cursor {
       flags.insert(.isAtStartOfLine)
     }
 
-    self.previousLexemeTrailingNewlinePresence = result.newlinePresence
+    self.previousLexemeTrailingNewlinePresence = result.trailingNewlinePresence
 
     if let stateTransition = result.stateTransition {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
@@ -1905,7 +1905,7 @@ extension Lexer.Cursor {
           if character == UInt8(ascii: "\r") {
             _ = self.advance(matching: "\n")
           }
-          return Lexer.Result(.stringSegment, error: error, newlinePresence: .present)
+          return Lexer.Result(.stringSegment, error: error, trailingNewlinePresence: .present)
         } else {
           // Single line literals cannot span multiple lines.
           // Terminate the string here and go back to normal lexing (instead of `afterStringLiteral`)

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -243,8 +243,8 @@ extension Lexer {
     /// If we have already lexed a token, the kind of the previously lexed token
     var previousTokenKind: RawTokenKind?
     
-    /// If we have already lexed a token, the `NewlinePresence` of the previously lexed token
-    var previousTokenNewlinePresence: NewlinePresence?
+    /// If we have already lexed a token, stores whether the previous lexeme‘s ending contains a newline.
+    var previousLexemeTrailingNewlinePresence: NewlinePresence?
 
     /// If the `previousTokenKind` is `.keyword`, the keyword kind. Otherwise
     /// `nil`.
@@ -410,10 +410,10 @@ extension Lexer.Cursor {
     if newlineInLeadingTrivia == .present {
       flags.insert(.isAtStartOfLine)
     }
-    if let previousTokenNewlinePresence, previousTokenNewlinePresence == .present {
+    if let previousLexemeTrailingNewlinePresence, previousLexemeTrailingNewlinePresence == .present {
       flags.insert(.isAtStartOfLine)
     }
-    self.previousTokenNewlinePresence = nil
+    self.previousLexemeTrailingNewlinePresence = nil
 
     // Token text.
     let textStart = self
@@ -450,7 +450,7 @@ extension Lexer.Cursor {
     let trailingTriviaStart = self
     if let trailingTriviaMode = result.trailingTriviaLexingMode ?? currentState.trailingTriviaLexingMode(cursor: self) {
       let triviaResult = self.lexTrivia(mode: trailingTriviaMode)
-      self.previousTokenNewlinePresence = triviaResult.newlinePresence
+      self.previousLexemeTrailingNewlinePresence = triviaResult.newlinePresence
       diagnostic = TokenDiagnostic(combining: diagnostic, triviaResult.error?.tokenDiagnostic(tokenStart: cursor))
     }
 
@@ -1897,7 +1897,7 @@ extension Lexer.Cursor {
           if character == UInt8(ascii: "\r") {
             _ = self.advance(matching: "\n")
           }
-          self.previousTokenNewlinePresence = .present
+          self.previousLexemeTrailingNewlinePresence = .present
           return Lexer.Result(.stringSegment, error: error)
         } else {
           // Single line literals cannot span multiple lines.

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -242,7 +242,7 @@ extension Lexer {
 
     /// If we have already lexed a token, the kind of the previously lexed token
     var previousTokenKind: RawTokenKind?
-    
+
     /// If we have already lexed a token, stores whether the previous lexeme‘s ending contains a newline.
     var previousLexemeTrailingNewlinePresence: NewlinePresence?
 
@@ -439,7 +439,7 @@ extension Lexer.Cursor {
     case .inRegexLiteral(let index, let lexemes):
       result = lexInRegexLiteral(lexemes.pointee[index...], existingPtr: lexemes)
     }
-    
+
     var flags = result.flags
     if newlineInLeadingTrivia == .present {
       flags.insert(.isAtStartOfLine)
@@ -447,13 +447,13 @@ extension Lexer.Cursor {
     if let previousLexemeTrailingNewlinePresence, previousLexemeTrailingNewlinePresence == .present {
       flags.insert(.isAtStartOfLine)
     }
-    
+
     self.previousLexemeTrailingNewlinePresence = result.newlinePresence
 
     if let stateTransition = result.stateTransition {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
     }
-    
+
     // Trailing trivia.
     let trailingTriviaStart = self
     if let trailingTriviaMode = result.trailingTriviaLexingMode ?? currentState.trailingTriviaLexingMode(cursor: self) {

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -150,20 +150,6 @@ extension Lexer.Cursor {
       case .inRegexLiteral: return false
       }
     }
-    
-    /// Returns whether the lexer is currently parsing the multiline string.
-    var isParsingMultilineString: Bool {
-      switch self {
-      case .normal, .preferRegexOverBinaryOperator: return false
-      case .afterRawStringDelimiter: return false
-      case .inStringLiteral(kind: let stringLiteralKind, delimiterLength: _): return stringLiteralKind == .multiLine
-      case .afterStringLiteral: return false
-      case .afterClosingStringQuote: return false
-      case .inStringInterpolationStart: return false
-      case .inStringInterpolation: return false
-      case .inRegexLiteral: return false
-      }
-    }
   }
 
   /// A data structure that holds the state stack entries in the lexer. It is
@@ -419,6 +405,15 @@ extension Lexer.Cursor {
     } else {
       newlineInLeadingTrivia = .absent
     }
+    
+    var flags: Lexer.Lexeme.Flags = []
+    if newlineInLeadingTrivia == .present {
+      flags.insert(.isAtStartOfLine)
+    }
+    if let previousTokenNewlinePresence, previousTokenNewlinePresence == .present {
+      flags.insert(.isAtStartOfLine)
+    }
+    self.previousTokenNewlinePresence = nil
 
     // Token text.
     let textStart = self
@@ -451,23 +446,12 @@ extension Lexer.Cursor {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
     }
     
-    var flags = result.flags
-    if newlineInLeadingTrivia == .present {
-      flags.insert(.isAtStartOfLine)
-    }
-    if let previousTokenNewlinePresence, previousTokenNewlinePresence == .present,
-       !currentState.isParsingMultilineString {
-      flags.insert(.isAtStartOfLine)
-    }
-    
     // Trailing trivia.
     let trailingTriviaStart = self
     if let trailingTriviaMode = result.trailingTriviaLexingMode ?? currentState.trailingTriviaLexingMode(cursor: self) {
       let triviaResult = self.lexTrivia(mode: trailingTriviaMode)
       self.previousTokenNewlinePresence = triviaResult.newlinePresence
       diagnostic = TokenDiagnostic(combining: diagnostic, triviaResult.error?.tokenDiagnostic(tokenStart: cursor))
-    } else {
-      self.previousTokenNewlinePresence = nil
     }
 
     if self.currentState.shouldPopStateWhenReachingNewlineInTrailingTrivia && self.is(at: "\r", "\n") {
@@ -478,7 +462,7 @@ extension Lexer.Cursor {
 
     let lexeme = Lexer.Lexeme(
       tokenKind: result.tokenKind,
-      flags: flags,
+      flags: result.flags.union(flags),
       diagnostic: diagnostic,
       start: leadingTriviaStart.pointer,
       leadingTriviaLength: leadingTriviaStart.distance(to: textStart),
@@ -1913,6 +1897,7 @@ extension Lexer.Cursor {
           if character == UInt8(ascii: "\r") {
             _ = self.advance(matching: "\n")
           }
+          self.previousTokenNewlinePresence = .present
           return Lexer.Result(.stringSegment, error: error)
         } else {
           // Single line literals cannot span multiple lines.

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -1182,9 +1182,9 @@ public class LexerTests: XCTestCase {
       """#,
       lexemes: [
         LexemeSpec(.multilineStringQuote, leading: "  ", text: #"""""#, trailing: "\n"),
-        LexemeSpec(.stringSegment, text: "  line 1\n"),
-        LexemeSpec(.stringSegment, text: "  line 2\n"),
-        LexemeSpec(.stringSegment, text: "  "),
+        LexemeSpec(.stringSegment, text: "  line 1\n", flags: .isAtStartOfLine),
+        LexemeSpec(.stringSegment, text: "  line 2\n", flags: .isAtStartOfLine),
+        LexemeSpec(.stringSegment, text: "  ", flags: .isAtStartOfLine),
         LexemeSpec(.multilineStringQuote, text: #"""""#),
       ]
     )
@@ -1198,9 +1198,9 @@ public class LexerTests: XCTestCase {
       """#,
       lexemes: [
         LexemeSpec(.multilineStringQuote, leading: "  ", text: #"""""#, trailing: "\n"),
-        LexemeSpec(.stringSegment, text: "  line 1 ", trailing: "\\\n"),
-        LexemeSpec(.stringSegment, text: "  line 2\n"),
-        LexemeSpec(.stringSegment, text: "  "),
+        LexemeSpec(.stringSegment, text: "  line 1 ", trailing: "\\\n", flags: .isAtStartOfLine),
+        LexemeSpec(.stringSegment, text: "  line 2\n", flags: .isAtStartOfLine),
+        LexemeSpec(.stringSegment, text: "  ", flags: .isAtStartOfLine),
         LexemeSpec(.multilineStringQuote, text: #"""""#),
       ]
     )

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -763,4 +763,23 @@ final class StatementTests: XCTestCase {
         """
     )
   }
+  
+  func testTrailingTriviaIncludesNewline() {
+    assertParse(
+        """
+        let a = 2/*
+        */let b = 3
+        """
+    )
+    
+    assertParse(
+        """
+        let a = 2/*
+        
+        
+        
+        */let b = 3
+        """
+    )
+  }
 }

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -763,23 +763,23 @@ final class StatementTests: XCTestCase {
         """
     )
   }
-  
+
   func testTrailingTriviaIncludesNewline() {
     assertParse(
-        """
-        let a = 2/*
-        */let b = 3
-        """
+      """
+      let a = 2/*
+      */let b = 3
+      """
     )
-    
+
     assertParse(
-        """
-        let a = 2/*
-        
-        
-        
-        */let b = 3
-        """
+      """
+      let a = 2/*
+
+
+
+      */let b = 3
+      """
     )
   }
 }


### PR DESCRIPTION
Resolve #1626 

Unlike leadingTrivia, trailingTrivia was not using the newlinePresence value of triviaResult.
Modified the logic to store the trailingTrivia newlinePresence value from the previous token and set isAtStartOfLine flag when parsing the next token.