### PR TITLE
Fix diagnostic of ternary operator missing only colon

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -317,7 +317,13 @@ extension Parser {
         arena: self.arena
       )
 
-      return (RawExprSyntax(op), nil)
+      let rhs: RawExprSyntax?
+      if colon.isMissing, currentToken.isAtStartOfLine {
+        rhs = RawExprSyntax(RawMissingExprSyntax(arena: self.arena))
+      } else {
+        rhs = nil
+      }
+      return (RawExprSyntax(op), rhs)
 
     case (.equal, let handle)?:
       switch pattern {

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -320,7 +320,8 @@ extension Parser {
       let rhs: RawExprSyntax?
       if colon.isMissing {
         if let previousTokenKind = currentToken.cursor.previousTokenKind,
-           self.at(TokenSpec(previousTokenKind)) {
+          self.at(TokenSpec(previousTokenKind))
+        {
           rhs = nil
         } else {
           rhs = RawExprSyntax(RawMissingExprSyntax(arena: self.arena))

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -318,9 +318,13 @@ extension Parser {
       )
 
       let rhs: RawExprSyntax?
-      if colon.isMissing,
-         currentToken.rawTokenKind != currentToken.cursor.previousTokenKind {
-        rhs = RawExprSyntax(RawMissingExprSyntax(arena: self.arena))
+      if colon.isMissing {
+        if let previousTokenKind = currentToken.cursor.previousTokenKind,
+           self.at(TokenSpec(previousTokenKind)) {
+          rhs = nil
+        } else {
+          rhs = RawExprSyntax(RawMissingExprSyntax(arena: self.arena))
+        }
       } else {
         rhs = nil
       }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -318,10 +318,8 @@ extension Parser {
       )
 
       let rhs: RawExprSyntax?
-      if colon.isMissing {
-        // If the colon is missing there's not much more structure we can
-        // expect out of this expression sequence. Emit a missing expression
-        // to end the parsing here.
+      if colon.isMissing,
+         currentToken.rawTokenKind != currentToken.cursor.previousTokenKind {
         rhs = RawExprSyntax(RawMissingExprSyntax(arena: self.arena))
       } else {
         rhs = nil

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -317,19 +317,7 @@ extension Parser {
         arena: self.arena
       )
 
-      let rhs: RawExprSyntax?
-      if colon.isMissing {
-        if let previousTokenKind = currentToken.cursor.previousTokenKind,
-          self.at(TokenSpec(previousTokenKind))
-        {
-          rhs = nil
-        } else {
-          rhs = RawExprSyntax(RawMissingExprSyntax(arena: self.arena))
-        }
-      } else {
-        rhs = nil
-      }
-      return (RawExprSyntax(op), rhs)
+      return (RawExprSyntax(op), nil)
 
     case (.equal, let handle)?:
       switch pattern {

--- a/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
@@ -92,4 +92,20 @@ final class InvalidIfExprTests: XCTestCase {
       fixedSource: "foo ? 1 : <#expression#>"
     )
   }
+
+  func testInvalidIfExpr7() {
+    assertParse(
+      """
+      condition ? 1 1️⃣
+      someOtherVariable
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ':' and expression after '? ...' in ternary expression", fixIts: ["insert ':' and expression"])
+      ],
+      fixedSource: """
+        condition ? 1 : <#expression#>
+        someOtherVariable
+        """
+    )
+  }
 }

--- a/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
@@ -69,4 +69,15 @@ final class InvalidIfExprTests: XCTestCase {
     )
   }
 
+  func testInvalidIfExpr5() {
+    assertParse(
+      """
+      foo ? 1 1️⃣2
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ':' after '? ...' in ternary expression", fixIts: ["insert ':'"])
+      ],
+      fixedSource: "foo ? 1 : 2"
+    )
+  }
 }

--- a/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
@@ -80,4 +80,16 @@ final class InvalidIfExprTests: XCTestCase {
       fixedSource: "foo ? 1 : 2"
     )
   }
+
+  func testInvalidIfExpr6() {
+    assertParse(
+      """
+      foo ? 1 1️⃣
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ':' and expression after '? ...' in ternary expression", fixIts: ["insert ':' and expression"])
+      ],
+      fixedSource: "foo ? 1 : <#expression#>"
+    )
+  }
 }


### PR DESCRIPTION
Resolve #1624 

Previously, in the ternary operator, the absence of a colon always resulted in parsing it as the right-hand side expression being missing.
Added logic to check if the next token is the same kind as the token before the colon when parsing a ternary operator, if there is no colon.