### PR TITLE
Add helper function for getting the source edits of two strings

### DIFF
--- a/Sources/_SwiftSyntaxTestSupport/SourceEditsTestUtils.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SourceEditsTestUtils.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import XCTest
+
+/// Returns the `ConcurrentEdits`s to transition from `base` to `new`.
+public func getConcurrentEdits(from base: String, to new: String) -> ConcurrentEdits {
+  let diffCollection = new.difference(from: base)
+
+  let diffArray: [(offset: Int, isInsert: Bool)] =
+    diffCollection
+    .map { diff in
+      switch diff {
+      case .remove(offset: let offset, element: _, associatedWith: _):
+        return (offset: offset, isInsert: false)
+      case .insert(offset: let offset, element: _, associatedWith: _):
+        return (offset: offset, isInsert: true)
+      }
+    }
+    .sorted {
+      // Change.remove should prior to Change.insert
+      if $0.offset < $1.offset {
+        return true
+      } else if $0.offset == $1.offset {
+        return !$0.isInsert
+      } else {
+        return false
+      }
+    }
+
+  let sourceEdits = diffArray.map({
+    return $0.isInsert ? SourceEdit(offset: $0.offset, length: 0, replacementLength: 1) : SourceEdit(offset: $0.offset, length: 1, replacementLength: 0)
+  })
+
+  return ConcurrentEdits(fromSequential: sourceEdits)
+}
+
+/// Apply the given edits to `testString` and return the resulting string.
+/// `concurrent` specifies whether the edits should be interpreted as being
+/// applied sequentially or concurrently.
+public func applyEdits(
+  _ edits: [SourceEdit],
+  concurrent: Bool,
+  to testString: String,
+  replacementChar: Character = "?"
+) -> String {
+  guard let replacementAscii = replacementChar.asciiValue else {
+    fatalError("replacementChar must be an ASCII character")
+  }
+  var edits = edits
+  if concurrent {
+    XCTAssert(ConcurrentEdits._isValidConcurrentEditArray(edits))
+
+    // If the edits are concurrent, sorted and not overlapping (as guaranteed by
+    // the check above, we can apply them sequentially to the string in reverse
+    // order because later edits don't affect earlier edits.
+    edits = edits.reversed()
+  }
+  var bytes = Array(testString.utf8)
+  for edit in edits {
+    assert(edit.endOffset <= bytes.count)
+    bytes.removeSubrange(edit.offset..<edit.endOffset)
+    bytes.insert(contentsOf: [UInt8](repeating: replacementAscii, count: edit.replacementLength), at: edit.offset)
+  }
+  return String(bytes: bytes, encoding: .utf8)!
+}

--- a/Sources/_SwiftSyntaxTestSupport/SourceEditsTestUtils.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SourceEditsTestUtils.swift
@@ -39,7 +39,11 @@ public func getConcurrentEdits(from base: String, to new: String) -> ConcurrentE
     }
 
   let sourceEdits = diffArray.map({
-    return $0.isInsert ? SourceEdit(offset: $0.offset, length: 0, replacementLength: 1) : SourceEdit(offset: $0.offset, length: 1, replacementLength: 0)
+    if $0.isInsert {
+      return SourceEdit(offset: $0.offset, length: 0, replacementLength: 1)
+    } else {
+      return SourceEdit(offset: $0.offset, length: 1, replacementLength: 0)
+    }
   })
 
   return ConcurrentEdits(fromSequential: sourceEdits)

--- a/Tests/SwiftParserTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftParserTest/IncrementalParsingTests.swift
@@ -40,7 +40,7 @@ public class IncrementalParsingTests: XCTestCase {
 
     let newSource =
       """
-      struct A {}
+      struct AA {}
       struct B {}
       """
 

--- a/Tests/SwiftSyntaxTestSupportTest/SourceEditsTestUtilsTest.swift
+++ b/Tests/SwiftSyntaxTestSupportTest/SourceEditsTestUtilsTest.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftSyntax
+import _SwiftSyntaxTestSupport
+
+public class SourceEditsUtilTest: XCTestCase {
+  public func testDiffOfTwoStringsSimple() throws {
+    let s1 = "struct A { func f() {"
+    let s2 = "struct AA { func f() {"
+
+    let diffs = getConcurrentEdits(from: s1, to: s2)
+    XCTAssertEqual(diffs.edits.count, 1)
+
+    let firstDiff = try XCTUnwrap(diffs.edits.first)
+    XCTAssertEqual(firstDiff, SourceEdit(offset: 8, length: 0, replacementLength: 1))
+  }
+
+  public func testDiffOfTwoSameStrings() {
+    let s1 = "0123456"
+
+    let diffs = getConcurrentEdits(from: s1, to: s1)
+    XCTAssert(diffs.edits.isEmpty)
+  }
+
+  public func testDiffOfTwoStrings() {
+    let s1 = "0123456"
+    let s2 = "x12456yz"
+
+    let diffs = getConcurrentEdits(from: s1, to: s2)
+
+    let expectedDiffs: [SourceEdit] = [
+      SourceEdit(offset: 0, length: 1, replacementLength: 1),
+      SourceEdit(offset: 3, length: 1, replacementLength: 0),
+      SourceEdit(offset: 7, length: 0, replacementLength: 2),
+    ]
+
+    XCTAssertEqual(diffs.edits, expectedDiffs)
+
+    let s3 = applyEdits(expectedDiffs, concurrent: true, to: s1)
+
+    XCTAssertEqual(s3, "?12456??")
+  }
+}

--- a/Tests/SwiftSyntaxTestSupportTest/SourceEditsTestUtilsTest.swift
+++ b/Tests/SwiftSyntaxTestSupportTest/SourceEditsTestUtilsTest.swift
@@ -15,11 +15,29 @@ import SwiftSyntax
 import _SwiftSyntaxTestSupport
 
 public class SourceEditsUtilTest: XCTestCase {
-  public func testDiffOfTwoStringsSimple() throws {
-    let s1 = "struct A { func f() {"
-    let s2 = "struct AA { func f() {"
+  public func testStringDifferenceReturnSequentialEdits() {
+    let base = "0123"
+    let new = "a0123bc"
 
-    let diffs = getConcurrentEdits(from: s1, to: s2)
+    let diffs = getConcurrentEdits(from: base, to: new)
+    XCTAssertEqual(
+      diffs.edits,
+      [
+        SourceEdit(offset: 0, length: 0, replacementLength: 1),
+        SourceEdit(offset: 4, length: 0, replacementLength: 2),
+      ]
+    )
+
+    let appliedDiffsBase = applyEdits(diffs.edits, concurrent: true, to: base)
+
+    XCTAssertEqual(appliedDiffsBase, "?0123??")
+  }
+
+  public func testDiffOfTwoStringsSimple() throws {
+    let base = "struct A { func f() {"
+    let new = "struct AA { func f() {"
+
+    let diffs = getConcurrentEdits(from: base, to: new)
     XCTAssertEqual(diffs.edits.count, 1)
 
     let firstDiff = try XCTUnwrap(diffs.edits.first)
@@ -27,17 +45,17 @@ public class SourceEditsUtilTest: XCTestCase {
   }
 
   public func testDiffOfTwoSameStrings() {
-    let s1 = "0123456"
+    let base = "0123456"
 
-    let diffs = getConcurrentEdits(from: s1, to: s1)
+    let diffs = getConcurrentEdits(from: base, to: base)
     XCTAssert(diffs.edits.isEmpty)
   }
 
   public func testDiffOfTwoStrings() {
-    let s1 = "0123456"
-    let s2 = "x12456yz"
+    let base = "0123456"
+    let new = "x12456yz"
 
-    let diffs = getConcurrentEdits(from: s1, to: s2)
+    let diffs = getConcurrentEdits(from: base, to: new)
 
     let expectedDiffs: [SourceEdit] = [
       SourceEdit(offset: 0, length: 1, replacementLength: 1),
@@ -47,8 +65,8 @@ public class SourceEditsUtilTest: XCTestCase {
 
     XCTAssertEqual(diffs.edits, expectedDiffs)
 
-    let s3 = applyEdits(expectedDiffs, concurrent: true, to: s1)
+    let appliedDiffsBase = applyEdits(expectedDiffs, concurrent: true, to: base)
 
-    XCTAssertEqual(s3, "?12456??")
+    XCTAssertEqual(appliedDiffsBase, "?12456??")
   }
 }


### PR DESCRIPTION
This change should make it easier to test two different source by getting `SourceEdit` with the helper function