### PR TITLE
Add a test for '@_spi(_)'

### DIFF
--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -371,6 +371,15 @@ final class AttributeTests: XCTestCase {
     )
   }
 
+  func testSpiAttributeWithUnderscore() {
+    assertParse(
+      "@_spi(_) class Foo {}"
+    )
+    assertParse(
+      "@_spi(_) import Foo"
+    )
+  }
+
   func testSilgenName() {
     assertParse(
       """


### PR DESCRIPTION
Tests '_' as an SPI group name; see https://github.com/apple/swift/pull/66261.
Ref rdar://109797632
