### PR TITLE
[5.9][Macros] Don't fold operators in unnecessary nodes

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -12,6 +12,7 @@
 
 import SwiftBasicFormat
 import SwiftDiagnostics
+import SwiftOperators
 import SwiftSyntax
 import SwiftSyntaxMacros
 
@@ -28,7 +29,7 @@ extension CompilerPluginMessageHandler {
     expandingSyntax: PluginMessage.Syntax
   ) throws {
     let sourceManager = SourceManager()
-    let syntax = sourceManager.add(expandingSyntax)
+    let syntax = sourceManager.add(expandingSyntax, foldingWith: .standardOperators)
 
     let context = PluginMacroExpansionContext(
       sourceManager: sourceManager,
@@ -97,7 +98,10 @@ extension CompilerPluginMessageHandler {
       expansionDiscriminator: discriminator
     )
 
-    let attributeNode = sourceManager.add(attributeSyntax).cast(AttributeSyntax.self)
+    let attributeNode = sourceManager.add(
+      attributeSyntax,
+      foldingWith: .standardOperators
+    ).cast(AttributeSyntax.self)
     let declarationNode = sourceManager.add(declSyntax).cast(DeclSyntax.self)
 
     let expandedSources: [String]

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -64,7 +64,10 @@ class SourceManager {
 
   /// Convert syntax information to a `Syntax` node. The location informations
   /// are cached in the source manager to provide `location(of:)` et al.
-  func add(_ syntaxInfo: PluginMessage.Syntax) -> Syntax {
+  func add(
+    _ syntaxInfo: PluginMessage.Syntax,
+    foldingWith operatorTable: OperatorTable? = nil
+  ) -> Syntax {
 
     var node: Syntax
     var parser = Parser(syntaxInfo.source)
@@ -82,7 +85,9 @@ class SourceManager {
     case .attribute:
       node = Syntax(AttributeSyntax.parse(from: &parser))
     }
-    node = OperatorTable.standardOperators.foldAll(node, errorHandler: { _ in /*ignore*/ })
+    if let operatorTable = operatorTable {
+      node = operatorTable.foldAll(node, errorHandler: { _ in /*ignore*/ })
+    }
 
     // Copy the location info from the plugin message.
     let location = KnownSourceSyntax.Location(


### PR DESCRIPTION
Cherry-pick #1657 into `release/5.9`

* **Explanation**: For attached macros, operator folding should only be done for the attribute syntax node, but not for the target declaration syntax and the parent decl syntax. This aligns with the compiler's ASTGen.
* **Scope**: Macro executable plugin
* **Risk**: Low. The change is small and straightforward, this is a new feature so nothing should depends on the old behavior
* **Testing**: Passes current test suite
* **Issue**: rdar://109494050
* **Reviwer**: Ben Barham (@bnbarham), Doug Gregor (@DougGregor)