### PR TITLE
Remove the last arbitrary keyword as a token choice

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -421,7 +421,6 @@ public let TYPE_NODES: [Node] = [
           .keyword(text: "self"),
           .keyword(text: "Self"),
           .keyword(text: "Any"),
-          .token(tokenKind: "KeywordToken"),
           .token(tokenKind: "WildcardToken"),
         ]),
         classification: "TypeIdentifier"

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -553,7 +553,7 @@ extension Parser {
 
   mutating func parseTransposeAttribute() -> RawAttributeSyntax {
     let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
-    let (unexpectedBeforeTranspose, transpose) = self.expect(.keyword(.transpose))
+    let (unexpectedBeforeTranspose, transpose) = self.expect(TokenSpec(.transpose, remapping: .identifier))
 
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
     let argument = self.parseDerivativeAttributeArguments()

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2277,7 +2277,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("self"), 
             .keyword("Self"), 
             .keyword("Any"), 
-            .tokenKind(.keyword), 
             .tokenKind(.wildcard)
           ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))


### PR DESCRIPTION
Having any keyword as a token choice in the syntax tree has been an anti-pattern for a while. `SimpleTypeIdentifier.name` has been the last lingering of this cases.