### PR TITLE
[5.9] [Macros] Pass macro role for freestanding macro expansion

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/CompilerPluginMessageHandler.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/CompilerPluginMessageHandler.swift
@@ -87,9 +87,10 @@ extension CompilerPluginMessageHandler {
       )
       try self.sendMessage(.getCapabilityResult(capability: capability))
 
-    case .expandFreestandingMacro(let macro, let discriminator, let expandingSyntax):
+    case .expandFreestandingMacro(let macro, let macroRole, let discriminator, let expandingSyntax):
       try expandFreestandingMacro(
         macro: macro,
+        macroRole: macroRole,
         discriminator: discriminator,
         expandingSyntax: expandingSyntax
       )

--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -14,17 +14,32 @@ import SwiftDiagnostics
 import SwiftSyntax
 
 /// Errors in macro handing.
-enum MacroExpansionError: String {
-  case macroTypeNotFound = "macro expanding type not found"
-  case unmathedMacroRole = "macro doesn't conform to required macro role"
-  case freestandingMacroSyntaxIsNotMacro = "macro syntax couldn't be parsed"
-  case invalidExpansionMessage = "internal message error; please file a bug report"
-  case invalidMacroRole = "invalid macro role for expansion"
+enum MacroExpansionError {
+  case macroTypeNotFound(PluginMessage.MacroReference)
+  case unmatchedMacroRole
+  case freestandingMacroSyntaxIsNotMacro
+  case invalidExpansionMessage
+  case invalidMacroRole(PluginMessage.MacroRole)
 }
 
 extension MacroExpansionError: DiagnosticMessage {
   var message: String {
-    self.rawValue
+    switch self {
+    case .macroTypeNotFound(let ref):
+      return "macro type '\(ref.moduleName).\(ref.typeName)' not found when expanding macro '\(ref.name)'"
+
+    case .unmatchedMacroRole:
+      return "macro doesn't conform to required macro role"
+
+    case .freestandingMacroSyntaxIsNotMacro:
+      return "macro syntax couldn't be parsed"
+
+    case .invalidExpansionMessage:
+      return "internal message error; please file a bug report"
+
+    case .invalidMacroRole(let role):
+      return "invalid macro role '\(role)' for expansion"
+    }
   }
   var diagnosticID: SwiftDiagnostics.MessageID {
     .init(domain: "SwiftCompilerPlugin", id: "\(type(of: self)).\(self)")

--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -16,7 +16,6 @@ import SwiftSyntax
 /// Errors in macro handing.
 enum MacroExpansionError {
   case macroTypeNotFound(PluginMessage.MacroReference)
-  case unmatchedMacroRole
   case freestandingMacroSyntaxIsNotMacro
   case invalidExpansionMessage
   case invalidMacroRole(PluginMessage.MacroRole)
@@ -27,9 +26,6 @@ extension MacroExpansionError: DiagnosticMessage {
     switch self {
     case .macroTypeNotFound(let ref):
       return "macro type '\(ref.moduleName).\(ref.typeName)' not found when expanding macro '\(ref.name)'"
-
-    case .unmatchedMacroRole:
-      return "macro doesn't conform to required macro role"
 
     case .freestandingMacroSyntaxIsNotMacro:
       return "macro syntax couldn't be parsed"

--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -19,6 +19,7 @@ enum MacroExpansionError: String {
   case unmathedMacroRole = "macro doesn't conform to required macro role"
   case freestandingMacroSyntaxIsNotMacro = "macro syntax couldn't be parsed"
   case invalidExpansionMessage = "internal message error; please file a bug report"
+  case invalidMacroRole = "invalid macro role for expansion"
 }
 
 extension MacroExpansionError: DiagnosticMessage {

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -44,7 +44,7 @@ extension CompilerPluginMessageHandler {
         throw MacroExpansionError.freestandingMacroSyntaxIsNotMacro
       }
       guard let macroDefinition = resolveMacro(macro) else {
-        throw MacroExpansionError.macroTypeNotFound
+        throw MacroExpansionError.macroTypeNotFound(macro)
       }
 
       let macroRole: MacroRole
@@ -55,7 +55,7 @@ extension CompilerPluginMessageHandler {
         case .codeItem: macroRole = .codeItem
 
         case .accessor, .conformance, .member, .memberAttribute, .peer:
-          throw MacroExpansionError.invalidMacroRole
+          throw MacroExpansionError.invalidMacroRole(pluginMacroRole)
         }
       } else {
         macroRole = try inferFreestandingMacroRole(definition: macroDefinition)
@@ -105,7 +105,7 @@ extension CompilerPluginMessageHandler {
     let expandedSources: [String]?
     do {
       guard let macroDefinition = resolveMacro(macro) else {
-        throw MacroExpansionError.macroTypeNotFound
+        throw MacroExpansionError.macroTypeNotFound(macro)
       }
 
       expandedSources = SwiftSyntaxMacroExpansion.expandAttachedMacro(

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -49,14 +49,7 @@ extension CompilerPluginMessageHandler {
 
       let macroRole: MacroRole
       if let pluginMacroRole {
-        switch pluginMacroRole {
-        case .expression: macroRole = .expression
-        case .declaration: macroRole = .declaration
-        case .codeItem: macroRole = .codeItem
-
-        case .accessor, .conformance, .member, .memberAttribute, .peer:
-          throw MacroExpansionError.invalidMacroRole(pluginMacroRole)
-        }
+        macroRole = MacroRole(messageMacroRole: pluginMacroRole)
       } else {
         macroRole = try inferFreestandingMacroRole(definition: macroDefinition)
       }

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
@@ -20,6 +20,7 @@ internal enum HostToPluginMessage: Codable {
   /// Expand a '@freestanding' macro.
   case expandFreestandingMacro(
     macro: PluginMessage.MacroReference,
+    macroRole: PluginMessage.MacroRole? = nil,
     discriminator: String,
     syntax: PluginMessage.Syntax
   )

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -12,13 +12,48 @@ public enum MacroRole {
   case codeItem
 }
 
+extension MacroRole {
+  var protocolName: String {
+    switch self {
+    case .expression: return "ExpressionMacro"
+    case .declaration: return "DeclarationMacro"
+    case .accessor: return "AccessorMacro"
+    case .memberAttribute: return "MemberAttributeMacro"
+    case .member: return "MemberMacro"
+    case .peer: return "PeerMacro"
+    case .conformance: return "ConformanceMacro"
+    case .codeItem: return "CodeItemMacro"
+    }
+  }
+}
+
 /// Simple diagnostic message
-private enum MacroExpansionError: String, Error, CustomStringConvertible {
-  case unmathedMacroRole = "macro doesn't conform to required macro role"
-  case parentDeclGroupNil = "parent decl group is nil"
-  case declarationNotDeclGroup = "declaration is not a decl group syntax"
-  case declarationNotIdentified = "declaration is not a 'Identified' syntax"
-  var description: String { self.rawValue }
+private enum MacroExpansionError: Error, CustomStringConvertible {
+  case unmatchedMacroRole(Macro.Type, MacroRole)
+  case parentDeclGroupNil
+  case declarationNotDeclGroup
+  case declarationNotIdentified
+  case noFreestandingMacroRoles(Macro.Type)
+
+  var description: String {
+    switch self {
+    case .unmatchedMacroRole(let type, let role):
+      return "macro implementation type '\(type)' doesn't conform to required protocol '\(role.protocolName)'"
+
+    case .parentDeclGroupNil:
+      return "parent decl group is nil"
+
+    case .declarationNotDeclGroup:
+      return "declaration is not a decl group syntax"
+
+    case .declarationNotIdentified:
+      return "declaration is not a 'Identified' syntax"
+
+    case .noFreestandingMacroRoles(let type):
+      return "macro implementation type '\(type)' does not conform to any freestanding macro protocol"
+
+    }
+  }
 }
 
 /// Expand `@freestanding(XXX)` macros.
@@ -66,11 +101,9 @@ public func expandFreestandingMacro(
         let rewritten = try codeItemMacroDef.expansion(of: node, in: context)
         expandedSyntax = Syntax(CodeBlockItemListSyntax(rewritten))
 
-      case (.expression, _), (.declaration, _), (.codeItem, _):
-        throw MacroExpansionError.unmathedMacroRole
-
-      case (.accessor, _), (.memberAttribute, _), (.member, _), (.peer, _), (.conformance, _), (.codeItem, _):
-        fatalError("macro role \(macroRole) is not a freestanding macro")
+      case (.accessor, _), (.memberAttribute, _), (.member, _), (.peer, _), (.conformance, _), (.expression, _), (.declaration, _),
+        (.codeItem, _):
+        throw MacroExpansionError.unmatchedMacroRole(definition, macroRole)
       }
       return expandedSyntax.formattedExpansion(definition.formatMode)
     }
@@ -91,7 +124,7 @@ public func inferFreestandingMacroRole(definition: Macro.Type) throws -> MacroRo
   case is CodeItemMacro.Type: return .codeItem
 
   default:
-    throw MacroExpansionError.unmathedMacroRole
+    throw MacroExpansionError.noFreestandingMacroRoles(definition)
   }
 }
 
@@ -251,7 +284,7 @@ public func expandAttachedMacro<Context: MacroExpansionContext>(
       }
 
     default:
-      throw MacroExpansionError.unmathedMacroRole
+      throw MacroExpansionError.unmatchedMacroRole(definition, macroRole)
     }
   } catch {
     context.addDiagnostics(from: error, node: attributeNode)


### PR DESCRIPTION
* **Explanation**: Extend the protocol used by the macro server to include a freestanding macro role in the freestanding macro expansion request, and provide improved diagnostics when the role requested is not implemented by the macro implementation type. This is, on the whole, more informative than crashing the compiler, which is what happened before.
* **Scope**: Narrow; only affects validation of freestanding macro expansions.
* **Risk**: Low; narrow change to perform better validation when expanding freestanding macros.
* **Reviewed by**: @rintaro 
* **Issue**: rdar://110418969
* **Original pull request**: https://github.com/apple/swift-syntax/pull/1757, https://github.com/apple/swift-syntax/pull/1762
