### PR TITLE
[5.9] Make CodeBlockItemSyntax expressible by string

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -26,6 +26,7 @@ public let COMMON_NODES: [Node] = [
     nameForDiagnostics: nil,
     description: "A CodeBlockItem is any Syntax node that appears on its own line inside a CodeBlock.",
     kind: "Syntax",
+    parserFunction: "parseNonOptionalCodeBlockItem",
     children: [
       Child(
         name: "Item",

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
@@ -100,5 +100,22 @@ let parserEntryFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       }
       """
     )
+
+    DeclSyntax(
+      """
+      mutating func parseNonOptionalCodeBlockItem() -> RawCodeBlockItemSyntax {
+        guard let node = self.parseCodeBlockItem(isAtTopLevel: false, allowInitDecl: true) else {
+          // The missing item is not neccessary to be a declaration,
+          // which is just a placeholder here
+          return RawCodeBlockItemSyntax(
+            item: .decl(RawDeclSyntax(RawMissingDeclSyntax(attributes: nil, modifiers: nil, arena: self.arena))),
+            semicolon: nil,
+            arena: self.arena
+          )
+        }
+        return node
+      }
+      """
+    )
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -34,6 +34,8 @@ extension CatchClauseSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension ClosureParameterSyntax: SyntaxExpressibleByStringInterpolation {}
 
+extension CodeBlockItemSyntax: SyntaxExpressibleByStringInterpolation {}
+
 extension DeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension EnumCaseParameterSyntax: SyntaxExpressibleByStringInterpolation {}

--- a/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
@@ -44,4 +44,19 @@ final class CollectionNodeFlatteningTests: XCTestCase {
       """
     )
   }
+
+  func test_FlattenCodeBlockItemListWithCodeBlockItemStrings() {
+    let buildable = CodeBlockItemListSyntax {
+      "let one = object.methodOne()"
+      "let two = object.methodTwo()"
+    }
+
+    assertBuildResult(
+      buildable,
+      """
+      let one = object.methodOne()
+      let two = object.methodTwo()
+      """
+    )
+  }
 }

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -408,6 +408,26 @@ final class StringInterpolationTests: XCTestCase {
     )
   }
 
+  func testCodeBlockItemInterpolation() {
+    let codeBlockItem: CodeBlockItemSyntax =
+      """
+      func foo() {
+        return bar
+      }
+      """
+
+    XCTAssertTrue(codeBlockItem.is(CodeBlockItemSyntax.self))
+    assertStringsEqualWithDiff(
+      codeBlockItem.description,
+      """
+      func foo() {
+        return bar
+      }
+      """
+    )
+
+  }
+
   func testInvalidTrivia() {
     let invalid = Trivia("/*comment*/ invalid /*comm*/")
     XCTAssertEqual(invalid, [.blockComment("/*comment*/"), .spaces(1), .unexpectedText("invalid"), .spaces(1), .blockComment("/*comm*/")])
@@ -455,6 +475,23 @@ final class StringInterpolationTests: XCTestCase {
         1 │ struct Foo {}
           │ │            ╰─ error: expected statement
           │ ╰─ error: unexpected code 'struct Foo {}' before statement
+
+        """
+      )
+    }
+  }
+
+  func testInvalidSyntax3() {
+    let invalid: CodeBlockItemSyntax = " "
+
+    XCTAssert(invalid.hasError)
+    XCTAssertThrowsError(try CodeBlockItemSyntax(validating: " ")) { error in
+      assertStringsEqualWithDiff(
+        String(describing: error),
+        """
+
+        1 │ 
+          │ ╰─ error: expected declaration
 
         """
       )


### PR DESCRIPTION
* Explanation: This commit adds `SyntaxParseable ` conformance for `CodeBlockItemSyntax`. This is needed to be able to do eg. `let item: CodeBlockItemSyntax = "let foo = 1"` which is very useful for code block macros. While these aren't enabled in 5.9, cherry-picks will often contain tests for them (with code item macros enabled).
* Risk: Very low, just adds a public parse for `CodeBlockItemSyntax`.
* Original PR: https://github.com/apple/swift-syntax/pull/1426