### PR TITLE
rename `higherThanOrLowerThan` to `higherThanOrLowerThanKeyword`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -1903,7 +1903,7 @@ public let DECL_NODES: [Node] = [
     documentation: "Specify the new precedence group's relation to existing precedence groups.",
     children: [
       Child(
-        name: "HigherThanOrLowerThan",
+        name: "HigherThanOrLowerThanKeyword",
         kind: .token(choices: [.keyword(text: "higherThan"), .keyword(text: "lowerThan")]),
         documentation: "The relation to specified other precedence groups.",
         classification: "Keyword"

--- a/Sources/SwiftIDEUtils/generated/SyntaxClassification.swift
+++ b/Sources/SwiftIDEUtils/generated/SyntaxClassification.swift
@@ -91,7 +91,7 @@ extension SyntaxClassification {
       return (.operatorIdentifier, false)
     case \PrecedenceGroupAssociativitySyntax.associativityKeyword:
       return (.keyword, false)
-    case \PrecedenceGroupRelationSyntax.higherThanOrLowerThan:
+    case \PrecedenceGroupRelationSyntax.higherThanOrLowerThanKeyword:
       return (.keyword, false)
     case \SimpleTypeIdentifierSyntax.name:
       return (.typeIdentifier, false)

--- a/Sources/SwiftOperators/OperatorTable+Semantics.swift
+++ b/Sources/SwiftOperators/OperatorTable+Semantics.swift
@@ -23,7 +23,7 @@ extension PrecedenceGroup {
       switch attr {
       // Relation (lowerThan, higherThan)
       case .precedenceGroupRelation(let relation):
-        let isLowerThan = relation.higherThanOrLowerThan.text == "lowerThan"
+        let isLowerThan = relation.higherThanOrLowerThanKeyword.text == "lowerThan"
         for otherGroup in relation.otherNames {
           let otherGroupName = otherGroup.name.text
           let relationKind: PrecedenceRelation.Kind =

--- a/Sources/SwiftOperators/SyntaxSynthesis.swift
+++ b/Sources/SwiftOperators/SyntaxSynthesis.swift
@@ -56,7 +56,7 @@ extension PrecedenceRelation {
     indentation: Int = 4
   ) -> PrecedenceGroupRelationSyntax {
     PrecedenceGroupRelationSyntax(
-      higherThanOrLowerThan: .keyword(
+      higherThanOrLowerThanKeyword: .keyword(
         kind.keyword,
         leadingTrivia: [.newlines(1), .spaces(indentation)]
       ),

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -2013,7 +2013,7 @@ extension Parser {
           elements.append(
             .precedenceGroupRelation(
               RawPrecedenceGroupRelationSyntax(
-                higherThanOrLowerThan: level,
+                higherThanOrLowerThanKeyword: level,
                 unexpectedBeforeColon,
                 colon: colon,
                 otherNames: RawPrecedenceGroupNameListSyntax(elements: names, arena: self.arena),

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -554,6 +554,64 @@ public extension NamedOpaqueReturnTypeSyntax {
   }
 }
 
+public extension PrecedenceGroupRelationSyntax {
+  @available(*, deprecated, renamed: "unexpectedBeforeHigherThanOrLowerThanKeyword")
+  var unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBeforeHigherThanOrLowerThanKeyword
+    }
+    set(value) {
+      unexpectedBeforeHigherThanOrLowerThanKeyword = value
+    }
+  }
+
+  @available(*, deprecated, renamed: "higherThanOrLowerThanKeyword")
+  var higherThanOrLowerThan: TokenSyntax {
+    get {
+      return higherThanOrLowerThanKeyword
+    }
+    set(value) {
+      higherThanOrLowerThanKeyword = value
+    }
+  }
+
+  @available(*, deprecated, renamed: "unexpectedBetweenHigherThanOrLowerThanKeywordAndColon")
+  var unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenHigherThanOrLowerThanKeywordAndColon
+    }
+    set(value) {
+      unexpectedBetweenHigherThanOrLowerThanKeywordAndColon = value
+    }
+  }
+
+  @available(*, deprecated, message: "Use an initializer with a genericParameterClause argument.")
+  @_disfavoredOverload
+  init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodesSyntax? = nil,
+    higherThanOrLowerThan: TokenSyntax,
+    _ unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? = nil,
+    colon: TokenSyntax = .colonToken(),
+    _ unexpectedBetweenColonAndOtherNames: UnexpectedNodesSyntax? = nil,
+    otherNames: PrecedenceGroupNameListSyntax,
+    _ unexpectedAfterOtherNames: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeHigherThanOrLowerThan,
+      higherThanOrLowerThanKeyword: higherThanOrLowerThan,
+      unexpectedBetweenHigherThanOrLowerThanAndColon,
+      colon: colon,
+      unexpectedBetweenColonAndOtherNames,
+      otherNames: otherNames,
+      unexpectedAfterOtherNames,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
 public extension SyntaxProtocol {
   @available(*, deprecated, message: "Use detached computed property instead.")
   func detach() -> Self {

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -2643,12 +2643,12 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "trailingComma"
   case \PrecedenceGroupNameElementSyntax.unexpectedAfterTrailingComma:
     return "unexpectedAfterTrailingComma"
-  case \PrecedenceGroupRelationSyntax.unexpectedBeforeHigherThanOrLowerThan:
-    return "unexpectedBeforeHigherThanOrLowerThan"
-  case \PrecedenceGroupRelationSyntax.higherThanOrLowerThan:
-    return "higherThanOrLowerThan"
-  case \PrecedenceGroupRelationSyntax.unexpectedBetweenHigherThanOrLowerThanAndColon:
-    return "unexpectedBetweenHigherThanOrLowerThanAndColon"
+  case \PrecedenceGroupRelationSyntax.unexpectedBeforeHigherThanOrLowerThanKeyword:
+    return "unexpectedBeforeHigherThanOrLowerThanKeyword"
+  case \PrecedenceGroupRelationSyntax.higherThanOrLowerThanKeyword:
+    return "higherThanOrLowerThanKeyword"
+  case \PrecedenceGroupRelationSyntax.unexpectedBetweenHigherThanOrLowerThanKeywordAndColon:
+    return "unexpectedBetweenHigherThanOrLowerThanKeywordAndColon"
   case \PrecedenceGroupRelationSyntax.colon:
     return "colon"
   case \PrecedenceGroupRelationSyntax.unexpectedBetweenColonAndOtherNames:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -17468,9 +17468,9 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol {
   }
   
   public init(
-      _ unexpectedBeforeHigherThanOrLowerThan: RawUnexpectedNodesSyntax? = nil, 
-      higherThanOrLowerThan: RawTokenSyntax, 
-      _ unexpectedBetweenHigherThanOrLowerThanAndColon: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeHigherThanOrLowerThanKeyword: RawUnexpectedNodesSyntax? = nil, 
+      higherThanOrLowerThanKeyword: RawTokenSyntax, 
+      _ unexpectedBetweenHigherThanOrLowerThanKeywordAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndOtherNames: RawUnexpectedNodesSyntax? = nil, 
       otherNames: RawPrecedenceGroupNameListSyntax, 
@@ -17480,9 +17480,9 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupRelation, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeHigherThanOrLowerThan?.raw
-      layout[1] = higherThanOrLowerThan.raw
-      layout[2] = unexpectedBetweenHigherThanOrLowerThanAndColon?.raw
+      layout[0] = unexpectedBeforeHigherThanOrLowerThanKeyword?.raw
+      layout[1] = higherThanOrLowerThanKeyword.raw
+      layout[2] = unexpectedBetweenHigherThanOrLowerThanKeywordAndColon?.raw
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndOtherNames?.raw
       layout[5] = otherNames.raw
@@ -17491,15 +17491,15 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol {
     self.init(unchecked: raw)
   }
   
-  public var unexpectedBeforeHigherThanOrLowerThan: RawUnexpectedNodesSyntax? {
+  public var unexpectedBeforeHigherThanOrLowerThanKeyword: RawUnexpectedNodesSyntax? {
     layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var higherThanOrLowerThan: RawTokenSyntax {
+  public var higherThanOrLowerThanKeyword: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenHigherThanOrLowerThanAndColon: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenHigherThanOrLowerThanKeywordAndColon: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -14625,9 +14625,9 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   
   public init(
       leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodesSyntax? = nil,
-      higherThanOrLowerThan: TokenSyntax,
-      _ unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBeforeHigherThanOrLowerThanKeyword: UnexpectedNodesSyntax? = nil,
+      higherThanOrLowerThanKeyword: TokenSyntax,
+      _ unexpectedBetweenHigherThanOrLowerThanKeywordAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndOtherNames: UnexpectedNodesSyntax? = nil,
       otherNames: PrecedenceGroupNameListSyntax,
@@ -14638,18 +14638,18 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
     let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
-            unexpectedBeforeHigherThanOrLowerThan, 
-            higherThanOrLowerThan, 
-            unexpectedBetweenHigherThanOrLowerThanAndColon, 
+            unexpectedBeforeHigherThanOrLowerThanKeyword, 
+            higherThanOrLowerThanKeyword, 
+            unexpectedBetweenHigherThanOrLowerThanKeywordAndColon, 
             colon, 
             unexpectedBetweenColonAndOtherNames, 
             otherNames, 
             unexpectedAfterOtherNames
           ))) {(arena, _) in
       let layout: [RawSyntax?] = [
-          unexpectedBeforeHigherThanOrLowerThan?.raw, 
-          higherThanOrLowerThan.raw, 
-          unexpectedBetweenHigherThanOrLowerThanAndColon?.raw, 
+          unexpectedBeforeHigherThanOrLowerThanKeyword?.raw, 
+          higherThanOrLowerThanKeyword.raw, 
+          unexpectedBetweenHigherThanOrLowerThanKeywordAndColon?.raw, 
           colon.raw, 
           unexpectedBetweenColonAndOtherNames?.raw, 
           otherNames.raw, 
@@ -14668,7 +14668,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     self.init(data)
   }
   
-  public var unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodesSyntax? {
+  public var unexpectedBeforeHigherThanOrLowerThanKeyword: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -14678,7 +14678,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   }
   
   /// The relation to specified other precedence groups.
-  public var higherThanOrLowerThan: TokenSyntax {
+  public var higherThanOrLowerThanKeyword: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
     }
@@ -14687,7 +14687,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenHigherThanOrLowerThanKeywordAndColon: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -14754,9 +14754,9 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   
   public static var structure: SyntaxNodeStructure {
     return .layout([
-          \Self.unexpectedBeforeHigherThanOrLowerThan, 
-          \Self.higherThanOrLowerThan, 
-          \Self.unexpectedBetweenHigherThanOrLowerThanAndColon, 
+          \Self.unexpectedBeforeHigherThanOrLowerThanKeyword, 
+          \Self.higherThanOrLowerThanKeyword, 
+          \Self.unexpectedBetweenHigherThanOrLowerThanKeywordAndColon, 
           \Self.colon, 
           \Self.unexpectedBetweenColonAndOtherNames, 
           \Self.otherNames, 


### PR DESCRIPTION
Resolved #1747 