### PR TITLE
build: add an option to control WMO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${SWIFT_HOST_LIBRARI
 
 set(CMAKE_MACOSX_RPATH YES)
 
+option(SWIFT_SYNTAX_ENABLE_WMO_PRE_3_26
+       "Enable Whole Module Optimization (WMO) - requires swift-driver"
+       $<IF:$<AND:$<NOT:$<CONFIG:Debug>>,$<PLATFORM_ID:Darwin>>,YES,NO>)
+
 include(AddSwiftHostLibrary)
 
 # Ensure that we do not link the _StringProcessing module. But we can

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -56,11 +56,9 @@ function(add_swift_host_library name)
       -emit-module-interface-path;${module_interface_file}
       >)
 
-  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  if(CMAKE_VERSION VERSION_LESS 3.26.0 AND SWIFT_SYNTAX_ENABLE_WMO_PRE_3_26)
     target_compile_options(${name} PRIVATE
-        $<$<COMPILE_LANGUAGE:Swift>:
-        -wmo
-        >)
+        $<$<COMPILE_LANGUAGE:Swift>:-wmo>)
   endif()
 
   # NOTE: workaround for CMake not setting up include flags yet


### PR DESCRIPTION
WMO requires the new swift-driver which requires an early swift-driver or a host toolchain that has Swift.  Since the only platform that guarantees this currently is Darwin, use a conditional value for the option, defaulting to `NO` for most other targets.  This should repair the build on Windows.