### PR TITLE
Generate grammar doc comments for layout nodes

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Generates grammar doc comments for syntax nodes.
+struct GrammarGenerator {
+  private func grammar(for tokenChoice: TokenChoice) -> String {
+    switch tokenChoice {
+    case .keyword(text: let text):
+      return "`'\(text)'`"
+    case .token(tokenKind: let tokenKind):
+      let token = SYNTAX_TOKEN_MAP[tokenKind]!
+      if let tokenText = token.text {
+        return "`'\(tokenText)'`"
+      } else {
+        return "`<\(token.swiftKind)>`"
+      }
+    }
+  }
+
+  private func grammar(for child: Child) -> String {
+    let optionality = child.isOptional ? "?" : ""
+    switch child.kind {
+    case .node(let kind):
+      return "``\(kind.syntaxType)``\(optionality)"
+    case .nodeChoices(let choices):
+      let choicesDescriptions = choices.map { grammar(for: $0) }
+      return "(\(choicesDescriptions.joined(separator: " | ")))\(optionality)"
+    case .collection(let kind, _, _):
+      return "``\(kind.syntaxType)``"
+    case .token(let choices, _, _):
+      if choices.count == 1 {
+        return "\(grammar(for: choices.first!))\(optionality)"
+      } else {
+        let choicesDescriptions = choices.map { grammar(for: $0) }
+        return "(\(choicesDescriptions.joined(separator: " | ")))\(optionality)"
+      }
+    }
+  }
+
+  /// Generates a markdown list containing the children’s names and their
+  /// grammar.
+  ///
+  /// - Parameter children: The children to show in the list
+  static func childrenList(for children: [Child]) -> String {
+    let generator = GrammarGenerator()
+    return
+      children
+      .filter { !$0.isUnexpectedNodes }
+      .map { " - `\($0.varName)`: \(generator.grammar(for: $0))" }
+      .joined(separator: "\n")
+  }
+}

--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -220,6 +220,20 @@ public struct LayoutNode {
       preconditionFailure("NodeLayoutView must wrap a Node with data `.layout`")
     }
   }
+
+  public var grammar: SwiftSyntax.Trivia {
+    guard !children.isEmpty else {
+      return []
+    }
+
+    return docCommentTrivia(
+      from: """
+        ### Children
+
+        \(GrammarGenerator.childrenList(for: children))
+        """
+    )
+  }
 }
 
 /// Provides a view into a collection node that offers access to the

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -40,6 +40,8 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
         // MARK: - \(raw: node.kind.syntaxType)
 
         \(raw: node.documentation)
+        \(raw: node.documentation.isEmpty ? "" : "///")
+        \(raw: node.grammar)
         public struct \(raw: node.kind.syntaxType): \(raw: node.baseType.syntaxBaseName)Protocol, SyntaxHashable
         """
       ) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -15,6 +15,16 @@
 // MARK: - AccessorDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifier`: ``DeclModifierSyntax``?
+///  - `accessorKind`: (`'get'` | `'set'` | `'didSet'` | `'willSet'` | `'unsafeAddress'` | `'addressWithOwner'` | `'addressWithNativeOwner'` | `'unsafeMutableAddress'` | `'mutableAddressWithOwner'` | `'mutableAddressWithNativeOwner'` | `'_read'` | `'_modify'` | `'init'`)
+///  - `parameter`: ``AccessorParameterSyntax``?
+///  - `effectSpecifiers`: ``AccessorEffectSpecifiersSyntax``?
+///  - `initEffects`: ``AccessorInitEffectsSyntax``?
+///  - `body`: ``CodeBlockSyntax``?
 public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -285,6 +295,17 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - ActorDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `actorKeyword`: `'actor'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -627,6 +648,16 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ```swift
 /// associatedtype Iterator: IteratorProtocol where Iterator.Element == Item
 /// ```
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `associatedtypeKeyword`: `'associatedtype'`
+///  - `identifier`: `<identifier>`
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `initializer`: ``TypeInitializerClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -948,6 +979,17 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ```
 /// 
 /// A class declaration may be declared without any members.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `classKeyword`: `'class'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1281,6 +1323,14 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// deinit {
 /// }
 /// ```
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `deinitKeyword`: `'deinit'`
+///  - `effectSpecifiers`: ``DeinitEffectSpecifiersSyntax``?
+///  - `body`: ``CodeBlockSyntax``?
 public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1527,6 +1577,12 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - EditorPlaceholderDeclSyntax
 
 /// An editor placeholder, e.g. `<#declaration#>` that is used in a position that expects a declaration.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `placeholder`: `<identifier>`
 public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1720,6 +1776,13 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - EnumCaseDeclSyntax
 
 /// A `case` declaration of a Swift `enum`. It can have 1 or more `EnumCaseElement`s inside, each declaring a different case of the enum.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `caseKeyword`: `'case'`
+///  - `elements`: ``EnumCaseElementListSyntax``
 public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1964,6 +2027,17 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - EnumDeclSyntax
 
 /// A Swift `enum` declaration.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `enumKeyword`: `'enum'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2292,6 +2366,16 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - ExtensionDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `extensionKeyword`: `'extension'`
+///  - `extendedType`: ``TypeSyntax``
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2586,6 +2670,17 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `funcKeyword`: `'func'`
+///  - `identifier`: (`<identifier>` | `<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `signature`: ``FunctionSignatureSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `body`: ``CodeBlockSyntax``?
 public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2906,6 +3001,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - IfConfigDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `clauses`: ``IfConfigClauseListSyntax``
+///  - `poundEndif`: `'#endif'`
 public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3050,6 +3150,14 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ```swift
 /// import Foundation
 /// ```
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `importKeyword`: `'import'`
+///  - `importKind`: (`'typealias'` | `'struct'` | `'class'` | `'enum'` | `'protocol'` | `'var'` | `'let'` | `'func'` | `'inout'`)?
+///  - `path`: ``ImportPathSyntax``
 public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3328,6 +3436,17 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ```
 /// 
 /// The body is optional because this node also represents initializer requirements inside protocols.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `initKeyword`: `'init'`
+///  - `optionalMark`: (`'?'` | `'?'` | `'!'`)?
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `signature`: ``FunctionSignatureSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `body`: ``CodeBlockSyntax``?
 public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3656,6 +3775,17 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - MacroDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `macroKeyword`: `'macro'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `signature`: ``FunctionSignatureSyntax``
+///  - `definition`: ``InitializerClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3976,6 +4106,19 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - MacroExpansionDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `poundToken`: `'#'`
+///  - `macro`: `<identifier>`
+///  - `genericArguments`: ``GenericArgumentClauseSyntax``?
+///  - `leftParen`: `'('`?
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`?
+///  - `trailingClosure`: ``ClosureExprSyntax``?
+///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
 public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4397,6 +4540,12 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingDeclSyntax
 
 /// In case the source code is missing a declaration, this node stands in place of the missing declaration.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `placeholder`: `<identifier>`
 public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4590,6 +4739,13 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - OperatorDeclSyntax
 
 /// A Swift `operator` declaration.
+///
+/// ### Children
+/// 
+///  - `fixity`: (`'prefix'` | `'postfix'` | `'infix'`)
+///  - `operatorKeyword`: `'operator'`
+///  - `identifier`: (`<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
+///  - `operatorPrecedenceAndTypes`: ``OperatorPrecedenceAndTypesSyntax``?
 public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4760,6 +4916,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - PoundSourceLocationSyntax
 
 
+
+/// ### Children
+/// 
+///  - `poundSourceLocation`: `'#sourceLocation'`
+///  - `leftParen`: `'('`
+///  - `args`: ``PoundSourceLocationArgsSyntax``?
+///  - `rightParen`: `')'`
 public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4928,6 +5091,16 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - PrecedenceGroupDeclSyntax
 
 /// A Swift `precedencegroup` declaration.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `precedencegroupKeyword`: `'precedencegroup'`
+///  - `identifier`: `<identifier>`
+///  - `leftBrace`: `'{'`
+///  - `groupAttributes`: ``PrecedenceGroupAttributeListSyntax``
+///  - `rightBrace`: `'}'`
 public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5256,6 +5429,17 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 ///   var isValid: Bool { get }
 /// }
 /// ```
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `protocolKeyword`: `'protocol'`
+///  - `identifier`: `<identifier>`
+///  - `primaryAssociatedTypeClause`: ``PrimaryAssociatedTypeClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5638,6 +5822,17 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 ///       }
 ///    }
 ///    ```
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `structKeyword`: `'struct'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5966,6 +6161,17 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - SubscriptDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `subscriptKeyword`: `'subscript'`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `indices`: ``ParameterClauseSyntax``
+///  - `result`: ``ReturnClauseSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `accessor`: (``AccessorBlockSyntax`` | ``CodeBlockSyntax``)?
 public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public enum Accessor: SyntaxChildChoices {
     case `accessors`(AccessorBlockSyntax)
@@ -6328,6 +6534,16 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - TypealiasDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `typealiasKeyword`: `'typealias'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `initializer`: ``TypeInitializerClauseSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6622,6 +6838,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - VariableDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `bindingKeyword`: (`'let'` | `'var'` | `'inout'`)
+///  - `bindings`: ``PatternBindingListSyntax``
 public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -15,6 +15,12 @@
 // MARK: - ArrayExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquare`: `'['`
+///  - `elements`: ``ArrayElementListSyntax``
+///  - `rightSquare`: `']'`
 public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -181,6 +187,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - ArrowExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `effectSpecifiers`: ``TypeEffectSpecifiersSyntax``?
+///  - `arrowToken`: `'->'`
 public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -297,6 +308,13 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - AsExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `asTok`: `'as'`
+///  - `questionOrExclamationMark`: (`'?'` | `'!'`)?
+///  - `typeName`: ``TypeSyntax``
 public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -465,6 +483,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - AssignmentExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `assignToken`: `'='`
 public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -543,6 +565,11 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - AwaitExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `awaitKeyword`: `'await'`
+///  - `expression`: ``ExprSyntax``
 public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -659,6 +686,10 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - BinaryOperatorExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `operatorToken`: `<binaryOperator>`
 public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -737,6 +768,10 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - BooleanLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `booleanLiteral`: (`'true'` | `'false'`)
 public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -815,6 +850,11 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - BorrowExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `borrowKeyword`: `'_borrow'`
+///  - `expression`: ``ExprSyntax``
 public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -931,6 +971,14 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - CanImportExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `canImportKeyword`: `'canImport'`
+///  - `leftParen`: `'('`
+///  - `importPath`: `<identifier>`
+///  - `versionInfo`: ``CanImportVersionInfoSyntax``?
+///  - `rightParen`: `')'`
 public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1125,6 +1173,13 @@ public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - CanImportVersionInfoSyntax
 
 
+
+/// ### Children
+/// 
+///  - `comma`: `','`
+///  - `label`: (`'_version'` | `'_underlyingVersion'`)
+///  - `colon`: `':'`
+///  - `versionTuple`: ``VersionTupleSyntax``
 public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1293,6 +1348,13 @@ public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBrace`: `'{'`
+///  - `signature`: ``ClosureSignatureSyntax``?
+///  - `statements`: ``CodeBlockItemListSyntax``
+///  - `rightBrace`: `'}'`
 public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1485,6 +1547,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - CopyExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `copyKeyword`: `'copy'`
+///  - `expression`: ``ExprSyntax``
 public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1601,6 +1668,12 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - DictionaryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquare`: `'['`
+///  - `content`: (`':'` | ``DictionaryElementListSyntax``)
+///  - `rightSquare`: `']'`
 public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public enum Content: SyntaxChildChoices {
     case `colon`(TokenSyntax)
@@ -1785,6 +1858,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - DiscardAssignmentExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `wildcard`: `'_'`
 public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1863,6 +1940,10 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - EditorPlaceholderExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `identifier`: `<identifier>`
 public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1941,6 +2022,10 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - FloatLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `floatingDigits`: `<floatingLiteral>`
 public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2019,6 +2104,11 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - ForcedValueExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `exclamationMark`: `'!'`
 public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2135,6 +2225,15 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionCallExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `calledExpression`: ``ExprSyntax``
+///  - `leftParen`: `'('`?
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`?
+///  - `trailingClosure`: ``ClosureExprSyntax``?
+///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
 public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2403,6 +2502,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - IdentifierExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `identifier`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<dollarIdentifier>` | `<binaryOperator>`)
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
 public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2519,6 +2623,14 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - IfExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `ifKeyword`: `'if'`
+///  - `conditions`: ``ConditionElementListSyntax``
+///  - `body`: ``CodeBlockSyntax``
+///  - `elseKeyword`: `'else'`?
+///  - `elseBody`: (``IfExprSyntax`` | ``CodeBlockSyntax``)?
 public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public enum ElseBody: SyntaxChildChoices {
     case `ifExpr`(IfExprSyntax)
@@ -2779,6 +2891,11 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - InOutExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `ampersand`: `'&'`
+///  - `expression`: ``ExprSyntax``
 public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2895,6 +3012,12 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - InfixOperatorExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftOperand`: ``ExprSyntax``
+///  - `operatorOperand`: ``ExprSyntax``
+///  - `rightOperand`: ``ExprSyntax``
 public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3037,6 +3160,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - IntegerLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `digits`: `<integerLiteral>`
 public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3121,6 +3248,12 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ```
 /// 
 /// This node is only generated after operators are folded using the `SwiftOperators` library. Beforehand, the parser does not know the precedences of operators and thus represents `is` by an `UnresolvedIsExpr`.
+///
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `isTok`: `'is'`
+///  - `typeName`: ``TypeSyntax``
 public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3266,6 +3399,12 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `backslash`: `'\'`
+///  - `root`: ``TypeSyntax``?
+///  - `components`: ``KeyPathComponentListSyntax``
 public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3432,6 +3571,17 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - MacroExpansionExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `poundToken`: `'#'`
+///  - `macro`: `<identifier>`
+///  - `genericArguments`: ``GenericArgumentClauseSyntax``?
+///  - `leftParen`: `'('`?
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`?
+///  - `trailingClosure`: ``ClosureExprSyntax``?
+///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
 public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3753,6 +3903,13 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - MemberAccessExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `base`: ``ExprSyntax``?
+///  - `dot`: `'.'`
+///  - `name`: ``TokenSyntax``
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
 public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3921,6 +4078,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingExprSyntax
 
 /// In case the source code is missing a expression, this node stands in place of the missing expression.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4000,6 +4161,11 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - MoveExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `moveKeyword`: (`'_move'` | `'consume'`)
+///  - `expression`: ``ExprSyntax``
 public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4116,6 +4282,10 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - NilLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `nilKeyword`: `'nil'`
 public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4194,6 +4364,11 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - OptionalChainingExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `questionMark`: `'?'`
 public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4310,6 +4485,11 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PackElementExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `eachKeyword`: `'each'`
+///  - `packRefExpr`: ``ExprSyntax``
 public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4426,6 +4606,11 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PackExpansionExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `repeatKeyword`: `'repeat'`
+///  - `patternExpr`: ``ExprSyntax``
 public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4542,6 +4727,11 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PostfixIfConfigExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `base`: ``ExprSyntax``?
+///  - `config`: ``IfConfigDeclSyntax``
 public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4658,6 +4848,11 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PostfixUnaryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `operatorToken`: `<postfixOperator>`
 public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4774,6 +4969,11 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PrefixOperatorExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `operatorToken`: `<prefixOperator>`?
+///  - `postfixExpression`: ``ExprSyntax``
 public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4890,6 +5090,14 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - RegexLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `openingPounds`: `<extendedRegexDelimiter>`?
+///  - `openSlash`: `'/'`
+///  - `regexPattern`: `<regexLiteralPattern>`
+///  - `closeSlash`: `'/'`
+///  - `closingPounds`: `<extendedRegexDelimiter>`?
 public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5084,6 +5292,10 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SequenceExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `elements`: ``ExprListSyntax``
 public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5186,6 +5398,11 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SpecializeExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``
 public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5302,6 +5519,14 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - StringLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `openDelimiter`: `<rawStringDelimiter>`?
+///  - `openQuote`: (`'"'` | `'"""'` | `'''`)
+///  - `segments`: ``StringLiteralSegmentsSyntax``
+///  - `closeQuote`: (`'"'` | `'"""'` | `'''`)
+///  - `closeDelimiter`: `<rawStringDelimiter>`?
 public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5520,6 +5745,15 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SubscriptExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `calledExpression`: ``ExprSyntax``
+///  - `leftBracket`: `'['`
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightBracket`: `']'`
+///  - `trailingClosure`: ``ClosureExprSyntax``?
+///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
 public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5788,6 +6022,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SuperRefExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `superKeyword`: `'super'`
 public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5866,6 +6104,14 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SwitchExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `switchKeyword`: `'switch'`
+///  - `expression`: ``ExprSyntax``
+///  - `leftBrace`: `'{'`
+///  - `cases`: ``SwitchCaseListSyntax``
+///  - `rightBrace`: `'}'`
 public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6084,6 +6330,14 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - TernaryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `conditionExpression`: ``ExprSyntax``
+///  - `questionMark`: `'?'`
+///  - `firstChoice`: ``ExprSyntax``
+///  - `colonMark`: `':'`
+///  - `secondChoice`: ``ExprSyntax``
 public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6278,6 +6532,12 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - TryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `tryKeyword`: `'try'`
+///  - `questionOrExclamationMark`: (`'?'` | `'!'`)?
+///  - `expression`: ``ExprSyntax``
 public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6420,6 +6680,12 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - TupleExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `elements`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`
 public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6586,6 +6852,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - TypeExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `type`: ``TypeSyntax``
 public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6664,6 +6934,11 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - UnresolvedAsExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `asTok`: `'as'`
+///  - `questionOrExclamationMark`: (`'?'` | `'!'`)?
 public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6780,6 +7055,10 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - UnresolvedIsExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `isTok`: `'is'`
 public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6858,6 +7137,10 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - UnresolvedPatternExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `pattern`: ``PatternSyntax``
 public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6936,6 +7219,12 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - UnresolvedTernaryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `questionMark`: `'?'`
+///  - `firstChoice`: ``ExprSyntax``
+///  - `colonMark`: `':'`
 public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -15,6 +15,13 @@
 // MARK: - AccessesEffectSyntax
 
 
+
+/// ### Children
+/// 
+///  - `accessesKeyword`: `'accesses'`
+///  - `leftParen`: `'('`
+///  - `propertyList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`
 public struct AccessesEffectSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -207,6 +214,12 @@ public struct AccessesEffectSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AccessorBlockSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBrace`: `'{'`
+///  - `accessors`: ``AccessorListSyntax``
+///  - `rightBrace`: `'}'`
 public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -373,6 +386,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AccessorEffectSpecifiersSyntax
 
 
+
+/// ### Children
+/// 
+///  - `asyncSpecifier`: `'async'`?
+///  - `throwsSpecifier`: `'throws'`?
 public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -489,6 +507,11 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AccessorInitEffectsSyntax
 
 
+
+/// ### Children
+/// 
+///  - `initializesEffect`: ``InitializesEffectSyntax``?
+///  - `accessesEffect`: ``AccessesEffectSyntax``?
 public struct AccessorInitEffectsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -605,6 +628,12 @@ public struct AccessorInitEffectsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AccessorParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `name`: `<identifier>`
+///  - `rightParen`: `')'`
 public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -747,6 +776,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ArrayElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `trailingComma`: `','`?
 public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -863,6 +897,14 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AttributeSyntax
 
 /// An `@` attribute.
+///
+/// ### Children
+/// 
+///  - `atSignToken`: `'@'`
+///  - `attributeName`: ``TypeSyntax``
+///  - `leftParen`: `'('`?
+///  - `argument`: (``TupleExprElementListSyntax`` | ``TokenSyntax`` | ``StringLiteralExprSyntax`` | ``AvailabilitySpecListSyntax`` | ``SpecializeAttributeSpecListSyntax`` | ``ObjCSelectorSyntax`` | ``ImplementsAttributeArgumentsSyntax`` | ``DifferentiableAttributeArgumentsSyntax`` | ``DerivativeRegistrationAttributeArgumentsSyntax`` | ``BackDeployedAttributeSpecListSyntax`` | ``ConventionAttributeArgumentsSyntax`` | ``ConventionWitnessMethodAttributeArgumentsSyntax`` | ``OpaqueReturnTypeOfAttributeArgumentsSyntax`` | ``ExposeAttributeArgumentsSyntax`` | ``OriginallyDefinedInArgumentsSyntax`` | ``UnderscorePrivateAttributeArgumentsSyntax`` | ``DynamicReplacementArgumentsSyntax`` | ``UnavailableFromAsyncArgumentsSyntax`` | ``EffectsArgumentsSyntax`` | ``DocumentationAttributeArgumentsSyntax``)?
+///  - `rightParen`: `')'`?
 public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Argument: SyntaxChildChoices {
     case `argumentList`(TupleExprElementListSyntax)
@@ -1323,6 +1365,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AvailabilityArgumentSyntax
 
 /// A single argument to an `@available` argument like `*`, `iOS 10.1`, or `message: "This has been deprecated"`.
+///
+/// ### Children
+/// 
+///  - `entry`: ((`<binaryOperator>` | `<identifier>`) | ``AvailabilityVersionRestrictionSyntax`` | ``AvailabilityLabeledArgumentSyntax``)
+///  - `trailingComma`: `','`?
 public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Entry: SyntaxChildChoices {
     case `token`(TokenSyntax)
@@ -1494,6 +1541,13 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AvailabilityConditionSyntax
 
 
+
+/// ### Children
+/// 
+///  - `availabilityKeyword`: (`'#available'` | `'#unavailable'`)
+///  - `leftParen`: `'('`
+///  - `availabilityArguments`: ``AvailabilitySpecListSyntax``
+///  - `rightParen`: `')'`
 public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1686,6 +1740,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AvailabilityEntrySyntax
 
 /// The availability argument for the _specialize attribute
+///
+/// ### Children
+/// 
+///  - `label`: `'availability'`
+///  - `colon`: `':'`
+///  - `availabilityArguments`: ``AvailabilitySpecListSyntax``
+///  - `semicolon`: `';'`
 public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1880,6 +1941,12 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AvailabilityLabeledArgumentSyntax
 
 /// A argument to an `@available` attribute that consists of a label and a value, e.g. `message: "This has been deprecated"`.
+///
+/// ### Children
+/// 
+///  - `label`: (`'message'` | `'renamed'` | `'introduced'` | `'obsoleted'` | `'deprecated'`)
+///  - `colon`: `':'`
+///  - `value`: (``StringLiteralExprSyntax`` | ``VersionTupleSyntax``)
 public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Value: SyntaxChildChoices {
     case `string`(StringLiteralExprSyntax)
@@ -2067,6 +2134,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 // MARK: - AvailabilityVersionRestrictionListEntrySyntax
 
 /// A single platform/version pair in an attribute, e.g. `iOS 10.1`.
+///
+/// ### Children
+/// 
+///  - `availabilityVersionRestriction`: ``AvailabilityVersionRestrictionSyntax``
+///  - `trailingComma`: `','`?
 public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2184,6 +2256,11 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
 // MARK: - AvailabilityVersionRestrictionSyntax
 
 /// An argument to `@available` that restricts the availability on a certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
+///
+/// ### Children
+/// 
+///  - `platform`: `<identifier>`
+///  - `version`: ``VersionTupleSyntax``?
 public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2301,6 +2378,12 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
 // MARK: - BackDeployedAttributeSpecListSyntax
 
 /// A collection of arguments for the `@backDeployed` attribute
+///
+/// ### Children
+/// 
+///  - `beforeLabel`: `'before'`
+///  - `colon`: `':'`
+///  - `platforms`: ``AvailabilityVersionRestrictionListSyntax``
 public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2470,6 +2553,12 @@ public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashabl
 // MARK: - CaseItemSyntax
 
 
+
+/// ### Children
+/// 
+///  - `pattern`: ``PatternSyntax``
+///  - `whereClause`: ``WhereClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2612,6 +2701,12 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CatchClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `catchKeyword`: `'catch'`
+///  - `catchItems`: ``CatchItemListSyntax``
+///  - `body`: ``CodeBlockSyntax``
 public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2778,6 +2873,12 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CatchItemSyntax
 
 
+
+/// ### Children
+/// 
+///  - `pattern`: ``PatternSyntax``?
+///  - `whereClause`: ``WhereClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2920,6 +3021,13 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureCaptureItemSpecifierSyntax
 
 
+
+/// ### Children
+/// 
+///  - `specifier`: (`'weak'` | `'unowned'`)
+///  - `leftParen`: `'('`?
+///  - `detail`: (`'safe'` | `'unsafe'`)?
+///  - `rightParen`: `')'`?
 public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3088,6 +3196,14 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
 // MARK: - ClosureCaptureItemSyntax
 
 
+
+/// ### Children
+/// 
+///  - `specifier`: ``ClosureCaptureItemSpecifierSyntax``?
+///  - `name`: `<identifier>`?
+///  - `assignToken`: `'='`?
+///  - `expression`: ``ExprSyntax``
+///  - `trailingComma`: `','`?
 public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3282,6 +3398,12 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureCaptureSignatureSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquare`: `'['`
+///  - `items`: ``ClosureCaptureItemListSyntax``
+///  - `rightSquare`: `']'`
 public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3448,6 +3570,11 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureParamSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: (`<identifier>` | `'_'`)
+///  - `trailingComma`: `','`?
 public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3564,6 +3691,12 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureParameterClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `parameterList`: ``ClosureParameterListSyntax``
+///  - `rightParen`: `')'`
 public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3733,6 +3866,17 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `firstName`: (`<identifier>` | `'_'`)
+///  - `secondName`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`?
+///  - `type`: ``TypeSyntax``?
+///  - `ellipsis`: `'...'`?
+///  - `trailingComma`: `','`?
 public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4059,6 +4203,15 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureSignatureSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `capture`: ``ClosureCaptureSignatureSyntax``?
+///  - `input`: (``ClosureParamListSyntax`` | ``ClosureParameterClauseSyntax``)?
+///  - `effectSpecifiers`: ``TypeEffectSpecifiersSyntax``?
+///  - `output`: ``ReturnClauseSyntax``?
+///  - `inTok`: `'in'`
 public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Input: SyntaxChildChoices {
     case `simpleInput`(ClosureParamListSyntax)
@@ -4345,6 +4498,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CodeBlockItemSyntax
 
 /// A CodeBlockItem is any Syntax node that appears on its own line inside a CodeBlock.
+///
+/// ### Children
+/// 
+///  - `item`: (``DeclSyntax`` | ``StmtSyntax`` | ``ExprSyntax``)
+///  - `semicolon`: `';'`?
 public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Item: SyntaxChildChoices {
     case `decl`(DeclSyntax)
@@ -4516,6 +4674,12 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CodeBlockSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBrace`: `'{'`
+///  - `statements`: ``CodeBlockItemListSyntax``
+///  - `rightBrace`: `'}'`
 public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4682,6 +4846,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CompositionTypeElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `type`: ``TypeSyntax``
+///  - `ampersand`: ``TokenSyntax``?
 public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4798,6 +4967,11 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ConditionElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `condition`: (``ExprSyntax`` | ``AvailabilityConditionSyntax`` | ``MatchingPatternConditionSyntax`` | ``OptionalBindingConditionSyntax``)
+///  - `trailingComma`: `','`?
 public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Condition: SyntaxChildChoices {
     case `expression`(ExprSyntax)
@@ -4983,6 +5157,12 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ConformanceRequirementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftTypeIdentifier`: ``TypeSyntax``
+///  - `colon`: `':'`
+///  - `rightTypeIdentifier`: ``TypeSyntax``
 public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5125,6 +5305,14 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ConventionAttributeArgumentsSyntax
 
 /// The arguments for the '@convention(...)'.
+///
+/// ### Children
+/// 
+///  - `conventionLabel`: `<identifier>`
+///  - `comma`: `','`?
+///  - `cTypeLabel`: `'cType'`?
+///  - `colon`: `':'`?
+///  - `cTypeString`: ``StringLiteralExprSyntax``?
 public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5320,6 +5508,12 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 // MARK: - ConventionWitnessMethodAttributeArgumentsSyntax
 
 /// The arguments for the '@convention(witness_method: ...)'.
+///
+/// ### Children
+/// 
+///  - `witnessMethodLabel`: `'witness_method'`
+///  - `colon`: `':'`
+///  - `protocolName`: `<identifier>`
 public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5462,6 +5656,12 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
 // MARK: - DeclModifierDetailSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `detail`: `<identifier>`
+///  - `rightParen`: `')'`
 public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5604,6 +5804,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DeclModifierSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: (`'__consuming'` | `'__setter_access'` | `'_const'` | `'_local'` | `'actor'` | `'async'` | `'borrowing'` | `'class'` | `'consuming'` | `'convenience'` | `'distributed'` | `'dynamic'` | `'fileprivate'` | `'final'` | `'indirect'` | `'infix'` | `'internal'` | `'isolated'` | `'lazy'` | `'mutating'` | `'nonisolated'` | `'nonmutating'` | `'open'` | `'optional'` | `'override'` | `'package'` | `'postfix'` | `'prefix'` | `'private'` | `'public'` | `'reasync'` | `'required'` | `'static'` | `'unowned'` | `'weak'`)
+///  - `detail`: ``DeclModifierDetailSyntax``?
 public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5720,6 +5925,11 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DeclNameArgumentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: ``TokenSyntax``
+///  - `colon`: `':'`
 public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5836,6 +6046,12 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DeclNameArgumentsSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `arguments`: ``DeclNameArgumentListSyntax``
+///  - `rightParen`: `')'`
 public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6002,6 +6218,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DeclNameSyntax
 
 
+
+/// ### Children
+/// 
+///  - `declBaseName`: (`<identifier>` | `<binaryOperator>` | `'init'` | `'self'` | `'Self'`)
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
 public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6120,6 +6341,10 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DeinitEffectSpecifiersSyntax
 
 
+
+/// ### Children
+/// 
+///  - `asyncSpecifier`: `'async'`?
 public struct DeinitEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6198,6 +6423,16 @@ public struct DeinitEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DerivativeRegistrationAttributeArgumentsSyntax
 
 /// The arguments for the '@derivative(of:)' and '@transpose(of:)' attributes: the 'of:' label, the original declaration name, and an optional differentiability parameter list.
+///
+/// ### Children
+/// 
+///  - `ofLabel`: `'of'`
+///  - `colon`: `':'`
+///  - `originalDeclName`: ``QualifiedDeclNameSyntax``
+///  - `period`: `'.'`?
+///  - `accessorKind`: (`'get'` | `'set'`)?
+///  - `comma`: `','`?
+///  - `diffParams`: ``DifferentiabilityParamsClauseSyntax``?
 public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6449,6 +6684,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
 // MARK: - DesignatedTypeElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leadingComma`: `','`
+///  - `name`: ``TokenSyntax``
 public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6565,6 +6805,13 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DictionaryElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `keyExpression`: ``ExprSyntax``
+///  - `colon`: `':'`
+///  - `valueExpression`: ``ExprSyntax``
+///  - `trailingComma`: `','`?
 public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6733,6 +6980,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DifferentiabilityParamSyntax
 
 /// A differentiability parameter: either the "self" identifier, a function parameter name, or a function parameter index.
+///
+/// ### Children
+/// 
+///  - `parameter`: (`<identifier>` | `<integerLiteral>` | `'self'`)
+///  - `trailingComma`: `','`?
 public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6849,6 +7101,12 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DifferentiabilityParamsClauseSyntax
 
 /// A clause containing differentiability parameters.
+///
+/// ### Children
+/// 
+///  - `wrtLabel`: `'wrt'`
+///  - `colon`: `':'`
+///  - `parameters`: (``DifferentiabilityParamSyntax`` | ``DifferentiabilityParamsSyntax``)
 public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Parameters: SyntaxChildChoices {
     case `parameter`(DifferentiabilityParamSyntax)
@@ -7035,6 +7293,12 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
 // MARK: - DifferentiabilityParamsSyntax
 
 /// The differentiability parameters.
+///
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `diffParams`: ``DifferentiabilityParamListSyntax``
+///  - `rightParen`: `')'`
 public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -7202,6 +7466,14 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DifferentiableAttributeArgumentsSyntax
 
 /// The arguments for the `@differentiable` attribute: an optional differentiability kind, an optional differentiability parameter clause, and an optional 'where' clause.
+///
+/// ### Children
+/// 
+///  - `diffKind`: (`'_forward'` | `'reverse'` | `'_linear'`)?
+///  - `diffKindComma`: `','`?
+///  - `diffParams`: ``DifferentiabilityParamsClauseSyntax``?
+///  - `diffParamsComma`: `','`?
+///  - `whereClause`: ``GenericWhereClauseSyntax``?
 public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -7398,6 +7670,13 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
 // MARK: - DocumentationAttributeArgumentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `label`: (`'visibility'` | `'metadata'`)
+///  - `colon`: `':'`
+///  - `value`: ((`<identifier>` | `'private'` | `'fileprivate'` | `'internal'` | `'public'` | `'open'`) | ``StringLiteralExprSyntax``)
+///  - `trailingComma`: `','`?
 public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Value: SyntaxChildChoices {
     case `token`(TokenSyntax)
@@ -7609,6 +7888,12 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
 // MARK: - DynamicReplacementArgumentsSyntax
 
 /// The arguments for the '@_dynamicReplacement' attribute
+///
+/// ### Children
+/// 
+///  - `forLabel`: `'for'`
+///  - `colon`: `':'`
+///  - `declname`: ``DeclNameSyntax``
 public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -7751,6 +8036,13 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
 // MARK: - EnumCaseElementSyntax
 
 /// An element of an enum case, containing the name of the case and, optionally, either associated values or an assignment to a raw value.
+///
+/// ### Children
+/// 
+///  - `identifier`: `<identifier>`
+///  - `associatedValue`: ``EnumCaseParameterClauseSyntax``?
+///  - `rawValue`: ``InitializerClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -7923,6 +8215,12 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - EnumCaseParameterClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `parameterList`: ``EnumCaseParameterListSyntax``
+///  - `rightParen`: `')'`
 public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8092,6 +8390,16 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - EnumCaseParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `firstName`: (`<identifier>` | `'_'`)?
+///  - `secondName`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`?
+///  - `type`: ``TypeSyntax``
+///  - `defaultArgument`: ``InitializerClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8366,6 +8674,12 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ExposeAttributeArgumentsSyntax
 
 /// The arguments for the '@_expose' attribute
+///
+/// ### Children
+/// 
+///  - `language`: ``TokenSyntax``
+///  - `comma`: `','`?
+///  - `cxxName`: ``StringLiteralExprSyntax``?
 public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8508,6 +8822,14 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ExpressionSegmentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `backslash`: `'\'`
+///  - `delimiter`: `<rawStringDelimiter>`?
+///  - `leftParen`: `'('`
+///  - `expressions`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`
 public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8726,6 +9048,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionEffectSpecifiersSyntax
 
 
+
+/// ### Children
+/// 
+///  - `asyncSpecifier`: (`'async'` | `'reasync'`)?
+///  - `throwsSpecifier`: (`'throws'` | `'rethrows'`)?
 public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8842,6 +9169,18 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `firstName`: (`<identifier>` | `'_'`)
+///  - `secondName`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`
+///  - `type`: ``TypeSyntax``
+///  - `ellipsis`: `'...'`?
+///  - `defaultArgument`: ``InitializerClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9188,6 +9527,12 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionSignatureSyntax
 
 
+
+/// ### Children
+/// 
+///  - `input`: ``ParameterClauseSyntax``
+///  - `effectSpecifiers`: ``FunctionEffectSpecifiersSyntax``?
+///  - `output`: ``ReturnClauseSyntax``?
 public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9330,6 +9675,12 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericArgumentClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftAngleBracket`: `'<'`
+///  - `arguments`: ``GenericArgumentListSyntax``
+///  - `rightAngleBracket`: `'>'`
 public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9496,6 +9847,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericArgumentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `argumentType`: ``TypeSyntax``
+///  - `trailingComma`: `','`?
 public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9612,6 +9968,13 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericParameterClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftAngleBracket`: `'<'`
+///  - `parameters`: ``GenericParameterListSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `rightAngleBracket`: `'>'`
 public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9804,6 +10167,15 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `each`: `'each'`?
+///  - `name`: `<identifier>`
+///  - `colon`: `':'`?
+///  - `inheritedType`: ``TypeSyntax``?
+///  - `trailingComma`: `','`?
 public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -10048,6 +10420,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericRequirementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `body`: (``SameTypeRequirementSyntax`` | ``ConformanceRequirementSyntax`` | ``LayoutRequirementSyntax``)
+///  - `trailingComma`: `','`?
 public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Body: SyntaxChildChoices {
     case `sameTypeRequirement`(SameTypeRequirementSyntax)
@@ -10217,6 +10594,11 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericWhereClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `whereKeyword`: `'where'`
+///  - `requirementList`: ``GenericRequirementListSyntax``
 public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -10357,6 +10739,12 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - IfConfigClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `poundKeyword`: (`'#if'` | `'#elseif'` | `'#else'`)
+///  - `condition`: ``ExprSyntax``?
+///  - `elements`: (``CodeBlockItemListSyntax`` | ``SwitchCaseListSyntax`` | ``MemberDeclListSyntax`` | ``ExprSyntax`` | ``AttributeListSyntax``)?
 public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Elements: SyntaxChildChoices {
     case `statements`(CodeBlockItemListSyntax)
@@ -10580,6 +10968,13 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ImplementsAttributeArgumentsSyntax
 
 /// The arguments for the `@_implements` attribute of the form `Type, methodName(arg1Label:arg2Label:)`
+///
+/// ### Children
+/// 
+///  - `type`: ``TypeSyntax``
+///  - `comma`: `','`
+///  - `declBaseName`: ``TokenSyntax``
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
 public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -10752,6 +11147,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 // MARK: - ImportPathComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: (`<identifier>` | `<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
+///  - `trailingDot`: `'.'`?
 public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -10868,6 +11268,11 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - InheritedTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `typeName`: ``TypeSyntax``
+///  - `trailingComma`: `','`?
 public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -10984,6 +11389,11 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - InitializerClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `equal`: `'='`
+///  - `value`: ``ExprSyntax``
 public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11100,6 +11510,13 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - InitializesEffectSyntax
 
 
+
+/// ### Children
+/// 
+///  - `initializesKeyword`: `'initializes'`
+///  - `leftParen`: `'('`
+///  - `propertyList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`
 public struct InitializesEffectSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11292,6 +11709,11 @@ public struct InitializesEffectSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `period`: `'.'`?
+///  - `component`: (``KeyPathPropertyComponentSyntax`` | ``KeyPathSubscriptComponentSyntax`` | ``KeyPathOptionalComponentSyntax``)
 public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Component: SyntaxChildChoices {
     case `property`(KeyPathPropertyComponentSyntax)
@@ -11461,6 +11883,10 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathOptionalComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `questionOrExclamationMark`: (`'?'` | `'!'`)
 public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11539,6 +11965,12 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathPropertyComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `identifier`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<dollarIdentifier>` | `<binaryOperator>` | `<integerLiteral>`)
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
+///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``?
 public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11681,6 +12113,12 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathSubscriptComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBracket`: `'['`
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightBracket`: `']'`
 public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11847,6 +12285,13 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - LabeledSpecializeEntrySyntax
 
 /// A labeled argument for the `@_specialize` attribute like `exported: true`
+///
+/// ### Children
+/// 
+///  - `label`: ``TokenSyntax``
+///  - `colon`: `':'`
+///  - `value`: ``TokenSyntax``
+///  - `trailingComma`: `','`?
 public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12019,6 +12464,17 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - LayoutRequirementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `typeIdentifier`: ``TypeSyntax``
+///  - `colon`: `':'`
+///  - `layoutConstraint`: (`'_Trivial'` | `'_TrivialAtMost'` | `'_UnknownLayout'` | `'_RefCountedObject'` | `'_NativeRefCountedObject'` | `'_Class'` | `'_NativeClass'`)
+///  - `leftParen`: `'('`?
+///  - `size`: `<integerLiteral>`?
+///  - `comma`: `','`?
+///  - `alignment`: `<integerLiteral>`?
+///  - `rightParen`: `')'`?
 public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12291,6 +12747,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MatchingPatternConditionSyntax
 
 
+
+/// ### Children
+/// 
+///  - `caseKeyword`: `'case'`
+///  - `pattern`: ``PatternSyntax``
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
+///  - `initializer`: ``InitializerClauseSyntax``
 public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12459,6 +12922,12 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MemberDeclBlockSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBrace`: `'{'`
+///  - `members`: ``MemberDeclListSyntax``
+///  - `rightBrace`: `'}'`
 public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12625,6 +13094,11 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MemberDeclListItemSyntax
 
 /// A member declaration of a type consisting of a declaration and an optional semicolon;
+///
+/// ### Children
+/// 
+///  - `decl`: ``DeclSyntax``
+///  - `semicolon`: `';'`?
 public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12743,6 +13217,10 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MissingSyntax
 
 /// In case the source code is missing a syntax node, this node stands in place of the missing node.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12822,6 +13300,12 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MultipleTrailingClosureElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `label`: (`<identifier>` | `'_'`)
+///  - `colon`: `':'`
+///  - `closure`: ``ClosureExprSyntax``
 public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12964,6 +13448,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
 // MARK: - ObjCSelectorPieceSyntax
 
 /// A piece of an Objective-C selector. Either consisting of just an identifier for a nullary selector, an identifier and a colon for a labeled argument or just a colon for an unlabeled argument
+///
+/// ### Children
+/// 
+///  - `name`: ``TokenSyntax``?
+///  - `colon`: `':'`?
 public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13080,6 +13569,12 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - OpaqueReturnTypeOfAttributeArgumentsSyntax
 
 /// The arguments for the '@_opaqueReturnTypeOf()'.
+///
+/// ### Children
+/// 
+///  - `mangledName`: ``StringLiteralExprSyntax``
+///  - `comma`: `','`
+///  - `ordinal`: `<integerLiteral>`
 public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13224,6 +13719,12 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
 // MARK: - OperatorPrecedenceAndTypesSyntax
 
 /// A clause to specify precedence group in infix operator declarations, and designated types in any operator declaration.
+///
+/// ### Children
+/// 
+///  - `colon`: `':'`
+///  - `precedenceGroup`: `<identifier>`
+///  - `designatedTypes`: ``DesignatedTypeListSyntax``
 public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13392,6 +13893,13 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - OptionalBindingConditionSyntax
 
 
+
+/// ### Children
+/// 
+///  - `bindingKeyword`: (`'let'` | `'var'` | `'inout'`)
+///  - `pattern`: ``PatternSyntax``
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
+///  - `initializer`: ``InitializerClauseSyntax``?
 public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13560,6 +14068,14 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - OriginallyDefinedInArgumentsSyntax
 
 /// The arguments for the '@_originallyDefinedIn' attribute
+///
+/// ### Children
+/// 
+///  - `moduleLabel`: `'module'`
+///  - `colon`: `':'`
+///  - `moduleName`: ``StringLiteralExprSyntax``
+///  - `comma`: `','`
+///  - `platforms`: ``AvailabilityVersionRestrictionListSyntax``
 public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13778,6 +14294,12 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 // MARK: - ParameterClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `parameterList`: ``FunctionParameterListSyntax``
+///  - `rightParen`: `')'`
 public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13944,6 +14466,14 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PatternBindingSyntax
 
 
+
+/// ### Children
+/// 
+///  - `pattern`: ``PatternSyntax``
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
+///  - `initializer`: ``InitializerClauseSyntax``?
+///  - `accessor`: (``AccessorBlockSyntax`` | ``CodeBlockSyntax``)?
+///  - `trailingComma`: `','`?
 public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Accessor: SyntaxChildChoices {
     case `accessors`(AccessorBlockSyntax)
@@ -14180,6 +14710,16 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PoundSourceLocationArgsSyntax
 
 
+
+/// ### Children
+/// 
+///  - `fileArgLabel`: `'file'`
+///  - `fileArgColon`: `':'`
+///  - `fileName`: ``StringLiteralExprSyntax``
+///  - `comma`: `','`
+///  - `lineArgLabel`: `'line'`
+///  - `lineArgColon`: `':'`
+///  - `lineNumber`: `<integerLiteral>`
 public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14426,6 +14966,12 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PrecedenceGroupAssignmentSyntax
 
 /// Specifies the precedence of an operator when used in an operation that includes optional chaining.
+///
+/// ### Children
+/// 
+///  - `assignmentKeyword`: `'assignment'`
+///  - `colon`: `':'`
+///  - `flag`: (`'true'` | `'false'`)
 public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14569,6 +15115,12 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PrecedenceGroupAssociativitySyntax
 
 /// Specifies how a sequence of operators with the same precedence level are grouped together in the absence of grouping parentheses.
+///
+/// ### Children
+/// 
+///  - `associativityKeyword`: `'associativity'`
+///  - `colon`: `':'`
+///  - `value`: (`'left'` | `'right'` | `'none'`)
 public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14712,6 +15264,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 // MARK: - PrecedenceGroupNameElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: `<identifier>`
+///  - `trailingComma`: `','`?
 public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14828,6 +15385,12 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PrecedenceGroupRelationSyntax
 
 /// Specify the new precedence group's relation to existing precedence groups.
+///
+/// ### Children
+/// 
+///  - `higherThanOrLowerThanKeyword`: (`'higherThan'` | `'lowerThan'`)
+///  - `colon`: `':'`
+///  - `otherNames`: ``PrecedenceGroupNameListSyntax``
 public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14996,6 +15559,12 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PrimaryAssociatedTypeClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftAngleBracket`: `'<'`
+///  - `primaryAssociatedTypeList`: ``PrimaryAssociatedTypeListSyntax``
+///  - `rightAngleBracket`: `'>'`
 public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15162,6 +15731,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
 // MARK: - PrimaryAssociatedTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: `<identifier>`
+///  - `trailingComma`: `','`?
 public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15278,6 +15852,13 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - QualifiedDeclNameSyntax
 
 /// An optionally qualified function declaration name (e.g. `+(_:_:)`, `A.B.C.foo(_:_:)`).
+///
+/// ### Children
+/// 
+///  - `baseType`: ``TypeSyntax``?
+///  - `dot`: `'.'`?
+///  - `name`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<binaryOperator>`)
+///  - `arguments`: ``DeclNameArgumentsSyntax``?
 public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15449,6 +16030,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ReturnClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `arrow`: `'->'`
+///  - `returnType`: ``TypeSyntax``
 public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15565,6 +16151,12 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SameTypeRequirementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftTypeIdentifier`: ``TypeSyntax``
+///  - `equalityToken`: (`<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
+///  - `rightTypeIdentifier`: ``TypeSyntax``
 public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15707,6 +16299,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SourceFileSyntax
 
 
+
+/// ### Children
+/// 
+///  - `statements`: ``CodeBlockItemListSyntax``
+///  - `eofToken`: `''`
 public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15847,6 +16444,10 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - StringSegmentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `content`: `<stringSegment>`
 public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15925,6 +16526,12 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SwitchCaseLabelSyntax
 
 
+
+/// ### Children
+/// 
+///  - `caseKeyword`: `'case'`
+///  - `caseItems`: ``CaseItemListSyntax``
+///  - `colon`: `':'`
 public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16091,6 +16698,12 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SwitchCaseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `unknownAttr`: ``AttributeSyntax``?
+///  - `label`: (``SwitchDefaultLabelSyntax`` | ``SwitchCaseLabelSyntax``)
+///  - `statements`: ``CodeBlockItemListSyntax``
 public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Label: SyntaxChildChoices {
     case `default`(SwitchDefaultLabelSyntax)
@@ -16299,6 +16912,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SwitchDefaultLabelSyntax
 
 
+
+/// ### Children
+/// 
+///  - `defaultKeyword`: `'default'`
+///  - `colon`: `':'`
 public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16415,6 +17033,13 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TargetFunctionEntrySyntax
 
 /// A labeled argument for the `@_specialize` attribute with a function decl value like `target: myFunc(_:)`
+///
+/// ### Children
+/// 
+///  - `label`: `'target'`
+///  - `colon`: `':'`
+///  - `declname`: ``DeclNameSyntax``
+///  - `trailingComma`: `','`?
 public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16587,6 +17212,13 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TupleExprElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `label`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`?
+///  - `expression`: ``ExprSyntax``
+///  - `trailingComma`: `','`?
 public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16755,6 +17387,13 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TuplePatternElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `labelName`: `<identifier>`?
+///  - `labelColon`: `':'`?
+///  - `pattern`: ``PatternSyntax``
+///  - `trailingComma`: `','`?
 public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16923,6 +17562,17 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TupleTypeElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `inOut`: `'inout'`?
+///  - `name`: (`<identifier>` | `'_'`)?
+///  - `secondName`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`?
+///  - `type`: ``TypeSyntax``
+///  - `ellipsis`: `'...'`?
+///  - `initializer`: ``InitializerClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17195,6 +17845,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TypeAnnotationSyntax
 
 
+
+/// ### Children
+/// 
+///  - `colon`: `':'`
+///  - `type`: ``TypeSyntax``
 public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17311,6 +17966,11 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TypeEffectSpecifiersSyntax
 
 
+
+/// ### Children
+/// 
+///  - `asyncSpecifier`: `'async'`?
+///  - `throwsSpecifier`: `'throws'`?
 public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17427,6 +18087,11 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TypeInheritanceClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `colon`: `':'`
+///  - `inheritedTypeCollection`: ``InheritedTypeListSyntax``
 public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17567,6 +18232,11 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TypeInitializerClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `equal`: `'='`
+///  - `value`: ``TypeSyntax``
 public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17683,6 +18353,12 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - UnavailableFromAsyncArgumentsSyntax
 
 /// The arguments for the '@_unavailableFromAsync' attribute
+///
+/// ### Children
+/// 
+///  - `messageLabel`: `'message'`
+///  - `colon`: `':'`
+///  - `message`: ``StringLiteralExprSyntax``
 public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17825,6 +18501,12 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
 // MARK: - UnderscorePrivateAttributeArgumentsSyntax
 
 /// The arguments for the '@_private' attribute
+///
+/// ### Children
+/// 
+///  - `sourceFileLabel`: `'sourceFile'`
+///  - `colon`: `':'`
+///  - `filename`: ``StringLiteralExprSyntax``
 public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17967,6 +18649,11 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
 // MARK: - VersionComponentSyntax
 
 /// An element to represent a single component in a version, like `.1`.
+///
+/// ### Children
+/// 
+///  - `period`: `'.'`
+///  - `number`: `<integerLiteral>`
 public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -18085,6 +18772,11 @@ public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - VersionTupleSyntax
 
 /// A version number like `1.2.0`. Only the first version component is required. There might be an arbitrary number of following components.
+///
+/// ### Children
+/// 
+///  - `major`: `<integerLiteral>`
+///  - `components`: ``VersionComponentListSyntax``
 public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -18227,6 +18919,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - WhereClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `whereKeyword`: `'where'`
+///  - `guardResult`: ``ExprSyntax``
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -18343,6 +19040,11 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - YieldExprListElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `comma`: `','`?
 public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -18459,6 +19161,12 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - YieldListSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `elementList`: ``YieldExprListSyntax``
+///  - `rightParen`: `')'`
 public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -15,6 +15,10 @@
 // MARK: - ExpressionPatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
 public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -93,6 +97,10 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - IdentifierPatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `identifier`: (`<identifier>` | `'self'` | `'init'`)
 public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -171,6 +179,11 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - IsTypePatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `isKeyword`: `'is'`
+///  - `type`: ``TypeSyntax``
 public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -287,6 +300,10 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingPatternSyntax
 
 /// In case the source code is missing a pattern, this node stands in place of the missing pattern.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -366,6 +383,12 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - TuplePatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `elements`: ``TuplePatternElementListSyntax``
+///  - `rightParen`: `')'`
 public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -532,6 +555,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - ValueBindingPatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `bindingKeyword`: (`'let'` | `'var'` | `'inout'`)
+///  - `valuePattern`: ``PatternSyntax``
 public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -648,6 +676,11 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - WildcardPatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `wildcard`: `'_'`
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
 public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -15,6 +15,11 @@
 // MARK: - BreakStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `breakKeyword`: `'break'`
+///  - `label`: `<identifier>`?
 public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -131,6 +136,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ContinueStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `continueKeyword`: `'continue'`
+///  - `label`: `<identifier>`?
 public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -247,6 +257,11 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - DeferStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `deferKeyword`: `'defer'`
+///  - `body`: ``CodeBlockSyntax``
 public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -363,6 +378,11 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - DiscardStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `discardKeyword`: (`'_forget'` | `'discard'`)
+///  - `expression`: ``ExprSyntax``
 public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -479,6 +499,12 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - DoStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `doKeyword`: `'do'`
+///  - `body`: ``CodeBlockSyntax``
+///  - `catchClauses`: ``CatchClauseListSyntax``
 public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -645,6 +671,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ExpressionStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
 public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -723,6 +753,10 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - FallthroughStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `fallthroughKeyword`: `'fallthrough'`
 public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -801,6 +835,19 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ForInStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `forKeyword`: `'for'`
+///  - `tryKeyword`: `'try'`?
+///  - `awaitKeyword`: `'await'`?
+///  - `caseKeyword`: `'case'`?
+///  - `pattern`: ``PatternSyntax``
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
+///  - `inKeyword`: `'in'`
+///  - `sequenceExpr`: ``ExprSyntax``
+///  - `whereClause`: ``WhereClauseSyntax``?
+///  - `body`: ``CodeBlockSyntax``
 public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1125,6 +1172,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - GuardStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `guardKeyword`: `'guard'`
+///  - `conditions`: ``ConditionElementListSyntax``
+///  - `elseKeyword`: `'else'`
+///  - `body`: ``CodeBlockSyntax``
 public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1317,6 +1371,12 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - LabeledStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `labelName`: `<identifier>`
+///  - `labelColon`: `':'`
+///  - `statement`: ``StmtSyntax``
 public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1459,6 +1519,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingStmtSyntax
 
 /// In case the source code is missing a statement, this node stands in place of the missing statement.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1538,6 +1602,13 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - RepeatWhileStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `repeatKeyword`: `'repeat'`
+///  - `body`: ``CodeBlockSyntax``
+///  - `whileKeyword`: `'while'`
+///  - `condition`: ``ExprSyntax``
 public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1706,6 +1777,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ReturnStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `returnKeyword`: `'return'`
+///  - `expression`: ``ExprSyntax``?
 public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1822,6 +1898,11 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ThrowStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `throwKeyword`: `'throw'`
+///  - `expression`: ``ExprSyntax``
 public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1938,6 +2019,12 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - WhileStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `whileKeyword`: `'while'`
+///  - `conditions`: ``ConditionElementListSyntax``
+///  - `body`: ``CodeBlockSyntax``
 public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2104,6 +2191,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - YieldStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `yieldKeyword`: `'yield'`
+///  - `yields`: (``YieldListSyntax`` | ``ExprSyntax``)
 public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public enum Yields: SyntaxChildChoices {
     case `yieldList`(YieldListSyntax)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -15,6 +15,12 @@
 // MARK: - ArrayTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquare`: `'['`
+///  - `elementType`: ``TypeSyntax``
+///  - `rightSquare`: `']'`
 public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -157,6 +163,12 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - AttributedTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `specifier`: (`'inout'` | `'__shared'` | `'__owned'` | `'isolated'` | `'_const'` | `'borrowing'` | `'consuming'`)?
+///  - `attributes`: ``AttributeListSyntax``
+///  - `baseType`: ``TypeSyntax``
 public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -323,6 +335,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - ClassRestrictionTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `classKeyword`: `'class'`
 public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -401,6 +417,10 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - CompositionTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `elements`: ``CompositionTypeElementListSyntax``
 public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -503,6 +523,11 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - ConstrainedSugarTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `someOrAnySpecifier`: (`'some'` | `'any'`)
+///  - `baseType`: ``TypeSyntax``
 public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -619,6 +644,14 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - DictionaryTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquare`: `'['`
+///  - `keyType`: ``TypeSyntax``
+///  - `colon`: `':'`
+///  - `valueType`: ``TypeSyntax``
+///  - `rightSquare`: `']'`
 public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -813,6 +846,14 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `parameters`: ``TupleTypeElementListSyntax``
+///  - `rightParen`: `')'`
+///  - `effectSpecifiers`: ``TypeEffectSpecifiersSyntax``?
+///  - `output`: ``ReturnClauseSyntax``
 public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1031,6 +1072,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - ImplicitlyUnwrappedOptionalTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `wrappedType`: ``TypeSyntax``
+///  - `exclamationMark`: `'!'`
 public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1147,6 +1193,13 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 // MARK: - MemberTypeIdentifierSyntax
 
 
+
+/// ### Children
+/// 
+///  - `baseType`: ``TypeSyntax``
+///  - `period`: `'.'`
+///  - `name`: (`<identifier>` | `'self'` | `'Self'`)
+///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``?
 public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1315,6 +1368,12 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - MetatypeTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `baseType`: ``TypeSyntax``
+///  - `period`: `'.'`
+///  - `typeOrProtocol`: (`'Type'` | `'Protocol'`)
 public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1457,6 +1516,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingTypeSyntax
 
 /// In case the source code is missing a type, this node stands in place of the missing type.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1536,6 +1599,11 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - NamedOpaqueReturnTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``
+///  - `baseType`: ``TypeSyntax``
 public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1652,6 +1720,11 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - OptionalTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `wrappedType`: ``TypeSyntax``
+///  - `questionMark`: `'?'`
 public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1768,6 +1841,11 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - PackExpansionTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `repeatKeyword`: `'repeat'`
+///  - `patternType`: ``TypeSyntax``
 public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1884,6 +1962,11 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - PackReferenceTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `eachKeyword`: `'each'`
+///  - `packType`: ``TypeSyntax``
 public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2000,6 +2083,11 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - SimpleTypeIdentifierSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: (`<identifier>` | `'self'` | `'Self'` | `'Any'` | `'_'`)
+///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``?
 public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2116,6 +2204,11 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - SuppressedTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `withoutTilde`: `<prefixOperator>`
+///  - `patternType`: ``TypeSyntax``
 public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2232,6 +2325,12 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - TupleTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `elements`: ``TupleTypeElementListSyntax``
+///  - `rightParen`: `')'`
 public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   


### PR DESCRIPTION
Generate a `Grammar` and a `Children` section as doc-comments for layout nodes.

The `Grammar` section is particularly useful for fairly simple syntax nodes to convey their structure. The `Children` section allows you to see the children of the syntax node at a glance in the source order.