### PR TITLE
[5.9] Fix 5 parser bugs

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -464,7 +464,7 @@ public let DECL_NODES: [Node] = [
       An editor placeholder, e.g. `<#declaration#>` that is used in a position that expects a declaration.
       """,
     kind: "Decl",
-    traits:[
+    traits: [
       "WithAttributes",
       "WithModifiers",
     ],

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -460,12 +460,36 @@ public let DECL_NODES: [Node] = [
   Node(
     name: "EditorPlaceholderDecl",
     nameForDiagnostics: "editor placeholder",
+    description: """
+      An editor placeholder, e.g. `<#declaration#>` that is used in a position that expects a declaration.
+      """,
     kind: "Decl",
+    traits:[
+      "WithAttributes",
+      "WithModifiers",
+    ],
     children: [
       Child(
-        name: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
-      )
+        name: "Attributes",
+        kind: .collection(kind: "AttributeList", collectionElementName: "Attribute"),
+        nameForDiagnostics: "attributes",
+        description: "If there were attributes before the editor placeholder, the ``EditorPlaceholderDecl`` will contain these.",
+        isOptional: true
+      ),
+      Child(
+        name: "Modifiers",
+        kind: .collection(kind: "ModifierList", collectionElementName: "Modifier"),
+        nameForDiagnostics: "modifiers",
+        description: "If there were modifiers before the editor placeholder, the `EditorPlaceholderDecl` will contain these.",
+        isOptional: true
+      ),
+      Child(
+        name: "Placeholder",
+        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        description: """
+          The actual editor placeholder that starts with `<#` and ends with `#>`.
+          """
+      ),
     ]
   ),
 

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -286,7 +286,9 @@ extension Parser {
           let placeholder = self.consumeAnyToken()
           return RawDeclSyntax(
             RawEditorPlaceholderDeclSyntax(
-              identifier: placeholder,
+              attributes: attrs.attributes,
+              modifiers: attrs.modifiers,
+              placeholder: placeholder,
               arena: self.arena
             )
           )
@@ -474,8 +476,12 @@ extension Parser {
       )
     }
 
-    precondition(self.currentToken.starts(with: "<"))
-    let langle = self.consumePrefix("<", as: .leftAngle)
+    let langle: RawTokenSyntax
+    if self.currentToken.starts(with: "<") {
+      langle = self.consumePrefix("<", as: .leftAngle)
+    } else {
+      langle = missingToken(.leftAngle)
+    }
     var elements = [RawGenericParameterSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -309,7 +309,7 @@ extension Parser {
   }
 
   mutating func parsePrimaryAssociatedTypes() -> RawPrimaryAssociatedTypeClauseSyntax {
-    let langle = self.consumeAnyToken(remapping: .leftAngle)
+    let langle = self.consumePrefix("<", as: .leftAngle)
     var associatedTypes = [RawPrimaryAssociatedTypeSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -546,7 +546,7 @@ extension Parser {
               inOut: nil,
               name: nil,
               secondName: nil,
-              unexpectedBeforeColon,
+              RawUnexpectedNodesSyntax(combining: misplacedSpecifiers, unexpectedBeforeColon, arena: self.arena),
               colon: nil,
               type: RawTypeSyntax(RawSimpleTypeIdentifierSyntax(name: first, genericArgumentClause: nil, arena: self.arena)),
               ellipsis: nil,

--- a/Sources/SwiftParserDiagnostics/MissingTokenError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingTokenError.swift
@@ -17,6 +17,7 @@ import SwiftDiagnostics
 extension ParseDiagnosticsGenerator {
   func handleMissingToken(_ missingToken: TokenSyntax) {
     guard let invalidToken = missingToken.previousToken(viewMode: .all),
+      invalidToken.presence == .present,
       let invalidTokenContainer = invalidToken.parent?.as(UnexpectedNodesSyntax.self),
       invalidTokenContainer.count == 1
     else {

--- a/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
@@ -14,26 +14,30 @@
 @_spi(Diagnostics) import SwiftParser
 
 extension UnexpectedNodesSyntax {
-  func tokens(satisfying isIncluded: (TokenSyntax) -> Bool) -> [TokenSyntax] {
+  func presentTokens(satisfying isIncluded: (TokenSyntax) -> Bool) -> [TokenSyntax] {
     return self.children(viewMode: .sourceAccurate).compactMap({ $0.as(TokenSyntax.self) }).filter(isIncluded)
   }
 
-  func tokens(withKind kind: TokenKind) -> [TokenSyntax] {
-    return self.tokens(satisfying: { $0.tokenKind == kind })
+  func presentTokens(withKind kind: TokenKind) -> [TokenSyntax] {
+    return self.presentTokens(satisfying: { $0.tokenKind == kind })
   }
 
-  /// If this only contains a single item, which is a token satisfying `condition`, return that token, otherwise return `nil`.
-  func onlyToken(where condition: (TokenSyntax) -> Bool) -> TokenSyntax? {
-    if self.count == 1, let token = self.first?.as(TokenSyntax.self), condition(token) {
+  /// If this only contains a single item, which is a present token satisfying `condition`, return that token, otherwise return `nil`.
+  func onlyPresentToken(where condition: (TokenSyntax) -> Bool) -> TokenSyntax? {
+    if self.count == 1,
+      let token = self.first?.as(TokenSyntax.self),
+      condition(token),
+      token.presence == .present
+    {
       return token
     } else {
       return nil
     }
   }
 
-  /// If this only contains tokens satisfying `condition`, return an array containing those tokens, otherwise return `nil`.
-  func onlyTokens(satisfying condition: (TokenSyntax) -> Bool) -> [TokenSyntax]? {
-    let tokens = tokens(satisfying: condition)
+  /// If this only contains present tokens satisfying `condition`, return an array containing those tokens, otherwise return `nil`.
+  func onlyPresentTokens(satisfying condition: (TokenSyntax) -> Bool) -> [TokenSyntax]? {
+    let tokens = presentTokens(satisfying: condition)
     if tokens.count == self.count {
       return tokens
     } else {
@@ -79,7 +83,7 @@ extension SyntaxProtocol {
       } else {
         return "braces"
       }
-    } else if let token = Syntax(self).as(UnexpectedNodesSyntax.self)?.onlyTokens(satisfying: { $0.tokenKind.isLexerClassifiedKeyword })?.only {
+    } else if let token = Syntax(self).as(UnexpectedNodesSyntax.self)?.onlyPresentTokens(satisfying: { $0.tokenKind.isLexerClassifiedKeyword })?.only {
       return "'\(token.text)' keyword"
     } else if let token = Syntax(self).as(TokenSyntax.self) {
       return "'\(token.text)' keyword"

--- a/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
@@ -108,6 +108,10 @@ private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
     return "body"
   case \DocumentationAttributeArgumentSyntax.label:
     return "label"
+  case \EditorPlaceholderDeclSyntax.attributes:
+    return "attributes"
+  case \EditorPlaceholderDeclSyntax.modifiers:
+    return "modifiers"
   case \EnumCaseDeclSyntax.attributes:
     return "attributes"
   case \EnumCaseDeclSyntax.modifiers:

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -95,7 +95,7 @@ public struct RawSyntaxTokenView {
   public var leadingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
-      let arena = raw.arena as! ParsingSyntaxArena
+      let arena = raw.arena.parsingArena!
       return arena.parseTrivia(source: dat.leadingTriviaText, position: .leading)
     case .materializedToken(let dat):
       return Array(dat.leadingTrivia)
@@ -108,7 +108,7 @@ public struct RawSyntaxTokenView {
   public var trailingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
-      let arena = raw.arena as! ParsingSyntaxArena
+      let arena = raw.arena.parsingArena!
       return arena.parseTrivia(source: dat.trailingTriviaText, position: .trailing)
     case .materializedToken(let dat):
       return Array(dat.trailingTrivia)

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -22,3 +22,23 @@ public extension DeclGroupSyntax {
 
 @available(*, deprecated, renamed: "WithAttributesSyntax")
 public typealias AttributedSyntax = WithAttributesSyntax
+
+public extension EditorPlaceholderDeclSyntax {
+  @available(*, deprecated, renamed: "placeholder")
+  var identifier: TokenSyntax { placeholder }
+
+  @available(*, deprecated, renamed: "placeholder")
+  init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeIdentifier,
+      placeholder: identifier,
+      unexpectedAfterIdentifier
+    )
+  }
+}

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -69,6 +69,33 @@ public class SyntaxArena {
     }
   }
 
+  /// If this arena or any of its child arenas is a ``ParsingSyntaxArena``
+  /// return one of these arenas, otherwise return `nil`.
+  ///
+  /// If the arena has multiple child nodes that are ``ParsingSyntaxArena``s, it
+  /// is undefined which one will be returned.
+  ///
+  /// The use case for this is to get the trivia parsing function of the arena.
+  /// Parsed tokens created by `SwiftParser` automatically reside in a
+  /// ``ParsingSyntaxArena`` but if they are modified (e.g. using the `with`
+  /// functions), they might reside in a new arena. But we still want to be able
+  /// to retrieve trivia from those modified tokens, which requires calling into
+  /// the `parseTrivia` function of the ``ParsingSyntaxArena`` that created the
+  /// token. Since the modified syntax arena needs to keep the original
+  /// ``ParsingSyntaxArena`` alive, we can search this arena’s `childRefs` for
+  /// the ``ParsingSyntaxArena`` that created the token.
+  var parsingArena: ParsingSyntaxArena? {
+    if let parsingArena = self as? ParsingSyntaxArena {
+      return parsingArena
+    }
+    for child in childRefs {
+      if let parsingArena = child.value.parsingArena {
+        return parsingArena
+      }
+    }
+    return nil
+  }
+
   /// Allocates a buffer of `RawSyntax?` with the given count, then returns the
   /// uninitlialized memory range as a `UnsafeMutableBufferPointer<RawSyntax?>`.
   func allocateRawSyntaxBuffer(count: Int) -> UnsafeMutableBufferPointer<RawSyntax?> {

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -1069,12 +1069,20 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "declname"
   case \DynamicReplacementArgumentsSyntax.unexpectedAfterDeclname:
     return "unexpectedAfterDeclname"
-  case \EditorPlaceholderDeclSyntax.unexpectedBeforeIdentifier:
-    return "unexpectedBeforeIdentifier"
-  case \EditorPlaceholderDeclSyntax.identifier:
-    return "identifier"
-  case \EditorPlaceholderDeclSyntax.unexpectedAfterIdentifier:
-    return "unexpectedAfterIdentifier"
+  case \EditorPlaceholderDeclSyntax.unexpectedBeforeAttributes:
+    return "unexpectedBeforeAttributes"
+  case \EditorPlaceholderDeclSyntax.attributes:
+    return "attributes"
+  case \EditorPlaceholderDeclSyntax.unexpectedBetweenAttributesAndModifiers:
+    return "unexpectedBetweenAttributesAndModifiers"
+  case \EditorPlaceholderDeclSyntax.modifiers:
+    return "modifiers"
+  case \EditorPlaceholderDeclSyntax.unexpectedBetweenModifiersAndPlaceholder:
+    return "unexpectedBetweenModifiersAndPlaceholder"
+  case \EditorPlaceholderDeclSyntax.placeholder:
+    return "placeholder"
+  case \EditorPlaceholderDeclSyntax.unexpectedAfterPlaceholder:
+    return "unexpectedAfterPlaceholder"
   case \EditorPlaceholderExprSyntax.unexpectedBeforeIdentifier:
     return "unexpectedBeforeIdentifier"
   case \EditorPlaceholderExprSyntax.identifier:

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -6997,7 +6997,7 @@ open class SyntaxRewriter {
   public func rewrite(_ node: Syntax) -> Syntax {
     let rewritten = self.visit(node)
     return withExtendedLifetime(rewritten) {
-      return Syntax(node.data.replacingSelf(rewritten.raw, arena: rewritten.raw.arena))
+      return Syntax(node.data.replacingSelf(rewritten.raw, arena: SyntaxArena()))
     }
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -539,6 +539,8 @@ extension DoStmtSyntax: WithCodeBlockSyntax {}
 
 extension DocumentationAttributeArgumentSyntax: WithTrailingCommaSyntax {}
 
+extension EditorPlaceholderDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
+
 extension EnumCaseDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension EnumCaseElementSyntax: WithTrailingCommaSyntax {}

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -7596,31 +7596,55 @@ public struct RawEditorPlaceholderDeclSyntax: RawDeclSyntaxNodeProtocol {
   }
   
   public init(
-      _ unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? = nil, 
-      identifier: RawTokenSyntax, 
-      _ unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? = nil, 
+      attributes: RawAttributeListSyntax?, 
+      _ unexpectedBetweenAttributesAndModifiers: RawUnexpectedNodesSyntax? = nil, 
+      modifiers: RawModifierListSyntax?, 
+      _ unexpectedBetweenModifiersAndPlaceholder: RawUnexpectedNodesSyntax? = nil, 
+      placeholder: RawTokenSyntax, 
+      _ unexpectedAfterPlaceholder: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .editorPlaceholderDecl, uninitializedCount: 3, arena: arena) { layout in
+      kind: .editorPlaceholderDecl, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeIdentifier?.raw
-      layout[1] = identifier.raw
-      layout[2] = unexpectedAfterIdentifier?.raw
+      layout[0] = unexpectedBeforeAttributes?.raw
+      layout[1] = attributes?.raw
+      layout[2] = unexpectedBetweenAttributesAndModifiers?.raw
+      layout[3] = modifiers?.raw
+      layout[4] = unexpectedBetweenModifiersAndPlaceholder?.raw
+      layout[5] = placeholder.raw
+      layout[6] = unexpectedAfterPlaceholder?.raw
     }
     self.init(unchecked: raw)
   }
   
-  public var unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? {
+  public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
     layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var identifier: RawTokenSyntax {
-    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  public var attributes: RawAttributeListSyntax? {
+    layoutView.children[1].map(RawAttributeListSyntax.init(raw:))
   }
   
-  public var unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenAttributesAndModifiers: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var modifiers: RawModifierListSyntax? {
+    layoutView.children[3].map(RawModifierListSyntax.init(raw:))
+  }
+  
+  public var unexpectedBetweenModifiersAndPlaceholder: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var placeholder: RawTokenSyntax {
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  
+  public var unexpectedAfterPlaceholder: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1042,10 +1042,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 5, verify(layout[5], as: RawDeclNameSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .editorPlaceholderDecl:
-    assert(layout.count == 3)
+    assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
+    assertNoError(kind, 1, verify(layout[1], as: RawAttributeListSyntax?.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawModifierListSyntax?.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
+    assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .editorPlaceholderExpr:
     assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -551,6 +551,8 @@ fileprivate func assertRoundTrip<S: SyntaxProtocol>(
     // the mutated source and that it round-trips
     var mutatedParser = Parser(buf)
     let mutatedTree = parse(&mutatedParser)
+    // Run the diagnostic generator to make sure it doesn’t crash
+    _ = ParseDiagnosticsGenerator.diagnostics(for: mutatedTree)
     assertStringsEqualWithDiff(
       "\(mutatedTree)",
       mutatedSource,

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -468,6 +468,32 @@ class MutatedTreePrinter: SyntaxVisitor {
   }
 }
 
+/// Flip the presence of the `flipTokenAtIndex`-th token in a tree, i.e. making
+/// it present if it is missing or missing if it is present. All other nodes are
+/// not modified.
+class TokenPresenceFlipper: SyntaxRewriter {
+  var visitedTokens = 0
+  let flipTokenAtIndex: Int
+
+  init(flipTokenAtIndex: Int) {
+    self.flipTokenAtIndex = flipTokenAtIndex
+  }
+
+  override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    defer { visitedTokens += 1 }
+    if visitedTokens == flipTokenAtIndex {
+      switch token.presence {
+      case .present:
+        return token.with(\.presence, .missing)
+      case .missing:
+        return token.with(\.presence, .present)
+      }
+    }
+
+    return token
+  }
+}
+
 public struct AssertParseOptions: OptionSet {
   public var rawValue: UInt8
 
@@ -511,6 +537,38 @@ func assertParse(
   )
 }
 
+/// After a test case has been mutated, assert that the mutated source
+/// round-trips and doesn’t hit any assertion failures in the parser.
+fileprivate func assertRoundTrip<S: SyntaxProtocol>(
+  source: [UInt8],
+  _ parse: (inout Parser) -> S,
+  file: StaticString,
+  line: UInt
+) {
+  source.withUnsafeBufferPointer { buf in
+    let mutatedSource = String(decoding: buf, as: UTF8.self)
+    // Check that we don't hit any assertions in the parser while parsing
+    // the mutated source and that it round-trips
+    var mutatedParser = Parser(buf)
+    let mutatedTree = parse(&mutatedParser)
+    assertStringsEqualWithDiff(
+      "\(mutatedTree)",
+      mutatedSource,
+      additionalInfo: """
+        Mutated source failed to round-trip.
+
+        Mutated source:
+        \(mutatedSource)
+
+        Actual syntax tree:
+        \(mutatedTree.debugDescription)
+        """,
+      file: file,
+      line: line
+    )
+  }
+}
+
 /// Removes any test markers from `markedSource` (1) and parses the result
 /// using `parse`. By default it only checks if the parsed syntax tree is
 /// printable back to the origin source, ie. it round trips.
@@ -545,11 +603,11 @@ func assertParse<S: SyntaxProtocol>(
   var (markerLocations, source) = extractMarkers(markedSource)
   markerLocations["START"] = 0
 
+  let enableLongTests = ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] != "1"
+
   var parser = Parser(source)
   #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
-  let enableTestCaseMutation = ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] != "1"
-
-  if enableTestCaseMutation {
+  if enableLongTests {
     parser.enableAlternativeTokenChoices()
   }
   #endif
@@ -618,39 +676,23 @@ func assertParse<S: SyntaxProtocol>(
     assertBasicFormat(source: source, parse: parse, file: file, line: line)
   }
 
-  #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
-  if enableTestCaseMutation {
+  if enableLongTests {
+    DispatchQueue.concurrentPerform(iterations: Array(tree.tokens(viewMode: .all)).count) { tokenIndex in
+      let flippedTokenTree = TokenPresenceFlipper(flipTokenAtIndex: tokenIndex).rewrite(Syntax(tree))
+      assertRoundTrip(source: flippedTokenTree.syntaxTextBytes, parse, file: file, line: line)
+    }
+
+    #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
     let mutations: [(offset: Int, replacement: TokenSpec)] = parser.alternativeTokenChoices.flatMap { offset, replacements in
       return replacements.map { (offset, $0) }
     }
     DispatchQueue.concurrentPerform(iterations: mutations.count) { index in
       let mutation = mutations[index]
       let alternateSource = MutatedTreePrinter.print(tree: Syntax(tree), mutations: [mutation.offset: mutation.replacement])
-      alternateSource.withUnsafeBufferPointer { buf in
-        let mutatedSource = String(decoding: buf, as: UTF8.self)
-        // Check that we don't hit any assertions in the parser while parsing
-        // the mutated source and that it round-trips
-        var mutatedParser = Parser(buf)
-        let mutatedTree = parse(&mutatedParser)
-        assertStringsEqualWithDiff(
-          "\(mutatedTree)",
-          mutatedSource,
-          additionalInfo: """
-            Mutated source failed to round-trip.
-
-            Mutated source:
-            \(mutatedSource)
-
-            Actual syntax tree:
-            \(mutatedTree.debugDescription)
-            """,
-          file: file,
-          line: line
-        )
-      }
+      assertRoundTrip(source: alternateSource, parse, file: file, line: line)
     }
+    #endif
   }
-  #endif
 }
 
 class TriviaRemover: SyntaxRewriter {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -681,6 +681,7 @@ func assertParse<S: SyntaxProtocol>(
   if enableLongTests {
     DispatchQueue.concurrentPerform(iterations: Array(tree.tokens(viewMode: .all)).count) { tokenIndex in
       let flippedTokenTree = TokenPresenceFlipper(flipTokenAtIndex: tokenIndex).rewrite(Syntax(tree))
+      _ = ParseDiagnosticsGenerator.diagnostics(for: flippedTokenTree)
       assertRoundTrip(source: flippedTokenTree.syntaxTextBytes, parse, file: file, line: line)
     }
 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -606,6 +606,19 @@ final class DeclarationTests: XCTestCase {
     )
   }
 
+  func testEditorPlaceholderWithModifier() {
+    assertParse(
+      """
+      struct a {
+        public1️⃣<#declaration#>
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "editor placeholder in source file")
+      ]
+    )
+  }
+
   func testMissingColonInFunctionSignature() {
     assertParse(
       "func test(first second 1️⃣Int)",
@@ -1592,7 +1605,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       substructure: Syntax(
-        MemberDeclListItemSyntax(decl: EditorPlaceholderDeclSyntax(identifier: .identifier("<#code#>")))
+        MemberDeclListItemSyntax(decl: EditorPlaceholderDeclSyntax(placeholder: .identifier("<#code#>")))
       ),
       diagnostics: [
         DiagnosticSpec(message: "editor placeholder in source file")
@@ -1699,48 +1712,55 @@ final class DeclarationTests: XCTestCase {
   }
 
   func testBorrowingConsumingParameterSpecifiers() {
+    assertParse("struct borrowing {}")
+    assertParse("struct consuming {}")
+
+    assertParse("struct Foo {}")
+
+    assertParse("func foo(x: borrowing Foo) {}")
+    assertParse("func bar(x: consuming Foo) {}")
+    assertParse("func baz(x: (borrowing Foo, consuming Foo) -> ()) {}")
+
+    // `borrowing` and `consuming` are contextual keywords, so they should also
+    // continue working as type and/or parameter names
+
+    assertParse("func zim(x: borrowing) {}")
+    assertParse("func zang(x: consuming) {}")
+    assertParse("func zung(x: borrowing consuming) {}")
+    assertParse("func zip(x: consuming borrowing) {}")
+    assertParse("func zap(x: (borrowing, consuming) -> ()) {}")
+    assertParse("func zoop(x: (borrowing consuming, consuming borrowing) -> ()) {}")
+
+    // Parameter specifier names are regular identifiers in other positions,
+    // including argument labels.
+
+    assertParse("func argumentLabelOnly(borrowing: Int) {}")
+    assertParse("func argumentLabelOnly(consuming: Int) {}")
+    assertParse("func argumentLabelOnly(__shared: Int) {}")
+    assertParse("func argumentLabelOnly(__owned: Int) {}")
+
+    assertParse("func argumentLabel(borrowing consuming: Int) {}")
+    assertParse("func argumentLabel(consuming borrowing: Int) {}")
+    assertParse("func argumentLabel(__shared __owned: Int) {}")
+    assertParse("func argumentLabel(__owned __shared: Int) {}")
+
+    // We should parse them as argument labels in function types, even though that
+    // isn't currently supported.
+
+    assertParse("func argumentLabel(anonBorrowingInClosure: (_ borrowing: Int) -> ()) {}")
+    assertParse("func argumentLabel(anonConsumingInClosure: (_ consuming: Int) -> ()) {}")
+    assertParse("func argumentLabel(anonSharedInClosure: (_ __shared: Int) -> ()) {}")
+    assertParse("func argumentLabel(anonOwnedInClosure: (_ __owned: Int) -> ()) {}")
+  }
+
+  func testMisplaceSpecifierInTupleTypeBody() {
     assertParse(
-      """
-      struct borrowing {}
-      struct consuming {}
-
-      struct Foo {}
-
-      func foo(x: borrowing Foo) {}
-      func bar(x: consuming Foo) {}
-      func baz(x: (borrowing Foo, consuming Foo) -> ()) {}
-
-      // `borrowing` and `consuming` are contextual keywords, so they should also
-      // continue working as type and/or parameter names
-
-      func zim(x: borrowing) {}
-      func zang(x: consuming) {}
-      func zung(x: borrowing consuming) {}
-      func zip(x: consuming borrowing) {}
-      func zap(x: (borrowing, consuming) -> ()) {}
-      func zoop(x: (borrowing consuming, consuming borrowing) -> ()) {}
-
-      // Parameter specifier names are regular identifiers in other positions,
-      // including argument labels.
-
-      func argumentLabelOnly(borrowing: Int) {}
-      func argumentLabelOnly(consuming: Int) {}
-      func argumentLabelOnly(__shared: Int) {}
-      func argumentLabelOnly(__owned: Int) {}
-
-      func argumentLabel(borrowing consuming: Int) {}
-      func argumentLabel(consuming borrowing: Int) {}
-      func argumentLabel(__shared __owned: Int) {}
-      func argumentLabel(__owned __shared: Int) {}
-
-      // We should parse them as argument labels in function types, even though that
-      // isn't currently supported.
-
-      func argumentLabel(anonBorrowingInClosure: (_ borrowing: Int) -> ()) {}
-      func argumentLabel(anonConsumingInClosure: (_ consuming: Int) -> ()) {}
-      func argumentLabel(anonSharedInClosure: (_ __shared: Int) -> ()) {}
-      func argumentLabel(anonOwnedInClosure: (_ __owned: Int) -> ()) {}
-      """
+      "func test(a: (1️⃣borrowing F 2️⃣o))",
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'borrowing' in tuple type"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ',' in tuple type", fixIts: ["insert ','"]),
+      ],
+      fixedSource: "func test(a: (borrowing F, o))"
     )
   }
 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1859,4 +1859,14 @@ final class DeclarationTests: XCTestCase {
         )
     )
   }
+
+  func testEmptyPrimaryAssociatedType() {
+    assertParse(
+      "protocol X<1️⃣> {}",
+      diagnostics: [
+        DiagnosticSpec(message: "expected name in primary associated type clause", fixIts: ["insert name"])
+      ],
+      fixedSource: "protocol X<<#identifier#>> {}"
+    )
+  }
 }

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -91,7 +91,7 @@ final class StatementTests: XCTestCase {
   }
 
   func testNestedIfs() {
-    let nest = 20
+    let nest = 10
     var source = "func nestThoseIfs() {\n"
     for index in (0...nest) {
       let indent = String(repeating: "    ", count: index + 1)


### PR DESCRIPTION
* **Explanation**: https://github.com/apple/swift-syntax/pull/1706 uncovered 5 parser bugs with different severities. Fix them and add the testing strategy that found them to `release/5.9`
1. A round-trip failure for unexpected modifiers in a tuple type
```swift
func test(a: (borrowing F o))
```
2. A round-trip failure for modifiers in front of an editor placeholder in declaration position
```swift
struct a {
  public<#declaration#>
}
```
3. A precondition failure when the primary associated type clause of a protocol is empty
```swift
protocol X<> {}
```
4. It also uncovered an issue where we weren’t able to retrieve the trivia pieces of a token after it had been modified using `with` because after the modification the token was a `parsedToken` that no longer resided in a `ParsingSyntaxArena`. The fix is to search through an arena’s `childRefs` to find the `ParsingSyntaxArena` that created it. @rintaro can you review this change?
5. It uncovered that we were making assumptions about the presence of tokens in `ParseDiagnosticGenerator`, mostly that tokens in `UnexpectedNodesSyntax` are present. While this assumption is valid for trees generated by `SwiftParser`, it doesn’t need to hold for manually generated trees. A couple of minor adjustments to filter for only present tokens fixes this.
* **Scope**: Each fix is pretty targeted
* **Risk**:  The previous behavior was plainly wrong/crashed. So I think it’s very acceptable.
* **Testing**: Fixed all issues found by the new testing strategy
* **Issue**: rdar://109783066
* **Reviewer**:  @rintaro and @bnbarham on https://github.com/apple/swift-syntax/pull/1706