### PR TITLE
Improve diagnosis of the missing expression in a for-each loop

### DIFF
--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -778,7 +778,17 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       )
     } else {  // If it's not a C-style for loop
       if node.sequenceExpr.is(MissingExprSyntax.self) {
-        addDiagnostic(node.sequenceExpr, .expectedSequenceExpressionInForEachLoop, handledNodes: [node.sequenceExpr.id])
+        addDiagnostic(
+          node.sequenceExpr,
+          .expectedSequenceExpressionInForEachLoop,
+          fixIts: [
+            FixIt(
+              message: InsertTokenFixIt(missingNodes: [Syntax(node.sequenceExpr)]),
+              changes: [.makePresent(node.sequenceExpr)]
+            )
+          ],
+          handledNodes: [node.sequenceExpr.id]
+        )
       }
     }
 

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -604,10 +604,10 @@ final class RecoveryTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "keyword 'for' cannot be used as an identifier here", fixIts: ["if this name is unavoidable, use backticks to escape it"]),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected Sequence expression for for-each loop"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected Sequence expression for for-each loop", fixIts: ["insert expression"]),
       ],
       fixedSource: """
-        for `for` in {
+        for `for` in <#expression#> {
         }
         """
     )
@@ -620,8 +620,12 @@ final class RecoveryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected Sequence expression for for-each loop")
-      ]
+        DiagnosticSpec(message: "expected Sequence expression for for-each loop", fixIts: ["insert expression"])
+      ],
+      fixedSource: """
+        for i in <#expression#> {
+        }
+        """
     )
   }
 


### PR DESCRIPTION
Resolve #1602 

The `expectedSequenceExpressionInForEachLoop` diagnostic message did not have FixIts.
I have added an appropriate FixIt and modified the related test case 🙂 