### PR TITLE
Add documentation to (nearly) all public functions in the SwiftSyntax module

### DIFF
--- a/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
@@ -61,7 +61,7 @@ final class MultiLineStringLiteralIndentatinDiagnosticsGenerator: SyntaxVisitor 
     let indentationStartIndex = tokenLeadingTrivia.pieces.lastIndex(where: { $0.isNewline })?.advanced(by: 1) ?? tokenLeadingTrivia.startIndex
     let preIndentationTrivia = Trivia(pieces: tokenLeadingTrivia[0..<indentationStartIndex])
     let indentationTrivia = Trivia(pieces: tokenLeadingTrivia[indentationStartIndex...])
-    var positionOffset = preIndentationTrivia.byteSize
+    var positionOffset = preIndentationTrivia.sourceLength.utf8Length
 
     for (invalidTriviaPiece, missingTriviaPiece) in zip(indentationTrivia.decomposed, closeQuote.leadingTrivia.decomposed) {
       if invalidTriviaPiece == missingTriviaPiece {

--- a/Sources/SwiftParserDiagnostics/Utils.swift
+++ b/Sources/SwiftParserDiagnostics/Utils.swift
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 extension String {
+  /// Returns this string with the first letter uppercased.
+  ///
+  /// If thes string does not start with a letter, no change is made to it.
   func withFirstLetterUppercased() -> String {
     if let firstLetter = self.first {
       return firstLetter.uppercased() + self.dropFirst()
@@ -19,6 +22,9 @@ extension String {
     }
   }
 
+  /// Replace the first occurance of `character` with `replacement`.
+  ///
+  /// If `character` does not occur in this string, no change is made.
   func replacingFirstOccurence(of character: Character, with replacement: Character) -> String {
     guard let match = self.firstIndex(of: character) else {
       return self
@@ -26,6 +32,9 @@ extension String {
     return self[startIndex..<match] + String(replacement) + self[index(after: match)...]
   }
 
+  /// Replace the last occurance of `character` with `replacement`.
+  ///
+  /// If `character` does not occur in this string, no change is made.
   func replacingLastOccurence(of character: Character, with replacement: Character) -> String {
     guard let match = self.lastIndex(of: character) else {
       return self

--- a/Sources/SwiftSyntax/BumpPtrAllocator.swift
+++ b/Sources/SwiftSyntax/BumpPtrAllocator.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Bump-pointer allocation.
+/// A `BumpPtrAllocator` that allocates `slabSize` at a time.
+/// Once all memory in a slab has been used, it allocates a new slab and no
+/// memory allocations are necessary until that slab is completely filled up.
 @_spi(RawSyntax) @_spi(Testing)
 public class BumpPtrAllocator {
   typealias Slab = UnsafeMutableRawBufferPointer
@@ -35,6 +37,9 @@ public class BumpPtrAllocator {
   private var customSizeSlabs: [Slab]
   private var _totalBytesAllocated: Int
 
+  /// Construct a new ``BumpPtrAllocator`` that allocates `slabSize` at a time.
+  /// Once all memory in a slab has been used, it allocates a new slab and no
+  /// memory allocations are necessary until that slab is completely filled up.
   public init(slabSize: Int) {
     self.slabSize = slabSize
     slabs = []

--- a/Sources/SwiftSyntax/IncrementalParseTransition.swift
+++ b/Sources/SwiftSyntax/IncrementalParseTransition.swift
@@ -206,6 +206,8 @@ public struct IncrementalParseLookup {
   fileprivate let transition: IncrementalParseTransition
   fileprivate var cursor: SyntaxCursor
 
+  /// Create a new `IncrementalParseLookup` that can look nodes up based on the
+  /// given ``IncrementalParseTransition``.
   public init(transition: IncrementalParseTransition) {
     self.transition = transition
     self.cursor = .init(root: transition.previousTree.data)

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -342,10 +342,12 @@ extension RawSyntax {
 }
 
 extension RawSyntax {
+  @_spi(RawSyntax)
   public func toOpaque() -> UnsafeRawPointer {
     UnsafeRawPointer(pointer)
   }
 
+  @_spi(RawSyntax)
   public static func fromOpaque(_ pointer: UnsafeRawPointer) -> RawSyntax {
     Self(pointer: pointer.assumingMemoryBound(to: RawSyntaxData.self))
   }
@@ -866,6 +868,7 @@ extension RawSyntax: CustomDebugStringConvertible {
     target.write(")")
   }
 
+  @_spi(RawSyntax)
   public var debugDescription: String {
     var string = ""
     debugWrite(to: &string, indent: 0, withChildren: false)
@@ -874,6 +877,7 @@ extension RawSyntax: CustomDebugStringConvertible {
 }
 
 extension RawSyntax: CustomReflectable {
+  @_spi(RawSyntax)
   public var customMirror: Mirror {
 
     let mirrorChildren: [Any]

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -58,15 +58,19 @@ public extension RawSyntaxNodeProtocol {
 
 /// `RawSyntax` itself conforms to `RawSyntaxNodeProtocol`.
 extension RawSyntax: RawSyntaxNodeProtocol {
+  @_spi(RawSyntax)
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     return true
   }
+
+  @_spi(RawSyntax)
   public var raw: RawSyntax { self }
 
   init(raw: RawSyntax) {
     self = raw
   }
 
+  @_spi(RawSyntax)
   public init(_ other: some RawSyntaxNodeProtocol) {
     self.init(raw: other.raw)
   }
@@ -75,6 +79,7 @@ extension RawSyntax: RawSyntaxNodeProtocol {
 #if swift(<5.8)
 // Cherry-pick this function from SE-0370
 extension Slice {
+  @_spi(RawSyntax)
   @inlinable
   public func initialize<S>(
     from source: S
@@ -90,6 +95,7 @@ extension Slice {
 
 @_spi(RawSyntax)
 public struct RawTokenSyntax: RawSyntaxNodeProtocol {
+  @_spi(RawSyntax)
   public typealias SyntaxType = TokenSyntax
 
   @_spi(RawSyntax)
@@ -97,10 +103,12 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     return raw.tokenView!
   }
 
+  @_spi(RawSyntax)
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     return raw.kind == .token
   }
 
+  @_spi(RawSyntax)
   public var raw: RawSyntax
 
   init(raw: RawSyntax) {
@@ -112,43 +120,53 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
 
+  @_spi(RawSyntax)
   public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else { return nil }
     self.init(unchecked: other.raw)
   }
 
+  @_spi(RawSyntax)
   public var tokenKind: RawTokenKind {
     return tokenView.rawKind
   }
 
+  @_spi(RawSyntax)
   public var tokenText: SyntaxText {
     return tokenView.rawText
   }
 
+  @_spi(RawSyntax)
   public var byteLength: Int {
     return raw.byteLength
   }
 
+  @_spi(RawSyntax)
   public var presence: SourcePresence {
     tokenView.presence
   }
 
+  @_spi(RawSyntax)
   public var isMissing: Bool {
     presence == .missing
   }
 
+  @_spi(RawSyntax)
   public var leadingTriviaByteLength: Int {
     return tokenView.leadingTriviaByteLength
   }
 
+  @_spi(RawSyntax)
   public var leadingTriviaPieces: [RawTriviaPiece] {
     tokenView.leadingRawTriviaPieces
   }
 
+  @_spi(RawSyntax)
   public var trailingTriviaByteLength: Int {
     return tokenView.trailingTriviaByteLength
   }
 
+  @_spi(RawSyntax)
   public var trailingTriviaPieces: [RawTriviaPiece] {
     tokenView.trailingRawTriviaPieces
   }

--- a/Sources/SwiftSyntax/SourceLength.swift
+++ b/Sources/SwiftSyntax/SourceLength.swift
@@ -13,6 +13,7 @@
 /// The length a syntax node spans in the source code. From any AbsolutePosition
 /// you reach a node's end location by adding its UTF-8 length.
 public struct SourceLength: Comparable {
+  /// The length in bytes when the text is represented as UTF-8.
   public let utf8Length: Int
 
   /// Construct the source length of a given text
@@ -20,6 +21,7 @@ public struct SourceLength: Comparable {
     self.utf8Length = text.utf8.count
   }
 
+  /// Construct a source length that takes up `utf8Length` bytes when represented as UTF-8.
   public init(utf8Length: Int) {
     self.utf8Length = utf8Length
   }
@@ -28,6 +30,7 @@ public struct SourceLength: Comparable {
   public static let zero: SourceLength =
     SourceLength(utf8Length: 0)
 
+  /// Returns `true` if `lhs` is shorter than `rhs`.
   public static func < (lhs: SourceLength, rhs: SourceLength) -> Bool {
     return lhs.utf8Length < rhs.utf8Length
   }
@@ -38,15 +41,18 @@ public struct SourceLength: Comparable {
     return SourceLength(utf8Length: utf8Length)
   }
 
+  /// Extend `lhs` by `rhs` bytes.
   public static func += (lhs: inout SourceLength, rhs: SourceLength) {
     lhs = lhs + rhs
   }
 
+  /// Return a source length that's `rhs` bytes shorter than `lhs`.
   public static func - (lhs: SourceLength, rhs: SourceLength) -> SourceLength {
     let utf8Length = lhs.utf8Length - rhs.utf8Length
     return SourceLength(utf8Length: utf8Length)
   }
 
+  /// Change `lhs` to be `rhs` bytes shorter than `lhs`.
   public static func -= (lhs: inout SourceLength, rhs: SourceLength) {
     lhs = lhs - rhs
   }
@@ -62,10 +68,12 @@ extension AbsolutePosition {
     return AbsolutePosition(utf8Offset: utf8Offset)
   }
 
+  /// Advance `lhs` by `rhs`, i.e. changing it to the position `rhs` bytes after `lhs`.
   public static func += (lhs: inout AbsolutePosition, rhs: SourceLength) {
     lhs = lhs + rhs
   }
 
+  /// Return the position `rhs` bytes before `lhs`.
   public static func - (
     lhs: AbsolutePosition,
     rhs: SourceLength
@@ -74,6 +82,7 @@ extension AbsolutePosition {
     return AbsolutePosition(utf8Offset: utf8Offset)
   }
 
+  /// Reverse `lhs` by `rhs`, i.e. changing it `lhs` to the position `rhs` bytes before `lhs`.
   public static func -= (lhs: inout AbsolutePosition, rhs: SourceLength) {
     lhs = lhs - rhs
   }

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -26,11 +26,27 @@ public struct SourceLocation: Hashable, Codable, CustomDebugStringConvertible {
   /// The file in which this location resides.
   public let file: String
 
+  /// Returns the location as `<line>:<column>` for debugging purposes.
+  /// Do not rely on this output being stable.
   public var debugDescription: String {
     // Print file name?
     return "\(line):\(column)"
   }
 
+  /// Create a new source location at the specified `line` and `column` in `file`.
+  ///
+  /// - Parameters:
+  ///   - line: 1-based, i.e. the first line in the file has line number 1
+  ///   - column: The UTF-8 byte offset of the location with its line, i.e. the
+  ///             number of bytes all characters in the line before the location
+  ///             occupy when encoded as UTF-8. 1-based, i.e. the leftmost
+  ///             column in the file has column 1.
+  ///   - offset: The UTF-8 offset of the location within the entire file, i.e.
+  ///             the number of bytes all source code before the location
+  ///             occupies when encoded as UTF-8. 0-based, i.e. the first
+  ///             location in the source file has `offset` 0.
+  ///   - file: A string describing the name of the file in which this location
+  ///           is contained.
   public init(line: Int, column: Int, offset: Int, file: String) {
     self.line = line
     self.offset = offset
@@ -43,15 +59,22 @@ public struct SourceLocation: Hashable, Codable, CustomDebugStringConvertible {
 public struct SourceRange: Hashable, Codable, CustomDebugStringConvertible {
 
   /// The beginning location in the source range.
+  ///
+  /// This location is included in the range
   public let start: SourceLocation
 
   /// The beginning location in the source range.
+  ///
+  /// This location is no longer part of the range
   public let end: SourceLocation
 
+  /// A description describing this range for debugging purposes, don't rely on it.
   public var debugDescription: String {
     return "(\(start.debugDescription),\(end.debugDescription))"
   }
 
+  /// Construct a new source range, starting at `start` (inclusive) and ending
+  /// at `end` (exclusive).
   public init(start: SourceLocation, end: SourceLocation) {
     self.start = start
     self.end = end

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -51,6 +51,7 @@ struct SyntaxChildrenIndexData: Comparable {
 
 /// An index in a syntax children collection.
 public struct SyntaxChildrenIndex: Comparable, ExpressibleByNilLiteral {
+  /// Construct the `endIndex` of a ``SyntaxChildren`` collection.
   public init(nilLiteral: ()) {
     self.data = nil
   }
@@ -84,6 +85,7 @@ public struct SyntaxChildrenIndex: Comparable, ExpressibleByNilLiteral {
     self.data = SyntaxChildrenIndexData(absoluteSyntaxInfo)
   }
 
+  /// Returns `true` if `lhs` occurs before `rhs`.
   public static func < (lhs: SyntaxChildrenIndex, rhs: SyntaxChildrenIndex)
     -> Bool
   {
@@ -423,7 +425,10 @@ struct NonNilRawSyntaxChildren: BidirectionalCollection {
 
 /// Collection that contains the present child `Syntax` nodes of the given node.
 public struct SyntaxChildren: BidirectionalCollection {
+  /// ``SyntaxChildren`` is indexed by ``SyntaxChildrenIndex``.
   public typealias Index = SyntaxChildrenIndex
+
+  /// ``SyntaxChildren`` contains ``Syntax`` nodes.
   public typealias Element = Syntax
 
   /// The collection that contains the raw child nodes. `Syntax` nodes are
@@ -433,19 +438,25 @@ public struct SyntaxChildren: BidirectionalCollection {
   /// The parent node of the children. Used to build the `Syntax` nodes.
   private let parent: Syntax
 
+  /// The index of the first child in this collection.
   public var startIndex: SyntaxChildrenIndex { return rawChildren.startIndex }
+
+  /// The index that’s one after the last element in the collection.
   public var endIndex: SyntaxChildrenIndex { return rawChildren.endIndex }
 
+  /// The index for the child that’s after the child at `index`.
   public func index(after index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
     return rawChildren.index(after: index)
   }
 
+  /// The index for the child that’s before the child at `index`.
   public func index(before index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
     return rawChildren.index(before: index)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> Syntax {
-    let child = rawChildren[position]
+  /// The syntax node at the given `index`
+  public subscript(index: SyntaxChildrenIndex) -> Syntax {
+    let child = rawChildren[index]
     let data = SyntaxData(child, parent: parent)
     return Syntax(data)
   }

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -87,12 +87,23 @@ public struct SyntaxIndexInTree: Comparable, Hashable {
     self.indexInTree = indexInTree
   }
 
+  /// Returns `true` if `lhs` occurs before `rhs` in the tree.
   public static func < (lhs: SyntaxIndexInTree, rhs: SyntaxIndexInTree) -> Bool {
     return lhs.indexInTree < rhs.indexInTree
   }
 }
 
 /// Provides a stable and unique identity for `Syntax` nodes.
+///
+/// Note that two nodes might have the same contents even if their IDs are
+/// different. For example two different `FunctionDeclSyntax` nodes in the
+/// might have the exact same contents but if they occur at a different
+/// location in the source file, they have different IDs.
+///
+/// Also note that the ID of a syntax node changes when it is anchored in a
+/// different syntax tree. Modifying any node in the syntax tree a node is
+/// contained in generates a copy of that tree and thus changes the IDs of all
+/// nodes in the tree, not just the modified node's children.
 public struct SyntaxIdentifier: Hashable {
   /// Unique value for the root node.
   ///

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -37,10 +37,15 @@
 public struct SyntaxText {
   var buffer: UnsafeBufferPointer<UInt8>
 
+  /// Construct a ``SyntaxText`` whose text is represented by the given `buffer`.
   public init(buffer: UnsafeBufferPointer<UInt8>) {
     self.buffer = buffer
   }
 
+  /// Construct a ``SyntaxText`` whose text is represented by the memory starting
+  /// at `baseAddress` and ranging `count` bytes.
+  ///
+  /// If count is not zero, `baseAddress` must not be `nil`.
   public init(baseAddress: UnsafePointer<UInt8>?, count: Int) {
     precondition(
       count == 0 || baseAddress != nil,
@@ -142,19 +147,29 @@ public struct SyntaxText {
 
 /// `SyntaxText` is a collection of `UInt8`.
 extension SyntaxText: RandomAccessCollection {
+  /// SyntaxText operates on bytes and each byte is represented by a `UInt8`.
   public typealias Element = UInt8
+
+  /// `SyntaxText` is a continuous memory region that can be accessed by an integer.
   public typealias Index = Int
+
+  /// `Slice<SyntaxText>` represents a part of a ``SyntaxText``.
   public typealias SubSequence = Slice<SyntaxText>
 
+  /// The index of the first byte in ``SyntaxText``
   public var startIndex: Index { buffer.startIndex }
+
+  /// The index one after the last byte in ``SyntaxText``.
   public var endIndex: Index { buffer.endIndex }
 
-  public subscript(position: Index) -> Element {
-    get { return buffer[position] }
+  /// Access the byte at `index`.
+  public subscript(index: Index) -> Element {
+    get { return buffer[index] }
   }
 }
 
 extension SyntaxText: Hashable {
+  /// Returns `true` if `lhs` and `rhs` contain the same bytes.
   public static func == (lhs: SyntaxText, rhs: SyntaxText) -> Bool {
     if lhs.buffer.count != rhs.buffer.count {
       return false
@@ -174,22 +189,40 @@ extension SyntaxText: Hashable {
     return compareMemory(lBase, rBase, lhs.count)
   }
 
+  /// Hash the contents of this ``SyntaxText`` into `hasher`.
   public func hash(into hasher: inout Hasher) {
     hasher.combine(bytes: .init(buffer))
   }
 }
 
 extension SyntaxText: ExpressibleByStringLiteral {
+  /// We can always safely create ``SyntaxText`` from a ``StaticString`` because
+  /// ``StaticString`` is guaranteed to be alive for the entire execution
+  /// duration of the process.
   public init(stringLiteral value: StaticString) { self.init(value) }
+
+  /// We can always safely create ``SyntaxText`` from a ``StaticString`` because
+  /// ``StaticString`` is guaranteed to be alive for the entire execution
+  /// duration of the process.
   public init(unicodeScalarLiteral value: StaticString) { self.init(value) }
+
+  /// We can always safely create ``SyntaxText`` from a ``StaticString`` because
+  /// ``StaticString`` is guaranteed to be alive for the entire execution
+  /// duration of the process.
   public init(extendedGraphemeClusterLiteral value: StaticString) { self.init(value) }
 }
 
 extension SyntaxText: CustomStringConvertible {
+  /// The contents of this ``SyntaxText`` as a ``String``.
+  ///
+  /// Note that ``SyntaxText`` can represent invalid Unicode, while ``String``
+  /// cannot, so if this text contains invalid UTF-8, the conversion is lossy.
   public var description: String { String(syntaxText: self) }
 }
 
 extension SyntaxText: CustomDebugStringConvertible {
+  /// The string value of this text, which may be lossy if the text contains
+  /// invalid Unicode.
   public var debugDescription: String { description.debugDescription }
 }
 

--- a/Sources/SwiftSyntax/TokenSyntax.swift
+++ b/Sources/SwiftSyntax/TokenSyntax.swift
@@ -14,13 +14,20 @@
 
 /// A Syntax node representing a single token.
 public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
+  /// The ``Syntax`` node that provides the underlying data.
+  ///
+  /// Don’t access this. Use `Syntax(token)` instead.
   public let _syntaxNode: Syntax
 
+  /// The ``RawSyntaxTokenView`` of this token that allows accessing raw
+  /// properties of the token.
   @_spi(RawSyntax)
   public var tokenView: RawSyntaxTokenView {
     return raw.tokenView!
   }
 
+  /// If `node` is a token, return the ``TokenSyntax`` that represents it.
+  /// Otherwise, return `nil`.
   public init?<S: SyntaxProtocol>(_ node: S) {
     guard node.raw.kind == .token else { return nil }
     self._syntaxNode = node._syntaxNode
@@ -34,6 +41,8 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  /// Construct a new token with the given `kind`, `leadingTrivia`,
+  /// `trailingTrivia` and `presence`.
   public init(
     _ kind: TokenKind,
     leadingTrivia: Trivia = [],
@@ -54,6 +63,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     self.init(data)
   }
 
+  /// Whether the token is present or missing.
   public var presence: SourcePresence {
     get {
       return tokenView.presence
@@ -125,6 +135,12 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     return raw.totalLength
   }
 
+  /// A token by itself has no structure, so we represent its structure by an
+  /// empty layout node.
+  ///
+  /// Every syntax node that contains a token will have a
+  /// ``SyntaxNodeStructure.SyntaxChoices.choices`` case for the token and those
+  /// choices represent the token kinds the token might have.
   public static var structure: SyntaxNodeStructure {
     return .layout([])
   }
@@ -136,6 +152,8 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 extension TokenSyntax: CustomReflectable {
+  /// A custom mirror that shows the token properties in a better for, making
+  /// the debug output of the token easier to read.
   public var customMirror: Mirror {
     return Mirror(
       self,

--- a/Sources/SwiftSyntax/Trivia.swift
+++ b/Sources/SwiftSyntax/Trivia.swift
@@ -18,6 +18,8 @@ public enum TriviaPosition {
 /// A collection of leading or trailing trivia. This is the main data structure
 /// for thinking about trivia.
 public struct Trivia {
+  /// The pieces this trivia consists of. Each ``TriviaPiece`` can represent
+  /// multiple characters, such as an entire comment or 4 spaces.
   public let pieces: [TriviaPiece]
 
   /// Creates Trivia with the provided underlying pieces.
@@ -30,11 +32,13 @@ public struct Trivia {
     pieces.isEmpty
   }
 
+  /// The length of all the pieces in this ``Trivia``.
   public var sourceLength: SourceLength {
     return pieces.map({ $0.sourceLength }).reduce(.zero, +)
   }
 
-  /// Get the byteSize of this trivia
+  /// Get the number of bytes this trivia needs to be represented as UTF-8.
+  @available(*, deprecated, renamed: "sourceLength.utf8Length")
   public var byteSize: Int {
     return sourceLength.utf8Length
   }
@@ -87,18 +91,22 @@ public struct Trivia {
 extension Trivia: Equatable {}
 
 extension Trivia: Collection {
+  /// The index of the first ``TriviaPiece`` within this trivia.
   public var startIndex: Int {
     return pieces.startIndex
   }
 
+  /// The index one after the last ``TriviaPiece`` within this trivia.
   public var endIndex: Int {
     return pieces.endIndex
   }
 
-  public func index(after i: Int) -> Int {
-    return pieces.index(after: i)
+  /// The index of the trivia piece after the piece at `index`.
+  public func index(after index: Int) -> Int {
+    return pieces.index(after: index)
   }
 
+  /// The ``TriviaPiece`` at `index`.
   public subscript(_ index: Int) -> TriviaPiece {
     return pieces[index]
   }
@@ -123,6 +131,7 @@ extension Trivia: TextOutputStreamable {
 }
 
 extension Trivia: CustomStringConvertible {
+  /// The trivia’s representation in source code.
   public var description: String {
     var description = ""
     self.write(to: &description)
@@ -131,6 +140,9 @@ extension Trivia: CustomStringConvertible {
 }
 
 extension Trivia: CustomDebugStringConvertible {
+  /// A debug description that shows the individual trivia pieces.
+  ///
+  /// Do not rely on this output being stable.
   public var debugDescription: String {
     if count == 1, let first {
       return first.debugDescription
@@ -172,12 +184,16 @@ extension Trivia {
 }
 
 extension RawTriviaPiece: TextOutputStreamable {
+  /// Write the source representation of this trivia piece to `target`.
   public func write(to target: inout some TextOutputStream) {
     TriviaPiece(raw: self).write(to: &target)
   }
 }
 
 extension RawTriviaPiece: CustomDebugStringConvertible {
+  /// A debug description of this trivia piece.
+  ///
+  /// Do not rely on this output being stable.
   public var debugDescription: String {
     TriviaPiece(raw: self).debugDescription
   }

--- a/Sources/SwiftSyntax/Utils.swift
+++ b/Sources/SwiftSyntax/Utils.swift
@@ -84,6 +84,11 @@ public struct SourceEdit: Equatable {
 }
 
 extension RawUnexpectedNodesSyntax {
+  /// Construct a ``RawUnexpectedNodesSyntax``with the given `elements`.
+  ///
+  /// If `isMaximumNestingLevelOverflow` is `true`, the node has the
+  /// `isMaximumNestingLevelOverflow` error bit set, indicating that the parser
+  /// overflowed its maximum nesting level and thus aborted parsing.
   public init(elements: [RawSyntax], isMaximumNestingLevelOverflow: Bool, arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .unexpectedNodes,

--- a/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
@@ -89,7 +89,8 @@ public class AbsolutePositionTests: XCTestCase {
     XCTAssertEqual(2, state.trailingTrivia.count)
     XCTAssertEqual(
       state.byteSize,
-      state.leadingTrivia.byteSize + state.trailingTrivia.byteSize
+      state.leadingTrivia.sourceLength.utf8Length
+        + state.trailingTrivia.sourceLength.utf8Length
         + state.byteSizeAfterTrimmingTrivia
     )
     XCTAssertFalse(root.statements.isImplicit)


### PR DESCRIPTION
Nothing more to say, really. Let’s write some documentation. Maybe, eventually, we can enable the swift-format rule that all public declarations must have a doc comment.