### PR TITLE
Avoid creating \dev\null file when building on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,7 @@ execute_process(
     "${CMAKE_Swift_COMPILER}"
     -Xfrontend -disable-implicit-string-processing-module-import
     -Xfrontend -parse-stdlib
-    -c - -typecheck
-  INPUT_FILE
-    "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift"
+    -typecheck
   OUTPUT_QUIET ERROR_QUIET
   RESULT_VARIABLE
     SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ execute_process(
     "${CMAKE_Swift_COMPILER}"
     -Xfrontend -disable-implicit-string-processing-module-import
     -Xfrontend -parse-stdlib
-    -typecheck
+    -typecheck "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift"
   OUTPUT_QUIET ERROR_QUIET
   RESULT_VARIABLE
     SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ execute_process(
     "${CMAKE_Swift_COMPILER}"
     -Xfrontend -disable-implicit-string-processing-module-import
     -Xfrontend -parse-stdlib
-    -c - -o /dev/null
+    -c
   INPUT_FILE
     "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift"
   OUTPUT_QUIET ERROR_QUIET

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ execute_process(
     "${CMAKE_Swift_COMPILER}"
     -Xfrontend -disable-implicit-string-processing-module-import
     -Xfrontend -parse-stdlib
-    -c
+    -c - -o "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.o"
   INPUT_FILE
     "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift"
   OUTPUT_QUIET ERROR_QUIET

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ execute_process(
     "${CMAKE_Swift_COMPILER}"
     -Xfrontend -disable-implicit-string-processing-module-import
     -Xfrontend -parse-stdlib
-    -c - -o "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.o"
+    -c - -typecheck
   INPUT_FILE
     "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift"
   OUTPUT_QUIET ERROR_QUIET


### PR DESCRIPTION
`/dev/null` has no special meaning on Windows and writing to it will create and write to a file under that path in the working directory's drive. After a swift toolchain build, `s:\dev\null` is created. Pass in a real file path instead.