### PR TITLE
Balance spacing around `=`

### DIFF
--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -169,8 +169,9 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       changes.append(
         FixIt.MultiNodeChange.makePresent(
           correctToken,
-          leadingTrivia: misplacedToken.leadingTrivia,
-          trailingTrivia: misplacedToken.trailingTrivia
+          // Transfer any existing trivia. If there is no trivia in the misplaced token, pass `nil` so that `makePresent` can add required trivia, if necessary.
+          leadingTrivia: misplacedToken.leadingTrivia.isEmpty ? nil : misplacedToken.leadingTrivia,
+          trailingTrivia: misplacedToken.trailingTrivia.isEmpty ? nil : misplacedToken.trailingTrivia
         )
       )
     } else {
@@ -978,7 +979,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
         fixIts: [
           FixIt(
             message: ReplaceTokensFixIt(replaceTokens: [.binaryOperator("==")], replacements: [node.equal]),
-            changes: [.makeMissing(unexpected), .makePresent(node.equal, leadingTrivia: [])]
+            changes: [.makeMissing(unexpected), .makePresent(node.equal)]
           )
         ],
         handledNodes: [unexpected.id, node.equal.id]
@@ -1333,7 +1334,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
         node.statements,
         .allStatmentsInSwitchMustBeCoveredByCase,
         fixIts: [
-          FixIt(message: InsertTokenFixIt(missingNodes: [Syntax(node.label)]), changes: .makePresent(node.label, leadingTrivia: .newline))
+          FixIt(message: InsertTokenFixIt(missingNodes: [Syntax(node.label)]), changes: .makePresent(node.label))
         ],
         handledNodes: [node.label.id]
       )

--- a/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
@@ -24,7 +24,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
-      fixedSource: "let a=[X]()"
+      fixedSource: "let a = [X]()"
     )
   }
 
@@ -36,7 +36,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
-      fixedSource: "let b= [X]()"
+      fixedSource: "let b = [X]()"
     )
   }
 
@@ -48,7 +48,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
-      fixedSource: "let c =[X]()"
+      fixedSource: "let c = [X]()"
     )
   }
 
@@ -72,7 +72,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
-      fixedSource: "let e= X(), ee: Int"
+      fixedSource: "let e = X(), ee: Int"
     )
   }
 
@@ -84,7 +84,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
-      fixedSource: "let f=/*comment*/[X]()"
+      fixedSource: "let f =/*comment*/[X]()"
     )
   }
 
@@ -96,7 +96,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
-      fixedSource: "let f/*comment*/=[X]()"
+      fixedSource: "let f/*comment*/ = [X]()"
     )
   }
 
@@ -129,7 +129,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
       fixedSource: """
-        let g= X(x)
+        let g = X(x)
         """
     )
   }
@@ -143,7 +143,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
       fixedSource: """
-        let h= X(x, y)
+        let h = X(x, y)
         """
     )
   }
@@ -157,7 +157,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
       fixedSource: """
-        let i= X() { foo() }
+        let i = X() { foo() }
         """
     )
   }
@@ -171,7 +171,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
       fixedSource: """
-        let j= X(x) { foo() }
+        let j = X(x) { foo() }
         """
     )
   }
@@ -185,7 +185,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
         DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' with '='"])
       ],
       fixedSource: """
-        let k= X(x, y) { foo() }
+        let k = X(x, y) { foo() }
         """
     )
   }
@@ -202,7 +202,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       ],
       fixedSource: """
         func nonTopLevel() {
-          let a=[X]()
+          let a = [X]()
         }
         """
     )
@@ -220,7 +220,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       ],
       fixedSource: """
         func nonTopLevel() {
-          let i= X() { foo() }
+          let i = X() { foo() }
         }
         """
     )
@@ -238,7 +238,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       ],
       fixedSource: """
         func nonTopLevel() {
-          let j= X(x) { foo() }
+          let j = X(x) { foo() }
         }
         """
     )
@@ -256,7 +256,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       ],
       fixedSource: """
         func nonTopLevel() {
-          let k= X(x, y) { foo() }
+          let k = X(x, y) { foo() }
         }
         """
     )

--- a/Tests/SwiftParserTest/translated/TypealiasTests.swift
+++ b/Tests/SwiftParserTest/translated/TypealiasTests.swift
@@ -68,7 +68,7 @@ final class TypealiasTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "expected '=' in typealias declaration", fixIts: ["replace ':' with '='"])
       ],
-      fixedSource: "typealias Foo2= Int"
+      fixedSource: "typealias Foo2 = Int"
     )
   }
 
@@ -80,7 +80,7 @@ final class TypealiasTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "expected '=' in typealias declaration", fixIts: ["replace ':' with '='"])
       ],
-      fixedSource: "typealias Foo3 =Int"
+      fixedSource: "typealias Foo3 = Int"
     )
   }
 
@@ -92,7 +92,7 @@ final class TypealiasTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "expected '=' in typealias declaration", fixIts: ["replace ':' with '='"])
       ],
-      fixedSource: "typealias Foo4=/*comment*/Int"
+      fixedSource: "typealias Foo4 =/*comment*/Int"
     )
   }
 
@@ -120,7 +120,7 @@ final class TypealiasTests: XCTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in typealias declaration", fixIts: ["insert type"]),
       ],
       fixedSource: """
-        typealias Recovery2 =<#type#>
+        typealias Recovery2 = <#type#>
         """
     )
   }


### PR DESCRIPTION
When the leading or trailing trivia was empty it was replacing the present nodes trivias