### PR TITLE
BasicFormat should not format unexpected nodes

### DIFF
--- a/CodeGeneration/Sources/Utils/CodeGenerationFormat.swift
+++ b/CodeGeneration/Sources/Utils/CodeGenerationFormat.swift
@@ -108,7 +108,7 @@ public class CodeGenerationFormat: BasicFormat {
   private func formatChildrenSeparatedByNewline<SyntaxType: SyntaxProtocol>(children: SyntaxChildren, elementType: SyntaxType.Type) -> [SyntaxType] {
     increaseIndentationLevel()
     var formattedChildren = children.map {
-      self.visit($0).as(SyntaxType.self)!
+      self.rewrite($0.cast(SyntaxType.self)).cast(SyntaxType.self)
     }
     formattedChildren = formattedChildren.map {
       if $0.leadingTrivia.first?.isNewline == true {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -30,33 +30,28 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     open class SyntaxRewriter
     """
   ) {
-    DeclSyntax("public init() {}")
+    DeclSyntax("public let viewMode: SyntaxTreeViewMode")
 
-    for node in SYNTAX_NODES where !node.kind.isBase {
-      if (node.base == .syntax || node.base == .syntaxCollection) && node.kind != .missing {
-        DeclSyntax(
-          """
-          /// Visit a ``\(node.kind.syntaxType)``.
-          ///   - Parameter node: the node that is being visited
-          ///   - Returns: the rewritten node
-          open func visit(_ node: \(node.kind.syntaxType)) -> \(node.kind.syntaxType) {
-            return Syntax(visitChildren(node)).cast(\(node.kind.syntaxType).self)
-          }
-          """
-        )
-      } else {
-        DeclSyntax(
-          """
-          /// Visit a ``\(node.kind.syntaxType)``.
-          ///   - Parameter node: the node that is being visited
-          ///   - Returns: the rewritten node
-          open func visit(_ node: \(node.kind.syntaxType)) -> \(raw: node.baseType.syntaxBaseName) {
-            return \(raw: node.baseType.syntaxBaseName)(visitChildren(node))
-          }
-          """
-        )
+    DeclSyntax(
+      """
+      public init(viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+        self.viewMode = viewMode
       }
-    }
+      """
+    )
+
+    DeclSyntax(
+      """
+      /// Rewrite `node` and anchor, making sure that the rewritten node also has
+      /// a parent if `node` had one.
+      public func rewrite(_ node: some SyntaxProtocol) -> Syntax {
+        let rewritten = self.visit(node.data)
+        return withExtendedLifetime(rewritten) {
+          return Syntax(node.data.replacingSelf(rewritten.raw, rawNodeArena: rewritten.raw.arena, allocationArena: SyntaxArena()))
+        }
+      }
+      """
+    )
 
     DeclSyntax(
       """
@@ -105,6 +100,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// Visit any Syntax node.
       ///   - Parameter node: the node that is being visited
       ///   - Returns: the rewritten node
+      @available(*, deprecated, renamed: "rewrite(_:)")
       public func visit(_ node: Syntax) -> Syntax {
         return visit(node.data)
       }
@@ -114,10 +110,36 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     DeclSyntax(
       """
       public func visit<T: SyntaxChildChoices>(_ node: T) -> T {
-        return visit(Syntax(node)).cast(T.self)
+        return visit(node.data).cast(T.self)
       }
       """
     )
+
+    for node in SYNTAX_NODES where !node.kind.isBase {
+      if (node.base == .syntax || node.base == .syntaxCollection) && node.kind != .missing {
+        DeclSyntax(
+          """
+          /// Visit a ``\(node.kind.syntaxType)``.
+          ///   - Parameter node: the node that is being visited
+          ///   - Returns: the rewritten node
+          open func visit(_ node: \(node.kind.syntaxType)) -> \(node.kind.syntaxType) {
+            return Syntax(visitChildren(node)).cast(\(node.kind.syntaxType).self)
+          }
+          """
+        )
+      } else {
+        DeclSyntax(
+          """
+          /// Visit a ``\(node.kind.syntaxType)``.
+          ///   - Parameter node: the node that is being visited
+          ///   - Returns: the rewritten node
+          open func visit(_ node: \(node.kind.syntaxType)) -> \(raw: node.baseType.syntaxBaseName) {
+            return \(raw: node.baseType.syntaxBaseName)(visitChildren(node))
+          }
+          """
+        )
+      }
+    }
 
     for baseKind in SyntaxNodeKind.allCases where baseKind.isBase && baseKind != .syntax && baseKind != .syntaxCollection {
       DeclSyntax(
@@ -258,34 +280,36 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         // initialize the new layout. Once we know that we have to rewrite the
         // layout, we need to collect all futher children, regardless of whether
         // they are rewritten or not.
-        
+
         // newLayout is nil until the first child node is rewritten and rewritten
         // nodes are being collected.
         var newLayout: ContiguousArray<RawSyntax?>?
-        
+
         // Rewritten children just to keep their 'SyntaxArena' alive until they are
         // wrapped with 'Syntax'
         var rewrittens: ContiguousArray<Syntax> = []
-        
+
         let syntaxNode = node._syntaxNode
-        
+
         // Incrementing i manually is faster than using .enumerated()
         var childIndex = 0
         for (raw, info) in RawSyntaxChildren(syntaxNode) {
           defer { childIndex += 1 }
-          guard let child = raw else {
-            // Node does not exist. If we are collecting rewritten nodes, we need to
-            // collect this one as well, otherwise we can ignore it.
+
+          guard let child = raw, viewMode.shouldTraverse(node: child) else {
+            // Node does not exist or should not be visited. If we are collecting
+            // rewritten nodes, we need to collect this one as well, otherwise we
+            // can ignore it.
             if newLayout != nil {
-              newLayout!.append(nil)
+              newLayout!.append(raw)
             }
             continue
           }
-          
+
           // Build the Syntax node to rewrite
           let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
           let data = SyntaxData(absoluteRaw, parent: syntaxNode)
-          
+
           let rewritten = visit(data)
           if rewritten.data.nodeId != info.nodeId {
             // The node was rewritten, let's handle it
@@ -293,7 +317,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
               // We have not yet collected any previous rewritten nodes. Initialize
               // the new layout with the previous nodes of the parent. This is
               // possible, since we know they were not rewritten.
-              
+
               // The below implementation is based on Collection.map but directly
               // reserves enough capacity for the entire layout.
               newLayout = ContiguousArray<RawSyntax?>()
@@ -302,7 +326,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                 newLayout!.append(node.raw.layoutView!.children[j])
               }
             }
-            
+
             // Now that we know we have a new layout in which we collect rewritten
             // nodes, add it.
             rewrittens.append(rewritten)
@@ -315,13 +339,13 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           }
         }
-        
+
         if let newLayout {
           // A child node was rewritten. Build the updated node.
-          
+
           // Sanity check, ensure the new children are the same length.
           precondition(newLayout.count == node.raw.layoutView!.children.count)
-          
+
           let arena = SyntaxArena()
           let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: arena)
           // 'withExtendedLifetime' to keep 'SyntaxArena's of them alive until here.
@@ -331,19 +355,6 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         } else {
           // No child node was rewritten. So no need to change this node as well.
           return node
-        }
-      }
-      """
-    )
-
-    DeclSyntax(
-      """
-      /// Rewrite `node` and anchor, making sure that the rewritten node also has
-      /// a parent if `node` had one.
-      public func rewrite(_ node: Syntax) -> Syntax {
-        let rewritten = self.visit(node)
-        return withExtendedLifetime(rewritten) {
-          return Syntax(node.data.replacingSelf(rewritten.raw, rawNodeArena: rewritten.raw.arena, allocationArena: SyntaxArena()))
         }
       }
       """

--- a/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
+++ b/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
@@ -36,6 +36,7 @@ final class SourceEditorCommand: NSObject, XCSourceEditorCommand {
 
       init(provider: any RefactoringProvider.Type) {
         self.provider = provider
+        super.init(viewMode: .sourceAccurate)
       }
 
       override func visitAny(_ node: Syntax) -> Syntax? {

--- a/Sources/SwiftBasicFormat/SyntaxProtocol+Formatted.swift
+++ b/Sources/SwiftBasicFormat/SyntaxProtocol+Formatted.swift
@@ -3,6 +3,6 @@ import SwiftSyntax
 public extension SyntaxProtocol {
   /// Build a syntax node from this `Buildable` and format it with the given format.
   func formatted(using format: BasicFormat = BasicFormat()) -> Syntax {
-    return format.visit(Syntax(self))
+    return format.rewrite(self)
   }
 }

--- a/Sources/SwiftOperators/OperatorTable+Folding.swift
+++ b/Sources/SwiftOperators/OperatorTable+Folding.swift
@@ -475,6 +475,7 @@ extension OperatorTable {
     ) {
       self.opPrecedence = opPrecedence
       self.errorHandler = errorHandler
+      super.init(viewMode: .fixedUp)
     }
 
     override func visitAny(_ node: Syntax) -> Syntax? {
@@ -538,7 +539,7 @@ extension OperatorTable {
         opPrecedence: self,
         errorHandler: errorHandler
       )
-      let result = folder.visit(Syntax(node))
+      let result = folder.rewrite(node)
 
       // If the sequence folder encountered an error that caused the error
       // handler to throw, invoke the error handler again with the original

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -78,7 +78,7 @@ extension FixIt.MultiNodeChange {
     guard let node = node else {
       return FixIt.MultiNodeChange(primitiveChanges: [])
     }
-    var changes = [FixIt.Change.replace(oldNode: Syntax(node), newNode: MissingMaker().visit(Syntax(node)))]
+    var changes = [FixIt.Change.replace(oldNode: Syntax(node), newNode: MissingMaker().rewrite(node))]
     if transferTrivia {
       changes += FixIt.MultiNodeChange.transferTriviaAtSides(from: [node]).primitiveChanges
     }
@@ -123,7 +123,7 @@ extension FixIt.MultiNodeChange {
     leadingTrivia: Trivia? = nil,
     trailingTrivia: Trivia? = nil
   ) -> Self {
-    var presentNode = MissingNodesBasicFormatter(viewMode: .fixedUp).visit(Syntax(node))
+    var presentNode = MissingNodesBasicFormatter(viewMode: .fixedUp).rewrite(node)
     presentNode = PresentMaker().rewrite(presentNode)
 
     if let leadingTrivia {

--- a/Sources/SwiftParserDiagnostics/PresenceUtils.swift
+++ b/Sources/SwiftParserDiagnostics/PresenceUtils.swift
@@ -45,6 +45,10 @@ extension SyntaxProtocol {
 
 /// Transforms a syntax tree by making all missing tokens present.
 class PresentMaker: SyntaxRewriter {
+  init() {
+    super.init(viewMode: .fixedUp)
+  }
+
   override func visit(_ token: TokenSyntax) -> TokenSyntax {
     if token.isMissing {
       let presentToken: TokenSyntax
@@ -62,7 +66,12 @@ class PresentMaker: SyntaxRewriter {
   }
 }
 
+/// Transforms a syntax tree by making all present tokens missing.
 class MissingMaker: SyntaxRewriter {
+  init() {
+    super.init(viewMode: .sourceAccurate)
+  }
+
   override func visit(_ node: TokenSyntax) -> TokenSyntax {
     guard node.isPresent else {
       return node

--- a/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
+++ b/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
@@ -125,7 +125,7 @@ public struct OpaqueParameterToGeneric: SyntaxRefactoringProvider {
     in params: ParameterClauseSyntax,
     augmenting genericParams: GenericParameterClauseSyntax?
   ) -> (ParameterClauseSyntax, GenericParameterClauseSyntax)? {
-    let rewriter = SomeParameterRewriter()
+    let rewriter = SomeParameterRewriter(viewMode: .sourceAccurate)
     let rewrittenParams = rewriter.visit(params.parameterList)
 
     if rewriter.rewrittenSomeParameters.isEmpty {

--- a/Sources/SwiftSyntaxBuilder/Indenter.swift
+++ b/Sources/SwiftSyntaxBuilder/Indenter.swift
@@ -30,6 +30,7 @@ class Indenter: SyntaxRewriter {
 
   init(indentation: Trivia) {
     self.indentation = indentation
+    super.init(viewMode: .sourceAccurate)
   }
 
   /// Adds `indentation` after all newlines in the syntax tree.
@@ -37,7 +38,7 @@ class Indenter: SyntaxRewriter {
     _ node: SyntaxType,
     indentation: Trivia
   ) -> SyntaxType {
-    return Indenter(indentation: indentation).visit(Syntax(node)).as(SyntaxType.self)!
+    return Indenter(indentation: indentation).rewrite(node).as(SyntaxType.self)!
   }
 
   public override func visit(_ token: TokenSyntax) -> TokenSyntax {

--- a/Sources/SwiftSyntaxMacros/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacros/MacroReplacement.swift
@@ -231,6 +231,7 @@ private final class MacroExpansionRewriter: SyntaxRewriter {
   init(parameterReplacements: [IdentifierExprSyntax: Int], arguments: [ExprSyntax]) {
     self.parameterReplacements = parameterReplacements
     self.arguments = arguments
+    super.init(viewMode: .sourceAccurate)
   }
 
   override func visit(_ node: IdentifierExprSyntax) -> ExprSyntax {

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -74,6 +74,7 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
   ) {
     self.macroSystem = macroSystem
     self.context = context
+    super.init(viewMode: .sourceAccurate)
   }
 
   override func visitAny(_ node: Syntax) -> Syntax? {
@@ -587,6 +588,6 @@ extension SyntaxProtocol {
       context: context
     )
 
-    return applier.visit(Syntax(self))
+    return applier.rewrite(self)
   }
 }

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -23,7 +23,7 @@ private class InitializerExprFormat: BasicFormat {
   private func formatChildrenSeparatedByNewline<SyntaxType: SyntaxProtocol>(children: SyntaxChildren, elementType: SyntaxType.Type) -> [SyntaxType] {
     increaseIndentationLevel()
     var formattedChildren = children.map {
-      self.visit($0).as(SyntaxType.self)!
+      self.rewrite($0.cast(SyntaxType.self)).cast(SyntaxType.self)
     }
     formattedChildren = formattedChildren.map {
       if $0.leadingTrivia.first?.isNewline == true {

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -257,7 +257,7 @@ func performClassifySyntax(args: CommandLineArguments) throws {
   let result = ClassifiedSyntaxTreePrinter.print(Syntax(tree))
   do {
     // Sanity check that we get the same result if the tree has constructed nodes.
-    let ctorTree = TreeReconstructor().visit(tree)
+    let ctorTree = TreeReconstructor(viewMode: .sourceAccurate).visit(tree)
     let ctorResult = ClassifiedSyntaxTreePrinter.print(Syntax(ctorTree))
     if ctorResult != result {
       throw TestingError.classificationVerificationFailed(result, ctorResult)

--- a/Tests/PerformanceTest/VisitorPerformanceTests.swift
+++ b/Tests/PerformanceTest/VisitorPerformanceTests.swift
@@ -48,7 +48,7 @@ public class VisitorPerformanceTests: XCTestCase {
       try {
         let parsed = Parser.parse(source: try String(contentsOf: inputFile))
 
-        let emptyRewriter = EmptyRewriter()
+        let emptyRewriter = EmptyRewriter(viewMode: .sourceAccurate)
 
         measure {
           _ = emptyRewriter.visit(parsed)

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -380,4 +380,17 @@ final class BasicFormatTest: XCTestCase {
         """
     )
   }
+
+  func testUnexpectedIsNotFormatted() {
+    let expr: ExprSyntax = """
+      let foo=1
+      """
+
+    assertFormatted(
+      tree: expr,
+      expected: """
+        let foo=1
+        """
+    )
+  }
 }

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -60,9 +60,9 @@ class ExplicitParenFolder: SyntaxRewriter {
     }
 
     return OperatorTable.makeBinaryOperationExpr(
-      lhs: visit(Syntax(leftOperand)).as(ExprSyntax.self)!,
-      op: visit(Syntax(middleExpr)).as(ExprSyntax.self)!,
-      rhs: visit(Syntax(rightOperand)).as(ExprSyntax.self)!
+      lhs: visit(leftOperand),
+      op: visit(middleExpr),
+      rhs: visit(rightOperand)
     )
   }
 }
@@ -86,7 +86,7 @@ extension OperatorTable {
 
     // Parse and "fold" the parenthesized version.
     let parenthesizedParsed = Parser.parse(source: fullyParenthesizedSource)
-    let parenthesizedSyntax = ExplicitParenFolder().visit(parenthesizedParsed)
+    let parenthesizedSyntax = ExplicitParenFolder(viewMode: .sourceAccurate).visit(parenthesizedParsed)
     XCTAssertFalse(parenthesizedSyntax.containsExprSequence)
 
     // Make sure the two have the same structure.

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -284,6 +284,8 @@ class FixItApplier: SyntaxRewriter {
         return messages.contains($0.message.message)
       }
       .flatMap { $0.changes }
+
+    super.init(viewMode: .all)
   }
 
   public override func visitAny(_ node: Syntax) -> Syntax? {
@@ -317,7 +319,7 @@ class FixItApplier: SyntaxRewriter {
   /// If `messages` is not `nil`, applies only Fix-Its whose message is in `messages`.
   public static func applyFixes<T: SyntaxProtocol>(in diagnostics: [Diagnostic], withMessages messages: [String]?, to tree: T) -> Syntax {
     let applier = FixItApplier(diagnostics: diagnostics, withMessages: messages)
-    return applier.visit(Syntax(tree))
+    return applier.rewrite(tree)
   }
 }
 
@@ -485,6 +487,8 @@ class TokenPresenceFlipper: SyntaxRewriter {
 
   init(flipTokenAtIndex: Int) {
     self.flipTokenAtIndex = flipTokenAtIndex
+
+    super.init(viewMode: .all)
   }
 
   override func visit(_ token: TokenSyntax) -> TokenSyntax {
@@ -743,8 +747,8 @@ func assertBasicFormat<S: SyntaxProtocol>(
   line: UInt = #line
 ) {
   var parser = Parser(source)
-  let sourceTree = Syntax(parse(&parser))
-  let withoutTrivia = TriviaRemover().visit(sourceTree)
+  let sourceTree = parse(&parser)
+  let withoutTrivia = TriviaRemover(viewMode: .sourceAccurate).rewrite(sourceTree)
   let formatted = withoutTrivia.formatted()
 
   var formattedParser = Parser(formatted.description)

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -235,7 +235,7 @@ final class StringInterpolationTests: XCTestCase {
         return DeclSyntax(newFunc)
       }
     }
-    let rewrittenSourceFile = Rewriter().visit(sourceFile)
+    let rewrittenSourceFile = Rewriter(viewMode: .sourceAccurate).visit(sourceFile)
     XCTAssertEqual(
       rewrittenSourceFile.description,
       """

--- a/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
@@ -14,14 +14,6 @@ import _SwiftSyntaxTestSupport
 import SwiftSyntax
 import XCTest
 
-fileprivate class FuncRenamer: SyntaxRewriter {
-  override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
-    let rewritten = super.visit(node).as(FunctionDeclSyntax.self)!
-    let modifiedFunctionDecl = rewritten.with(\.identifier, .identifier("anotherName"))
-    return DeclSyntax(modifiedFunctionDecl)
-  }
-}
-
 public class AbsolutePositionTests: XCTestCase {
   public func testRecursion() {
     var l = [CodeBlockItemSyntax]()

--- a/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
@@ -158,7 +158,7 @@ public class SyntaxVisitorTests: XCTestCase {
     let closure = ClosureExprSyntax(
       statements: CodeBlockItemListSyntax([])
     )
-    let rewriter = ClosureRewriter()
+    let rewriter = ClosureRewriter(viewMode: .sourceAccurate)
     let rewritten = rewriter.visit(closure)
     XCTAssertEqual(closure.description, rewritten.description)
   }
@@ -168,6 +168,7 @@ public class SyntaxVisitorTests: XCTestCase {
       let transform: (TokenSyntax) -> TokenSyntax
       init(transform: @escaping (TokenSyntax) -> TokenSyntax) {
         self.transform = transform
+        super.init(viewMode: .sourceAccurate)
       }
       override func visitAny(_ node: Syntax) -> Syntax? {
         if let tok = node.as(TokenSyntax.self) {
@@ -235,7 +236,7 @@ public class SyntaxVisitorTests: XCTestCase {
       ])
     )
     XCTAssertEqual(source.description, "let a = 5")
-    let visitor = TriviaRemover()
+    let visitor = TriviaRemover(viewMode: .sourceAccurate)
     let rewritten = visitor.visit(source)
     XCTAssertEqual(rewritten.description, "leta=5")
   }

--- a/Tests/SwiftSyntaxTest/VisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTests.swift
@@ -144,8 +144,8 @@ public class VisitorTests: XCTestCase {
       }
 
       static func print<Tree: SyntaxProtocol>(_ tree: Tree, viewMode: SyntaxTreeViewMode) -> String {
-        let printer = TreePrinter(viewMode: viewMode)
-        printer.walk(tree)
+        let printer = RewritingTreePrinter(viewMode: viewMode)
+        _ = printer.rewrite(Syntax(tree))
         return printer.out
       }
     }


### PR DESCRIPTION
`BasicFormat` depends on the parent layout nodes to determine formatting in some cases, so it doesn't make sense to visit unexpected nodes.

Also fix up `SyntaxRewriter` to take a `viewMode`, since as it was `BasicFormat` was actually visiting `missing` nodes, which also doesn't make much sense.

Resolves rdar://110463876.