### PR TITLE
Rename `TupleExprSyntax.elementList` to  `TupleExprSyntax.elements`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -1760,7 +1760,7 @@ public let EXPR_NODES: [Node] = [
         kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
       ),
       Child(
-        name: "ElementList",
+        name: "Elements",
         kind: .collection(kind: .tupleExprElementList, collectionElementName: "Element"),
         isIndented: true
       ),

--- a/Sources/SwiftBasicFormat/generated/BasicFormat+Extensions.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat+Extensions.swift
@@ -52,7 +52,7 @@ fileprivate extension AnyKeyPath {
       return true
     case \SwitchCaseSyntax.statements:
       return true
-    case \TupleExprSyntax.elementList:
+    case \TupleExprSyntax.elements:
       return true
     case \TupleTypeSyntax.elements:
       return true

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1576,7 +1576,7 @@ extension Parser {
     return RawTupleExprSyntax(
       unexpectedBeforeLParen,
       leftParen: lparen,
-      elementList: RawTupleExprElementListSyntax(elements: elements, arena: self.arena),
+      elements: RawTupleExprElementListSyntax(elements: elements, arena: self.arena),
       unexpectedBeforeRParen,
       rightParen: rparen,
       arena: self.arena

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -116,3 +116,39 @@ public extension NamedOpaqueReturnTypeSyntax {
     )
   }
 }
+
+extension TupleExprSyntax {
+  @available(*, deprecated, renamed: "unexpectedBetweenLeftParenAndElements")
+  public var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? { unexpectedBetweenLeftParenAndElements }
+
+  @available(*, deprecated, renamed: "elements")
+  public var elementList: TupleExprElementListSyntax { elements }
+
+  @available(*, deprecated, renamed: "unexpectedBetweenElementsAndRightParen")
+  public var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? { unexpectedBetweenElementsAndRightParen }
+
+  @available(*, deprecated, message: "Use an initializer with a elements argument")
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
+    leftParen: TokenSyntax = .leftParenToken(),
+    _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil,
+    elementList: TupleExprElementListSyntax,
+    _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil,
+    rightParen: TokenSyntax = .rightParenToken(),
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeLeftParen,
+      leftParen: leftParen,
+      unexpectedBetweenLeftParenAndElementList,
+      elements: elementList,
+      unexpectedBetweenElementListAndRightParen,
+      rightParen: rightParen,
+      unexpectedAfterRightParen,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -3079,12 +3079,12 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "unexpectedBeforeLeftParen"
   case \TupleExprSyntax.leftParen:
     return "leftParen"
-  case \TupleExprSyntax.unexpectedBetweenLeftParenAndElementList:
-    return "unexpectedBetweenLeftParenAndElementList"
-  case \TupleExprSyntax.elementList:
-    return "elementList"
-  case \TupleExprSyntax.unexpectedBetweenElementListAndRightParen:
-    return "unexpectedBetweenElementListAndRightParen"
+  case \TupleExprSyntax.unexpectedBetweenLeftParenAndElements:
+    return "unexpectedBetweenLeftParenAndElements"
+  case \TupleExprSyntax.elements:
+    return "elements"
+  case \TupleExprSyntax.unexpectedBetweenElementsAndRightParen:
+    return "unexpectedBetweenElementsAndRightParen"
   case \TupleExprSyntax.rightParen:
     return "rightParen"
   case \TupleExprSyntax.unexpectedAfterRightParen:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -20339,9 +20339,9 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol {
   public init(
       _ unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? = nil, 
       leftParen: RawTokenSyntax, 
-      _ unexpectedBetweenLeftParenAndElementList: RawUnexpectedNodesSyntax? = nil, 
-      elementList: RawTupleExprElementListSyntax, 
-      _ unexpectedBetweenElementListAndRightParen: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenLeftParenAndElements: RawUnexpectedNodesSyntax? = nil, 
+      elements: RawTupleExprElementListSyntax, 
+      _ unexpectedBetweenElementsAndRightParen: RawUnexpectedNodesSyntax? = nil, 
       rightParen: RawTokenSyntax, 
       _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
@@ -20351,9 +20351,9 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol {
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
-      layout[2] = unexpectedBetweenLeftParenAndElementList?.raw
-      layout[3] = elementList.raw
-      layout[4] = unexpectedBetweenElementListAndRightParen?.raw
+      layout[2] = unexpectedBetweenLeftParenAndElements?.raw
+      layout[3] = elements.raw
+      layout[4] = unexpectedBetweenElementsAndRightParen?.raw
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
@@ -20368,15 +20368,15 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenLeftParenAndElementList: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenLeftParenAndElements: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var elementList: RawTupleExprElementListSyntax {
+  public var elements: RawTupleExprElementListSyntax {
     layoutView.children[3].map(RawTupleExprElementListSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenElementListAndRightParen: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenElementsAndRightParen: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -6377,9 +6377,9 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
       leftParen: TokenSyntax = .leftParenToken(),
-      _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil,
-      elementList: TupleExprElementListSyntax,
-      _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil,
+      elements: TupleExprElementListSyntax,
+      _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil,
       rightParen: TokenSyntax = .rightParenToken(),
       _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
@@ -6390,18 +6390,18 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
             unexpectedBeforeLeftParen, 
             leftParen, 
-            unexpectedBetweenLeftParenAndElementList, 
-            elementList, 
-            unexpectedBetweenElementListAndRightParen, 
+            unexpectedBetweenLeftParenAndElements, 
+            elements, 
+            unexpectedBetweenElementsAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
           ))) {(arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
-          unexpectedBetweenLeftParenAndElementList?.raw, 
-          elementList.raw, 
-          unexpectedBetweenElementListAndRightParen?.raw, 
+          unexpectedBetweenLeftParenAndElements?.raw, 
+          elements.raw, 
+          unexpectedBetweenElementsAndRightParen?.raw, 
           rightParen.raw, 
           unexpectedAfterRightParen?.raw
         ]
@@ -6436,7 +6436,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -6445,7 +6445,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var elementList: TupleExprElementListSyntax {
+  public var elements: TupleExprElementListSyntax {
     get {
       return TupleExprElementListSyntax(data.child(at: 3, parent: Syntax(self))!)
     }
@@ -6454,12 +6454,12 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// Adds the provided `Element` to the node's `elementList`
+  /// Adds the provided `Element` to the node's `elements`
   /// collection.
   /// - param element: The new `Element` to add to the node's
-  ///                  `elementList` collection.
+  ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
-  ///            appended to its `elementList` collection.
+  ///            appended to its `elements` collection.
   public func addElement(_ element: TupleExprElementSyntax) -> TupleExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6473,7 +6473,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return TupleExprSyntax(newData)
   }
   
-  public var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -6504,9 +6504,9 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return .layout([
           \Self.unexpectedBeforeLeftParen, 
           \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndElementList, 
-          \Self.elementList, 
-          \Self.unexpectedBetweenElementListAndRightParen, 
+          \Self.unexpectedBetweenLeftParenAndElements, 
+          \Self.elements, 
+          \Self.unexpectedBetweenElementsAndRightParen, 
           \Self.rightParen, 
           \Self.unexpectedAfterRightParen
         ])

--- a/Sources/SwiftSyntaxBuilder/SwiftSyntaxBuilderCompatibility.swift
+++ b/Sources/SwiftSyntaxBuilder/SwiftSyntaxBuilderCompatibility.swift
@@ -13,5 +13,34 @@
 // This file provides compatiblity aliases to keep dependents of SwiftSyntaxBuilder building.
 // All users of the declarations in this file should transition away from them ASAP.
 
+import SwiftSyntax
+
 @available(*, deprecated, renamed: "ImportPathBuilder")
 public typealias AccessPathBuilder = ImportPathBuilder
+
+extension TupleExprSyntax {
+  @available(*, deprecated, message: "Use an initializer with a elements argument")
+  public init(
+    leadingTrivia: Trivia? = nil,
+    unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
+    leftParen: TokenSyntax = .leftParenToken(),
+    unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil,
+    unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil,
+    rightParen: TokenSyntax = .rightParenToken(),
+    unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
+    @TupleExprElementListBuilder elementListBuilder: () throws -> TupleExprElementListSyntax,
+    trailingTrivia: Trivia? = nil
+  ) rethrows {
+    try self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeLeftParen,
+      leftParen: leftParen,
+      unexpectedBetweenLeftParenAndElementList,
+      elements: elementListBuilder(),
+      unexpectedBetweenElementListAndRightParen,
+      rightParen: rightParen,
+      unexpectedAfterRightParen,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -1350,20 +1350,20 @@ extension TupleExprSyntax {
       leadingTrivia: Trivia? = nil, 
       unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, 
       leftParen: TokenSyntax = .leftParenToken(), 
-      unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil, 
-      unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil, 
+      unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil, 
+      unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil, 
       rightParen: TokenSyntax = .rightParenToken(), 
       unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil, 
-      @TupleExprElementListBuilder elementListBuilder: () throws -> TupleExprElementListSyntax, 
+      @TupleExprElementListBuilder elementsBuilder: () throws -> TupleExprElementListSyntax, 
       trailingTrivia: Trivia? = nil
     ) rethrows {
     try self.init(
         leadingTrivia: leadingTrivia, 
         unexpectedBeforeLeftParen, 
         leftParen: leftParen, 
-        unexpectedBetweenLeftParenAndElementList, 
-        elementList: elementListBuilder(), 
-        unexpectedBetweenElementListAndRightParen, 
+        unexpectedBetweenLeftParenAndElements, 
+        elements: elementsBuilder(), 
+        unexpectedBetweenElementsAndRightParen, 
         rightParen: rightParen, 
         unexpectedAfterRightParen, 
         trailingTrivia: trailingTrivia

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -46,8 +46,8 @@ class ExplicitParenFolder: SyntaxRewriter {
   override func visit(_ node: TupleExprSyntax) -> ExprSyntax {
     // Identify syntax nodes of the form (x (op) y), which is a
     // TupleExprSyntax(SequenceExpr(x, (op), y)).
-    guard node.elementList.count == 1,
-      let firstNode = node.elementList.first,
+    guard node.elements.count == 1,
+      let firstNode = node.elements.first,
       firstNode.label == nil,
       let sequenceExpr = firstNode.expression.as(SequenceExprSyntax.self),
       sequenceExpr.elements.count == 3,

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -206,7 +206,7 @@ final class VariadicGenericsTests: XCTestCase {
             callee: MemberAccessExprSyntax(
               base: ExprSyntax(
                 TupleExprSyntax(
-                  elementList: .init([
+                  elements: .init([
                     TupleExprElementSyntax(
                       expression: PackElementExprSyntax(
                         eachKeyword: .keyword(.each),

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
@@ -1077,7 +1077,7 @@ final class ForwardSlashRegexTests: XCTestCase {
         TupleExprElementListSyntax([
           .init(
             expression: TupleExprSyntax(
-              elementList: .init([
+              elements: .init([
                 .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/")))
               ])
             ),
@@ -1118,7 +1118,7 @@ final class ForwardSlashRegexTests: XCTestCase {
         TupleExprElementListSyntax([
           .init(
             expression: TupleExprSyntax(
-              elementList: .init([
+              elements: .init([
                 .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/^")))
               ])
             ),


### PR DESCRIPTION
Resolves #1713

This is to be more consistent in naming