### PR TITLE
[5.9][Macros] Ability to opt-out from auto-propagation of attrs/modifiers

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -46,8 +46,10 @@ public func expandFreestandingMacro(
         var rewritten = try declMacroDef.expansion(of: node, in: context)
         // Copy attributes and modifiers to the generated decls.
         if let expansionDecl = node.as(MacroExpansionDeclSyntax.self) {
+          let attributes = declMacroDef.propagateFreestandingMacroAttributes ? expansionDecl.attributes : nil
+          let modifiers = declMacroDef.propagateFreestandingMacroModifiers ? expansionDecl.modifiers : nil
           rewritten = rewritten.map {
-            $0.applying(attributes: expansionDecl.attributes, modifiers: expansionDecl.modifiers)
+            $0.applying(attributes: attributes, modifiers: modifiers)
           }
         }
         expandedSyntax = Syntax(

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/DeclarationMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/DeclarationMacro.swift
@@ -20,4 +20,16 @@ public protocol DeclarationMacro: FreestandingMacro {
     of node: Node,
     in context: Context
   ) throws -> [DeclSyntax]
+
+  /// Whether to copy attributes on the expansion syntax to expanded declarations,
+  /// 'true' by default.
+  static var propagateFreestandingMacroAttributes: Bool { get }
+  /// Whether to copy modifiers on the expansion syntax to expanded declarations,
+  /// 'true' by default.
+  static var propagateFreestandingMacroModifiers: Bool { get }
+}
+
+public extension DeclarationMacro {
+  static var propagateFreestandingMacroAttributes: Bool { true }
+  static var propagateFreestandingMacroModifiers: Bool { true }
 }

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -141,8 +141,10 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
               in: context
             )
             if let declExpansion = expansion.as(MacroExpansionDeclSyntax.self) {
+              let attributes = macro.propagateFreestandingMacroAttributes ? declExpansion.attributes : nil
+              let modifiers = macro.propagateFreestandingMacroModifiers ? declExpansion.modifiers : nil
               expandedItemList = expandedItemList.map {
-                $0.applying(attributes: declExpansion.attributes, modifiers: declExpansion.modifiers)
+                $0.applying(attributes: attributes, modifiers: modifiers)
               }
             }
             newItems.append(
@@ -198,8 +200,10 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
             of: declExpansion,
             in: context
           )
+          let attributes = freestandingMacro.propagateFreestandingMacroAttributes ? declExpansion.attributes : nil
+          let modifiers = freestandingMacro.propagateFreestandingMacroModifiers ? declExpansion.modifiers : nil
           expandedList = expandedList.map {
-            $0.applying(attributes: declExpansion.attributes, modifiers: declExpansion.modifiers)
+            $0.applying(attributes: attributes, modifiers: modifiers)
           }
 
           newItems.append(


### PR DESCRIPTION
Cherry-pick #1738  into release/5.9

* **Explanation**: By default, attributes/modifiers on macro expansion syntax are copied/propagated to expanded declarations. But there're cases that behavior is not desirable. Add ability to `DeclarationMacro` opting-out from it, and handle attributes/modifiers themselves.
* **Scope**: Freestanding macro expansion
* **Risk**: Low, this doesn't affect existing macro implementations
* **Testing**: Added regression test cases.
* **Issue**: rdar://110364154
* **Reviewer**: Alex Hoppen (@ahoppen) Doug Gregor (@DougGregor)