### PR TITLE
[5.9] Fix newline parsing at trailing trivia

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -242,7 +242,7 @@ extension Lexer {
 
     /// If we have already lexed a token, the kind of the previously lexed token
     var previousTokenKind: RawTokenKind?
-    
+
     /// If we have already lexed a token, stores whether the previous lexeme‘s ending contains a newline.
     var previousLexemeTrailingNewlinePresence: NewlinePresence?
 
@@ -440,7 +440,7 @@ extension Lexer.Cursor {
     case .inRegexLiteral(let index, let lexemes):
       result = lexInRegexLiteral(lexemes.pointee[index...], existingPtr: lexemes)
     }
-    
+
     var flags = result.flags
     if newlineInLeadingTrivia == .present {
       flags.insert(.isAtStartOfLine)
@@ -448,13 +448,13 @@ extension Lexer.Cursor {
     if let previousLexemeTrailingNewlinePresence, previousLexemeTrailingNewlinePresence == .present {
       flags.insert(.isAtStartOfLine)
     }
-    
+
     self.previousLexemeTrailingNewlinePresence = result.newlinePresence
 
     if let stateTransition = result.stateTransition {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
     }
-    
+
     // Trailing trivia.
     let trailingTriviaStart = self
     if let trailingTriviaMode = result.trailingTriviaLexingMode ?? currentState.trailingTriviaLexingMode(cursor: self) {

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -321,8 +321,8 @@ extension Lexer {
     /// If `tokenKind` is `.keyword`, the kind of keyword produced, otherwise
     /// `nil`.
     let keywordKind: Keyword?
-    /// Indicates whether the lexed token text contains a newline.
-    let newlinePresence: Lexer.Cursor.NewlinePresence
+    /// Indicates whether the end of the lexed token text contains a newline.
+    let trailingNewlinePresence: Lexer.Cursor.NewlinePresence
 
     private init(
       _ tokenKind: RawTokenKind,
@@ -331,7 +331,7 @@ extension Lexer {
       stateTransition: StateTransition?,
       trailingTriviaLexingMode: Lexer.Cursor.TriviaLexingMode?,
       keywordKind: Keyword?,
-      newlinePresence: Lexer.Cursor.NewlinePresence
+      trailingNewlinePresence: Lexer.Cursor.NewlinePresence
     ) {
       self.tokenKind = tokenKind
       self.flags = flags
@@ -339,7 +339,7 @@ extension Lexer {
       self.stateTransition = stateTransition
       self.trailingTriviaLexingMode = trailingTriviaLexingMode
       self.keywordKind = keywordKind
-      self.newlinePresence = newlinePresence
+      self.trailingNewlinePresence = trailingNewlinePresence
     }
 
     /// Create a lexer result. Note that keywords should use `Result.keyword`
@@ -350,7 +350,7 @@ extension Lexer {
       error: Cursor.LexingDiagnostic? = nil,
       stateTransition: StateTransition? = nil,
       trailingTriviaLexingMode: Lexer.Cursor.TriviaLexingMode? = nil,
-      newlinePresence: Lexer.Cursor.NewlinePresence = .absent
+      trailingNewlinePresence: Lexer.Cursor.NewlinePresence = .absent
     ) {
       precondition(tokenKind != .keyword, "Use Result.keyword instead")
       self.init(
@@ -360,7 +360,7 @@ extension Lexer {
         stateTransition: stateTransition,
         trailingTriviaLexingMode: trailingTriviaLexingMode,
         keywordKind: nil,
-        newlinePresence: newlinePresence
+        trailingNewlinePresence: trailingNewlinePresence
       )
     }
 
@@ -373,7 +373,7 @@ extension Lexer {
         stateTransition: nil,
         trailingTriviaLexingMode: nil,
         keywordKind: kind,
-        newlinePresence: .absent
+        trailingNewlinePresence: .absent
       )
     }
   }
@@ -449,7 +449,7 @@ extension Lexer.Cursor {
       flags.insert(.isAtStartOfLine)
     }
 
-    self.previousLexemeTrailingNewlinePresence = result.newlinePresence
+    self.previousLexemeTrailingNewlinePresence = result.trailingNewlinePresence
 
     if let stateTransition = result.stateTransition {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
@@ -1906,7 +1906,7 @@ extension Lexer.Cursor {
           if character == UInt8(ascii: "\r") {
             _ = self.advance(matching: "\n")
           }
-          return Lexer.Result(.stringSegment, error: error, newlinePresence: .present)
+          return Lexer.Result(.stringSegment, error: error, trailingNewlinePresence: .present)
         } else {
           // Single line literals cannot span multiple lines.
           // Terminate the string here and go back to normal lexing (instead of `afterStringLiteral`)

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -243,8 +243,8 @@ extension Lexer {
     /// If we have already lexed a token, the kind of the previously lexed token
     var previousTokenKind: RawTokenKind?
     
-    /// If we have already lexed a token, the `NewlinePresence` of the previously lexed token
-    var previousTokenNewlinePresence: NewlinePresence?
+    /// If we have already lexed a token, stores whether the previous lexeme‘s ending contains a newline.
+    var previousLexemeTrailingNewlinePresence: NewlinePresence?
 
     /// If the `previousTokenKind` is `.keyword`, the keyword kind. Otherwise
     /// `nil`.
@@ -411,10 +411,10 @@ extension Lexer.Cursor {
     if newlineInLeadingTrivia == .present {
       flags.insert(.isAtStartOfLine)
     }
-    if let previousTokenNewlinePresence, previousTokenNewlinePresence == .present {
+    if let previousLexemeTrailingNewlinePresence, previousLexemeTrailingNewlinePresence == .present {
       flags.insert(.isAtStartOfLine)
     }
-    self.previousTokenNewlinePresence = nil
+    self.previousLexemeTrailingNewlinePresence = nil
 
     // Token text.
     let textStart = self
@@ -451,7 +451,7 @@ extension Lexer.Cursor {
     let trailingTriviaStart = self
     if let trailingTriviaMode = result.trailingTriviaLexingMode ?? currentState.trailingTriviaLexingMode(cursor: self) {
       let triviaResult = self.lexTrivia(mode: trailingTriviaMode)
-      self.previousTokenNewlinePresence = triviaResult.newlinePresence
+      self.previousLexemeTrailingNewlinePresence = triviaResult.newlinePresence
       diagnostic = TokenDiagnostic(combining: diagnostic, triviaResult.error?.tokenDiagnostic(tokenStart: cursor))
     }
 
@@ -1898,7 +1898,7 @@ extension Lexer.Cursor {
           if character == UInt8(ascii: "\r") {
             _ = self.advance(matching: "\n")
           }
-          self.previousTokenNewlinePresence = .present
+          self.previousLexemeTrailingNewlinePresence = .present
           return Lexer.Result(.stringSegment, error: error)
         } else {
           // Single line literals cannot span multiple lines.

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -150,6 +150,20 @@ extension Lexer.Cursor {
       case .inRegexLiteral: return false
       }
     }
+    
+    /// Returns whether the lexer is currently parsing the multiline string.
+    var isParsingMultilineString: Bool {
+      switch self {
+      case .normal, .preferRegexOverBinaryOperator: return false
+      case .afterRawStringDelimiter: return false
+      case .inStringLiteral(kind: let stringLiteralKind, delimiterLength: _): return stringLiteralKind == .multiLine
+      case .afterStringLiteral: return false
+      case .afterClosingStringQuote: return false
+      case .inStringInterpolationStart: return false
+      case .inStringInterpolation: return false
+      case .inRegexLiteral: return false
+      }
+    }
   }
 
   /// A data structure that holds the state stack entries in the lexer. It is
@@ -242,6 +256,9 @@ extension Lexer {
 
     /// If we have already lexed a token, the kind of the previously lexed token
     var previousTokenKind: RawTokenKind?
+    
+    /// If we have already lexed a token, the `NewlinePresence` of the previously lexed token
+    var previousTokenNewlinePresence: NewlinePresence?
 
     /// If the `previousTokenKind` is `.keyword`, the keyword kind. Otherwise
     /// `nil`.
@@ -434,21 +451,28 @@ extension Lexer.Cursor {
     if let stateTransition = result.stateTransition {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
     }
-
+    
+    var flags = result.flags
+    if newlineInLeadingTrivia == .present {
+      flags.insert(.isAtStartOfLine)
+    }
+    if let previousTokenNewlinePresence, previousTokenNewlinePresence == .present,
+       !currentState.isParsingMultilineString {
+      flags.insert(.isAtStartOfLine)
+    }
+    
     // Trailing trivia.
     let trailingTriviaStart = self
     if let trailingTriviaMode = result.trailingTriviaLexingMode ?? currentState.trailingTriviaLexingMode(cursor: self) {
       let triviaResult = self.lexTrivia(mode: trailingTriviaMode)
+      self.previousTokenNewlinePresence = triviaResult.newlinePresence
       diagnostic = TokenDiagnostic(combining: diagnostic, triviaResult.error?.tokenDiagnostic(tokenStart: cursor))
+    } else {
+      self.previousTokenNewlinePresence = nil
     }
 
     if self.currentState.shouldPopStateWhenReachingNewlineInTrailingTrivia && self.is(at: "\r", "\n") {
       self.stateStack.perform(stateTransition: .pop, stateAllocator: stateAllocator)
-    }
-
-    var flags = result.flags
-    if newlineInLeadingTrivia == .present {
-      flags.insert(.isAtStartOfLine)
     }
 
     diagnostic = TokenDiagnostic(combining: diagnostic, result.error?.tokenDiagnostic(tokenStart: cursor))

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -1182,9 +1182,9 @@ public class LexerTests: XCTestCase {
       """#,
       lexemes: [
         LexemeSpec(.multilineStringQuote, leading: "  ", text: #"""""#, trailing: "\n"),
-        LexemeSpec(.stringSegment, text: "  line 1\n"),
-        LexemeSpec(.stringSegment, text: "  line 2\n"),
-        LexemeSpec(.stringSegment, text: "  "),
+        LexemeSpec(.stringSegment, text: "  line 1\n", flags: .isAtStartOfLine),
+        LexemeSpec(.stringSegment, text: "  line 2\n", flags: .isAtStartOfLine),
+        LexemeSpec(.stringSegment, text: "  ", flags: .isAtStartOfLine),
         LexemeSpec(.multilineStringQuote, text: #"""""#),
       ]
     )
@@ -1198,9 +1198,9 @@ public class LexerTests: XCTestCase {
       """#,
       lexemes: [
         LexemeSpec(.multilineStringQuote, leading: "  ", text: #"""""#, trailing: "\n"),
-        LexemeSpec(.stringSegment, text: "  line 1 ", trailing: "\\\n"),
-        LexemeSpec(.stringSegment, text: "  line 2\n"),
-        LexemeSpec(.stringSegment, text: "  "),
+        LexemeSpec(.stringSegment, text: "  line 1 ", trailing: "\\\n", flags: .isAtStartOfLine),
+        LexemeSpec(.stringSegment, text: "  line 2\n", flags: .isAtStartOfLine),
+        LexemeSpec(.stringSegment, text: "  ", flags: .isAtStartOfLine),
         LexemeSpec(.multilineStringQuote, text: #"""""#),
       ]
     )

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -718,23 +718,23 @@ final class StatementTests: XCTestCase {
       ]
     )
   }
-  
+
   func testTrailingTriviaIncludesNewline() {
     assertParse(
-        """
-        let a = 2/*
-        */let b = 3
-        """
+      """
+      let a = 2/*
+      */let b = 3
+      """
     )
-    
+
     assertParse(
-        """
-        let a = 2/*
-        
-        
-        
-        */let b = 3
-        """
+      """
+      let a = 2/*
+
+
+
+      */let b = 3
+      """
     )
   }
 }

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -718,4 +718,23 @@ final class StatementTests: XCTestCase {
       ]
     )
   }
+  
+  func testTrailingTriviaIncludesNewline() {
+    assertParse(
+        """
+        let a = 2/*
+        */let b = 3
+        """
+    )
+    
+    assertParse(
+        """
+        let a = 2/*
+        
+        
+        
+        */let b = 3
+        """
+    )
+  }
 }


### PR DESCRIPTION
* **Explanation**: Previously, we would not consider newlines inside comments as making a token start on a new line. Because of this we would reject the following, saying that the two elements should be separated by a semicolon
```swift
let a = 1 /*
*/let b = 2
```
* **Scope**: Parsing of tokens that start with a multi-line comment
* **Risk**: Relatively low
* **Testing**: Added a test case
* **Reviewer**:  rdar://108762344 / https://github.com/apple/swift-syntax/issues/1626