### PR TITLE
[Macros] Ability to opt-out from auto-propagation of attrs/modifiers

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -46,8 +46,10 @@ public func expandFreestandingMacro(
         var rewritten = try declMacroDef.expansion(of: node, in: context)
         // Copy attributes and modifiers to the generated decls.
         if let expansionDecl = node.as(MacroExpansionDeclSyntax.self) {
+          let attributes = declMacroDef.propagateFreestandingMacroAttributes ? expansionDecl.attributes : nil
+          let modifiers = declMacroDef.propagateFreestandingMacroModifiers ? expansionDecl.modifiers : nil
           rewritten = rewritten.map {
-            $0.applying(attributes: expansionDecl.attributes, modifiers: expansionDecl.modifiers)
+            $0.applying(attributes: attributes, modifiers: modifiers)
           }
         }
         expandedSyntax = Syntax(

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/DeclarationMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/DeclarationMacro.swift
@@ -20,4 +20,16 @@ public protocol DeclarationMacro: FreestandingMacro {
     of node: Node,
     in context: Context
   ) throws -> [DeclSyntax]
+
+  /// Whether to copy attributes on the expansion syntax to expanded declarations,
+  /// 'true' by default.
+  static var propagateFreestandingMacroAttributes: Bool { get }
+  /// Whether to copy modifiers on the expansion syntax to expanded declarations,
+  /// 'true' by default.
+  static var propagateFreestandingMacroModifiers: Bool { get }
+}
+
+public extension DeclarationMacro {
+  static var propagateFreestandingMacroAttributes: Bool { true }
+  static var propagateFreestandingMacroModifiers: Bool { true }
 }

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -146,8 +146,10 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
               in: context
             )
             if let declExpansion = expansion.as(MacroExpansionDeclSyntax.self) {
+              let attributes = macro.propagateFreestandingMacroAttributes ? declExpansion.attributes : nil
+              let modifiers = macro.propagateFreestandingMacroModifiers ? declExpansion.modifiers : nil
               expandedItemList = expandedItemList.map {
-                $0.applying(attributes: declExpansion.attributes, modifiers: declExpansion.modifiers)
+                $0.applying(attributes: attributes, modifiers: modifiers)
               }
             }
             newItems.append(
@@ -203,8 +205,10 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
             of: declExpansion,
             in: context
           )
+          let attributes = freestandingMacro.propagateFreestandingMacroAttributes ? declExpansion.attributes : nil
+          let modifiers = freestandingMacro.propagateFreestandingMacroModifiers ? declExpansion.modifiers : nil
           expandedList = expandedList.map {
-            $0.applying(attributes: declExpansion.attributes, modifiers: declExpansion.modifiers)
+            $0.applying(attributes: attributes, modifiers: modifiers)
           }
 
           newItems.append(


### PR DESCRIPTION
`DeclarationMacro` now have two optional requirements that is defaulted to 'true':
```
  static var propagateFreestandingMacroAttributes: Bool { get }
  static var propagateFreestandingMacroModifiers: Bool { get }
```
By implementing these and returning 'false', macro expansion system won't copy attributes and/or modifiers to the expanded declarations.

rdar://110364154

I will add a test case with actual plugins in `swift` repo.