### PR TITLE
Add a new test mutation strategy to flip the presence of token in the `assertParse` tests (fixes 5 parser bugs)

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -549,11 +549,33 @@ public let DECL_NODES: [Node] = [
     kind: .editorPlaceholderDecl,
     base: .decl,
     nameForDiagnostics: "editor placeholder",
+    documentation: """
+      An editor placeholder, e.g. `<#declaration#>` that is used in a position that expects a declaration.
+      """,
+    traits: [
+      "WithAttributes",
+      "WithModifiers",
+    ],
     children: [
       Child(
-        name: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
-      )
+        name: "Attributes",
+        kind: .collection(kind: .attributeList, collectionElementName: "Attribute"),
+        description: "If there were attributes before the editor placeholder, the ``EditorPlaceholderDecl`` will contain these.",
+        isOptional: true
+      ),
+      Child(
+        name: "Modifiers",
+        kind: .collection(kind: .modifierList, collectionElementName: "Modifier"),
+        description: "If there were modifiers before the editor placeholder, the `EditorPlaceholderDecl` will contain these.",
+        isOptional: true
+      ),
+      Child(
+        name: "Placeholder",
+        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        description: """
+          The actual editor placeholder that starts with `<#` and ends with `#>`.
+          """
+      ),
     ]
   ),
 

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -560,19 +560,19 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Attributes",
         kind: .collection(kind: .attributeList, collectionElementName: "Attribute"),
-        description: "If there were attributes before the editor placeholder, the ``EditorPlaceholderDecl`` will contain these.",
+        documentation: "If there were attributes before the editor placeholder, the ``EditorPlaceholderDecl`` will contain these.",
         isOptional: true
       ),
       Child(
         name: "Modifiers",
         kind: .collection(kind: .modifierList, collectionElementName: "Modifier"),
-        description: "If there were modifiers before the editor placeholder, the `EditorPlaceholderDecl` will contain these.",
+        documentation: "If there were modifiers before the editor placeholder, the `EditorPlaceholderDecl` will contain these.",
         isOptional: true
       ),
       Child(
         name: "Placeholder",
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
-        description: """
+        documentation: """
           The actual editor placeholder that starts with `<#` and ends with `#>`.
           """
       ),

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -286,7 +286,9 @@ extension Parser {
           let placeholder = self.consumeAnyToken()
           return RawDeclSyntax(
             RawEditorPlaceholderDeclSyntax(
-              identifier: placeholder,
+              attributes: attrs.attributes,
+              modifiers: attrs.modifiers,
+              placeholder: placeholder,
               arena: self.arena
             )
           )
@@ -474,8 +476,12 @@ extension Parser {
       )
     }
 
-    precondition(self.currentToken.starts(with: "<"))
-    let langle = self.consumePrefix("<", as: .leftAngle)
+    let langle: RawTokenSyntax
+    if self.currentToken.starts(with: "<") {
+      langle = self.consumePrefix("<", as: .leftAngle)
+    } else {
+      langle = missingToken(.leftAngle)
+    }
     var elements = [RawGenericParameterSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -333,7 +333,7 @@ extension Parser {
   }
 
   mutating func parsePrimaryAssociatedTypes() -> RawPrimaryAssociatedTypeClauseSyntax {
-    let langle = self.consumeAnyToken(remapping: .leftAngle)
+    let langle = self.consumePrefix("<", as: .leftAngle)
     var associatedTypes = [RawPrimaryAssociatedTypeSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -546,7 +546,7 @@ extension Parser {
               inOut: nil,
               name: nil,
               secondName: nil,
-              unexpectedBeforeColon,
+              RawUnexpectedNodesSyntax(combining: misplacedSpecifiers, unexpectedBeforeColon, arena: self.arena),
               colon: nil,
               type: RawTypeSyntax(RawSimpleTypeIdentifierSyntax(name: first, genericArgumentClause: nil, arena: self.arena)),
               ellipsis: nil,

--- a/Sources/SwiftParserDiagnostics/MissingTokenError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingTokenError.swift
@@ -17,6 +17,7 @@ import SwiftDiagnostics
 extension ParseDiagnosticsGenerator {
   func handleMissingToken(_ missingToken: TokenSyntax) {
     guard let invalidToken = missingToken.previousToken(viewMode: .all),
+      invalidToken.presence == .present,
       let invalidTokenContainer = invalidToken.parent?.as(UnexpectedNodesSyntax.self),
       invalidTokenContainer.count == 1
     else {

--- a/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
@@ -14,26 +14,30 @@
 @_spi(Diagnostics) import SwiftParser
 
 extension UnexpectedNodesSyntax {
-  func tokens(satisfying isIncluded: (TokenSyntax) -> Bool) -> [TokenSyntax] {
+  func presentTokens(satisfying isIncluded: (TokenSyntax) -> Bool) -> [TokenSyntax] {
     return self.children(viewMode: .sourceAccurate).compactMap({ $0.as(TokenSyntax.self) }).filter(isIncluded)
   }
 
-  func tokens(withKind kind: TokenKind) -> [TokenSyntax] {
-    return self.tokens(satisfying: { $0.tokenKind == kind })
+  func presentTokens(withKind kind: TokenKind) -> [TokenSyntax] {
+    return self.presentTokens(satisfying: { $0.tokenKind == kind })
   }
 
-  /// If this only contains a single item, which is a token satisfying `condition`, return that token, otherwise return `nil`.
-  func onlyToken(where condition: (TokenSyntax) -> Bool) -> TokenSyntax? {
-    if self.count == 1, let token = self.first?.as(TokenSyntax.self), condition(token) {
+  /// If this only contains a single item, which is a present token satisfying `condition`, return that token, otherwise return `nil`.
+  func onlyPresentToken(where condition: (TokenSyntax) -> Bool) -> TokenSyntax? {
+    if self.count == 1,
+      let token = self.first?.as(TokenSyntax.self),
+      condition(token),
+      token.presence == .present
+    {
       return token
     } else {
       return nil
     }
   }
 
-  /// If this only contains tokens satisfying `condition`, return an array containing those tokens, otherwise return `nil`.
-  func onlyTokens(satisfying condition: (TokenSyntax) -> Bool) -> [TokenSyntax]? {
-    let tokens = tokens(satisfying: condition)
+  /// If this only contains present tokens satisfying `condition`, return an array containing those tokens, otherwise return `nil`.
+  func onlyPresentTokens(satisfying condition: (TokenSyntax) -> Bool) -> [TokenSyntax]? {
+    let tokens = presentTokens(satisfying: condition)
     if tokens.count == self.count {
       return tokens
     } else {
@@ -41,9 +45,9 @@ extension UnexpectedNodesSyntax {
     }
   }
 
-  /// If this only contains two tokens, the first satisfying `firstCondition`, and the second satisfying `secondCondition`,
+  /// If this only contains two present tokens, the first satisfying `firstCondition`, and the second satisfying `secondCondition`,
   /// return these tokens as a tuple, otherwise return `nil`.
-  func twoTokens(
+  func twoPresentTokens(
     firstSatisfying firstCondition: (TokenSyntax) -> Bool,
     secondSatisfying secondCondition: (TokenSyntax) -> Bool
   ) -> (first: TokenSyntax, second: TokenSyntax)? {
@@ -95,7 +99,7 @@ extension SyntaxProtocol {
       } else {
         return "braces"
       }
-    } else if let token = Syntax(self).as(UnexpectedNodesSyntax.self)?.onlyTokens(satisfying: { $0.tokenKind.isLexerClassifiedKeyword })?.only {
+    } else if let token = Syntax(self).as(UnexpectedNodesSyntax.self)?.onlyPresentTokens(satisfying: { $0.tokenKind.isLexerClassifiedKeyword })?.only {
       return "'\(token.text)' keyword"
     } else if let token = Syntax(self).as(TokenSyntax.self) {
       return "'\(token.text)' keyword"

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -95,7 +95,7 @@ public struct RawSyntaxTokenView {
   public var leadingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
-      let arena = raw.arena as! ParsingSyntaxArena
+      let arena = raw.arena.parsingArena!
       return arena.parseTrivia(source: dat.leadingTriviaText, position: .leading)
     case .materializedToken(let dat):
       return Array(dat.leadingTrivia)
@@ -108,7 +108,7 @@ public struct RawSyntaxTokenView {
   public var trailingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
-      let arena = raw.arena as! ParsingSyntaxArena
+      let arena = raw.arena.parsingArena!
       return arena.parseTrivia(source: dat.trailingTriviaText, position: .trailing)
     case .materializedToken(let dat):
       return Array(dat.trailingTrivia)

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -152,3 +152,23 @@ extension TupleExprSyntax {
     )
   }
 }
+
+public extension EditorPlaceholderDeclSyntax {
+  @available(*, deprecated, renamed: "placeholder")
+  var identifier: TokenSyntax { placeholder }
+
+  @available(*, deprecated, renamed: "placeholder")
+  init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeIdentifier,
+      placeholder: identifier,
+      unexpectedAfterIdentifier
+    )
+  }
+}

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -1099,12 +1099,20 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "declname"
   case \DynamicReplacementArgumentsSyntax.unexpectedAfterDeclname:
     return "unexpectedAfterDeclname"
-  case \EditorPlaceholderDeclSyntax.unexpectedBeforeIdentifier:
-    return "unexpectedBeforeIdentifier"
-  case \EditorPlaceholderDeclSyntax.identifier:
-    return "identifier"
-  case \EditorPlaceholderDeclSyntax.unexpectedAfterIdentifier:
-    return "unexpectedAfterIdentifier"
+  case \EditorPlaceholderDeclSyntax.unexpectedBeforeAttributes:
+    return "unexpectedBeforeAttributes"
+  case \EditorPlaceholderDeclSyntax.attributes:
+    return "attributes"
+  case \EditorPlaceholderDeclSyntax.unexpectedBetweenAttributesAndModifiers:
+    return "unexpectedBetweenAttributesAndModifiers"
+  case \EditorPlaceholderDeclSyntax.modifiers:
+    return "modifiers"
+  case \EditorPlaceholderDeclSyntax.unexpectedBetweenModifiersAndPlaceholder:
+    return "unexpectedBetweenModifiersAndPlaceholder"
+  case \EditorPlaceholderDeclSyntax.placeholder:
+    return "placeholder"
+  case \EditorPlaceholderDeclSyntax.unexpectedAfterPlaceholder:
+    return "unexpectedAfterPlaceholder"
   case \EditorPlaceholderExprSyntax.unexpectedBeforeIdentifier:
     return "unexpectedBeforeIdentifier"
   case \EditorPlaceholderExprSyntax.identifier:

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -539,6 +539,8 @@ extension DoStmtSyntax: WithCodeBlockSyntax {}
 
 extension DocumentationAttributeArgumentSyntax: WithTrailingCommaSyntax {}
 
+extension EditorPlaceholderDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
+
 extension EnumCaseDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension EnumCaseElementSyntax: WithTrailingCommaSyntax {}

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -7666,31 +7666,55 @@ public struct RawEditorPlaceholderDeclSyntax: RawDeclSyntaxNodeProtocol {
   }
   
   public init(
-      _ unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? = nil, 
-      identifier: RawTokenSyntax, 
-      _ unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? = nil, 
+      attributes: RawAttributeListSyntax?, 
+      _ unexpectedBetweenAttributesAndModifiers: RawUnexpectedNodesSyntax? = nil, 
+      modifiers: RawModifierListSyntax?, 
+      _ unexpectedBetweenModifiersAndPlaceholder: RawUnexpectedNodesSyntax? = nil, 
+      placeholder: RawTokenSyntax, 
+      _ unexpectedAfterPlaceholder: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .editorPlaceholderDecl, uninitializedCount: 3, arena: arena) { layout in
+      kind: .editorPlaceholderDecl, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeIdentifier?.raw
-      layout[1] = identifier.raw
-      layout[2] = unexpectedAfterIdentifier?.raw
+      layout[0] = unexpectedBeforeAttributes?.raw
+      layout[1] = attributes?.raw
+      layout[2] = unexpectedBetweenAttributesAndModifiers?.raw
+      layout[3] = modifiers?.raw
+      layout[4] = unexpectedBetweenModifiersAndPlaceholder?.raw
+      layout[5] = placeholder.raw
+      layout[6] = unexpectedAfterPlaceholder?.raw
     }
     self.init(unchecked: raw)
   }
   
-  public var unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? {
+  public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
     layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var identifier: RawTokenSyntax {
-    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  public var attributes: RawAttributeListSyntax? {
+    layoutView.children[1].map(RawAttributeListSyntax.init(raw:))
   }
   
-  public var unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenAttributesAndModifiers: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var modifiers: RawModifierListSyntax? {
+    layoutView.children[3].map(RawModifierListSyntax.init(raw:))
+  }
+  
+  public var unexpectedBetweenModifiersAndPlaceholder: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var placeholder: RawTokenSyntax {
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  
+  public var unexpectedAfterPlaceholder: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1050,10 +1050,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 5, verify(layout[5], as: RawDeclNameSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .editorPlaceholderDecl:
-    assert(layout.count == 3)
+    assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
+    assertNoError(kind, 1, verify(layout[1], as: RawAttributeListSyntax?.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawModifierListSyntax?.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
+    assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .editorPlaceholderExpr:
     assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -1429,7 +1429,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - EditorPlaceholderDeclSyntax
 
-
+/// An editor placeholder, e.g. `<#declaration#>` that is used in a position that expects a declaration.
 public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1450,16 +1450,36 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   public init(
       leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
-      identifier: TokenSyntax,
-      _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
+      attributes: AttributeListSyntax? = nil,
+      _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
+      modifiers: ModifierListSyntax? = nil,
+      _ unexpectedBetweenModifiersAndPlaceholder: UnexpectedNodesSyntax? = nil,
+      placeholder: TokenSyntax,
+      _ unexpectedAfterPlaceholder: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedAfterIdentifier))) {(arena, _) in
-      let layout: [RawSyntax?] = [unexpectedBeforeIdentifier?.raw, identifier.raw, unexpectedAfterIdentifier?.raw]
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
+            unexpectedBeforeAttributes, 
+            attributes, 
+            unexpectedBetweenAttributesAndModifiers, 
+            modifiers, 
+            unexpectedBetweenModifiersAndPlaceholder, 
+            placeholder, 
+            unexpectedAfterPlaceholder
+          ))) {(arena, _) in
+      let layout: [RawSyntax?] = [
+          unexpectedBeforeAttributes?.raw, 
+          attributes?.raw, 
+          unexpectedBetweenAttributesAndModifiers?.raw, 
+          modifiers?.raw, 
+          unexpectedBetweenModifiersAndPlaceholder?.raw, 
+          placeholder.raw, 
+          unexpectedAfterPlaceholder?.raw
+        ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.editorPlaceholderDecl,
         from: layout,
@@ -1473,7 +1493,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self.init(data)
   }
   
-  public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
+  public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -1482,16 +1502,36 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var identifier: TokenSyntax {
+  /// If there were attributes before the editor placeholder, the ``EditorPlaceholderDecl`` will contain these.
+  public var attributes: AttributeListSyntax? {
     get {
-      return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
+      return data.child(at: 1, parent: Syntax(self)).map(AttributeListSyntax.init)
     }
     set(value) {
-      self = EditorPlaceholderDeclSyntax(data.replacingChild(at: 1, with: value.raw, arena: SyntaxArena()))
+      self = EditorPlaceholderDeclSyntax(data.replacingChild(at: 1, with: value?.raw, arena: SyntaxArena()))
     }
   }
   
-  public var unexpectedAfterIdentifier: UnexpectedNodesSyntax? {
+  /// Adds the provided `Attribute` to the node's `attributes`
+  /// collection.
+  /// - param element: The new `Attribute` to add to the node's
+  ///                  `attributes` collection.
+  /// - returns: A copy of the receiver with the provided `Attribute`
+  ///            appended to its `attributes` collection.
+  public func addAttribute(_ element: Syntax) -> EditorPlaceholderDeclSyntax {
+    var collection: RawSyntax
+    let arena = SyntaxArena()
+    if let col = raw.layoutView!.children[1] {
+      collection = col.layoutView!.appending(element.raw, arena: arena)
+    } else {
+      collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
+                                        from: [element.raw], arena: arena)
+    }
+    let newData = data.replacingChild(at: 1, with: collection, arena: arena)
+    return EditorPlaceholderDeclSyntax(newData)
+  }
+  
+  public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -1500,8 +1540,73 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// If there were modifiers before the editor placeholder, the `EditorPlaceholderDecl` will contain these.
+  public var modifiers: ModifierListSyntax? {
+    get {
+      return data.child(at: 3, parent: Syntax(self)).map(ModifierListSyntax.init)
+    }
+    set(value) {
+      self = EditorPlaceholderDeclSyntax(data.replacingChild(at: 3, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  /// Adds the provided `Modifier` to the node's `modifiers`
+  /// collection.
+  /// - param element: The new `Modifier` to add to the node's
+  ///                  `modifiers` collection.
+  /// - returns: A copy of the receiver with the provided `Modifier`
+  ///            appended to its `modifiers` collection.
+  public func addModifier(_ element: DeclModifierSyntax) -> EditorPlaceholderDeclSyntax {
+    var collection: RawSyntax
+    let arena = SyntaxArena()
+    if let col = raw.layoutView!.children[3] {
+      collection = col.layoutView!.appending(element.raw, arena: arena)
+    } else {
+      collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
+                                        from: [element.raw], arena: arena)
+    }
+    let newData = data.replacingChild(at: 3, with: collection, arena: arena)
+    return EditorPlaceholderDeclSyntax(newData)
+  }
+  
+  public var unexpectedBetweenModifiersAndPlaceholder: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = EditorPlaceholderDeclSyntax(data.replacingChild(at: 4, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  /// The actual editor placeholder that starts with `<#` and ends with `#>`.
+  public var placeholder: TokenSyntax {
+    get {
+      return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)
+    }
+    set(value) {
+      self = EditorPlaceholderDeclSyntax(data.replacingChild(at: 5, with: value.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedAfterPlaceholder: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 6, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = EditorPlaceholderDeclSyntax(data.replacingChild(at: 6, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
   public static var structure: SyntaxNodeStructure {
-    return .layout([\Self.unexpectedBeforeIdentifier, \Self.identifier, \Self.unexpectedAfterIdentifier])
+    return .layout([
+          \Self.unexpectedBeforeAttributes, 
+          \Self.attributes, 
+          \Self.unexpectedBetweenAttributesAndModifiers, 
+          \Self.modifiers, 
+          \Self.unexpectedBetweenModifiersAndPlaceholder, 
+          \Self.placeholder, 
+          \Self.unexpectedAfterPlaceholder
+        ])
   }
 }
 

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -702,6 +702,7 @@ func assertParse<S: SyntaxProtocol>(
   if enableLongTests {
     DispatchQueue.concurrentPerform(iterations: Array(tree.tokens(viewMode: .all)).count) { tokenIndex in
       let flippedTokenTree = TokenPresenceFlipper(flipTokenAtIndex: tokenIndex).rewrite(Syntax(tree))
+      _ = ParseDiagnosticsGenerator.diagnostics(for: flippedTokenTree)
       assertRoundTrip(source: flippedTokenTree.syntaxTextBytes, parse, file: file, line: line)
     }
 

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -477,6 +477,32 @@ class MutatedTreePrinter: SyntaxVisitor {
   }
 }
 
+/// Flip the presence of the `flipTokenAtIndex`-th token in a tree, i.e. making
+/// it present if it is missing or missing if it is present. All other nodes are
+/// not modified.
+class TokenPresenceFlipper: SyntaxRewriter {
+  var visitedTokens = 0
+  let flipTokenAtIndex: Int
+
+  init(flipTokenAtIndex: Int) {
+    self.flipTokenAtIndex = flipTokenAtIndex
+  }
+
+  override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    defer { visitedTokens += 1 }
+    if visitedTokens == flipTokenAtIndex {
+      switch token.presence {
+      case .present:
+        return token.with(\.presence, .missing)
+      case .missing:
+        return token.with(\.presence, .present)
+      }
+    }
+
+    return token
+  }
+}
+
 public struct AssertParseOptions: OptionSet {
   public var rawValue: UInt8
 
@@ -520,6 +546,38 @@ func assertParse(
   )
 }
 
+/// After a test case has been mutated, assert that the mutated source
+/// round-trips and doesn’t hit any assertion failures in the parser.
+fileprivate func assertRoundTrip<S: SyntaxProtocol>(
+  source: [UInt8],
+  _ parse: (inout Parser) -> S,
+  file: StaticString,
+  line: UInt
+) {
+  source.withUnsafeBufferPointer { buf in
+    let mutatedSource = String(decoding: buf, as: UTF8.self)
+    // Check that we don't hit any assertions in the parser while parsing
+    // the mutated source and that it round-trips
+    var mutatedParser = Parser(buf)
+    let mutatedTree = parse(&mutatedParser)
+    assertStringsEqualWithDiff(
+      "\(mutatedTree)",
+      mutatedSource,
+      additionalInfo: """
+        Mutated source failed to round-trip.
+
+        Mutated source:
+        \(mutatedSource)
+
+        Actual syntax tree:
+        \(mutatedTree.debugDescription)
+        """,
+      file: file,
+      line: line
+    )
+  }
+}
+
 /// Removes any test markers from `markedSource` (1) and parses the result
 /// using `parse`. By default it only checks if the parsed syntax tree is
 /// printable back to the origin source, ie. it round trips.
@@ -554,11 +612,11 @@ func assertParse<S: SyntaxProtocol>(
   var (markerLocations, source) = extractMarkers(markedSource)
   markerLocations["START"] = 0
 
+  let enableLongTests = ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] != "1"
+
   var parser = Parser(source)
   #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
-  let enableTestCaseMutation = ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] != "1"
-
-  if enableTestCaseMutation {
+  if enableLongTests {
     parser.enableAlternativeTokenChoices()
   }
   #endif
@@ -639,39 +697,23 @@ func assertParse<S: SyntaxProtocol>(
     assertBasicFormat(source: source, parse: parse, file: file, line: line)
   }
 
-  #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
-  if enableTestCaseMutation {
+  if enableLongTests {
+    DispatchQueue.concurrentPerform(iterations: Array(tree.tokens(viewMode: .all)).count) { tokenIndex in
+      let flippedTokenTree = TokenPresenceFlipper(flipTokenAtIndex: tokenIndex).rewrite(Syntax(tree))
+      assertRoundTrip(source: flippedTokenTree.syntaxTextBytes, parse, file: file, line: line)
+    }
+
+    #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
     let mutations: [(offset: Int, replacement: TokenSpec)] = parser.alternativeTokenChoices.flatMap { offset, replacements in
       return replacements.map { (offset, $0) }
     }
     DispatchQueue.concurrentPerform(iterations: mutations.count) { index in
       let mutation = mutations[index]
       let alternateSource = MutatedTreePrinter.print(tree: Syntax(tree), mutations: [mutation.offset: mutation.replacement])
-      alternateSource.withUnsafeBufferPointer { buf in
-        let mutatedSource = String(decoding: buf, as: UTF8.self)
-        // Check that we don't hit any assertions in the parser while parsing
-        // the mutated source and that it round-trips
-        var mutatedParser = Parser(buf)
-        let mutatedTree = parse(&mutatedParser)
-        assertStringsEqualWithDiff(
-          "\(mutatedTree)",
-          mutatedSource,
-          additionalInfo: """
-            Mutated source failed to round-trip.
-
-            Mutated source:
-            \(mutatedSource)
-
-            Actual syntax tree:
-            \(mutatedTree.debugDescription)
-            """,
-          file: file,
-          line: line
-        )
-      }
+      assertRoundTrip(source: alternateSource, parse, file: file, line: line)
     }
+    #endif
   }
-  #endif
 }
 
 class TriviaRemover: SyntaxRewriter {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -560,6 +560,8 @@ fileprivate func assertRoundTrip<S: SyntaxProtocol>(
     // the mutated source and that it round-trips
     var mutatedParser = Parser(buf)
     let mutatedTree = parse(&mutatedParser)
+    // Run the diagnostic generator to make sure it doesn’t crash
+    _ = ParseDiagnosticsGenerator.diagnostics(for: mutatedTree)
     assertStringsEqualWithDiff(
       "\(mutatedTree)",
       mutatedSource,

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -2222,4 +2222,14 @@ final class DeclarationTests: XCTestCase {
         """
     )
   }
+
+  func testEmptyPrimaryAssociatedType() {
+    assertParse(
+      "protocol X<1️⃣> {}",
+      diagnostics: [
+        DiagnosticSpec(message: "expected name in primary associated type clause", fixIts: ["insert name"])
+      ],
+      fixedSource: "protocol X<<#identifier#>> {}"
+    )
+  }
 }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -690,6 +690,19 @@ final class DeclarationTests: XCTestCase {
     )
   }
 
+  func testEditorPlaceholderWithModifier() {
+    assertParse(
+      """
+      struct a {
+        public1️⃣<#declaration#>
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "editor placeholder in source file")
+      ]
+    )
+  }
+
   func testMissingColonInFunctionSignature() {
     assertParse(
       "func test(first second 1️⃣Int)",
@@ -1920,7 +1933,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       substructure: Syntax(
-        MemberDeclListItemSyntax(decl: EditorPlaceholderDeclSyntax(identifier: .identifier("<#code#>")))
+        MemberDeclListItemSyntax(decl: EditorPlaceholderDeclSyntax(placeholder: .identifier("<#code#>")))
       ),
       diagnostics: [
         DiagnosticSpec(message: "editor placeholder in source file")
@@ -2027,48 +2040,55 @@ final class DeclarationTests: XCTestCase {
   }
 
   func testBorrowingConsumingParameterSpecifiers() {
+    assertParse("struct borrowing {}")
+    assertParse("struct consuming {}")
+
+    assertParse("struct Foo {}")
+
+    assertParse("func foo(x: borrowing Foo) {}")
+    assertParse("func bar(x: consuming Foo) {}")
+    assertParse("func baz(x: (borrowing Foo, consuming Foo) -> ()) {}")
+
+    // `borrowing` and `consuming` are contextual keywords, so they should also
+    // continue working as type and/or parameter names
+
+    assertParse("func zim(x: borrowing) {}")
+    assertParse("func zang(x: consuming) {}")
+    assertParse("func zung(x: borrowing consuming) {}")
+    assertParse("func zip(x: consuming borrowing) {}")
+    assertParse("func zap(x: (borrowing, consuming) -> ()) {}")
+    assertParse("func zoop(x: (borrowing consuming, consuming borrowing) -> ()) {}")
+
+    // Parameter specifier names are regular identifiers in other positions,
+    // including argument labels.
+
+    assertParse("func argumentLabelOnly(borrowing: Int) {}")
+    assertParse("func argumentLabelOnly(consuming: Int) {}")
+    assertParse("func argumentLabelOnly(__shared: Int) {}")
+    assertParse("func argumentLabelOnly(__owned: Int) {}")
+
+    assertParse("func argumentLabel(borrowing consuming: Int) {}")
+    assertParse("func argumentLabel(consuming borrowing: Int) {}")
+    assertParse("func argumentLabel(__shared __owned: Int) {}")
+    assertParse("func argumentLabel(__owned __shared: Int) {}")
+
+    // We should parse them as argument labels in function types, even though that
+    // isn't currently supported.
+
+    assertParse("func argumentLabel(anonBorrowingInClosure: (_ borrowing: Int) -> ()) {}")
+    assertParse("func argumentLabel(anonConsumingInClosure: (_ consuming: Int) -> ()) {}")
+    assertParse("func argumentLabel(anonSharedInClosure: (_ __shared: Int) -> ()) {}")
+    assertParse("func argumentLabel(anonOwnedInClosure: (_ __owned: Int) -> ()) {}")
+  }
+
+  func testMisplaceSpecifierInTupleTypeBody() {
     assertParse(
-      """
-      struct borrowing {}
-      struct consuming {}
-
-      struct Foo {}
-
-      func foo(x: borrowing Foo) {}
-      func bar(x: consuming Foo) {}
-      func baz(x: (borrowing Foo, consuming Foo) -> ()) {}
-
-      // `borrowing` and `consuming` are contextual keywords, so they should also
-      // continue working as type and/or parameter names
-
-      func zim(x: borrowing) {}
-      func zang(x: consuming) {}
-      func zung(x: borrowing consuming) {}
-      func zip(x: consuming borrowing) {}
-      func zap(x: (borrowing, consuming) -> ()) {}
-      func zoop(x: (borrowing consuming, consuming borrowing) -> ()) {}
-
-      // Parameter specifier names are regular identifiers in other positions,
-      // including argument labels.
-
-      func argumentLabelOnly(borrowing: Int) {}
-      func argumentLabelOnly(consuming: Int) {}
-      func argumentLabelOnly(__shared: Int) {}
-      func argumentLabelOnly(__owned: Int) {}
-
-      func argumentLabel(borrowing consuming: Int) {}
-      func argumentLabel(consuming borrowing: Int) {}
-      func argumentLabel(__shared __owned: Int) {}
-      func argumentLabel(__owned __shared: Int) {}
-
-      // We should parse them as argument labels in function types, even though that
-      // isn't currently supported.
-
-      func argumentLabel(anonBorrowingInClosure: (_ borrowing: Int) -> ()) {}
-      func argumentLabel(anonConsumingInClosure: (_ consuming: Int) -> ()) {}
-      func argumentLabel(anonSharedInClosure: (_ __shared: Int) -> ()) {}
-      func argumentLabel(anonOwnedInClosure: (_ __owned: Int) -> ()) {}
-      """
+      "func test(a: (1️⃣borrowing F 2️⃣o))",
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'borrowing' in tuple type"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ',' in tuple type", fixIts: ["insert ','"]),
+      ],
+      fixedSource: "func test(a: (borrowing F, o))"
     )
   }
 

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -96,7 +96,7 @@ final class StatementTests: XCTestCase {
   }
 
   func testNestedIfs() {
-    let nest = 20
+    let nest = 10
     var source = "func nestThoseIfs() {\n"
     for index in (0...nest) {
       let indent = String(repeating: "    ", count: index + 1)


### PR DESCRIPTION
The idea is simple: From the tree generated during parsing, iterate over all the tokens. For each token create a new test case that has the token missing, if it was present in the original source or present if it was missing in the original source. Then run the parser to check that it round-trips and check that generating diagnostics for the mutated tree doesn’t crash.

This testing strategy found three parser bugs:

1. A round-trip failure for unexpected modifiers in a tuple type
```swift
func test(a: (borrowing F o))
```
2. A round-trip failure for modifiers in front of an editor placeholder in declaration position
```swift
struct a {
  public<#declaration#>
}
```
3. A precondition failure when the primary associated type clause of a protocol is empty
```swift
protocol X<> {}
```
4. It also uncovered an issue where we weren’t able to retrieve the trivia pieces of a token after it had been modified using `with` because after the modification the token was a `parsedToken` that no longer resided in a `ParsingSyntaxArena`. The fix is to search through an arena’s `childRefs` to find the `ParsingSyntaxArena` that created it. @rintaro can you review this change?
5. It uncovered that we were making assumptions about the presence of tokens in `ParseDiagnosticGenerator`, mostly that tokens in `UnexpectedNodesSyntax` are present. While this assumption is valid for trees generated by `SwiftParser`, it doesn’t need to hold for manually generated trees. A couple of minor adjustments to filter for only present tokens fixes this.

rdar://109783066