### PR TITLE
[5.9] In `assertStringsEqualWithDiff` trim newlines from expanded source

### DIFF
--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -282,8 +282,12 @@ public func assertMacroExpansion(
   let expandedSourceFile = origSourceFile.expand(macros: macros, in: context).formatted(using: BasicFormat(indentationWidth: indentationWidth))
 
   assertStringsEqualWithDiff(
-    expandedSourceFile.description.trimmingTrailingWhitespace(),
-    expandedSource.trimmingTrailingWhitespace(),
+    expandedSourceFile.description.trimmingTrailingWhitespace().trimmingCharacters(in: .newlines),
+    expandedSource.trimmingTrailingWhitespace().trimmingCharacters(in: .newlines),
+    additionalInfo: """
+      Actual expanded source:
+      \(expandedSource)
+      """,
     file: file,
     line: line
   )

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -783,7 +783,6 @@ final class MacroSystemTests: XCTestCase {
       }
       """,
       expandedSource: """
-
         struct X {
           func f() {
           }
@@ -807,7 +806,6 @@ final class MacroSystemTests: XCTestCase {
       #bitwidthNumberedStructs("MyInt")
       """,
       expandedSource: """
-
         struct MyInt8 {
         }
         struct MyInt16 {
@@ -829,7 +827,6 @@ final class MacroSystemTests: XCTestCase {
       var x: Int
       """,
       expandedSource: """
-
         var x: Int {
           get {
             _x.wrappedValue
@@ -852,7 +849,6 @@ final class MacroSystemTests: XCTestCase {
       func f(a: Int, for b: String, _ value: Double) async -> String { }
       """,
       expandedSource: """
-
         func f(a: Int, for b: String, _ value: Double) async -> String {
         }
 
@@ -876,7 +872,6 @@ final class MacroSystemTests: XCTestCase {
       }
       """,
       expandedSource: """
-
         struct S {
           var value: Int
           var _storage: Storage<Self>
@@ -904,7 +899,6 @@ final class MacroSystemTests: XCTestCase {
       }
       """,
       expandedSource: """
-
         struct Point {
           @Wrapper
           var x: Int
@@ -949,7 +943,6 @@ final class MacroSystemTests: XCTestCase {
       }
       """,
       expandedSource: """
-
         struct Point {
           @Wrapper
           var x: Int


### PR DESCRIPTION
This removes the oddity that if you expand an attached macro on the first line, the expected expanded source needs to start with a newline.

Also, when the actual expanded source does not match the expected one, print the actual expanded source as it’s sometimes easier to read than the diff, especially if there are multiple differences.