### PR TITLE
Update link for documentation in the New Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,5 +11,5 @@
      url: https://forums.swift.org/tags/c/development/tooling/39/swift-syntax
      about: Ask and answer questions about SwiftSyntax
    - name: SwiftSyntax Documentation
-     url: https://github.com/apple/swift-syntax/tree/main/Documentation
+     url: https://swiftpackageindex.com/apple/swift-syntax/documentation/swiftsyntax
      about: Learn about how to use the SwiftSyntax in your projects


### PR DESCRIPTION
The documentation link was update. Update it to point to swiftpackageindex.com