### PR TITLE
Fix a link to leadingTrivia

### DIFF
--- a/Sources/SwiftSyntax/Documentation.docc/Working with SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/Working with SwiftSyntax.md
@@ -129,7 +129,7 @@ reason, tools like compilers often discard trivia during source code processing.
 However, maintaining trivia is important for tools like editors, IDEs, 
 formatters, and refactoring engines. SwiftSyntax represents trivia explicitly
 with the ``Trivia`` type. Trivia associated with token syntax can be inspected 
-with  the ``TokenSyntax/leadingTrivia-7p6tp`` and 
+with  the ``TokenSyntax/leadingTrivia-9512z`` and 
 ``TokenSyntax/trailingTrivia-5jclz`` accessors.
 
 ## Navigating the Syntax Tree


### PR DESCRIPTION
I noticed that the link to TokenSyntax/leadingTrivia on `https://swiftpackageindex.com/apple/swift-syntax/main/documentation/swiftsyntax/working-with-swiftsyntax` is incorrect.

<img width="500" alt="image" src="https://github.com/apple/swift-syntax/assets/7476703/31b13e93-9196-4852-8538-0b2c5c2f5992">
