### PR TITLE
[Parser] Improve FixIt for function parameter with missing type (`name1 Name2`)

### DIFF
--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -312,19 +312,19 @@ final class InvalidTests: XCTestCase {
       do {
         class Starfish {}
         struct Salmon {}
-        func f(s Starfish1️⃣,
+        func f(s 1️⃣Starfish,
                   _ ss: Salmon) -> [Int] {}
         func g() { f(Starfish(), Salmon()) }
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected ':' and type in parameter", fixIts: ["insert ':' and type"])
+        DiagnosticSpec(message: "expected ':' in parameter", fixIts: ["insert ':'"])
       ],
       fixedSource: """
         do {
           class Starfish {}
           struct Salmon {}
-          func f(s Starfish: <#type#>,
+          func f(s: Starfish,
                     _ ss: Salmon) -> [Int] {}
           func g() { f(Starfish(), Salmon()) }
         }


### PR DESCRIPTION
# Goal

To solve issue https://github.com/apple/swift-syntax/issues/1608.

## Notes

There are some `TODOs` in the code I want to solve but I didn't know how. Any help is appreciated. Thank you.