### PR TITLE
[5.9] Reduce SwiftParser’s public surface area

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/IsLexerClassifiedFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/IsLexerClassifiedFile.swift
@@ -53,6 +53,7 @@ let isLexerClassifiedFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// Keywords are reserved unconditionally for use by Swift and may not
       /// appear as identifiers in any position without being escaped. For example,
       /// `class`, `func`, or `import`.
+      @_spi(Diagnostics) @_spi(Testing)
       public var isLexerClassifiedKeyword: Bool
       """
     ) {

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -131,12 +131,11 @@ extension TokenConsumer {
 }
 
 extension Parser {
-  @_spi(RawSyntax)
-  public struct DeclAttributes {
-    public var attributes: RawAttributeListSyntax?
-    public var modifiers: RawModifierListSyntax?
+  struct DeclAttributes {
+    var attributes: RawAttributeListSyntax?
+    var modifiers: RawModifierListSyntax?
 
-    public init(attributes: RawAttributeListSyntax?, modifiers: RawModifierListSyntax?) {
+    init(attributes: RawAttributeListSyntax?, modifiers: RawModifierListSyntax?) {
       self.attributes = attributes
       self.modifiers = modifiers
     }
@@ -169,8 +168,7 @@ extension Parser {
   ///
   /// If `inMemberDeclList` is `true`, we know that the next item must be a
   /// declaration and thus start with a keyword. This allows futher recovery.
-  @_spi(RawSyntax)
-  public mutating func parseDeclaration(inMemberDeclList: Bool = false) -> RawDeclSyntax {
+  mutating func parseDeclaration(inMemberDeclList: Bool = false) -> RawDeclSyntax {
     switch self.at(anyIn: PoundDeclarationStart.self) {
     case (.poundIfKeyword, _)?:
       if self.withLookahead({ $0.consumeIfConfigOfAttributes() }) {
@@ -303,8 +301,7 @@ extension Parser {
   ///     import-declaration → attributes? 'import' import-kind? import-path
   ///     import-kind → 'typealias' | 'struct' | 'class' | 'enum' | 'protocol' | 'let' | 'var' | 'func'
   ///     import-path → identifier | identifier '.' import-path
-  @_spi(RawSyntax)
-  public mutating func parseImportDeclaration(
+  mutating func parseImportDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawImportDeclSyntax {
@@ -322,8 +319,7 @@ extension Parser {
     )
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseImportKind() -> RawTokenSyntax? {
+  mutating func parseImportKind() -> RawTokenSyntax? {
     enum ImportKind: TokenSpecSet {
       case `typealias`
       case `struct`
@@ -368,8 +364,7 @@ extension Parser {
     return self.consume(ifAnyIn: ImportKind.self)
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseImportAccessPath() -> RawAccessPathSyntax {
+  mutating func parseImportAccessPath() -> RawAccessPathSyntax {
     var elements = [RawAccessPathComponentSyntax]()
     var keepGoing: RawTokenSyntax? = nil
     var loopProgress = LoopProgressCondition()
@@ -398,8 +393,7 @@ extension Parser {
   ///     extension-body → '{' extension-members? '}'
   ///     extension-members → extension-member extension-members?
   ///     extension-member → declaration | compiler-control-statement
-  @_spi(RawSyntax)
-  public mutating func parseExtensionDeclaration(
+  mutating func parseExtensionDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawExtensionDeclSyntax {
@@ -451,8 +445,7 @@ extension Parser {
     )
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseGenericParameters() -> RawGenericParameterClauseSyntax {
+  mutating func parseGenericParameters() -> RawGenericParameterClauseSyntax {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawGenericParameterClauseSyntax(
         remainingTokens,
@@ -614,8 +607,7 @@ extension Parser {
     }
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseGenericWhereClause() -> RawGenericWhereClauseSyntax {
+  mutating func parseGenericWhereClause() -> RawGenericWhereClauseSyntax {
     let (unexpectedBeforeWhereKeyword, whereKeyword) = self.expect(.keyword(.where))
 
     var elements = [RawGenericRequirementSyntax]()
@@ -779,8 +771,7 @@ extension Parser {
 }
 
 extension Parser {
-  @_spi(RawSyntax)
-  public mutating func parseMemberDeclListItem() -> RawMemberDeclListItemSyntax? {
+  mutating func parseMemberDeclListItem() -> RawMemberDeclListItemSyntax? {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       let item = RawMemberDeclListItemSyntax(
         remainingTokens,
@@ -819,8 +810,7 @@ extension Parser {
   /// `introducer` is the `struct`, `class`, ... keyword that is the cause that the member decl block is being parsed.
   /// If the left brace is missing, its indentation will be used to judge whether a following `}` was
   /// indented to close this code block or a surrounding context. See `expectRightBrace`.
-  @_spi(RawSyntax)
-  public mutating func parseMemberDeclList(introducer: RawTokenSyntax? = nil) -> RawMemberDeclBlockSyntax {
+  mutating func parseMemberDeclList(introducer: RawTokenSyntax? = nil) -> RawMemberDeclBlockSyntax {
     var elements = [RawMemberDeclListItemSyntax]()
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     do {
@@ -878,8 +868,7 @@ extension Parser {
   ///     raw-value-style-enum-case → enum-case-name raw-value-assignment?
   ///     raw-value-assignment → = raw-value-literal
   ///     raw-value-literal → numeric-literal | static-string-literal | boolean-literal
-  @_spi(RawSyntax)
-  public mutating func parseEnumCaseDeclaration(
+  mutating func parseEnumCaseDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawEnumCaseDeclSyntax {
@@ -945,8 +934,7 @@ extension Parser {
   /// =======
   ///
   ///     protocol-associated-type-declaration → attributes? access-level-modifier? 'associatedtype' typealias-name type-inheritance-clause? typealias-assignment? generic-where-clause?
-  @_spi(RawSyntax)
-  public mutating func parseAssociatedTypeDeclaration(
+  mutating func parseAssociatedTypeDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawAssociatedtypeDeclSyntax {
@@ -1036,8 +1024,7 @@ extension Parser {
   ///     initializer-head → attributes? declaration-modifiers? 'init' '?'
   ///     initializer-head → attributes? declaration-modifiers? 'init' '!'
   ///     initializer-body → code-block
-  @_spi(RawSyntax)
-  public mutating func parseInitializerDeclaration(
+  mutating func parseInitializerDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawInitializerDeclSyntax {
@@ -1092,8 +1079,7 @@ extension Parser {
   /// =======
   ///
   /// deinitializer-declaration → attributes? 'deinit' code-block
-  @_spi(RawSyntax)
-  public mutating func parseDeinitializerDeclaration(
+  mutating func parseDeinitializerDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawDeinitializerDeclSyntax {
@@ -1141,8 +1127,7 @@ extension Parser {
 }
 
 extension Parser {
-  @_spi(RawSyntax)
-  public mutating func parseFuncDeclaration(
+  mutating func parseFuncDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawFunctionDeclSyntax {
@@ -1192,8 +1177,7 @@ extension Parser {
     )
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseFunctionSignature(allowOutput: Bool = true) -> RawFunctionSignatureSyntax {
+  mutating func parseFunctionSignature(allowOutput: Bool = true) -> RawFunctionSignatureSyntax {
     let input = self.parseParameterClause(RawParameterClauseSyntax.self) { parser in
       parser.parseFunctionParameter()
     }
@@ -1239,8 +1223,7 @@ extension Parser {
   ///     subscript-declaration → subscript-head subscript-result generic-where-clause? getter-setter-keyword-block
   ///     subscript-head → attributes? declaration-modifiers? 'subscript' generic-parameter-clause? parameter-clause
   ///     subscript-result → '->' attributes? type
-  @_spi(RawSyntax)
-  public mutating func parseSubscriptDeclaration(
+  mutating func parseSubscriptDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawSubscriptDeclSyntax {
@@ -1320,8 +1303,7 @@ extension Parser {
   ///   }
   /// }
   /// ```
-  @_spi(RawSyntax)
-  public mutating func parseBindingDeclaration(
+  mutating func parseBindingDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle,
     inMemberDeclList: Bool = false
@@ -1543,8 +1525,7 @@ extension Parser {
   ///     getter-setter-block → code-block
   ///     getter-setter-block → { getter-clause setter-clause opt }
   ///     getter-setter-block → { setter-clause getter-clause }
-  @_spi(RawSyntax)
-  public mutating func parseGetSet() -> RawSubscriptDeclSyntax.Accessor {
+  mutating func parseGetSet() -> RawSubscriptDeclSyntax.Accessor {
     // Parse getter and setter.
     let unexpectedBeforeLBrace: RawUnexpectedNodesSyntax?
     let lbrace: RawTokenSyntax
@@ -1618,8 +1599,7 @@ extension Parser {
   ///     typealias-declaration → attributes? access-level-modifier? 'typealias' typealias-name generic-parameter-clause? typealias-assignment
   ///     typealias-name → identifier
   ///     typealias-assignment → '=' type
-  @_spi(RawSyntax)
-  public mutating func parseTypealiasDeclaration(
+  mutating func parseTypealiasDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawTypealiasDeclSyntax {
@@ -1685,8 +1665,7 @@ extension Parser {
   ///     postfix-operator-declaration → 'postfix' 'operator' operator
   ///     infix-operator-declaration → 'infix' 'operator' operator infix-operator-group?
   ///     infix-operator-group → ':' precedence-group-name
-  @_spi(RawSyntax)
-  public mutating func parseOperatorDeclaration(
+  mutating func parseOperatorDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawOperatorDeclSyntax {
@@ -1803,8 +1782,7 @@ extension Parser {
   ///
   ///     precedence-group-names → precedence-group-name | precedence-group-name ',' precedence-group-names
   ///     precedence-group-name → identifier
-  @_spi(RawSyntax)
-  public mutating func parsePrecedenceGroupDeclaration(
+  mutating func parsePrecedenceGroupDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
   ) -> RawPrecedenceGroupDeclSyntax {
@@ -1831,8 +1809,7 @@ extension Parser {
     )
   }
 
-  @_spi(RawSyntax)
-  public mutating func parsePrecedenceGroupAttributeListSyntax() -> RawPrecedenceGroupAttributeListSyntax {
+  mutating func parsePrecedenceGroupAttributeListSyntax() -> RawPrecedenceGroupAttributeListSyntax {
     enum LabelText: TokenSpecSet {
       case associativity
       case assignment

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -84,8 +84,7 @@ extension Parser {
   ///                   previous element.
   ///   - syntax: A function that aggregates the parsed conditional elements
   ///             into a syntax collection.
-  @_spi(RawSyntax)
-  public mutating func parsePoundIfDirective<Element: RawSyntaxNodeProtocol>(
+  mutating func parsePoundIfDirective<Element: RawSyntaxNodeProtocol>(
     _ parseElement: (_ parser: inout Parser, _ isFirstElement: Bool) -> Element?,
     addSemicolonIfNeeded: (_ lastElement: Element, _ newItemAtStartOfLine: Bool, _ parser: inout Parser) -> Element? = { _, _, _ in nil },
     syntax: (inout Parser, [Element]) -> RawIfConfigClauseSyntax.Elements?
@@ -172,8 +171,7 @@ extension Parser {
   ///     line-control-statement → '#sourceLocation' '(' ')'
   ///     line-number → `A decimal integer greater than zero`
   ///     file-path → static-string-literal
-  @_spi(RawSyntax)
-  public mutating func parsePoundSourceLocationDirective() -> RawPoundSourceLocationSyntax {
+  mutating func parsePoundSourceLocationDirective() -> RawPoundSourceLocationSyntax {
     let line = self.consumeAnyToken()
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let args: RawPoundSourceLocationArgsSyntax?

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -59,12 +59,12 @@ extension TokenConsumer {
 }
 
 extension Parser {
-  public enum ExprFlavor {
+  enum ExprFlavor {
     case basic
     case trailingClosure
   }
 
-  public enum PatternContext {
+  enum PatternContext {
     /// There is no ambient pattern context.
     case none
     /// We're parsing a matching pattern that is not introduced via `let` or `var`.
@@ -99,8 +99,7 @@ extension Parser {
   ///
   ///     expression → try-operator? await-operator? prefix-expression infix-expressions?
   ///     expression-list → expression | expression ',' expression-list
-  @_spi(RawSyntax)
-  public mutating func parseExpression(_ flavor: ExprFlavor = .trailingClosure, pattern: PatternContext = .none) -> RawExprSyntax {
+  mutating func parseExpression(_ flavor: ExprFlavor = .trailingClosure, pattern: PatternContext = .none) -> RawExprSyntax {
     // If we are parsing a refutable pattern, check to see if this is the start
     // of a let/var/is pattern.  If so, parse it as an UnresolvedPatternExpr and
     // let pattern type checking determine its final form.
@@ -126,8 +125,7 @@ extension Parser {
   ///     infix-expression → conditional-operator try-operator? prefix-expression
   ///     infix-expression → type-casting-operator
   ///     infix-expressions → infix-expression infix-expressions?
-  @_spi(RawSyntax)
-  public mutating func parseSequenceExpression(
+  mutating func parseSequenceExpression(
     _ flavor: ExprFlavor,
     forDirective: Bool = false,
     pattern: PatternContext = .none
@@ -391,8 +389,7 @@ extension Parser {
   ///
   ///     expression → try-operator? await-operator? prefix-expression infix-expressions?
   ///     expression-list → expression | expression ',' expression-list
-  @_spi(RawSyntax)
-  public mutating func parseSequenceExpressionElement(
+  mutating func parseSequenceExpressionElement(
     _ flavor: ExprFlavor,
     forDirective: Bool = false,
     pattern: PatternContext = .none
@@ -513,8 +510,7 @@ extension Parser {
   ///     prefix-expression → in-out-expression
   ///
   ///     in-out-expression → '&' identifier
-  @_spi(RawSyntax)
-  public mutating func parseUnaryExpression(
+  mutating func parseUnaryExpression(
     _ flavor: ExprFlavor,
     forDirective: Bool = false,
     pattern: PatternContext = .none
@@ -593,8 +589,7 @@ extension Parser {
   ///     postfix-expression → subscript-expression
   ///     postfix-expression → forced-value-expression
   ///     postfix-expression → optional-chaining-expression
-  @_spi(RawSyntax)
-  public mutating func parsePostfixExpression(
+  mutating func parsePostfixExpression(
     _ flavor: ExprFlavor,
     forDirective: Bool,
     pattern: PatternContext
@@ -611,8 +606,7 @@ extension Parser {
     )
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseDottedExpressionSuffix<R: RawSyntaxNodeProtocol>(previousNode: R?) -> (
+  mutating func parseDottedExpressionSuffix<R: RawSyntaxNodeProtocol>(previousNode: R?) -> (
     unexpectedPeriod: RawUnexpectedNodesSyntax?,
     period: RawTokenSyntax,
     name: RawTokenSyntax,
@@ -653,8 +647,7 @@ extension Parser {
     return (unexpectedPeriod, period, name, declNameArgs, generics)
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseDottedExpressionSuffix(_ start: RawExprSyntax?) -> RawExprSyntax {
+  mutating func parseDottedExpressionSuffix(_ start: RawExprSyntax?) -> RawExprSyntax {
     let (unexpectedPeriod, period, name, declNameArgs, generics) = parseDottedExpressionSuffix(previousNode: start)
 
     let memberAccess = RawMemberAccessExprSyntax(
@@ -679,8 +672,7 @@ extension Parser {
     )
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseIfConfigExpressionSuffix(
+  mutating func parseIfConfigExpressionSuffix(
     _ start: RawExprSyntax?,
     _ flavor: ExprFlavor,
     forDirective: Bool
@@ -739,8 +731,7 @@ extension Parser {
   ///     postfix-expression → subscript-expression
   ///     postfix-expression → forced-value-expression
   ///     postfix-expression → optional-chaining-expression
-  @_spi(RawSyntax)
-  public mutating func parsePostfixExpressionSuffix(
+  mutating func parsePostfixExpressionSuffix(
     _ start: RawExprSyntax,
     _ flavor: ExprFlavor,
     forDirective: Bool,
@@ -1011,8 +1002,7 @@ extension Parser {
   ///
   ///     key-path-postfixes → key-path-postfix key-path-postfixes?
   ///     key-path-postfix → '?' | '!' | 'self' | '[' function-call-argument-list ']'
-  @_spi(RawSyntax)
-  public mutating func parseKeyPathExpression(forDirective: Bool, pattern: PatternContext) -> RawKeyPathExprSyntax {
+  mutating func parseKeyPathExpression(forDirective: Bool, pattern: PatternContext) -> RawKeyPathExprSyntax {
     // Consume '\'.
     let (unexpectedBeforeBackslash, backslash) = self.expect(.backslash)
 
@@ -1146,8 +1136,7 @@ extension Parser {
   ///     primary-expression → wildcard-expression
   ///     primary-expression → key-path-expression
   ///     primary-expression → macro-expansion-expression
-  @_spi(RawSyntax)
-  public mutating func parsePrimaryExpression(
+  mutating func parsePrimaryExpression(
     pattern: PatternContext,
     flavor: ExprFlavor
   ) -> RawExprSyntax {
@@ -1296,8 +1285,7 @@ extension Parser {
   /// =======
   ///
   ///     primary-expression → identifier
-  @_spi(RawSyntax)
-  public mutating func parseIdentifierExpression() -> RawExprSyntax {
+  mutating func parseIdentifierExpression() -> RawExprSyntax {
     let (name, args) = self.parseDeclNameRef(.compoundNames)
     guard self.withLookahead({ $0.canParseAsGenericArgumentList() }) else {
       if name.tokenText.isEditorPlaceholder && args == nil {
@@ -1341,8 +1329,7 @@ extension Parser {
   /// =======
   ///
   /// macro-expansion-expression → '#' identifier expr-call-suffix?
-  @_spi(RawSyntax)
-  public mutating func parseMacroExpansionExpr(
+  mutating func parseMacroExpansionExpr(
     pattern: PatternContext,
     flavor: ExprFlavor
   ) -> RawMacroExpansionExprSyntax {
@@ -1409,8 +1396,7 @@ extension Parser {
   ///
   /// pack-expansion-expression → 'repeat' pattern-expression
   /// pattern-expression → expression
-  @_spi(RawSyntax)
-  public mutating func parsePackExpansionExpr(
+  mutating func parsePackExpansionExpr(
     _ flavor: ExprFlavor,
     pattern: PatternContext
   ) -> RawPackExpansionExprSyntax {
@@ -1434,8 +1420,7 @@ extension Parser {
   /// =======
   ///
   ///     regular-expression-literal → '#'* '/' `Any valid regular expression characters` '/' '#'*
-  @_spi(RawSyntax)
-  public mutating func parseRegexLiteral() -> RawRegexLiteralExprSyntax {
+  mutating func parseRegexLiteral() -> RawRegexLiteralExprSyntax {
     // See if we have an opening set of pounds.
     let openPounds = self.consume(if: .extendedRegexDelimiter)
 
@@ -1476,8 +1461,7 @@ extension Parser {
   /// =======
   ///
   ///     primary-expression → 'super'
-  @_spi(RawSyntax)
-  public mutating func parseSuperExpression() -> RawSuperRefExprSyntax {
+  mutating func parseSuperExpression() -> RawSuperRefExprSyntax {
     // Parse the 'super' reference.
     let (unexpectedBeforeSuperKeyword, superKeyword) = self.expect(.keyword(.super))
     return RawSuperRefExprSyntax(
@@ -1496,8 +1480,7 @@ extension Parser {
   ///
   ///     tuple-expression → '(' ')' | '(' tuple-element ',' tuple-element-list ')'
   ///     tuple-element-list → tuple-element | tuple-element ',' tuple-element-list
-  @_spi(RawSyntax)
-  public mutating func parseTupleExpression(pattern: PatternContext) -> RawTupleExprSyntax {
+  mutating func parseTupleExpression(pattern: PatternContext) -> RawTupleExprSyntax {
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let elements = self.parseArgumentListElements(pattern: pattern)
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
@@ -1553,8 +1536,7 @@ extension Parser {
   ///
   ///     dictionary-literal → '[' dictionary-literal-items ']' | '[' ':' ']'
   ///     dictionary-literal-items → dictionary-literal-item ','? | dictionary-literal-item ',' dictionary-literal-items
-  @_spi(RawSyntax)
-  public mutating func parseCollectionLiteral() -> RawExprSyntax {
+  mutating func parseCollectionLiteral() -> RawExprSyntax {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawExprSyntax(
         RawArrayExprSyntax(
@@ -1693,8 +1675,7 @@ extension Parser {
 }
 
 extension Parser {
-  @_spi(RawSyntax)
-  public mutating func parseDefaultArgument() -> RawInitializerClauseSyntax {
+  mutating func parseDefaultArgument() -> RawInitializerClauseSyntax {
     let unexpectedBeforeEq: RawUnexpectedNodesSyntax?
     let eq: RawTokenSyntax
     if let comparison = self.consumeIfContextualPunctuator("==") {
@@ -1718,8 +1699,7 @@ extension Parser {
 }
 
 extension Parser {
-  @_spi(RawSyntax)
-  public mutating func parseAnonymousClosureArgument() -> RawIdentifierExprSyntax {
+  mutating func parseAnonymousClosureArgument() -> RawIdentifierExprSyntax {
     let (unexpectedBeforeIdent, ident) = self.expect(.dollarIdentifier)
     return RawIdentifierExprSyntax(
       unexpectedBeforeIdent,
@@ -1737,8 +1717,7 @@ extension Parser {
   /// =======
   ///
   ///     closure-expression → '{' attributes? closure-signature? statements? '}'
-  @_spi(RawSyntax)
-  public mutating func parseClosureExpression() -> RawClosureExprSyntax {
+  mutating func parseClosureExpression() -> RawClosureExprSyntax {
     // Parse the opening left brace.
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     // Parse the closure-signature, if present.
@@ -1784,8 +1763,7 @@ extension Parser {
   ///     capture-list-item → capture-specifier? self-expression
   ///
   ///     capture-specifier → 'weak' | 'unowned' | 'unowned(safe)' | 'unowned(unsafe)'
-  @_spi(RawSyntax)
-  public mutating func parseClosureSignatureIfPresent() -> RawClosureSignatureSyntax? {
+  mutating func parseClosureSignatureIfPresent() -> RawClosureSignatureSyntax? {
     // If we have a leading token that may be part of the closure signature, do a
     // speculative parse to validate it and look for 'in'.
     guard self.at(.atSign, .leftParen, .leftSquareBracket) || self.at(.wildcard, .identifier) else {
@@ -1928,8 +1906,7 @@ extension Parser {
     )
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseClosureCaptureSpecifiers() -> RawClosureCaptureItemSpecifierSyntax? {
+  mutating func parseClosureCaptureSpecifiers() -> RawClosureCaptureItemSpecifierSyntax? {
     // Check for the strength specifier: "weak", "unowned", or
     // "unowned(safe/unsafe)".
     if let weakContextualKeyword = self.consume(if: .keyword(.weak)) {
@@ -1978,8 +1955,7 @@ extension Parser {
   /// =======
   ///
   ///     tuple-element → expression | identifier ':' expression
-  @_spi(RawSyntax)
-  public mutating func parseArgumentListElements(pattern: PatternContext) -> [RawTupleExprElementSyntax] {
+  mutating func parseArgumentListElements(pattern: PatternContext) -> [RawTupleExprElementSyntax] {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return [
         RawTupleExprElementSyntax(
@@ -2056,8 +2032,7 @@ extension Parser {
   ///     trailing-closures → closure-expression labeled-trailing-closures?
   ///     labeled-trailing-closures → labeled-trailing-closure labeled-trailing-closures?
   ///     labeled-trailing-closure → identifier ':' closure-expression
-  @_spi(RawSyntax)
-  public mutating func parseTrailingClosures(_ flavor: ExprFlavor) -> (RawClosureExprSyntax, RawMultipleTrailingClosureElementListSyntax?) {
+  mutating func parseTrailingClosures(_ flavor: ExprFlavor) -> (RawClosureExprSyntax, RawMultipleTrailingClosureElementListSyntax?) {
     // Parse the closure.
     let closure = self.parseClosureExpression()
 
@@ -2201,8 +2176,7 @@ extension Parser {
   ///
   ///     if-expression → 'if' condition-list code-block else-clause?
   ///     else-clause  → 'else' code-block | else if-statement
-  @_spi(RawSyntax)
-  public mutating func parseIfExpression(
+  mutating func parseIfExpression(
     ifHandle: RecoveryConsumptionHandle
   ) -> RawIfExprSyntax {
     let (unexpectedBeforeIfKeyword, ifKeyword) = self.eat(ifHandle)
@@ -2263,8 +2237,7 @@ extension Parser {
   ///
   ///     switch-expression → 'switch' expression '{' switch-cases? '}'
   ///     switch-cases → switch-case switch-cases?
-  @_spi(RawSyntax)
-  public mutating func parseSwitchExpression(
+  mutating func parseSwitchExpression(
     switchHandle: RecoveryConsumptionHandle
   ) -> RawSwitchExprSyntax {
     let (unexpectedBeforeSwitchKeyword, switchKeyword) = self.eat(switchHandle)
@@ -2308,8 +2281,7 @@ extension Parser {
   /// isn't covered by a case, we assume that the developer forgot to wrote the
   /// `case` and synthesize it. If `allowStandaloneStmtOrDeclRecovery` is `false`,
   /// this recovery is disabled.
-  @_spi(RawSyntax)
-  public mutating func parseSwitchCases(allowStandaloneStmtRecovery: Bool) -> RawSwitchCaseListSyntax {
+  mutating func parseSwitchCases(allowStandaloneStmtRecovery: Bool) -> RawSwitchCaseListSyntax {
     var elements = [RawSwitchCaseListSyntax.Element]()
     var elementsProgress = LoopProgressCondition()
     while !self.at(.eof, .rightBrace) && !self.at(.poundEndifKeyword, .poundElseifKeyword, .poundElseKeyword)
@@ -2395,8 +2367,7 @@ extension Parser {
   ///     switch-case → case-label statements
   ///     switch-case → default-label statements
   ///     switch-case → conditional-switch-case
-  @_spi(RawSyntax)
-  public mutating func parseSwitchCase() -> RawSwitchCaseSyntax {
+  mutating func parseSwitchCase() -> RawSwitchCaseSyntax {
     var unknownAttr: RawAttributeSyntax?
     if let at = self.consume(if: .atSign) {
       let (unexpectedBeforeIdent, ident) = self.expectIdentifier()
@@ -2459,8 +2430,7 @@ extension Parser {
   ///
   ///     case-label → attributes? case case-item-list ':'
   ///     case-item-list → pattern where-clause? | pattern where-clause? ',' case-item-list
-  @_spi(RawSyntax)
-  public mutating func parseSwitchCaseLabel(
+  mutating func parseSwitchCaseLabel(
     _ handle: RecoveryConsumptionHandle
   ) -> RawSwitchCaseLabelSyntax {
     let (unexpectedBeforeCaseKeyword, caseKeyword) = self.eat(handle)
@@ -2498,8 +2468,7 @@ extension Parser {
   /// =======
   ///
   ///     default-label → attributes? 'default' ':'
-  @_spi(RawSyntax)
-  public mutating func parseSwitchDefaultLabel(
+  mutating func parseSwitchDefaultLabel(
     _ handle: RecoveryConsumptionHandle
   ) -> RawSwitchDefaultLabelSyntax {
     let (unexpectedBeforeDefaultKeyword, defaultKeyword) = self.eat(handle)

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -264,7 +264,7 @@ extension Lexer {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
     }
 
-    public func starts<PossiblePrefix>(with possiblePrefix: PossiblePrefix) -> Bool
+    func starts<PossiblePrefix>(with possiblePrefix: PossiblePrefix) -> Bool
     where PossiblePrefix: Sequence, PossiblePrefix.Element == UInt8 {
       return self.input.starts(with: possiblePrefix)
     }

--- a/Sources/SwiftParser/Lexer/Lexeme.swift
+++ b/Sources/SwiftParser/Lexer/Lexeme.swift
@@ -18,16 +18,22 @@ extension Lexer {
   /// A lexeme is the fundamental output unit of lexical analysis. Each lexeme
   /// represents a fully identified, meaningful part of the input text that
   /// will can be consumed by a ``Parser``.
+  @_spi(Testing)
   public struct Lexeme: CustomDebugStringConvertible {
+    @_spi(Testing)
     public struct Flags: OptionSet, CustomDebugStringConvertible {
+      @_spi(Testing)
       public var rawValue: UInt8
 
+      @_spi(Testing)
       public init(rawValue: UInt8) {
         self.rawValue = rawValue
       }
 
+      @_spi(Testing)
       public static let isAtStartOfLine = Flags(rawValue: 1 << 0)
 
+      @_spi(Testing)
       public var debugDescription: String {
         var descriptionComponents: [String] = []
         if self.contains(.isAtStartOfLine) {
@@ -37,14 +43,23 @@ extension Lexer {
       }
     }
 
-    @_spi(RawSyntax)
+    @_spi(Testing)
     public var rawTokenKind: RawTokenKind
+
+    @_spi(Testing)
     public var flags: Lexeme.Flags
+
+    @_spi(Testing)
     public var diagnostic: TokenDiagnostic?
+
     var start: UnsafePointer<UInt8>
-    public var leadingTriviaByteLength: Int
-    public var textByteLength: Int
-    public var trailingTriviaByteLength: Int
+
+    var leadingTriviaByteLength: Int
+
+    var textByteLength: Int
+
+    var trailingTriviaByteLength: Int
+
     /// The cursor that produces this lexeme by calling `nextToken` on it.
     /// Used if the token needs to be re-lexed in a different lexer state.
     var cursor: Lexer.Cursor
@@ -77,35 +92,37 @@ extension Lexer {
       self.cursor = cursor
     }
 
+    @_spi(Testing)
     public var byteLength: Int {
       leadingTriviaByteLength + textByteLength + trailingTriviaByteLength
     }
 
-    @_spi(RawSyntax)
+    @_spi(Testing)
     public var wholeText: SyntaxText {
       SyntaxText(baseAddress: start, count: byteLength)
     }
 
-    @_spi(RawSyntax)
-    public var textRange: Range<SyntaxText.Index> {
+    var textRange: Range<SyntaxText.Index> {
       leadingTriviaByteLength..<leadingTriviaByteLength + textByteLength
     }
 
-    @_spi(RawSyntax)
+    @_spi(Testing)
     public var tokenText: SyntaxText {
       SyntaxText(
         baseAddress: start.advanced(by: leadingTriviaByteLength),
         count: textByteLength
       )
     }
-    @_spi(RawSyntax)
+
+    @_spi(Testing)
     public var leadingTriviaText: SyntaxText {
       SyntaxText(
         baseAddress: start,
         count: leadingTriviaByteLength
       )
     }
-    @_spi(RawSyntax)
+
+    @_spi(Testing)
     public var trailingTriviaText: SyntaxText {
       SyntaxText(
         baseAddress: start.advanced(by: leadingTriviaByteLength + textByteLength),
@@ -113,6 +130,7 @@ extension Lexer {
       )
     }
 
+    @_spi(Testing)
     public var debugDescription: String {
       return String(syntaxText: SyntaxText(baseAddress: start, count: byteLength))
     }

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -15,6 +15,7 @@
 extension Lexer {
   /// A sequence of ``Lexer/Lexeme`` tokens starting from a ``Lexer/Cursor``
   /// that points into an input buffer.
+  @_spi(Testing)
   public struct LexemeSequence: IteratorProtocol, Sequence, CustomDebugStringConvertible {
     fileprivate let sourceBufferStart: Lexer.Cursor
     fileprivate var cursor: Lexer.Cursor
@@ -37,6 +38,7 @@ extension Lexer {
       self.nextToken = self.cursor.nextToken(sourceBufferStart: self.sourceBufferStart, stateAllocator: lexerStateAllocator)
     }
 
+    @_spi(Testing)
     public mutating func next() -> Lexer.Lexeme? {
       return self.advance()
     }
@@ -73,6 +75,7 @@ extension Lexer {
       currentToken = self.advance()
     }
 
+    @_spi(Testing)
     public var debugDescription: String {
       let remainingText = self.nextToken.debugDescription + String(syntaxText: SyntaxText(baseAddress: self.cursor.input.baseAddress, count: self.cursor.input.count))
       if remainingText.count > 100 {
@@ -97,7 +100,7 @@ extension Lexer {
     #endif
   }
 
-  @_spi(RawSyntax)
+  @_spi(Testing)
   public static func tokenize(
     _ input: UnsafeBufferPointer<UInt8>,
     from startIndex: Int = 0

--- a/Sources/SwiftParser/Lexer/Lexer.swift
+++ b/Sources/SwiftParser/Lexer/Lexer.swift
@@ -16,5 +16,6 @@
 ///
 /// - Seealso: ``Lexer/Lexeme``
 /// - Seealso: ``Lexer/Cursor``
+@_spi(Testing)
 public enum Lexer {
 }

--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -145,7 +145,7 @@ extension Unicode.Scalar {
 
   /// Whether this character represents a printable ASCII character,
   /// for the purposes of pattern parsing.
-  public var isPrintableASCII: Bool {
+  var isPrintableASCII: Bool {
     // Exclude non-printables before the space character U+20, and anything
     // including and above the DEL character U+7F.
     return self.value >= 0x20 && self.value < 0x7F
@@ -226,6 +226,7 @@ extension Unicode.Scalar {
   }
 
   /// Returns the first unicode scalar in `byteSequence`, which may span multiple bytes.
+  @_spi(Diagnostics)
   public static func lexing<S: Collection>(from byteSequence: S) -> Self? where S.Element == UInt8 {
     var index = byteSequence.startIndex
     let peek = { () -> UInt8? in

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -20,10 +20,9 @@ extension Parser {
   /// arbitrary number of tokens ahead in the input stream. Instances of
   /// ``Lookahead`` are distinct from their parent ``Parser`` instances, so
   /// any tokens they consume will not be reflected in the parent parser.
-  public struct Lookahead {
+  struct Lookahead {
     var lexemes: Lexer.LexemeSequence
-    @_spi(RawSyntax)
-    public var currentToken: Lexer.Lexeme
+    var currentToken: Lexer.Lexeme
     /// Number of tokens this ``Lookahead`` has consumed from where it was started,
     /// i.e. how far it looked ahead.
     var tokensConsumed: Int = 0
@@ -42,23 +41,22 @@ extension Parser {
 
     /// Initiates a lookahead session from the current point in this
     /// lookahead session.
-    public func lookahead() -> Lookahead {
+    func lookahead() -> Lookahead {
       return Lookahead(lexemes: self.lexemes, currentToken: self.currentToken)
     }
   }
 
   /// Initiates a lookahead session from the current point in this parse.
-  public func lookahead() -> Lookahead {
+  func lookahead() -> Lookahead {
     return Lookahead(cloning: self)
   }
 
-  public func withLookahead<T>(_ body: (_: inout Lookahead) -> T) -> T {
+  func withLookahead<T>(_ body: (_: inout Lookahead) -> T) -> T {
     var lookahead = lookahead()
     return body(&lookahead)
   }
 }
 
-@_spi(RawSyntax)
 extension Parser.Lookahead: TokenConsumer {
   /// Consumes the current token, and asserts that it matches `spec`.
   ///
@@ -74,30 +72,27 @@ extension Parser.Lookahead: TokenConsumer {
   #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
   var shouldRecordAlternativeTokenChoices: Bool { false }
 
-  mutating public func recordAlternativeTokenChoice(for lexeme: Lexer.Lexeme, choices: [TokenSpec]) {}
+  mutating func recordAlternativeTokenChoice(for lexeme: Lexer.Lexeme, choices: [TokenSpec]) {}
   #endif
 }
 
 extension Parser.Lookahead {
-  @_spi(RawSyntax)
-  public func peek() -> Lexer.Lexeme {
+  func peek() -> Lexer.Lexeme {
     return self.lexemes.peek()
   }
 }
 
 extension Parser.Lookahead {
-  @_spi(RawSyntax)
-  public mutating func missingToken(_ kind: RawTokenKind, text: SyntaxText?) {
+  mutating func missingToken(_ kind: RawTokenKind, text: SyntaxText?) {
     // do nothing
   }
 
-  public mutating func consumeAnyToken() {
+  mutating func consumeAnyToken() {
     tokensConsumed += 1
     self.currentToken = self.lexemes.advance()
   }
 
-  @_spi(RawSyntax)
-  public mutating func consumeAnyToken(remapping: RawTokenKind) {
+  mutating func consumeAnyToken(remapping: RawTokenKind) {
     self.consumeAnyToken()
   }
 

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -13,8 +13,7 @@
 @_spi(RawSyntax) import SwiftSyntax
 
 extension Parser {
-  @_spi(RawSyntax)
-  public mutating func parseModifierList() -> RawModifierListSyntax? {
+  mutating func parseModifierList() -> RawModifierListSyntax? {
     var elements = [RawDeclModifierSyntax]()
     var modifierLoopCondition = LoopProgressCondition()
     MODIFIER_LOOP: while modifierLoopCondition.evaluate(currentToken) {

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -168,8 +168,7 @@ extension Parser {
     )
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseQualifiedTypeIdentifier() -> RawTypeSyntax {
+  mutating func parseQualifiedTypeIdentifier() -> RawTypeSyntax {
     if self.at(.keyword(.Any)) {
       return RawTypeSyntax(self.parseAnyType())
     }

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -271,8 +271,7 @@ extension Parser {
   }
 
   /// Parse an inheritance clause.
-  @_spi(RawSyntax)
-  public mutating func parseInheritance() -> RawTypeInheritanceClauseSyntax {
+  mutating func parseInheritance() -> RawTypeInheritanceClauseSyntax {
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     var elements = [RawInheritedTypeSyntax]()
     do {
@@ -309,8 +308,7 @@ extension Parser {
     )
   }
 
-  @_spi(RawSyntax)
-  public mutating func parsePrimaryAssociatedTypes() -> RawPrimaryAssociatedTypeClauseSyntax {
+  mutating func parsePrimaryAssociatedTypes() -> RawPrimaryAssociatedTypeClauseSyntax {
     let langle = self.consumeAnyToken(remapping: .leftAngle)
     var associatedTypes = [RawPrimaryAssociatedTypeSyntax]()
     do {

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -44,8 +44,7 @@ extension Parser {
   ///     as-pattern → pattern 'as' type
   ///
   ///     expression-pattern → expression
-  @_spi(RawSyntax)
-  public mutating func parsePattern() -> RawPatternSyntax {
+  mutating func parsePattern() -> RawPatternSyntax {
     enum ExpectedTokens: TokenSpecSet {
       case leftParen
       case wildcard

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -17,8 +17,7 @@
 /// After calling `consume(ifAnyFrom:)` we know which token we are positioned
 /// at based on that function's return type. This handle allows consuming that
 /// token.
-@_spi(RawSyntax)
-public struct RecoveryConsumptionHandle {
+struct RecoveryConsumptionHandle {
   var unexpectedTokens: Int
   var tokenConsumptionHandle: TokenConsumptionHandle
 

--- a/Sources/SwiftParser/Specifiers.swift
+++ b/Sources/SwiftParser/Specifiers.swift
@@ -14,6 +14,7 @@
 
 // MARK: - TokenSpecSet
 
+@_spi(Diagnostics)
 public enum AsyncEffectSpecifier: TokenSpecSet {
   case async
   case await
@@ -30,6 +31,7 @@ public enum AsyncEffectSpecifier: TokenSpecSet {
     }
   }
 
+  @_spi(Diagnostics)
   public init?(token: TokenSyntax) {
     switch token.tokenKind {
     case .keyword(.async): self = .async
@@ -48,6 +50,7 @@ public enum AsyncEffectSpecifier: TokenSpecSet {
   }
 }
 
+@_spi(Diagnostics)
 public enum ThrowsEffectSpecifier: TokenSpecSet {
   case `rethrows`
   case `throw`
@@ -66,6 +69,7 @@ public enum ThrowsEffectSpecifier: TokenSpecSet {
     }
   }
 
+  @_spi(Diagnostics)
   public init?(token: TokenSyntax) {
     switch token.tokenKind {
     case .keyword(.rethrows): self = .rethrows
@@ -86,6 +90,7 @@ public enum ThrowsEffectSpecifier: TokenSpecSet {
   }
 }
 
+@_spi(Diagnostics)
 public enum EffectSpecifier: TokenSpecSet {
   case asyncSpecifier(AsyncEffectSpecifier)
   case throwsSpecifier(ThrowsEffectSpecifier)
@@ -100,6 +105,7 @@ public enum EffectSpecifier: TokenSpecSet {
     }
   }
 
+  @_spi(Diagnostics)
   public init?(token: TokenSyntax) {
     if let subset = AsyncEffectSpecifier(token: token) {
       self = .asyncSpecifier(subset)
@@ -110,6 +116,7 @@ public enum EffectSpecifier: TokenSpecSet {
     }
   }
 
+  @_spi(Diagnostics)
   public static var allCases: [EffectSpecifier] {
     return AsyncEffectSpecifier.allCases.map(Self.asyncSpecifier)
       + ThrowsEffectSpecifier.allCases.map(Self.throwsSpecifier)

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -75,8 +75,7 @@ extension Parser {
   ///     control-transfer-statement → fallthrough-statement
   ///     control-transfer-statement → return-statement
   ///     control-transfer-statement → throw-statement
-  @_spi(RawSyntax)
-  public mutating func parseStatement() -> RawStmtSyntax {
+  mutating func parseStatement() -> RawStmtSyntax {
     // If this is a label on a loop/switch statement, consume it and pass it into
     // parsing logic below.
     func label<S: RawStmtSyntaxNodeProtocol>(_ stmt: S, with label: Parser.StatementLabel?) -> RawStmtSyntax {
@@ -154,8 +153,7 @@ extension Parser {
   /// =======
   ///
   ///     guard-statement → 'guard' condition-list 'else' code-block
-  @_spi(RawSyntax)
-  public mutating func parseGuardStatement(guardHandle: RecoveryConsumptionHandle) -> RawGuardStmtSyntax {
+  mutating func parseGuardStatement(guardHandle: RecoveryConsumptionHandle) -> RawGuardStmtSyntax {
     let (unexpectedBeforeGuardKeyword, guardKeyword) = self.eat(guardHandle)
     let conditions = self.parseConditionList()
     let (unexpectedBeforeElseKeyword, elseKeyword) = self.expect(.keyword(.else))
@@ -179,8 +177,7 @@ extension Parser {
   /// =======
   ///
   ///     condition-list → condition | condition , condition-list
-  @_spi(RawSyntax)
-  public mutating func parseConditionList() -> RawConditionElementListSyntax {
+  mutating func parseConditionList() -> RawConditionElementListSyntax {
     // We have a simple comma separated list of clauses, but also need to handle
     // a variety of common errors situations (including migrating from Swift 2
     // syntax).
@@ -220,9 +217,8 @@ extension Parser {
   ///     case-condition → 'case' pattern initializer
   ///     optional-binding-condition → 'let' pattern initializer? | 'var' pattern initializer? |
   ///                                  'inout' pattern initializer?
-  @_spi(RawSyntax)
   /// `lastBindingKind` will be used to get a correct fall back, when there is missing `var` or `let` in a `if` statement etc.
-  public mutating func parseConditionElement(lastBindingKind: RawTokenSyntax?) -> RawConditionElementSyntax.Condition {
+  mutating func parseConditionElement(lastBindingKind: RawTokenSyntax?) -> RawConditionElementSyntax.Condition {
     // Parse a leading #available/#unavailable condition if present.
     if self.at(.poundAvailableKeyword, .poundUnavailableKeyword) {
       return self.parsePoundAvailableConditionElement()
@@ -336,8 +332,7 @@ extension Parser {
   ///
   ///     availability-condition → '#available' '(' availability-arguments ')'
   ///     availability-condition → '#unavailable' '(' availability-arguments ')'
-  @_spi(RawSyntax)
-  public mutating func parsePoundAvailableConditionElement() -> RawConditionElementSyntax.Condition {
+  mutating func parsePoundAvailableConditionElement() -> RawConditionElementSyntax.Condition {
     precondition(self.at(.poundAvailableKeyword, .poundUnavailableKeyword))
     let keyword = self.consumeAnyToken()
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
@@ -366,8 +361,7 @@ extension Parser {
   /// =======
   ///
   ///     throw-statement → 'throw' expression
-  @_spi(RawSyntax)
-  public mutating func parseThrowStatement(throwHandle: RecoveryConsumptionHandle) -> RawThrowStmtSyntax {
+  mutating func parseThrowStatement(throwHandle: RecoveryConsumptionHandle) -> RawThrowStmtSyntax {
     let (unexpectedBeforeThrowKeyword, throwKeyword) = self.eat(throwHandle)
     let hasMisplacedTry = unexpectedBeforeThrowKeyword?.containsToken(where: { TokenSpec(.try) ~= $0 }) ?? false
     var expr = self.parseExpression()
@@ -401,8 +395,7 @@ extension Parser {
   ///     discard-statement → 'discard' expression
   ///
   /// where expression's first token is an identifier.
-  @_spi(RawSyntax)
-  public mutating func parseDiscardStatement(discardHandle: RecoveryConsumptionHandle) -> RawDiscardStmtSyntax {
+  mutating func parseDiscardStatement(discardHandle: RecoveryConsumptionHandle) -> RawDiscardStmtSyntax {
     let (unexpectedBeforeDiscardKeyword, discardKeyword) = self.eat(discardHandle)
     let expr = self.parseExpression()
     return RawDiscardStmtSyntax(
@@ -423,8 +416,7 @@ extension Parser {
   /// =======
   ///
   ///     defer-statement → 'defer' code-block
-  @_spi(RawSyntax)
-  public mutating func parseDeferStatement(deferHandle: RecoveryConsumptionHandle) -> RawDeferStmtSyntax {
+  mutating func parseDeferStatement(deferHandle: RecoveryConsumptionHandle) -> RawDeferStmtSyntax {
     let (unexpectedBeforeDeferKeyword, deferKeyword) = self.eat(deferHandle)
     let items = self.parseCodeBlock(introducer: deferKeyword)
     return RawDeferStmtSyntax(
@@ -445,8 +437,7 @@ extension Parser {
   /// =======
   ///
   ///     do-statement → 'do' code-block catch-clauses?
-  @_spi(RawSyntax)
-  public mutating func parseDoStatement(doHandle: RecoveryConsumptionHandle) -> RawDoStmtSyntax {
+  mutating func parseDoStatement(doHandle: RecoveryConsumptionHandle) -> RawDoStmtSyntax {
     let (unexpectedBeforeDoKeyword, doKeyword) = self.eat(doHandle)
     let body = self.parseCodeBlock(introducer: doKeyword)
 
@@ -478,8 +469,7 @@ extension Parser {
   ///     catch-clauses → catch-clause catch-clauses?
   ///     catch-clause → catch catch-pattern-list? code-block
   ///     catch-pattern-list → catch-pattern | catch-pattern ',' catch-pattern-list
-  @_spi(RawSyntax)
-  public mutating func parseCatchClause() -> RawCatchClauseSyntax {
+  mutating func parseCatchClause() -> RawCatchClauseSyntax {
     let (unexpectedBeforeCatchKeyword, catchKeyword) = self.expect(.keyword(.catch))
     var catchItems = [RawCatchItemSyntax]()
     if !self.at(.leftBrace) {
@@ -550,8 +540,7 @@ extension Parser {
   /// =======
   ///
   ///     while-statement → 'while' condition-list code-block
-  @_spi(RawSyntax)
-  public mutating func parseWhileStatement(whileHandle: RecoveryConsumptionHandle) -> RawWhileStmtSyntax {
+  mutating func parseWhileStatement(whileHandle: RecoveryConsumptionHandle) -> RawWhileStmtSyntax {
     let (unexpectedBeforeWhileKeyword, whileKeyword) = self.eat(whileHandle)
     let conditions: RawConditionElementListSyntax
 
@@ -587,8 +576,7 @@ extension Parser {
   /// =======
   ///
   ///     repeat-while-statement → 'repeat' code-block 'while' expression
-  @_spi(RawSyntax)
-  public mutating func parseRepeatWhileStatement(repeatHandle: RecoveryConsumptionHandle) -> RawRepeatWhileStmtSyntax {
+  mutating func parseRepeatWhileStatement(repeatHandle: RecoveryConsumptionHandle) -> RawRepeatWhileStmtSyntax {
     let (unexpectedBeforeRepeatKeyword, repeatKeyword) = self.eat(repeatHandle)
     let body = self.parseCodeBlock(introducer: repeatKeyword)
     let (unexpectedBeforeWhileKeyword, whileKeyword) = self.expect(.keyword(.while))
@@ -614,8 +602,7 @@ extension Parser {
   /// =======
   ///
   ///     for-in-statement → 'for' 'case'? pattern 'in' expression where-clause? code-block
-  @_spi(RawSyntax)
-  public mutating func parseForEachStatement(forHandle: RecoveryConsumptionHandle) -> RawForInStmtSyntax {
+  mutating func parseForEachStatement(forHandle: RecoveryConsumptionHandle) -> RawForInStmtSyntax {
     let (unexpectedBeforeForKeyword, forKeyword) = self.eat(forHandle)
     let tryKeyword = self.consume(if: .keyword(.try))
     let awaitKeyword = self.consume(if: .keyword(.await))
@@ -751,8 +738,7 @@ extension Parser {
   /// =======
   ///
   ///     return-statement → 'return' expression?
-  @_spi(RawSyntax)
-  public mutating func parseReturnStatement(returnHandle: RecoveryConsumptionHandle) -> RawReturnStmtSyntax {
+  mutating func parseReturnStatement(returnHandle: RecoveryConsumptionHandle) -> RawReturnStmtSyntax {
     let (unexpectedBeforeRet, ret) = self.eat(returnHandle)
     let hasMisplacedTry = unexpectedBeforeRet?.containsToken(where: { TokenSpec(.try) ~= $0 }) ?? false
 
@@ -795,8 +781,7 @@ extension Parser {
   /// =======
   ///
   ///     yield-statement → 'yield' '('? expr-list? ')'?
-  @_spi(RawSyntax)
-  public mutating func parseYieldStatement(yieldHandle: RecoveryConsumptionHandle) -> RawYieldStmtSyntax {
+  mutating func parseYieldStatement(yieldHandle: RecoveryConsumptionHandle) -> RawYieldStmtSyntax {
     let (unexpectedBeforeYield, yield) = self.eat(yieldHandle)
 
     let yields: RawYieldStmtSyntax.Yields
@@ -845,12 +830,11 @@ extension Parser {
 }
 
 extension Parser {
-  @_spi(RawSyntax)
-  public struct StatementLabel {
-    public var label: RawTokenSyntax
-    public var colon: RawTokenSyntax
+  struct StatementLabel {
+    var label: RawTokenSyntax
+    var colon: RawTokenSyntax
 
-    public init(
+    init(
       label: RawTokenSyntax,
       colon: RawTokenSyntax
     ) {
@@ -866,8 +850,7 @@ extension Parser {
   ///
   ///     statement-label → label-name ':'
   ///     label-name → identifier
-  @_spi(RawSyntax)
-  public mutating func parseOptionalStatementLabel() -> StatementLabel? {
+  mutating func parseOptionalStatementLabel() -> StatementLabel? {
     if let (label, colon) = self.consume(if: .identifier, followedBy: .colon) {
       return StatementLabel(
         label: label,
@@ -886,8 +869,7 @@ extension Parser {
   /// =======
   ///
   ///     break-statement → 'break' label-name?
-  @_spi(RawSyntax)
-  public mutating func parseBreakStatement(breakHandle: RecoveryConsumptionHandle) -> RawBreakStmtSyntax {
+  mutating func parseBreakStatement(breakHandle: RecoveryConsumptionHandle) -> RawBreakStmtSyntax {
     let (unexpectedBeforeBreakKeyword, breakKeyword) = self.eat(breakHandle)
     let label = self.parseOptionalControlTransferTarget()
     return RawBreakStmtSyntax(
@@ -904,8 +886,7 @@ extension Parser {
   /// =======
   ///
   ///     continue-statement → 'continue' label-name?
-  @_spi(RawSyntax)
-  public mutating func parseContinueStatement(continueHandle: RecoveryConsumptionHandle) -> RawContinueStmtSyntax {
+  mutating func parseContinueStatement(continueHandle: RecoveryConsumptionHandle) -> RawContinueStmtSyntax {
     let (unexpectedBeforeContinueKeyword, continueKeyword) = self.eat(continueHandle)
     let label = self.parseOptionalControlTransferTarget()
     return RawContinueStmtSyntax(
@@ -922,8 +903,7 @@ extension Parser {
   /// =======
   ///
   ///     fallthrough-statement → 'fallthrough'
-  @_spi(RawSyntax)
-  public mutating func parseFallthroughStatement(fallthroughHandle: RecoveryConsumptionHandle) -> RawFallthroughStmtSyntax {
+  mutating func parseFallthroughStatement(fallthroughHandle: RecoveryConsumptionHandle) -> RawFallthroughStmtSyntax {
     let (unexpectedBeforeFallthroughKeyword, fallthroughKeyword) = self.eat(fallthroughHandle)
     return RawFallthroughStmtSyntax(
       unexpectedBeforeFallthroughKeyword,
@@ -933,8 +913,7 @@ extension Parser {
   }
 
   // label-name → identifier
-  @_spi(RawSyntax)
-  public mutating func parseOptionalControlTransferTarget() -> RawTokenSyntax? {
+  mutating func parseOptionalControlTransferTarget() -> RawTokenSyntax? {
     guard !self.currentToken.isAtStartOfLine else {
       return nil
     }
@@ -957,7 +936,7 @@ extension Parser.Lookahead {
   ///
   /// - Note: This function must be kept in sync with `parseStatement()`.
   /// - Seealso: ``Parser/parseStatement()``
-  public mutating func isStartOfStatement(allowRecovery: Bool = false) -> Bool {
+  mutating func isStartOfStatement(allowRecovery: Bool = false) -> Bool {
     if (self.at(anyIn: SwitchCaseStart.self) != nil || self.at(.atSign)) && withLookahead({ $0.atStartOfSwitchCaseItem() }) {
       // We consider SwitchCaseItems statements so we don't parse the start of a new case item as trailing parts of an expresion.
       return true

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -462,8 +462,7 @@ extension Parser {
   }
 
   /// Parse a string literal expression.
-  @_spi(RawSyntax)
-  public mutating func parseStringLiteral() -> RawStringLiteralExprSyntax {
+  mutating func parseStringLiteral() -> RawStringLiteralExprSyntax {
     /// Parse opening raw string delimiter if exist.
     let openDelimiter = self.consume(if: .rawStringDelimiter)
 
@@ -590,7 +589,7 @@ fileprivate extension SyntaxText {
   }
 }
 
-public extension RawTriviaPiece {
+fileprivate extension RawTriviaPiece {
   var isBackslash: Bool {
     switch self {
     case .backslashes: return true

--- a/Sources/SwiftParser/SwiftParser.docc/ParsingBasics.md
+++ b/Sources/SwiftParser/SwiftParser.docc/ParsingBasics.md
@@ -92,15 +92,17 @@ mutually-recursive functions.
 
 ```swift
 extension Parser {
-  // optional-type → type '?'
-  public mutating func parseOptionalType() -> OptionalTypeSyntax {
+  mutating func parseOptionalType() -> OptionalTypeSyntax {
     // First, recursively parse a type
     let base = self.parseType()
     // Then, parse a postfix question mark token
     let mark = self.eat(.postfixQuestionMark)
     // Finally, yield the optional type syntax node.
     return RawOptionalTypeSyntax(
-      wrappedType: base, questionMark: mark, arena: self.arena)
+      wrappedType: base, 
+      questionMark: mark, 
+      arena: self.arena
+    )
   }
 }
 ```
@@ -156,9 +158,7 @@ a comma-delimited sequence of type syntax elements:
 
 ```swift
 extension Parser {
-  /// type-inheritance-clause → ':' type-inheritance-list
-  /// type-inheritance-list → attributes? type-identifier | attributes? type-identifier ',' type-inheritance-list
-  public mutating func parseInheritance() -> RawTypeInheritanceClauseSyntax {
+  mutating func parseInheritance() -> RawTypeInheritanceClauseSyntax {
     // Eat the colon character.
     let colon = self.eat(.colon)
     // Start parsing a list of inherited types.

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -57,7 +57,7 @@ enum TokenPrecedence: Comparable {
     }
   }
 
-  public static func < (lhs: TokenPrecedence, rhs: TokenPrecedence) -> Bool {
+  static func < (lhs: TokenPrecedence, rhs: TokenPrecedence) -> Bool {
     func precedence(_ precedence: TokenPrecedence) -> Int {
       /// Should match the order of the cases in the enum.
       switch precedence {
@@ -99,8 +99,7 @@ enum TokenPrecedence: Comparable {
     return self >= .stmtKeyword
   }
 
-  @_spi(RawSyntax)
-  public init(_ lexeme: Lexer.Lexeme) {
+  init(_ lexeme: Lexer.Lexeme) {
     if lexeme.rawTokenKind == .keyword {
       self.init(Keyword(lexeme.tokenText)!)
     } else {
@@ -108,8 +107,7 @@ enum TokenPrecedence: Comparable {
     }
   }
 
-  @_spi(RawSyntax)
-  public init(nonKeyword tokenKind: RawTokenKind) {
+  init(nonKeyword tokenKind: RawTokenKind) {
     switch tokenKind {
     case .unknown:
       self = .unknownToken
@@ -178,8 +176,7 @@ enum TokenPrecedence: Comparable {
     }
   }
 
-  @_spi(RawSyntax)
-  public init(_ keyword: Keyword) {
+  init(_ keyword: Keyword) {
     switch keyword {
     // MARK: Identifier like
     case  // Literals

--- a/Sources/SwiftParser/TokenSpec.swift
+++ b/Sources/SwiftParser/TokenSpec.swift
@@ -44,7 +44,7 @@ struct PrepareForKeywordMatch {
 /// marked `@inline(__always)` so the compiler inlines the `RawTokenKind` we are
 /// matching against and is thus able to rule out one of the branches in
 /// `matches(rawTokenKind:text:)` based on the matched kind.
-@_spi(RawSyntax)
+@_spi(AlternateTokenIntrospection)
 public struct TokenSpec {
   /// The kind we expect the token that we want to consume to have.
   /// This can be a keyword, in which case the `TokenSpec` will also match an
@@ -167,6 +167,7 @@ public struct TokenSpec {
   ///
   /// IMPORTANT: Should only be used when generating tokens during the
   /// modification of test cases. This should never be used in the parser itself.
+  @_spi(AlternateTokenIntrospection)
   public var synthesizedTokenKind: TokenKind {
     switch rawTokenKind {
     case .binaryOperator: return .binaryOperator("+")

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -410,6 +410,7 @@ enum SwitchCaseStart: TokenSpecSet {
   }
 }
 
+@_spi(Diagnostics)
 public enum TypeSpecifier: TokenSpecSet {
   case inoutKeyword
   case owned
@@ -428,6 +429,7 @@ public enum TypeSpecifier: TokenSpecSet {
     }
   }
 
+  @_spi(Diagnostics)
   public init?(token: TokenSyntax) {
     switch token {
     case TokenSpec(.inout): self = .inoutKeyword

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -44,8 +44,7 @@ extension Parser {
   /// =======
   ///
   ///     source-file → top-level-declaration?
-  @_spi(RawSyntax)
-  public mutating func parseSourceFile() -> RawSourceFileSyntax {
+  mutating func parseSourceFile() -> RawSourceFileSyntax {
     let items = self.parseTopLevelCodeBlockItems()
     let unexpectedBeforeEof = consumeRemainingTokens()
     let eof = self.consume(if: .eof)!
@@ -147,8 +146,7 @@ extension Parser {
   ///     statement → do-statement ';'?
   ///     statement → compiler-control-statement
   ///     statements → statement statements?
-  @_spi(RawSyntax)
-  public mutating func parseCodeBlockItem(isAtTopLevel: Bool, allowInitDecl: Bool) -> RawCodeBlockItemSyntax? {
+  mutating func parseCodeBlockItem(isAtTopLevel: Bool, allowInitDecl: Bool) -> RawCodeBlockItemSyntax? {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawCodeBlockItemSyntax(
         remainingTokens,

--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -12,8 +12,9 @@
 
 @_spi(RawSyntax) import SwiftSyntax
 
+@_spi(Testing)
 public struct TriviaParser {
-  @_spi(RawSyntax)
+  @_spi(Testing)
   public static func parseTrivia(_ source: SyntaxText, position: TriviaPosition) -> [RawTriviaPiece] {
     if source.isEmpty { return [] }
 

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -23,8 +23,7 @@ extension Parser {
   ///     type → protocol-composition-type
   ///     type → constrained-sugar-type
   ///     type → opaque-type
-  @_spi(RawSyntax)
-  public mutating func parseType(misplacedSpecifiers: [RawTokenSyntax] = []) -> RawTypeSyntax {
+  mutating func parseType(misplacedSpecifiers: [RawTokenSyntax] = []) -> RawTypeSyntax {
     // Parse pack expansion 'repeat T'.
     if let repeatKeyword = self.consume(if: .keyword(.repeat)) {
       let type = self.parseTypeScalar(misplacedSpecifiers: misplacedSpecifiers)
@@ -138,8 +137,7 @@ extension Parser {
   ///     constrained-sugar-type-specifier → 'any' | 'some'
   ///     constrained-sugar-type-constraint → protocol-composition-type
   ///     constrained-sugar-type-constraint → type-simple
-  @_spi(RawSyntax)
-  public mutating func parseSimpleOrCompositionType() -> RawTypeSyntax {
+  mutating func parseSimpleOrCompositionType() -> RawTypeSyntax {
     // 'each' is a contextual keyword for a pack reference.
     if let each = consume(if: .keyword(.each)) {
       let packType = parseSimpleType()
@@ -234,8 +232,7 @@ extension Parser {
   ///
   ///     member-type-identifier → member-type-identifier-base '.' type-identifier
   ///     member-type-identifier-base → simple-type | member-type-identifier
-  @_spi(RawSyntax)
-  public mutating func parseSimpleType(
+  mutating func parseSimpleType(
     stopAtFirstPeriod: Bool = false
   ) -> RawTypeSyntax {
     var base: RawTypeSyntax
@@ -321,8 +318,7 @@ extension Parser {
   /// =======
   ///
   ///     optional-type → type '?'
-  @_spi(RawSyntax)
-  public mutating func parseOptionalType(_ base: RawTypeSyntax) -> RawOptionalTypeSyntax {
+  mutating func parseOptionalType(_ base: RawTypeSyntax) -> RawOptionalTypeSyntax {
     let (unexpectedBeforeMark, mark) = self.expect(.postfixQuestionMark)
     return RawOptionalTypeSyntax(
       wrappedType: base,
@@ -338,8 +334,7 @@ extension Parser {
   /// =======
   ///
   ///     implicitly-unwrapped-optional-type → type '!'
-  @_spi(RawSyntax)
-  public mutating func parseImplicitlyUnwrappedOptionalType(_ base: RawTypeSyntax) -> RawImplicitlyUnwrappedOptionalTypeSyntax {
+  mutating func parseImplicitlyUnwrappedOptionalType(_ base: RawTypeSyntax) -> RawImplicitlyUnwrappedOptionalTypeSyntax {
     let (unexpectedBeforeMark, mark) = self.expect(.exclamationMark)
     return RawImplicitlyUnwrappedOptionalTypeSyntax(
       wrappedType: base,
@@ -391,8 +386,7 @@ extension Parser {
   /// =======
   ///
   ///     any-type → 'Any'
-  @_spi(RawSyntax)
-  public mutating func parseAnyType() -> RawSimpleTypeIdentifierSyntax {
+  mutating func parseAnyType() -> RawSimpleTypeIdentifierSyntax {
     let (unexpectedBeforeName, name) = self.expect(.keyword(.Any))
     return RawSimpleTypeIdentifierSyntax(
       unexpectedBeforeName,
@@ -408,8 +402,7 @@ extension Parser {
   /// =======
   ///
   ///     placeholder-type → wildcard
-  @_spi(RawSyntax)
-  public mutating func parsePlaceholderType() -> RawSimpleTypeIdentifierSyntax {
+  mutating func parsePlaceholderType() -> RawSimpleTypeIdentifierSyntax {
     let (unexpectedBeforeName, name) = self.expect(.wildcard)
     // FIXME: Need a better syntax node than this
     return RawSimpleTypeIdentifierSyntax(
@@ -430,8 +423,7 @@ extension Parser {
   ///     generic-argument-clause → '<' generic-argument-list '>'
   ///     generic-argument-list → generic-argument | generic-argument ',' generic-argument-list
   ///     generic-argument → type
-  @_spi(RawSyntax)
-  public mutating func parseGenericArguments() -> RawGenericArgumentClauseSyntax {
+  mutating func parseGenericArguments() -> RawGenericArgumentClauseSyntax {
     precondition(self.currentToken.starts(with: "<"))
     let langle = self.consumePrefix("<", as: .leftAngle)
     var arguments = [RawGenericArgumentSyntax]()
@@ -488,8 +480,7 @@ extension Parser {
   ///     tuple-type-element-list → tuple-type-element | tuple-type-element ',' tuple-type-element-list
   ///     tuple-type-element → element-name type-annotation | type
   ///     element-name → identifier
-  @_spi(RawSyntax)
-  public mutating func parseTupleTypeBody() -> RawTupleTypeSyntax {
+  mutating func parseTupleTypeBody() -> RawTupleTypeSyntax {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawTupleTypeSyntax(
         remainingTokens,
@@ -615,8 +606,7 @@ extension Parser {
   ///     array-type → '[' type ']'
   ///
   ///     dictionary-type → '[' type ':' type ']'
-  @_spi(RawSyntax)
-  public mutating func parseCollectionType() -> RawTypeSyntax {
+  mutating func parseCollectionType() -> RawTypeSyntax {
     if let remaingingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawTypeSyntax(
         RawArrayTypeSyntax(
@@ -945,8 +935,7 @@ extension Parser.Lookahead {
 }
 
 extension Parser {
-  @_spi(RawSyntax)
-  public mutating func parseTypeAttributeList(misplacedSpecifiers: [RawTokenSyntax] = []) -> (
+  mutating func parseTypeAttributeList(misplacedSpecifiers: [RawTokenSyntax] = []) -> (
     specifier: RawTokenSyntax?, unexpectedBeforeAttributes: RawUnexpectedNodesSyntax?, attributes: RawAttributeListSyntax?
   ) {
     var specifier: RawTokenSyntax? = nil
@@ -1012,8 +1001,7 @@ extension Parser {
     return (specifier, unexpectedBeforeAttributeList, nil)
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseTypeAttributeListPresent() -> RawAttributeListSyntax {
+  mutating func parseTypeAttributeListPresent() -> RawAttributeListSyntax {
     var elements = [RawAttributeListSyntax.Element]()
     var attributeProgress = LoopProgressCondition()
     while self.at(.atSign) && attributeProgress.evaluate(currentToken) {
@@ -1022,8 +1010,7 @@ extension Parser {
     return RawAttributeListSyntax(elements: elements, arena: self.arena)
   }
 
-  @_spi(RawSyntax)
-  public mutating func parseTypeAttribute() -> RawAttributeListSyntax.Element {
+  mutating func parseTypeAttribute() -> RawAttributeListSyntax.Element {
     let typeAttr = Parser.TypeAttribute(lexeme: self.peek())
 
     switch typeAttr {

--- a/Sources/SwiftParser/generated/IsLexerClassified.swift
+++ b/Sources/SwiftParser/generated/IsLexerClassified.swift
@@ -137,6 +137,7 @@ extension TokenKind {
   /// Keywords are reserved unconditionally for use by Swift and may not
   /// appear as identifiers in any position without being escaped. For example,
   /// `class`, `func`, or `import`.
+  @_spi(Diagnostics) @_spi(Testing)
   public var isLexerClassifiedKeyword: Bool {
     switch self {
     case .eof:

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -12,6 +12,7 @@
 
 import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
+@_spi(Diagnostics) import SwiftParser
 
 fileprivate let diagnosticDomain: String = "SwiftLexer"
 

--- a/Sources/SwiftParserDiagnostics/MissingTokenError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingTokenError.swift
@@ -12,6 +12,7 @@
 
 import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
+@_spi(Diagnostics) import SwiftParser
 
 extension ParseDiagnosticsGenerator {
   func handleMissingToken(_ missingToken: TokenSyntax) {

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-import SwiftParser
+@_spi(Diagnostics) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
 
 fileprivate extension TokenSyntax {

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -12,6 +12,7 @@
 
 import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
+@_spi(Diagnostics) import SwiftParser
 
 fileprivate let diagnosticDomain: String = "SwiftParser"
 

--- a/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax) import SwiftSyntax
+@_spi(Diagnostics) import SwiftParser
 
 extension UnexpectedNodesSyntax {
   func tokens(satisfying isIncluded: (TokenSyntax) -> Bool) -> [TokenSyntax] {

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -228,6 +228,16 @@ extension String {
   }
 }
 
+fileprivate extension Unicode.Scalar {
+  /// Whether this character represents a printable ASCII character,
+  /// for the purposes of pattern parsing.
+  var isPrintableASCII: Bool {
+    // Exclude non-printables before the space character U+20, and anything
+    // including and above the DEL character U+7F.
+    return self.value >= 0x20 && self.value < 0x7F
+  }
+}
+
 extension StringLiteralExprSyntax {
   private enum PoundState {
     case afterQuote, afterBackslash, none

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -13,7 +13,7 @@
 import SwiftBasicFormat
 import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
-@_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax)@_spi(Testing) import SwiftParser
 
 /// An individual interpolated syntax node.
 struct InterpolatedSyntaxNode {

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -13,6 +13,7 @@
 import SwiftBasicFormat
 @_spi(RawSyntax) import SwiftSyntax
 import SwiftSyntaxBuilder
+@_spi(Testing) import SwiftParser
 
 private class InitializerExprFormat: BasicFormat {
   public init() {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 @_spi(RawSyntax) import SwiftSyntax
-@_spi(Testing)@_spi(RawSyntax) import SwiftParser
+@_spi(Testing)@_spi(RawSyntax)@_spi(AlternateTokenIntrospection) import SwiftParser
 @_spi(RawSyntax) import SwiftParserDiagnostics
 import SwiftDiagnostics
 import _SwiftSyntaxTestSupport

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1638,7 +1638,3 @@ final class DeclarationTests: XCTestCase {
     )
   }
 }
-
-extension Parser.DeclAttributes {
-  static let empty = Parser.DeclAttributes(attributes: nil, modifiers: nil)
-}

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 @_spi(RawSyntax) import SwiftSyntax
-@_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax)@_spi(Testing) import SwiftParser
 
 fileprivate func lex(_ sourceBytes: [UInt8], body: ([Lexer.Lexeme]) throws -> Void) rethrows {
   try sourceBytes.withUnsafeBufferPointer { (buf) in

--- a/Tests/SwiftParserTest/TriviaParserTests.swift
+++ b/Tests/SwiftParserTest/TriviaParserTests.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 @_spi(RawSyntax) import SwiftSyntax
-@_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax)@_spi(Testing) import SwiftParser
 
 final class TriviaParserTests: XCTestCase {
 
@@ -175,32 +175,32 @@ final class TriviaParserTests: XCTestCase {
         }
         """
     ) { parser in
-      let fn = parser.parseDeclaration().as(RawFunctionDeclSyntax.self)!
+      let fn = DeclSyntax.parse(from: &parser).cast(FunctionDeclSyntax.self)
 
       XCTAssertEqual(
-        fn.funcKeyword.leadingTriviaPieces,
+        fn.funcKeyword.leadingTrivia,
         [
           .docLineComment("/// Foo."),
           .newlines(1),
         ]
       )
       XCTAssertEqual(
-        fn.funcKeyword.trailingTriviaPieces,
+        fn.funcKeyword.trailingTrivia,
         [
           .spaces(1)
         ]
       )
 
-      XCTAssertEqual(fn.body!.leftBrace.leadingTriviaPieces, [])
-      XCTAssertEqual(fn.body!.leftBrace.trailingTriviaPieces, [])
+      XCTAssertEqual(fn.body!.leftBrace.leadingTrivia, [])
+      XCTAssertEqual(fn.body!.leftBrace.trailingTrivia, [])
 
       XCTAssertEqual(
-        fn.body!.rightBrace.leadingTriviaPieces,
+        fn.body!.rightBrace.leadingTrivia,
         [
           .newlines(1)
         ]
       )
-      XCTAssertEqual(fn.body!.rightBrace.trailingTriviaPieces, [])
+      XCTAssertEqual(fn.body!.rightBrace.trailingTrivia, [])
     }
 
   }


### PR DESCRIPTION
* **Explanation**: Make all `public` functions in SwiftParser that aren’t the parser’s entry functions either SPI or `internal`. Also make a lot of the `RawSyntax` SPI internal. Most of the public functions were never intended to be public.
* **Scope**: The entire previously public surface area of `SwiftParser` is removed
* **Risk**: Any issues will be found at compile time as there is no functionality change
* **Testing**: n/a
* **Issue**: rdar://106874944
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/1667