### PR TITLE
[5.9][CMake] Allow install_name_tool to edit shared library load paths

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -65,6 +65,13 @@ function(add_swift_host_library name)
     BUILD_WITH_INSTALL_RPATH YES
   )
 
+  get_target_property(lib_type ${name} TYPE)
+  if(lib_type STREQUAL SHARED_LIBRARY AND CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    # Allow install_name_tool to update paths (for rdar://109473564)
+    set_property(TARGET ${name} APPEND_STRING PROPERTY
+                 LINK_FLAGS " -Xlinker -headerpad_max_install_names")
+  endif()
+
   # Install this target
   install(TARGETS ${name}
     EXPORT SwiftSyntaxTargets


### PR DESCRIPTION
* Explanation: `install_name_tool` is able to update install names as long as there's enough room. That sometimes happens to be the case (if eg. your path ends up being smaller/a similar size), but not always. Allow the maximum length so they can be updated to longer paths.
* Scope: Build
* Risk: Very low - sets `-headerpad_max_install_names` when linking Swift libraries. Either this links or doesn't.
* Testing: Builds and runs
* Original PR: https://github.com/apple/swift-syntax/pull/1734