### PR TITLE
[Macros] Copy attrs/modifiers on MacroExpansionDecl to expanded decls 

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -147,7 +147,8 @@ public let COMMON_NODES: [Node] = [
     description: "In case the source code is missing a declaration, this node stands in place of the missing declaration.",
     kind: "Decl",
     traits: [
-      "Attributed"
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -66,7 +66,7 @@ public let DECL_NODES: [Node] = [
     nameForDiagnostics: "accessor",
     kind: "Decl",
     traits: [
-      "Attributed"
+      "WithAttributes"
     ],
     parserFunction: "parseAccessorDecl",
     children: [
@@ -151,7 +151,8 @@ public let DECL_NODES: [Node] = [
     traits: [
       "DeclGroup",
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -235,7 +236,8 @@ public let DECL_NODES: [Node] = [
     kind: "Decl",
     traits: [
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -322,7 +324,8 @@ public let DECL_NODES: [Node] = [
     traits: [
       "DeclGroup",
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -469,7 +472,8 @@ public let DECL_NODES: [Node] = [
       """,
     kind: "Decl",
     traits: [
-      "Attributed"
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -577,7 +581,8 @@ public let DECL_NODES: [Node] = [
     nameForDiagnostics: "parameter",
     kind: "Syntax",
     traits: [
-      "WithTrailingComma"
+      "WithTrailingComma",
+      "WithModifiers",
     ],
     parserFunction: "parseEnumCaseParameter",
     children: [
@@ -631,7 +636,8 @@ public let DECL_NODES: [Node] = [
     description: "A `case` declaration of a Swift `enum`. It can have 1 or more `EnumCaseElement`s inside, each declaring a different case of the enum.",
     kind: "Decl",
     traits: [
-      "Attributed"
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -714,7 +720,8 @@ public let DECL_NODES: [Node] = [
     traits: [
       "DeclGroup",
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -782,7 +789,8 @@ public let DECL_NODES: [Node] = [
     kind: "Decl",
     traits: [
       "DeclGroup",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -830,7 +838,8 @@ public let DECL_NODES: [Node] = [
     kind: "Decl",
     traits: [
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -894,7 +903,8 @@ public let DECL_NODES: [Node] = [
     kind: "Syntax",
     traits: [
       "WithTrailingComma",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     parserFunction: "parseFunctionParameter",
     children: [
@@ -1062,7 +1072,8 @@ public let DECL_NODES: [Node] = [
       """,
     kind: "Decl",
     traits: [
-      "Attributed"
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -1157,7 +1168,8 @@ public let DECL_NODES: [Node] = [
       """,
     kind: "Decl",
     traits: [
-      "Attributed"
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -1220,7 +1232,8 @@ public let DECL_NODES: [Node] = [
     kind: "Decl",
     traits: [
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -1275,7 +1288,9 @@ public let DECL_NODES: [Node] = [
     nameForDiagnostics: "macro expansion",
     kind: "Decl",
     traits: [
-      "FreestandingMacroExpansion"
+      "FreestandingMacroExpansion",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -1426,7 +1441,8 @@ public let DECL_NODES: [Node] = [
     kind: "Decl",
     traits: [
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -1702,7 +1718,8 @@ public let DECL_NODES: [Node] = [
     kind: "Decl",
     traits: [
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -1813,7 +1830,8 @@ public let DECL_NODES: [Node] = [
     traits: [
       "DeclGroup",
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -1980,7 +1998,8 @@ public let DECL_NODES: [Node] = [
     traits: [
       "DeclGroup",
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -2041,7 +2060,8 @@ public let DECL_NODES: [Node] = [
     nameForDiagnostics: "subscript",
     kind: "Decl",
     traits: [
-      "Attributed"
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(
@@ -2142,7 +2162,7 @@ public let DECL_NODES: [Node] = [
     kind: "Decl",
     traits: [
       "IdentifiedDecl",
-      "Attributed",
+      "WithAttributes",
     ],
     children: [
       Child(
@@ -2189,7 +2209,8 @@ public let DECL_NODES: [Node] = [
     nameForDiagnostics: "variable",
     kind: "Decl",
     traits: [
-      "Attributed"
+      "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(

--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -360,7 +360,9 @@ public let EXPR_NODES: [Node] = [
     nameForDiagnostics: "parameter",
     kind: "Syntax",
     traits: [
-      "WithTrailingComma"
+      "WithTrailingComma",
+      "WithAttributes",
+      "WithModifiers",
     ],
     parserFunction: "parseClosureParameter",
     children: [
@@ -515,7 +517,7 @@ public let EXPR_NODES: [Node] = [
     nameForDiagnostics: "closure signature",
     kind: "Syntax",
     traits: [
-      "Attributed"
+      "WithAttributes"
     ],
     children: [
       Child(

--- a/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
@@ -75,7 +75,7 @@ public let GENERIC_NODES: [Node] = [
     kind: "Syntax",
     traits: [
       "WithTrailingComma",
-      "Attributed",
+      "WithAttributes",
     ],
     children: [
       Child(

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -24,12 +24,6 @@ public class Trait {
 
 public let TRAITS: [Trait] = [
   Trait(
-    traitName: "Attributed",
-    children: [
-      Child(name: "Attributes", kind: .node(kind: "AttributeList"), isOptional: true)
-    ]
-  ),
-  Trait(
     traitName: "Braced",
     children: [
       Child(name: "LeftBrace", kind: .token(choices: [.token(tokenKind: "LeftBraceToken")])),
@@ -81,9 +75,21 @@ public let TRAITS: [Trait] = [
     ]
   ),
   Trait(
+    traitName: "WithAttributes",
+    children: [
+      Child(name: "Attributes", kind: .node(kind: "AttributeList"), isOptional: true)
+    ]
+  ),
+  Trait(
     traitName: "WithCodeBlock",
     children: [
       Child(name: "Body", kind: .node(kind: "CodeBlock"))
+    ]
+  ),
+  Trait(
+    traitName: "WithModifiers",
+    children: [
+      Child(name: "Modifiers", kind: .node(kind: "ModifierList"), isOptional: true)
     ]
   ),
   Trait(

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -39,7 +39,7 @@ public let TYPE_NODES: [Node] = [
     nameForDiagnostics: "type",
     kind: "Type",
     traits: [
-      "Attributed"
+      "WithAttributes"
     ],
     children: [
       Child(

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -19,6 +19,8 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   DeclSyntax(
     """
     public protocol SyntaxCollection: SyntaxProtocol, Sequence where Element: SyntaxProtocol {
+      /// Creates a new collection with the elements.
+      init(_ children: [Element])
       /// The number of elements, `present` or `missing`, in this collection.
       var count: Int { get }
     }

--- a/Package.swift
+++ b/Package.swift
@@ -179,15 +179,17 @@ let package = Package(
       exclude: ["CMakeLists.txt"]
     ),
 
+    .testTarget(
+      name: "SwiftSyntaxMacrosTest",
+      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics", "SwiftOperators", "SwiftParser", "SwiftSyntaxBuilder", "SwiftSyntaxMacros", "SwiftSyntaxMacrosTestSupport"]
+    ),
+
+    // MARK: SwiftSyntaxMacroExpansion
+
     .target(
       name: "SwiftSyntaxMacroExpansion",
       dependencies: ["SwiftSyntax", "SwiftSyntaxMacros"],
       exclude: ["CMakeLists.txt"]
-    ),
-
-    .testTarget(
-      name: "SwiftSyntaxMacrosTest",
-      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics", "SwiftOperators", "SwiftParser", "SwiftSyntaxBuilder", "SwiftSyntaxMacros", "SwiftSyntaxMacrosTestSupport"]
     ),
 
     // MARK: SwiftSyntaxMacrosTestSupport

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -27,6 +27,7 @@ add_swift_host_library(SwiftParser
   Specifiers.swift
   Statements.swift
   StringLiterals.swift
+  StringLiteralRepresentedLiteralValue.swift
   SyntaxUtils.swift
   TokenConsumer.swift
   TokenPrecedence.swift

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -362,14 +362,15 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 
 ### Traits
 
-- <doc:SwiftSyntax/Attributed>
 - <doc:SwiftSyntax/Braced>
 - <doc:SwiftSyntax/DeclGroup>
 - <doc:SwiftSyntax/EffectSpecifiers>
 - <doc:SwiftSyntax/FreestandingMacroExpansion>
 - <doc:SwiftSyntax/IdentifiedDecl>
 - <doc:SwiftSyntax/Parenthesized>
+- <doc:SwiftSyntax/WithAttributes>
 - <doc:SwiftSyntax/WithCodeBlock>
+- <doc:SwiftSyntax/WithModifiers>
 - <doc:SwiftSyntax/WithStatements>
 - <doc:SwiftSyntax/WithTrailingComma>
 

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -25,3 +25,6 @@ public typealias AccessPathSyntax = ImportPathSyntax
 
 @available(*, deprecated, renamed: "ImportPathComponentSyntax")
 public typealias AccessPathComponentSyntax = ImportPathComponentSyntax
+
+@available(*, deprecated, renamed: "WithAttributesSyntax")
+public typealias AttributedSyntax = WithAttributesSyntax

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -13,6 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 public protocol SyntaxCollection: SyntaxProtocol, Sequence where Element: SyntaxProtocol {
+  /// Creates a new collection with the elements.
+  init(_ children: [Element])
+  
   /// The number of elements, `present` or `missing`, in this collection.
   var count: Int {
     get

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -12,42 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// MARK: - AttributedSyntax
-
-public protocol AttributedSyntax: SyntaxProtocol {
-  var attributes: AttributeListSyntax? {
-    get
-    set
-  }
-}
-
-public extension AttributedSyntax {
-  /// Without this function, the `with` function defined on `SyntaxProtocol`
-  /// does not work on existentials of this protocol type.
-  @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<AttributedSyntax, T>, _ newChild: T) -> AttributedSyntax {
-    var copy: AttributedSyntax = self
-    copy[keyPath: keyPath] = newChild
-    return copy
-  }
-}
-
-public extension SyntaxProtocol {
-  /// Check whether the non-type erased version of this syntax node conforms to
-  /// `AttributedSyntax`.
-  /// Note that this will incur an existential conversion.
-  func isProtocol(_: AttributedSyntax.Protocol) -> Bool {
-    return self.asProtocol(AttributedSyntax.self) != nil
-  }
-  
-  /// Return the non-type erased version of this syntax node if it conforms to
-  /// `AttributedSyntax`. Otherwise return `nil`.
-  /// Note that this will incur an existential conversion.
-  func asProtocol(_: AttributedSyntax.Protocol) -> AttributedSyntax? {
-    return Syntax(self).asProtocol(SyntaxProtocol.self) as? AttributedSyntax
-  }
-}
-
 // MARK: - BracedSyntax
 
 public protocol BracedSyntax: SyntaxProtocol {
@@ -339,6 +303,42 @@ public extension SyntaxProtocol {
   }
 }
 
+// MARK: - WithAttributesSyntax
+
+public protocol WithAttributesSyntax: SyntaxProtocol {
+  var attributes: AttributeListSyntax? {
+    get
+    set
+  }
+}
+
+public extension WithAttributesSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<WithAttributesSyntax, T>, _ newChild: T) -> WithAttributesSyntax {
+    var copy: WithAttributesSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
+}
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to
+  /// `WithAttributesSyntax`.
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: WithAttributesSyntax.Protocol) -> Bool {
+    return self.asProtocol(WithAttributesSyntax.self) != nil
+  }
+  
+  /// Return the non-type erased version of this syntax node if it conforms to
+  /// `WithAttributesSyntax`. Otherwise return `nil`.
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: WithAttributesSyntax.Protocol) -> WithAttributesSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithAttributesSyntax
+  }
+}
+
 // MARK: - WithCodeBlockSyntax
 
 public protocol WithCodeBlockSyntax: SyntaxProtocol {
@@ -372,6 +372,42 @@ public extension SyntaxProtocol {
   /// Note that this will incur an existential conversion.
   func asProtocol(_: WithCodeBlockSyntax.Protocol) -> WithCodeBlockSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithCodeBlockSyntax
+  }
+}
+
+// MARK: - WithModifiersSyntax
+
+public protocol WithModifiersSyntax: SyntaxProtocol {
+  var modifiers: ModifierListSyntax? {
+    get
+    set
+  }
+}
+
+public extension WithModifiersSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<WithModifiersSyntax, T>, _ newChild: T) -> WithModifiersSyntax {
+    var copy: WithModifiersSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
+}
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to
+  /// `WithModifiersSyntax`.
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: WithModifiersSyntax.Protocol) -> Bool {
+    return self.asProtocol(WithModifiersSyntax.self) != nil
+  }
+  
+  /// Return the non-type erased version of this syntax node if it conforms to
+  /// `WithModifiersSyntax`. Otherwise return `nil`.
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: WithModifiersSyntax.Protocol) -> WithModifiersSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithModifiersSyntax
   }
 }
 
@@ -449,19 +485,19 @@ public extension SyntaxProtocol {
 
 extension AccessorBlockSyntax: BracedSyntax {}
 
-extension AccessorDeclSyntax: AttributedSyntax {}
+extension AccessorDeclSyntax: WithAttributesSyntax {}
 
 extension AccessorEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
 extension AccessorParameterSyntax: ParenthesizedSyntax {}
 
-extension ActorDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {}
+extension ActorDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension ArrayElementSyntax: WithTrailingCommaSyntax {}
 
-extension AssociatedtypeDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {}
+extension AssociatedtypeDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
-extension AttributedTypeSyntax: AttributedSyntax {}
+extension AttributedTypeSyntax: WithAttributesSyntax {}
 
 extension CaseItemSyntax: WithTrailingCommaSyntax {}
 
@@ -469,7 +505,7 @@ extension CatchClauseSyntax: WithCodeBlockSyntax {}
 
 extension CatchItemSyntax: WithTrailingCommaSyntax {}
 
-extension ClassDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {}
+extension ClassDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension ClosureCaptureItemSyntax: WithTrailingCommaSyntax {}
 
@@ -479,9 +515,9 @@ extension ClosureParamSyntax: WithTrailingCommaSyntax {}
 
 extension ClosureParameterClauseSyntax: ParenthesizedSyntax {}
 
-extension ClosureParameterSyntax: WithTrailingCommaSyntax {}
+extension ClosureParameterSyntax: WithTrailingCommaSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
-extension ClosureSignatureSyntax: AttributedSyntax {}
+extension ClosureSignatureSyntax: WithAttributesSyntax {}
 
 extension CodeBlockSyntax: BracedSyntax, WithStatementsSyntax {}
 
@@ -493,7 +529,7 @@ extension DeclNameArgumentsSyntax: ParenthesizedSyntax {}
 
 extension DeferStmtSyntax: WithCodeBlockSyntax {}
 
-extension DeinitializerDeclSyntax: AttributedSyntax {}
+extension DeinitializerDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension DictionaryElementSyntax: WithTrailingCommaSyntax {}
 
@@ -503,33 +539,33 @@ extension DoStmtSyntax: WithCodeBlockSyntax {}
 
 extension DocumentationAttributeArgumentSyntax: WithTrailingCommaSyntax {}
 
-extension EnumCaseDeclSyntax: AttributedSyntax {}
+extension EnumCaseDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension EnumCaseElementSyntax: WithTrailingCommaSyntax {}
 
 extension EnumCaseParameterClauseSyntax: ParenthesizedSyntax {}
 
-extension EnumCaseParameterSyntax: WithTrailingCommaSyntax {}
+extension EnumCaseParameterSyntax: WithTrailingCommaSyntax, WithModifiersSyntax {}
 
-extension EnumDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {}
+extension EnumDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension ExpressionSegmentSyntax: ParenthesizedSyntax {}
 
-extension ExtensionDeclSyntax: DeclGroupSyntax, AttributedSyntax {}
+extension ExtensionDeclSyntax: DeclGroupSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension ForInStmtSyntax: WithCodeBlockSyntax {}
 
-extension FunctionDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {}
+extension FunctionDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension FunctionEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
-extension FunctionParameterSyntax: WithTrailingCommaSyntax, AttributedSyntax {}
+extension FunctionParameterSyntax: WithTrailingCommaSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension FunctionTypeSyntax: ParenthesizedSyntax {}
 
 extension GenericArgumentSyntax: WithTrailingCommaSyntax {}
 
-extension GenericParameterSyntax: WithTrailingCommaSyntax, AttributedSyntax {}
+extension GenericParameterSyntax: WithTrailingCommaSyntax, WithAttributesSyntax {}
 
 extension GenericRequirementSyntax: WithTrailingCommaSyntax {}
 
@@ -537,25 +573,25 @@ extension GuardStmtSyntax: WithCodeBlockSyntax {}
 
 extension IfExprSyntax: WithCodeBlockSyntax {}
 
-extension ImportDeclSyntax: AttributedSyntax {}
+extension ImportDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension InheritedTypeSyntax: WithTrailingCommaSyntax {}
 
-extension InitializerDeclSyntax: AttributedSyntax {}
+extension InitializerDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension LabeledSpecializeEntrySyntax: WithTrailingCommaSyntax {}
 
-extension MacroDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {}
+extension MacroDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
-extension MacroExpansionDeclSyntax: FreestandingMacroExpansionSyntax {}
+extension MacroExpansionDeclSyntax: FreestandingMacroExpansionSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension MacroExpansionExprSyntax: FreestandingMacroExpansionSyntax {}
 
 extension MemberDeclBlockSyntax: BracedSyntax {}
 
-extension MissingDeclSyntax: AttributedSyntax {}
+extension MissingDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
-extension OperatorDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {}
+extension OperatorDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension ParameterClauseSyntax: ParenthesizedSyntax {}
 
@@ -563,19 +599,19 @@ extension PatternBindingSyntax: WithTrailingCommaSyntax {}
 
 extension PoundSourceLocationSyntax: ParenthesizedSyntax {}
 
-extension PrecedenceGroupDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {}
+extension PrecedenceGroupDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension PrimaryAssociatedTypeSyntax: WithTrailingCommaSyntax {}
 
-extension ProtocolDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {}
+extension ProtocolDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension RepeatWhileStmtSyntax: WithCodeBlockSyntax {}
 
 extension SourceFileSyntax: WithStatementsSyntax {}
 
-extension StructDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {}
+extension StructDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
-extension SubscriptDeclSyntax: AttributedSyntax {}
+extension SubscriptDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension SwitchCaseSyntax: WithStatementsSyntax {}
 
@@ -597,8 +633,8 @@ extension TupleTypeSyntax: ParenthesizedSyntax {}
 
 extension TypeEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
-extension TypealiasDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {}
+extension TypealiasDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax {}
 
-extension VariableDeclSyntax: AttributedSyntax {}
+extension VariableDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension WhileStmtSyntax: WithCodeBlockSyntax {}

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -13,11 +13,23 @@ public enum MacroRole {
 }
 
 /// Simple diagnostic message
-private struct MacroExpansionError: Error, CustomStringConvertible {
-  let description: String
+private enum MacroExpansionError: String, Error, CustomStringConvertible {
+  case unmathedMacroRole = "macro doesn't conform to required macro role"
+  case parentDeclGroupNil = "parent decl group is nil"
+  case declarationNotDeclGroup = "declaration is not a decl group syntax"
+  case declarationNotIdentified = "declaration is not a 'Identified' syntax"
+  var description: String { self.rawValue }
 }
 
 /// Expand `@freestanding(XXX)` macros.
+///
+/// - Parameters:
+///   - definition: a type conforms to one of freestanding `Macro` protocol.
+///   - node: macro expansion syntax node (e.g. `#macroName(argument)`).
+///   - in: context of the expansion.
+/// - Returns: expanded source text. Upon failure (i.e. `defintion.expansion()`
+///   throws) returns `nil`, and the diagnostics representing the `Error` are
+///   guaranteed to be added to context.
 public func expandFreestandingMacro(
   definition: Macro.Type,
   node: FreestandingMacroExpansionSyntax,
@@ -51,7 +63,7 @@ public func expandFreestandingMacro(
         expandedSyntax = Syntax(CodeBlockItemListSyntax(rewritten))
 
       default:
-        throw MacroExpansionError(description: "macro doesn't conform to required macro role")
+        throw MacroExpansionError.unmathedMacroRole
       }
       return expandedSyntax.formattedExpansion(definition.formatMode)
     }
@@ -63,6 +75,18 @@ public func expandFreestandingMacro(
 }
 
 /// Expand `@attached(XXX)` macros.
+///
+/// - Parameters:
+///   - definition: a type that conforms to one or more attached `Macro` protocols.
+///   - macroRole: indicates which `Macro` protocol expansion should be performed
+///   - attributeNode: attribute syntax node (e.g. `@macroName(argument)`).
+///   - declarationNode: target declaration syntax node to apply the expansion.
+///   - parentDeclNode: Only used for `MacroRole.memberAttribute`. The parent
+///     context node of `declarationNode`.
+///   - in: context of the expansion.
+/// - Returns: A list of expanded source text. Upon failure (i.e.
+///   `defintion.expansion()` throws) returns `nil`, and the diagnostics
+///   representing the `Error` are guaranteed to be added to context.
 public func expandAttachedMacro<Context: MacroExpansionContext>(
   definition: Macro.Type,
   macroRole: MacroRole,
@@ -88,7 +112,7 @@ public func expandAttachedMacro<Context: MacroExpansionContext>(
         let parentDeclGroup = parentDeclNode?.asProtocol(DeclGroupSyntax.self)
       else {
         // Compiler error: 'parentDecl' is mandatory for MemberAttributeMacro.
-        throw MacroExpansionError(description: "parent decl group is nil")
+        throw MacroExpansionError.parentDeclGroupNil
       }
 
       // Local function to expand a member attribute macro once we've opened up
@@ -118,7 +142,7 @@ public func expandAttachedMacro<Context: MacroExpansionContext>(
       guard let declGroup = declarationNode.asProtocol(DeclGroupSyntax.self)
       else {
         // Compiler error: declNode for member macro must be DeclGroupSyntax.
-        throw MacroExpansionError(description: "declaration is not a decl group syntax")
+        throw MacroExpansionError.declarationNotDeclGroup
       }
 
       // Local function to expand a member macro once we've opened up
@@ -151,12 +175,14 @@ public func expandAttachedMacro<Context: MacroExpansionContext>(
       }
 
     case (let attachedMacro as ConformanceMacro.Type, .conformance):
-      guard
-        let declGroup = declarationNode.asProtocol(DeclGroupSyntax.self),
-        let identified = declarationNode.asProtocol(IdentifiedDeclSyntax.self)
+      guard let declGroup = declarationNode.asProtocol(DeclGroupSyntax.self) else {
+        // Compiler error: type mismatch.
+        throw MacroExpansionError.declarationNotDeclGroup
+      }
+      guard let identified = declarationNode.asProtocol(IdentifiedDeclSyntax.self)
       else {
         // Compiler error: type mismatch.
-        throw MacroExpansionError(description: "declaration is not a identified decl group")
+        throw MacroExpansionError.declarationNotIdentified
       }
 
       // Local function to expand a conformance macro once we've opened up
@@ -185,7 +211,7 @@ public func expandAttachedMacro<Context: MacroExpansionContext>(
       }
 
     default:
-      throw MacroExpansionError(description: "macro doesn't conform to required macro role")
+      throw MacroExpansionError.unmathedMacroRole
     }
   } catch {
     context.addDiagnostics(from: error, node: attributeNode)

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -89,12 +89,12 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
     }
 
     if let declSyntax = node.as(DeclSyntax.self),
-      let attributedNode = node.asProtocol(AttributedSyntax.self),
+      let attributedNode = node.asProtocol(WithAttributesSyntax.self),
       let attributes = attributedNode.attributes
     {
       // Visit the node.
       skipNodes.insert(node)
-      let visitedNode = self.visit(declSyntax).asProtocol(AttributedSyntax.self)!
+      let visitedNode = self.visit(declSyntax).asProtocol(WithAttributesSyntax.self)!
       skipNodes.remove(node)
 
       // Remove any attached attributes.
@@ -340,7 +340,7 @@ extension MacroApplication {
     attachedTo decl: DeclSyntax,
     ofType: MacroType.Type
   ) -> [(AttributeSyntax, MacroType)] {
-    guard let attributedNode = decl.asProtocol(AttributedSyntax.self),
+    guard let attributedNode = decl.asProtocol(WithAttributesSyntax.self),
       let attributes = attributedNode.attributes
     else {
       return []
@@ -433,7 +433,7 @@ extension MacroApplication {
     attachedTo decl: DeclSyntax,
     annotating member: MemberDeclListSyntax.Element
   ) -> MemberDeclListSyntax.Element {
-    guard let attributedDecl = member.decl.asProtocol(AttributedSyntax.self) else {
+    guard let attributedDecl = member.decl.asProtocol(WithAttributesSyntax.self) else {
       return member
     }
 

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -125,24 +125,26 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
   override func visit(_ node: CodeBlockItemListSyntax) -> CodeBlockItemListSyntax {
     var newItems: [CodeBlockItemSyntax] = []
     for item in node {
-      // Expand declaration macros that were parsed as macro expansion
-      // expressions in this context.
-      if case let .expr(exprItem) = item.item,
-        let exprExpansion = exprItem.as(MacroExpansionExprSyntax.self),
-        let macro = macroSystem.macros[exprExpansion.macro.text]
+      if let expansion = item.item.asProtocol(FreestandingMacroExpansionSyntax.self),
+        let macro = macroSystem.macros[expansion.macro.text]
       {
-        do {
+        func _expand(expansion: some FreestandingMacroExpansionSyntax) throws {
           if let macro = macro as? CodeItemMacro.Type {
             let expandedItemList = try macro.expansion(
-              of: exprExpansion,
+              of: expansion,
               in: context
             )
             newItems.append(contentsOf: expandedItemList)
           } else if let macro = macro as? DeclarationMacro.Type {
-            let expandedItemList = try macro.expansion(
-              of: exprExpansion,
+            var expandedItemList = try macro.expansion(
+              of: expansion,
               in: context
             )
+            if let declExpansion = expansion.as(MacroExpansionDeclSyntax.self) {
+              expandedItemList = expandedItemList.map {
+                $0.applying(attributes: declExpansion.attributes, modifiers: declExpansion.modifiers)
+              }
+            }
             newItems.append(
               contentsOf: expandedItemList.map {
                 CodeBlockItemSyntax(item: .decl($0))
@@ -150,11 +152,14 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
             )
           } else if let macro = macro as? ExpressionMacro.Type {
             let expandedExpr = try macro.expansion(
-              of: exprExpansion,
+              of: expansion,
               in: context
             )
             newItems.append(CodeBlockItemSyntax(item: .init(expandedExpr)))
           }
+        }
+        do {
+          try _openExistential(expansion, do: _expand)
         } catch {
           context.addDiagnostics(from: error, node: node)
         }
@@ -189,10 +194,13 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
         let freestandingMacro = macro as? DeclarationMacro.Type
       {
         do {
-          let expandedList = try freestandingMacro.expansion(
+          var expandedList = try freestandingMacro.expansion(
             of: declExpansion,
             in: context
           )
+          expandedList = expandedList.map {
+            $0.applying(attributes: declExpansion.attributes, modifiers: declExpansion.modifiers)
+          }
 
           newItems.append(
             contentsOf: expandedList.map { decl in
@@ -465,6 +473,44 @@ extension MacroApplication {
 
     let newDecl = attributedDecl.with(\.attributes, newAttributes).as(DeclSyntax.self)!
     return member.with(\.decl, newDecl)
+  }
+}
+
+extension DeclSyntax {
+  /// Returns this node with `attributes` and `modifiers` prepended to the
+  /// node’s attributes and modifiers, respectively. If the node doesn’t contain
+  /// attributes or modifiers, `attributes` or `modifiers` are ignored and not
+  /// applied.
+  @_spi(MacroExpansion)
+  public func applying(
+    attributes: AttributeListSyntax?,
+    modifiers: ModifierListSyntax?
+  ) -> DeclSyntax {
+    func _combine<C: SyntaxCollection>(_ left: C, _ right: C?) -> C? {
+      guard let right = right else { return left }
+      var elems: [C.Element] = []
+      elems.append(contentsOf: left)
+      elems.append(contentsOf: right)
+      return C(elems)
+    }
+    var node = self
+    if let attributes = attributes,
+      let withAttrs = node.asProtocol(WithAttributesSyntax.self)
+    {
+      node = withAttrs.with(
+        \.attributes,
+        _combine(attributes, withAttrs.attributes)
+      ).cast(DeclSyntax.self)
+    }
+    if let modifiers = modifiers,
+      let withModifiers = node.asProtocol(WithModifiersSyntax.self)
+    {
+      node = withModifiers.with(
+        \.modifiers,
+        _combine(modifiers, withModifiers.modifiers)
+      ).cast(DeclSyntax.self)
+    }
+    return node
   }
 }
 


### PR DESCRIPTION
As per the SE-0397 amendment, copy attributes and modifiers on `MacroExpansionDecl` to the expanded declarations.

Preparation:
* Rename `AttributedSyntax` to `WithAttributesSyntax`.
* Keep `AttributedSyntax` as a typealias to  `WithAttributeSyntax`
* Introduce `WithModifiersSyntax`
* Add `init(_: [Element])` to `SyntaxCollection`'s requirements

