### PR TITLE
`Functiontypesyntax.arguments` should be named `parameters`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -183,8 +183,8 @@ public let TYPE_NODES: [Node] = [
         kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
       ),
       Child(
-        name: "Arguments",
-        kind: .collection(kind: .tupleTypeElementList, collectionElementName: "Argument"),
+        name: "Parameters",
+        kind: .collection(kind: .tupleTypeElementList, collectionElementName: "Parameter"),
         isIndented: true
       ),
       Child(

--- a/Sources/SwiftBasicFormat/generated/BasicFormat+Extensions.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat+Extensions.swift
@@ -44,7 +44,7 @@ fileprivate extension AnyKeyPath {
       return true
     case \FunctionCallExprSyntax.argumentList:
       return true
-    case \FunctionTypeSyntax.arguments:
+    case \FunctionTypeSyntax.parameters:
       return true
     case \MemberDeclBlockSyntax.members:
       return true

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -61,21 +61,21 @@ extension Parser {
       let unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax?
       let leftParen: RawTokenSyntax
       let unexpectedBetweenLeftParenAndElements: RawUnexpectedNodesSyntax?
-      let arguments: RawTupleTypeElementListSyntax
+      let parameters: RawTupleTypeElementListSyntax
       let unexpectedBetweenElementsAndRightParen: RawUnexpectedNodesSyntax?
       let rightParen: RawTokenSyntax
       if let input = base.as(RawTupleTypeSyntax.self) {
         unexpectedBeforeLeftParen = input.unexpectedBeforeLeftParen
         leftParen = input.leftParen
         unexpectedBetweenLeftParenAndElements = input.unexpectedBetweenLeftParenAndElements
-        arguments = input.elements
+        parameters = input.elements
         unexpectedBetweenElementsAndRightParen = input.unexpectedBetweenElementsAndRightParen
         rightParen = input.rightParen
       } else {
         unexpectedBeforeLeftParen = nil
         leftParen = RawTokenSyntax(missing: .leftParen, arena: self.arena)
         unexpectedBetweenLeftParenAndElements = nil
-        arguments = RawTupleTypeElementListSyntax(
+        parameters = RawTupleTypeElementListSyntax(
           elements: [
             RawTupleTypeElementSyntax(
               inOut: nil,
@@ -100,7 +100,7 @@ extension Parser {
           unexpectedBeforeLeftParen,
           leftParen: leftParen,
           unexpectedBetweenLeftParenAndElements,
-          arguments: arguments,
+          parameters: parameters,
           unexpectedBetweenElementsAndRightParen,
           rightParen: rightParen,
           effectSpecifiers: effectSpecifiers,

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -13,13 +13,6 @@
 // This file provides compatiblity aliases to keep dependents of SwiftSyntax building.
 // All users of the declarations in this file should transition away from them ASAP.
 
-public extension DeclGroupSyntax {
-  @available(*, deprecated, renamed: "memberBlock")
-  var members: MemberDeclBlockSyntax {
-    return self.memberBlock
-  }
-}
-
 @available(*, deprecated, renamed: "ImportPathSyntax")
 public typealias AccessPathSyntax = ImportPathSyntax
 
@@ -28,6 +21,13 @@ public typealias AccessPathComponentSyntax = ImportPathComponentSyntax
 
 @available(*, deprecated, renamed: "WithAttributesSyntax")
 public typealias AttributedSyntax = WithAttributesSyntax
+
+public extension DeclGroupSyntax {
+  @available(*, deprecated, renamed: "memberBlock")
+  var members: MemberDeclBlockSyntax {
+    return self.memberBlock
+  }
+}
 
 public extension EnumDeclSyntax {
   @available(*, deprecated, renamed: "unexpectedBetweenIdentifierAndGenericParameterClause")
@@ -192,18 +192,18 @@ public extension NamedOpaqueReturnTypeSyntax {
   }
 }
 
-extension TupleExprSyntax {
+public extension TupleExprSyntax {
   @available(*, deprecated, renamed: "unexpectedBetweenLeftParenAndElements")
-  public var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? { unexpectedBetweenLeftParenAndElements }
+  var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? { unexpectedBetweenLeftParenAndElements }
 
   @available(*, deprecated, renamed: "elements")
-  public var elementList: TupleExprElementListSyntax { elements }
+  var elementList: TupleExprElementListSyntax { elements }
 
   @available(*, deprecated, renamed: "unexpectedBetweenElementsAndRightParen")
-  public var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? { unexpectedBetweenElementsAndRightParen }
+  var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? { unexpectedBetweenElementsAndRightParen }
 
   @available(*, deprecated, message: "Use an initializer with a elements argument")
-  public init(
+  init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
     leftParen: TokenSyntax = .leftParenToken(),

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -85,6 +85,81 @@ public extension EnumDeclSyntax {
   }
 }
 
+public extension FunctionTypeSyntax {
+  @available(*, deprecated, renamed: "unexpectedBetweenLeftParenAndParameters")
+  var unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenLeftParenAndParameters
+    }
+    set(value) {
+      unexpectedBetweenLeftParenAndParameters = value
+    }
+  }
+
+  @available(*, deprecated, renamed: "parameters")
+  var arguments: TupleTypeElementListSyntax {
+    get {
+      return parameters
+    }
+    set(value) {
+      parameters = value
+    }
+  }
+
+  @available(*, deprecated, renamed: "unexpectedBetweenParametersAndRightParen")
+  var unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenParametersAndRightParen
+    }
+    set(value) {
+      unexpectedBetweenParametersAndRightParen = value
+    }
+  }
+
+  /// Adds the provided `element` to the node's `arguments`
+  /// - param element: The new `Argument` to add to the node's
+  ///                  `arguments` collection.
+  /// - returns: A copy of the receiver with the provided `Argument`
+  ///            appended to its `arguments` collection.
+  @available(*, deprecated, renamed: "addParameter")
+  func addArgument(_ element: TupleTypeElementSyntax) -> FunctionTypeSyntax {
+    return self.addParameter(element)
+  }
+
+  @available(*, deprecated, message: "Use an initializer with a parameters")
+  init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
+    leftParen: TokenSyntax = .leftParenToken(),
+    _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil,
+    arguments: TupleTypeElementListSyntax,
+    _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil,
+    rightParen: TokenSyntax = .rightParenToken(),
+    _ unexpectedBetweenRightParenAndEffectSpecifiers: UnexpectedNodesSyntax? = nil,
+    effectSpecifiers: TypeEffectSpecifiersSyntax? = nil,
+    _ unexpectedBetweenEffectSpecifiersAndOutput: UnexpectedNodesSyntax? = nil,
+    output: ReturnClauseSyntax,
+    _ unexpectedAfterOutput: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeLeftParen,
+      leftParen: leftParen,
+      unexpectedBetweenLeftParenAndArguments,
+      parameters: arguments,
+      unexpectedBetweenArgumentsAndRightParen,
+      rightParen: rightParen,
+      unexpectedBetweenRightParenAndEffectSpecifiers,
+      effectSpecifiers: effectSpecifiers,
+      unexpectedBetweenEffectSpecifiersAndOutput,
+      output: output,
+      unexpectedAfterOutput,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
 public extension NamedOpaqueReturnTypeSyntax {
   @available(*, deprecated, renamed: "unexpectedBeforeGenericParameterClause")
   var unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? { unexpectedBeforeGenericParameterClause }

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -25,19 +25,45 @@ public typealias AttributedSyntax = WithAttributesSyntax
 public extension DeclGroupSyntax {
   @available(*, deprecated, renamed: "memberBlock")
   var members: MemberDeclBlockSyntax {
-    return self.memberBlock
+    get {
+      return memberBlock
+    }
+    set(value) {
+      memberBlock = value
+    }
   }
 }
 
 public extension EnumDeclSyntax {
   @available(*, deprecated, renamed: "unexpectedBetweenIdentifierAndGenericParameterClause")
-  var unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodesSyntax? { unexpectedBetweenIdentifierAndGenericParameterClause }
+  var unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenIdentifierAndGenericParameterClause
+    }
+    set(value) {
+      unexpectedBetweenIdentifierAndGenericParameterClause = value
+    }
+  }
 
   @available(*, deprecated, renamed: "genericParameterClause")
-  var genericParameters: GenericParameterClauseSyntax? { genericParameterClause }
+  var genericParameters: GenericParameterClauseSyntax? {
+    get {
+      return genericParameterClause
+    }
+    set(value) {
+      genericParameterClause = value
+    }
+  }
 
   @available(*, deprecated, renamed: "unexpectedBetweenGenericParameterClauseAndInheritanceClause")
-  var unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodesSyntax? { unexpectedBetweenGenericParameterClauseAndInheritanceClause }
+  var unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenGenericParameterClauseAndInheritanceClause
+    }
+    set(value) {
+      unexpectedBetweenGenericParameterClauseAndInheritanceClause = value
+    }
+  }
 
   @available(*, deprecated, message: "Use an initializer with a genericParameterClause argument.")
   init(
@@ -162,13 +188,34 @@ public extension FunctionTypeSyntax {
 
 public extension NamedOpaqueReturnTypeSyntax {
   @available(*, deprecated, renamed: "unexpectedBeforeGenericParameterClause")
-  var unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? { unexpectedBeforeGenericParameterClause }
+  var unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBeforeGenericParameterClause
+    }
+    set(value) {
+      unexpectedBeforeGenericParameterClause = value
+    }
+  }
 
   @available(*, deprecated, renamed: "genericParameterClause")
-  var genericParameters: GenericParameterClauseSyntax? { genericParameterClause }
+  var genericParameters: GenericParameterClauseSyntax {
+    get {
+      return genericParameterClause
+    }
+    set(value) {
+      genericParameterClause = value
+    }
+  }
 
   @available(*, deprecated, renamed: "unexpectedBetweenGenericParameterClauseAndBaseType")
-  var unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? { unexpectedBetweenGenericParameterClauseAndBaseType }
+  var unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenGenericParameterClauseAndBaseType
+    }
+    set(value) {
+      unexpectedBetweenGenericParameterClauseAndBaseType = value
+    }
+  }
 
   @available(*, deprecated, message: "Use an initializer with a genericParameterClause argument.")
   init(
@@ -194,13 +241,34 @@ public extension NamedOpaqueReturnTypeSyntax {
 
 public extension TupleExprSyntax {
   @available(*, deprecated, renamed: "unexpectedBetweenLeftParenAndElements")
-  var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? { unexpectedBetweenLeftParenAndElements }
+  var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenLeftParenAndElements
+    }
+    set(value) {
+      unexpectedBetweenLeftParenAndElements = value
+    }
+  }
 
   @available(*, deprecated, renamed: "elements")
-  var elementList: TupleExprElementListSyntax { elements }
+  var elementList: TupleExprElementListSyntax {
+    get {
+      return elements
+    }
+    set(value) {
+      elements = value
+    }
+  }
 
   @available(*, deprecated, renamed: "unexpectedBetweenElementsAndRightParen")
-  var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? { unexpectedBetweenElementsAndRightParen }
+  var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenElementsAndRightParen
+    }
+    set(value) {
+      unexpectedBetweenElementsAndRightParen = value
+    }
+  }
 
   @available(*, deprecated, message: "Use an initializer with a elements argument")
   init(

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -1493,12 +1493,12 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "unexpectedBeforeLeftParen"
   case \FunctionTypeSyntax.leftParen:
     return "leftParen"
-  case \FunctionTypeSyntax.unexpectedBetweenLeftParenAndArguments:
-    return "unexpectedBetweenLeftParenAndArguments"
-  case \FunctionTypeSyntax.arguments:
-    return "arguments"
-  case \FunctionTypeSyntax.unexpectedBetweenArgumentsAndRightParen:
-    return "unexpectedBetweenArgumentsAndRightParen"
+  case \FunctionTypeSyntax.unexpectedBetweenLeftParenAndParameters:
+    return "unexpectedBetweenLeftParenAndParameters"
+  case \FunctionTypeSyntax.parameters:
+    return "parameters"
+  case \FunctionTypeSyntax.unexpectedBetweenParametersAndRightParen:
+    return "unexpectedBetweenParametersAndRightParen"
   case \FunctionTypeSyntax.rightParen:
     return "rightParen"
   case \FunctionTypeSyntax.unexpectedBetweenRightParenAndEffectSpecifiers:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -9967,9 +9967,9 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol {
   public init(
       _ unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? = nil, 
       leftParen: RawTokenSyntax, 
-      _ unexpectedBetweenLeftParenAndArguments: RawUnexpectedNodesSyntax? = nil, 
-      arguments: RawTupleTypeElementListSyntax, 
-      _ unexpectedBetweenArgumentsAndRightParen: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenLeftParenAndParameters: RawUnexpectedNodesSyntax? = nil, 
+      parameters: RawTupleTypeElementListSyntax, 
+      _ unexpectedBetweenParametersAndRightParen: RawUnexpectedNodesSyntax? = nil, 
       rightParen: RawTokenSyntax, 
       _ unexpectedBetweenRightParenAndEffectSpecifiers: RawUnexpectedNodesSyntax? = nil, 
       effectSpecifiers: RawTypeEffectSpecifiersSyntax?, 
@@ -9983,9 +9983,9 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
-      layout[2] = unexpectedBetweenLeftParenAndArguments?.raw
-      layout[3] = arguments.raw
-      layout[4] = unexpectedBetweenArgumentsAndRightParen?.raw
+      layout[2] = unexpectedBetweenLeftParenAndParameters?.raw
+      layout[3] = parameters.raw
+      layout[4] = unexpectedBetweenParametersAndRightParen?.raw
       layout[5] = rightParen.raw
       layout[6] = unexpectedBetweenRightParenAndEffectSpecifiers?.raw
       layout[7] = effectSpecifiers?.raw
@@ -10004,15 +10004,15 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenLeftParenAndArguments: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenLeftParenAndParameters: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var arguments: RawTupleTypeElementListSyntax {
+  public var parameters: RawTupleTypeElementListSyntax {
     layoutView.children[3].map(RawTupleTypeElementListSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenArgumentsAndRightParen: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenParametersAndRightParen: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -825,9 +825,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
       leftParen: TokenSyntax = .leftParenToken(),
-      _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil,
-      arguments: TupleTypeElementListSyntax,
-      _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenLeftParenAndParameters: UnexpectedNodesSyntax? = nil,
+      parameters: TupleTypeElementListSyntax,
+      _ unexpectedBetweenParametersAndRightParen: UnexpectedNodesSyntax? = nil,
       rightParen: TokenSyntax = .rightParenToken(),
       _ unexpectedBetweenRightParenAndEffectSpecifiers: UnexpectedNodesSyntax? = nil,
       effectSpecifiers: TypeEffectSpecifiersSyntax? = nil,
@@ -842,9 +842,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
             unexpectedBeforeLeftParen, 
             leftParen, 
-            unexpectedBetweenLeftParenAndArguments, 
-            arguments, 
-            unexpectedBetweenArgumentsAndRightParen, 
+            unexpectedBetweenLeftParenAndParameters, 
+            parameters, 
+            unexpectedBetweenParametersAndRightParen, 
             rightParen, 
             unexpectedBetweenRightParenAndEffectSpecifiers, 
             effectSpecifiers, 
@@ -855,9 +855,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
-          unexpectedBetweenLeftParenAndArguments?.raw, 
-          arguments.raw, 
-          unexpectedBetweenArgumentsAndRightParen?.raw, 
+          unexpectedBetweenLeftParenAndParameters?.raw, 
+          parameters.raw, 
+          unexpectedBetweenParametersAndRightParen?.raw, 
           rightParen.raw, 
           unexpectedBetweenRightParenAndEffectSpecifiers?.raw, 
           effectSpecifiers?.raw, 
@@ -896,7 +896,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenLeftParenAndParameters: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -905,7 +905,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var arguments: TupleTypeElementListSyntax {
+  public var parameters: TupleTypeElementListSyntax {
     get {
       return TupleTypeElementListSyntax(data.child(at: 3, parent: Syntax(self))!)
     }
@@ -914,13 +914,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// Adds the provided `element` to the node's `arguments`
+  /// Adds the provided `element` to the node's `parameters`
   /// collection.
-  /// - param element: The new `Argument` to add to the node's
-  ///                  `arguments` collection.
-  /// - returns: A copy of the receiver with the provided `Argument`
-  ///            appended to its `arguments` collection.
-  public func addArgument(_ element: TupleTypeElementSyntax) -> FunctionTypeSyntax {
+  /// - param element: The new `Parameter` to add to the node's
+  ///                  `parameters` collection.
+  /// - returns: A copy of the receiver with the provided `Parameter`
+  ///            appended to its `parameters` collection.
+  public func addParameter(_ element: TupleTypeElementSyntax) -> FunctionTypeSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
@@ -933,7 +933,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return FunctionTypeSyntax(newData)
   }
   
-  public var unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenParametersAndRightParen: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -1000,9 +1000,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return .layout([
           \Self.unexpectedBeforeLeftParen, 
           \Self.leftParen, 
-          \Self.unexpectedBetweenLeftParenAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedBetweenArgumentsAndRightParen, 
+          \Self.unexpectedBetweenLeftParenAndParameters, 
+          \Self.parameters, 
+          \Self.unexpectedBetweenParametersAndRightParen, 
           \Self.rightParen, 
           \Self.unexpectedBetweenRightParenAndEffectSpecifiers, 
           \Self.effectSpecifiers, 

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTypeSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTypeSyntaxTests.swift
@@ -17,7 +17,7 @@ import SwiftSyntaxBuilder
 final class FunctionTypeSyntaxTests: XCTestCase {
   func testFunctionEffectSpecifiersSyntax() throws {
     let typeEffects = TypeEffectSpecifiersSyntax(asyncSpecifier: .keyword(.async), throwsSpecifier: .keyword(.throws))
-    let buildable = FunctionTypeSyntax(arguments: [], effectSpecifiers: typeEffects, output: .init(returnType: TypeSyntax("String")))
+    let buildable = FunctionTypeSyntax(parameters: [], effectSpecifiers: typeEffects, output: .init(returnType: TypeSyntax("String")))
 
     assertBuildResult(
       buildable,

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -225,7 +225,7 @@ final class VariableTests: XCTestCase {
   }
 
   func testClosureTypeVariableDecl() {
-    let type = FunctionTypeSyntax(arguments: [TupleTypeElementSyntax(type: TypeSyntax("Int"))], output: ReturnClauseSyntax(returnType: TypeSyntax("Bool")))
+    let type = FunctionTypeSyntax(parameters: [TupleTypeElementSyntax(type: TypeSyntax("Int"))], output: ReturnClauseSyntax(returnType: TypeSyntax("Bool")))
     let buildable = VariableDeclSyntax(bindingKeyword: .keyword(.let)) {
       PatternBindingSyntax(pattern: PatternSyntax("c"), typeAnnotation: TypeAnnotationSyntax(type: type))
     }


### PR DESCRIPTION
Resolves #1720