### PR TITLE
Replace deprecated code of FunctionTypeSyntax

### DIFF
--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -2350,7 +2350,7 @@ final class DeclarationTests: XCTestCase {
           SuppressedTypeSyntax(
             withoutTilde: .prefixOperator("~"),
             patternType: FunctionTypeSyntax(
-              arguments: [TupleTypeElementSyntax(type: TypeSyntax("Int"))],
+              parameters: [TupleTypeElementSyntax(type: TypeSyntax("Int"))],
               output: ReturnClauseSyntax(returnType: TypeSyntax("Bool"))
             )
           )


### PR DESCRIPTION
Trivial changes 😉 