### PR TITLE
[5.9] fix wrong diagnostic for wrong pattern

### DIFF
--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -175,10 +175,12 @@ extension Parser {
       && !self.currentToken.isAtStartOfLine
       && lookahead.canParseType()
     {
-      // Recovery if the user forgot to add ':'
-      let result = self.parseResultType()
+      let (unexpectedBeforeColon, colon) = self.expect(.colon)
+      let result = self.parseType()
+
       type = RawTypeAnnotationSyntax(
-        colon: self.missingToken(.colon),
+        unexpectedBeforeColon,
+        colon: colon,
         type: result,
         arena: self.arena
       )

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -315,7 +315,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     } else if node.first?.as(TokenSyntax.self)?.tokenKind.isIdentifier == true,
       let previousToken = node.previousToken(viewMode: .sourceAccurate),
       previousToken.tokenKind.isIdentifier,
-      previousToken.parent?.is(DeclSyntax.self) == true
+      previousToken.parent?.is(DeclSyntax.self) == true || previousToken.parent?.is(IdentifierPatternSyntax.self) == true
     {
       // If multiple identifiers are used for a declaration name, offer to join them together.
       let tokens =

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -806,19 +806,39 @@ final class RecoveryTests: XCTestCase {
     assertParse(
       #"""
       struct SS 1️⃣SS : Multi {
-        private var a 2️⃣b 3️⃣: Int = ""
+        private var a 2️⃣b : Int = ""
         func f() {
-          var c 4️⃣d = 5
+          var c 3️⃣d = 5
           let _ = 0
         }
       }
       """#,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "found an unexpected second identifier in struct; is there an accidental break?", fixIts: ["join the identifiers together"]),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ':' in type annotation"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: #"unexpected code ': Int = ""' before function"#),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected ':' in type annotation"),
-      ]
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "found an unexpected second identifier in struct; is there an accidental break?",
+          fixIts: ["join the identifiers together"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "found an unexpected second identifier in pattern; is there an accidental break?",
+          fixIts: ["join the identifiers together", "join the identifiers together with camel-case"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "3️⃣",
+          message: "expected ':' in type annotation",
+          fixIts: ["insert ':'"]
+        ),
+      ],
+      fixedSource: #"""
+        struct SSSS : Multi {
+          private var ab : Int = ""
+          func f() {
+            var c: d = 5
+            let _ = 0
+          }
+        }
+        """#
     )
   }
 
@@ -846,6 +866,24 @@ final class RecoveryTests: XCTestCase {
       ],
       fixedSource: """
         let (efg: Hij, foobar) = (5, 6)
+        """
+    )
+  }
+
+  func testRecovery64c() {
+    assertParse(
+      """
+      private var a 1️⃣b : Int = ""
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "found an unexpected second identifier in pattern; is there an accidental break?",
+          fixIts: ["join the identifiers together", "join the identifiers together with camel-case"]
+        )
+      ],
+      fixedSource: """
+        private var ab : Int = ""
         """
     )
   }


### PR DESCRIPTION
* **Explanation**: If there was two identifiers with a space between, followed by a colon and a type, the parser didn't suggest a fix-it to merge them, neither did it show the correct diagnostic.
* **Scope**: Swift parser and diagnostics
* **Risk**: Low
* **Testing**: Added correct test cases
* **Issue**: N/A
* **Reviewer**: @ahoppen on https://github.com/apple/swift-syntax/pull/1580