### PR TITLE
Remove `requiresLeadingNewline` from basic format

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Child.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Child.swift
@@ -62,7 +62,6 @@ public class Child {
   public let description: String?
   public let forceClassification: Bool
   public let isIndented: Bool
-  public let requiresLeadingNewline: Bool
   public let isOptional: Bool
   public let classification: SyntaxClassification?
 
@@ -160,8 +159,7 @@ public class Child {
     isOptional: Bool = false,
     classification: String? = nil,
     forceClassification: Bool = false,
-    isIndented: Bool = false,
-    requiresLeadingNewline: Bool = false
+    isIndented: Bool = false
   ) {
     if let firstCharInName = name.first {
       precondition(firstCharInName.isUppercase == true, "The first letter of a child’s name should be uppercase")
@@ -173,7 +171,6 @@ public class Child {
     self.classification = classificationByName(classification)
     self.forceClassification = forceClassification
     self.isIndented = isIndented
-    self.requiresLeadingNewline = requiresLeadingNewline
     self.isOptional = isOptional
   }
 }

--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -76,8 +76,7 @@ public let COMMON_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")]),
-        requiresLeadingNewline: true
+        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -55,8 +55,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")]),
-        requiresLeadingNewline: true
+        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
       ),
     ]
   ),
@@ -992,8 +991,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "PoundKeyword",
         kind: .token(choices: [.token(tokenKind: "PoundIfToken"), .token(tokenKind: "PoundElseifToken"), .token(tokenKind: "PoundElseToken")]),
-        classification: "BuildConfigId",
-        requiresLeadingNewline: true
+        classification: "BuildConfigId"
       ),
       Child(
         name: "Condition",
@@ -1045,8 +1043,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "PoundEndif",
         kind: .token(choices: [.token(tokenKind: "PoundEndifToken")]),
-        classification: "BuildConfigId",
-        requiresLeadingNewline: true
+        classification: "BuildConfigId"
       ),
     ]
   ),
@@ -1355,8 +1352,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")]),
-        requiresLeadingNewline: true
+        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -473,8 +473,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")]),
-        requiresLeadingNewline: true
+        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
       ),
     ]
   ),
@@ -1643,8 +1642,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")]),
-        requiresLeadingNewline: true
+        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
       ),
     ]
   ),

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftbasicformat/BasicFormatExtensionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftbasicformat/BasicFormatExtensionsFile.swift
@@ -65,39 +65,11 @@ let basicFormatExtensionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader)
     )
   }
 
-  try! ExtensionDeclSyntax("public extension TokenSyntax") {
-    DeclSyntax(
-      """
-      var requiresLeadingNewline: Bool {
-        if let keyPath = keyPathInParent, keyPath.requiresLeadingNewline {
-          return true
-        }
-        return false
-      }
-      """
-    )
-  }
-
   try! ExtensionDeclSyntax("fileprivate extension AnyKeyPath") {
     try VariableDeclSyntax("var requiresIndent: Bool") {
       try SwitchExprSyntax("switch self") {
         for node in SYNTAX_NODES.compactMap(\.layoutNode) {
           for child in node.children where child.isIndented {
-            SwitchCaseSyntax("case \\\(raw: node.type.syntaxBaseName).\(raw: child.varName):") {
-              StmtSyntax("return true")
-            }
-          }
-        }
-        SwitchCaseSyntax("default:") {
-          StmtSyntax("return false")
-        }
-      }
-    }
-
-    try VariableDeclSyntax("var requiresLeadingNewline: Bool") {
-      try SwitchExprSyntax("switch self") {
-        for node in SYNTAX_NODES.compactMap(\.layoutNode) {
-          for child in node.children where child.requiresLeadingNewline {
             SwitchCaseSyntax("case \\\(raw: node.type.syntaxBaseName).\(raw: child.varName):") {
               StmtSyntax("return true")
             }

--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -155,10 +155,6 @@ open class BasicFormat: SyntaxRewriter {
     {
       return false
     } else if let second {
-      if second.requiresLeadingNewline {
-        return true
-      }
-
       var ancestor: Syntax = Syntax(second)
       while let parent = ancestor.parent {
         ancestor = parent
@@ -178,11 +174,16 @@ open class BasicFormat: SyntaxRewriter {
     }
 
     switch (first?.tokenKind, second?.tokenKind) {
+
     case (.multilineStringQuote, .backslash),  // string interpolation segment inside a multi-line string literal
       (.multilineStringQuote, .multilineStringQuote),  // empty multi-line string literal
       (.multilineStringQuote, .stringSegment),  // segment starting a multi-line string literal
       (.stringSegment, .multilineStringQuote),  // ending a multi-line string literal that has a string interpolation segment at its end
-      (.rightParen, .multilineStringQuote):  // ending a multi-line string literal that has a string interpolation segment at its end
+      (.rightParen, .multilineStringQuote),  // ending a multi-line string literal that has a string interpolation segment at its end
+      (_, .poundElseKeyword),
+      (_, .poundElseifKeyword),
+      (_, .poundEndifKeyword),
+      (_, .rightBrace):
       return true
     default:
       return false

--- a/Sources/SwiftBasicFormat/generated/BasicFormat+Extensions.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat+Extensions.swift
@@ -23,15 +23,6 @@ public extension SyntaxProtocol {
   }
 }
 
-public extension TokenSyntax {
-  var requiresLeadingNewline: Bool {
-    if let keyPath = keyPathInParent, keyPath.requiresLeadingNewline {
-      return true
-    }
-    return false
-  }
-}
-
 fileprivate extension AnyKeyPath {
   var requiresIndent: Bool {
     switch self {
@@ -64,27 +55,6 @@ fileprivate extension AnyKeyPath {
     case \TupleExprSyntax.elementList:
       return true
     case \TupleTypeSyntax.elements:
-      return true
-    default:
-      return false
-    }
-  }
-  
-  var requiresLeadingNewline: Bool {
-    switch self {
-    case \AccessorBlockSyntax.rightBrace:
-      return true
-    case \ClosureExprSyntax.rightBrace:
-      return true
-    case \CodeBlockSyntax.rightBrace:
-      return true
-    case \IfConfigClauseSyntax.poundKeyword:
-      return true
-    case \IfConfigDeclSyntax.poundEndif:
-      return true
-    case \MemberDeclBlockSyntax.rightBrace:
-      return true
-    case \SwitchExprSyntax.rightBrace:
       return true
     default:
       return false

--- a/Tests/SwiftSyntaxBuilderTest/IfConfigDeclSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IfConfigDeclSyntaxTests.swift
@@ -34,7 +34,22 @@ final class IfConfigDeclSyntaxTests: XCTestCase {
           )
         )
         IfConfigClauseSyntax(
-          poundKeyword: .poundElseKeyword(leadingTrivia: .newline),
+          poundKeyword: .poundElseifKeyword(),
+          condition: ExprSyntax("TEST"),
+          elements: .statements(
+            CodeBlockItemListSyntax {
+              DeclSyntax(
+                """
+                public func debug(_ data: Foo) -> String {
+                  return data.description
+                }
+                """
+              )
+            }
+          )
+        )
+        IfConfigClauseSyntax(
+          poundKeyword: .poundElseKeyword(),
           elements: .statements(
             CodeBlockItemListSyntax {
               DeclSyntax(
@@ -48,7 +63,7 @@ final class IfConfigDeclSyntaxTests: XCTestCase {
           )
         )
       },
-      poundEndif: .poundEndifKeyword(leadingTrivia: .newline)
+      poundEndif: .poundEndifKeyword()
     )
 
     assertBuildResult(
@@ -57,6 +72,10 @@ final class IfConfigDeclSyntaxTests: XCTestCase {
       #if DEBUG
       public func debug(_ data: Foo) -> String {
         return data.debugDescription
+      }
+      #elseif TEST
+      public func debug(_ data: Foo) -> String {
+        return data.description
       }
       #else
       public func debug(_ data: Foo) -> String {

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralExprSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralExprSyntaxTests.swift
@@ -168,9 +168,9 @@ final class StringLiteralExprSyntaxTests: XCTestCase {
     // Tab should not be escaped in single-line string literals
     assertBuildResult(
       StringLiteralExprSyntax(
-        openQuote: .multilineStringQuoteToken(trailingTrivia: .newline),
+        openQuote: .multilineStringQuoteToken(),
         content: "a\tb",
-        closeQuote: .multilineStringQuoteToken(leadingTrivia: .newline)
+        closeQuote: .multilineStringQuoteToken()
       ),
       #"""
       """
@@ -225,7 +225,7 @@ final class StringLiteralExprSyntaxTests: XCTestCase {
 
   func testMultiLineStringWithResultBuilder() {
     let buildable = StringLiteralExprSyntax(
-      openQuote: .multilineStringQuoteToken(trailingTrivia: .newline),
+      openQuote: .multilineStringQuoteToken(),
       segments: StringLiteralSegmentsSyntax {
         StringSegmentSyntax(content: .stringSegment(#"Error validating child at index \(index) of \(nodeKind):"#), trailingTrivia: .newline)
         StringSegmentSyntax(content: .stringSegment(#"Node did not satisfy any node choice requirement."#), trailingTrivia: .newline)
@@ -236,7 +236,7 @@ final class StringLiteralExprSyntaxTests: XCTestCase {
           }
         )
       },
-      closeQuote: .multilineStringQuoteToken(leadingTrivia: .newline)
+      closeQuote: .multilineStringQuoteToken()
     )
 
     assertBuildResult(


### PR DESCRIPTION
As part of this comment I started by removing the first part

https://github.com/apple/swift-syntax/pull/1623#discussion_r1196921113