### PR TITLE
[5.9][CMake] Use WMO for release builds

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -56,6 +56,13 @@ function(add_swift_host_library name)
       -emit-module-interface-path;${module_interface_file}
       >)
 
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(${name} PRIVATE
+        $<$<COMPILE_LANGUAGE:Swift>:
+        -wmo
+        >)
+  endif()
+
   # NOTE: workaround for CMake not setting up include flags yet
   set_target_properties(${name} PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${module_dir}


### PR DESCRIPTION
* Explanation: CMake builds were not using WMO for release (this is fixed in 3.26+). This has a significant impact on parsing times (5x).
* Scope: swift-syntax libraries included in the compiler
* Risk: Very low. Just enables WMO for release builds.
* Original PR: https://github.com/apple/swift-syntax/pull/1692