### PR TITLE
[WIP] Fix memory corruption bugs in SwiftSyntax

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
@@ -63,9 +63,16 @@ let parserEntryFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         """
         extension \(node.kind.syntaxType): SyntaxParseable {
           public static func parse(from parser: inout Parser) -> Self {
+            // Keep the parser alive so that the arena in which `raw` is allocated
+            // doesn’t get deallocated before we have a chance to create a syntax node
+            // from it. We can’t use `parser.arena` as the parameter to
+            // `Syntax(raw:arena:)` because the node might have been re-used during an
+            // incremental parse and would then live in a different arena than
+            // `parser.arena`.
+            defer { withExtendedLifetime(parser) {} }
             let node = parser.\(raw: parserFunction)()
             let raw = RawSyntax(parser.parseRemainder(into: node))
-            return Syntax(raw: raw).cast(Self.self)
+            return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
           }
         }
         """

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -168,12 +168,10 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         public init(_ children: [Element]) {
-          let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-            let raw = RawSyntax.makeLayout(kind: SyntaxKind.\(node.varOrCaseName),
-                                           from: children.map { $0.raw }, arena: arena)
-            return SyntaxData.forRoot(raw)
-          }
-          self.init(data)
+          let arena = SyntaxArena()
+          let raw = RawSyntax.makeLayout(kind: SyntaxKind.\(node.varOrCaseName),
+                                         from: children.map { $0.raw }, arena: arena)
+          self.init(SyntaxData.forRoot(raw, arena: arena))
         }
         """
       )

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -129,7 +129,7 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
                   """
                 )
               }
-              StmtSyntax("return SyntaxData.forRoot(raw)")
+              StmtSyntax("return SyntaxData.forRoot(raw, arena: arena)")
             }
           )
 

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -326,7 +326,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: arena)
           // 'withExtendedLifetime' to keep 'SyntaxArena's of them alive until here.
           return withExtendedLifetime((arena, rewrittens)) {
-            Syntax(raw: newRaw).cast(SyntaxType.self)
+            Syntax(raw: newRaw, arena: arena).cast(SyntaxType.self)
           }
         } else {
           // No child node was rewritten. So no need to change this node as well.
@@ -342,8 +342,9 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// a parent if `node` had one.
       public func rewrite(_ node: Syntax) -> Syntax {
         let rewritten = self.visit(node)
-        let arena = SyntaxArena()
-        return Syntax(node.data.replacingSelf(rewritten.raw, arena: arena))
+        return withExtendedLifetime(rewritten) {
+          return Syntax(node.data.replacingSelf(rewritten.raw, arena: rewritten.raw.arena))
+        }
       }
       """
     )

--- a/Sources/SwiftParser/generated/Parser+Entry.swift
+++ b/Sources/SwiftParser/generated/Parser+Entry.swift
@@ -43,129 +43,289 @@ public protocol SyntaxParseable: SyntaxProtocol {
 
 extension AccessorDeclSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseAccessorDecl()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension AttributeSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseAttribute()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension CatchClauseSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseCatchClause()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension ClosureParameterSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseClosureParameter()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension CodeBlockItemSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseNonOptionalCodeBlockItem()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension DeclSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseDeclaration()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension EnumCaseParameterSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseEnumCaseParameter()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension ExprSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseExpression()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension FunctionParameterSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseFunctionParameter()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension GenericParameterClauseSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseGenericParameters()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension MemberDeclBlockSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseMemberDeclList()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension PatternSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parsePattern()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension SourceFileSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseSourceFile()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension StmtSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseStatement()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension SwitchCaseSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseSwitchCase()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 
 extension TypeSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
     let node = parser.parseType()
     let raw = RawSyntax(parser.parseRemainder(into: node))
-    return Syntax(raw: raw).cast(Self.self)
+    return Syntax(raw: raw, arena: raw.arena).cast(Self.self)
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -209,7 +209,8 @@ public struct RawSyntax {
     rawData.arenaReference
   }
 
-  internal var arena: SyntaxArena {
+  @_spi(RawSyntax)
+  public var arena: SyntaxArena {
     rawData.arenaReference.value
   }
 

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -69,8 +69,8 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
   }
 
   @_spi(RawSyntax)
-  public init(raw: RawSyntax) {
-    self.init(.forRoot(raw))
+  public init(raw: RawSyntax, arena: __shared SyntaxArena) {
+    self.init(.forRoot(raw, arena: arena))
   }
 
   /// Create a ``Syntax`` node from a specialized syntax node.
@@ -226,7 +226,11 @@ extension SyntaxProtocol {
   /// Return this subtree with this node as the root, ie. detach this node
   /// from its parent.
   public var detached: Self {
-    return Syntax(raw: self.raw).cast(Self.self)
+    // Make sure `self` (and thus the arena of `self.raw`) can’t get deallocated
+    // before the detached node can be created.
+    return withExtendedLifetime(self) {
+      return Syntax(raw: self.raw, arena: self.raw.arena).cast(Self.self)
+    }
   }
 
   /// The kind of the syntax node, e.g. if it is a `functionDecl`.

--- a/Sources/SwiftSyntax/TokenSyntax.swift
+++ b/Sources/SwiftSyntax/TokenSyntax.swift
@@ -49,18 +49,16 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     trailingTrivia: Trivia = [],
     presence: SourcePresence
   ) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeMaterializedToken(
-        kind: kind,
-        leadingTrivia: leadingTrivia,
-        trailingTrivia: trailingTrivia,
-        presence: presence,
-        tokenDiagnostic: nil,
-        arena: arena
-      )
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeMaterializedToken(
+      kind: kind,
+      leadingTrivia: leadingTrivia,
+      trailingTrivia: trailingTrivia,
+      presence: presence,
+      tokenDiagnostic: nil,
+      arena: arena
+    )
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
 
   /// Whether the token is present or missing.

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -57,14 +57,12 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -266,14 +264,12 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -517,14 +513,12 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -726,14 +720,12 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -935,14 +927,12 @@ public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, Syntax
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityVersionRestrictionList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityVersionRestrictionList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -1144,14 +1134,12 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -1353,14 +1341,12 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -1562,14 +1548,12 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -1771,14 +1755,12 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -1980,14 +1962,12 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParamList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParamList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -2189,14 +2169,12 @@ public struct ClosureParameterListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParameterList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParameterList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -2398,14 +2376,12 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -2607,14 +2583,12 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -2816,14 +2790,12 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -3025,14 +2997,12 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -3234,14 +3204,12 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -3443,14 +3411,12 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -3652,14 +3618,12 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -3858,14 +3822,12 @@ public struct DocumentationAttributeArgumentsSyntax: SyntaxCollection, SyntaxHas
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.documentationAttributeArguments,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.documentationAttributeArguments,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -4064,14 +4026,12 @@ public struct EffectsArgumentsSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.effectsArguments,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.effectsArguments,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -4270,14 +4230,12 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -4479,14 +4437,12 @@ public struct EnumCaseParameterListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseParameterList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseParameterList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -4685,14 +4641,12 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -4894,14 +4848,12 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -5103,14 +5055,12 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -5312,14 +5262,12 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -5521,14 +5469,12 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -5730,14 +5676,12 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -5939,14 +5883,12 @@ public struct ImportPathSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.importPath,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.importPath,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -6148,14 +6090,12 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -6357,14 +6297,12 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponentList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponentList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -6566,14 +6504,12 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -6775,14 +6711,12 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -6984,14 +6918,12 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -7193,14 +7125,12 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelector,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelector,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -7402,14 +7332,12 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -7665,14 +7593,12 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -7874,14 +7800,12 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -8083,14 +8007,12 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -8356,14 +8278,12 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeAttributeSpecList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeAttributeSpecList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -8607,14 +8527,12 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -8858,14 +8776,12 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -9067,14 +8983,12 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -9276,14 +9190,12 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -9485,14 +9397,12 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -9691,14 +9601,12 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unexpectedNodes,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unexpectedNodes,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -9900,14 +9808,12 @@ public struct VersionComponentListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.versionComponentList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.versionComponentList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.
@@ -10109,14 +10015,12 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   }
   
   public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
+    let arena = SyntaxArena()
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
+                                   from: children.map {
+        $0.raw
+      }, arena: arena)
+    self.init(SyntaxData.forRoot(raw, arena: arena))
   }
   
   /// The number of elements, `present` or `missing`, in this collection.

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -7159,7 +7159,7 @@ open class SyntaxRewriter {
       let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: arena)
       // 'withExtendedLifetime' to keep 'SyntaxArena's of them alive until here.
       return withExtendedLifetime((arena, rewrittens)) {
-        Syntax(raw: newRaw).cast(SyntaxType.self)
+        Syntax(raw: newRaw, arena: arena).cast(SyntaxType.self)
       }
     } else {
       // No child node was rewritten. So no need to change this node as well.
@@ -7171,7 +7171,8 @@ open class SyntaxRewriter {
   /// a parent if `node` had one.
   public func rewrite(_ node: Syntax) -> Syntax {
     let rewritten = self.visit(node)
-    let arena = SyntaxArena()
-    return Syntax(node.data.replacingSelf(rewritten.raw, arena: arena))
+    return withExtendedLifetime(rewritten) {
+      return Syntax(node.data.replacingSelf(rewritten.raw, arena: rewritten.raw.arena))
+    }
   }
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -97,7 +97,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -368,7 +368,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -694,7 +694,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1011,7 +1011,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1310,7 +1310,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1514,7 +1514,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1703,7 +1703,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1956,7 +1956,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2268,7 +2268,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2558,7 +2558,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2832,7 +2832,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2989,7 +2989,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3270,7 +3270,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3588,7 +3588,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3910,7 +3910,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4269,7 +4269,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4458,7 +4458,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4628,7 +4628,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4814,7 +4814,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5133,7 +5133,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5505,7 +5505,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5865,7 +5865,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6169,7 +6169,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6435,7 +6435,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -73,7 +73,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -228,7 +228,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -356,7 +356,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -498,7 +498,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -590,7 +590,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -692,7 +692,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -770,7 +770,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -862,7 +862,7 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -996,7 +996,7 @@ public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1184,7 +1184,7 @@ public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1352,7 +1352,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1527,7 +1527,7 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1691,7 +1691,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1813,7 +1813,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1891,7 +1891,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1969,7 +1969,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2061,7 +2061,7 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2201,7 +2201,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2435,7 +2435,7 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2611,7 +2611,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2806,7 +2806,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2928,7 +2928,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3050,7 +3050,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3154,7 +3154,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3299,7 +3299,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3490,7 +3490,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3777,7 +3777,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3919,7 +3919,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4012,7 +4012,7 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4114,7 +4114,7 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4206,7 +4206,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4322,7 +4322,7 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4438,7 +4438,7 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4554,7 +4554,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4670,7 +4670,7 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4786,7 +4786,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4920,7 +4920,7 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5082,7 +5082,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5193,7 +5193,7 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5327,7 +5327,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5546,7 +5546,7 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5766,7 +5766,7 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5876,7 +5876,7 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6089,7 +6089,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6271,7 +6271,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6413,7 +6413,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6554,7 +6554,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6646,7 +6646,7 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6748,7 +6748,7 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6826,7 +6826,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6924,7 +6924,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -79,7 +79,7 @@ public struct AccessesEffectSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -260,7 +260,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -415,7 +415,7 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -531,7 +531,7 @@ public struct AccessorInitEffectsSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -653,7 +653,7 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -789,7 +789,7 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1184,7 +1184,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1418,7 +1418,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1548,7 +1548,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1735,7 +1735,7 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1960,7 +1960,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2099,7 +2099,7 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2216,7 +2216,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2339,7 +2339,7 @@ public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashabl
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2503,7 +2503,7 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2645,7 +2645,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2806,7 +2806,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2954,7 +2954,7 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3128,7 +3128,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3310,7 +3310,7 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3465,7 +3465,7 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3587,7 +3587,7 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -3781,7 +3781,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4127,7 +4127,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4395,7 +4395,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4519,7 +4519,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4674,7 +4674,7 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4859,7 +4859,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -4981,7 +4981,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5135,7 +5135,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5318,7 +5318,7 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5460,7 +5460,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5596,7 +5596,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5712,7 +5712,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5834,7 +5834,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -5989,7 +5989,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6137,7 +6137,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6358,7 +6358,7 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6486,7 +6486,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6642,7 +6642,7 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6806,7 +6806,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -6950,7 +6950,7 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -7124,7 +7124,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -7356,7 +7356,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -7519,7 +7519,7 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -7667,7 +7667,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -7833,7 +7833,7 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -8021,7 +8021,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -8266,7 +8266,7 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -8420,7 +8420,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -8615,7 +8615,7 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -8773,7 +8773,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -9073,7 +9073,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -9215,7 +9215,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -9370,7 +9370,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -9498,7 +9498,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -9697,7 +9697,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -9965,7 +9965,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -10081,7 +10081,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -10303,7 +10303,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -10451,7 +10451,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -10611,7 +10611,7 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -10727,7 +10727,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -10843,7 +10843,7 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -10971,7 +10971,7 @@ public struct InitializesEffectSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -11199,7 +11199,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -11301,7 +11301,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -11399,7 +11399,7 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -11541,7 +11541,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -11708,7 +11708,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -11904,7 +11904,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -12152,7 +12152,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -12314,7 +12314,7 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -12469,7 +12469,7 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -12573,7 +12573,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -12672,7 +12672,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -12808,7 +12808,7 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -12930,7 +12930,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -13074,7 +13074,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -13243,7 +13243,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -13417,7 +13417,7 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -13618,7 +13618,7 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -13833,7 +13833,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -14039,7 +14039,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -14261,7 +14261,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -14404,7 +14404,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -14541,7 +14541,7 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -14663,7 +14663,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -14826,7 +14826,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -14981,7 +14981,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -15109,7 +15109,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -15268,7 +15268,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -15390,7 +15390,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -15526,7 +15526,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -15647,7 +15647,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -15745,7 +15745,7 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -15948,7 +15948,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -16103,7 +16103,7 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -16231,7 +16231,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -16403,7 +16403,7 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -16571,7 +16571,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -16763,7 +16763,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -16999,7 +16999,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -17115,7 +17115,7 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -17231,7 +17231,7 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -17366,7 +17366,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -17488,7 +17488,7 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -17630,7 +17630,7 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -17766,7 +17766,7 @@ public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -17884,7 +17884,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -18021,7 +18021,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -18137,7 +18137,7 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -18259,7 +18259,7 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -53,7 +53,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -131,7 +131,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -223,7 +223,7 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -325,7 +325,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -424,7 +424,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -579,7 +579,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -695,7 +695,7 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -67,7 +67,7 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -183,7 +183,7 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -299,7 +299,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -415,7 +415,7 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -537,7 +537,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -678,7 +678,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -756,7 +756,7 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -896,7 +896,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1184,7 +1184,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1365,7 +1365,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1487,7 +1487,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1592,7 +1592,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1748,7 +1748,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1864,7 +1864,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1986,7 +1986,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2183,7 +2183,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -73,7 +73,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -215,7 +215,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -356,7 +356,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -434,7 +434,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -545,7 +545,7 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -679,7 +679,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -873,7 +873,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1068,7 +1068,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1196,7 +1196,7 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1358,7 +1358,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1480,7 +1480,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1573,7 +1573,7 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1689,7 +1689,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1805,7 +1805,7 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -1921,7 +1921,7 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2037,7 +2037,7 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2153,7 +2153,7 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }
@@ -2275,7 +2275,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         trailingTrivia: trailingTrivia
         
       )
-      return SyntaxData.forRoot(raw)
+      return SyntaxData.forRoot(raw, arena: arena)
     }
     self.init(data)
   }

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -141,7 +141,7 @@ final class RawSyntaxTests: XCTestCase {
       XCTAssertEqual(ident.trailingTriviaPieces, [.unexpectedText(" ")])
       XCTAssertEqual(ident.description, "\nfoo ")
 
-      let identSyntax = Syntax(raw: ident.raw).as(TokenSyntax.self)!
+      let identSyntax = Syntax(raw: ident.raw, arena: arena).as(TokenSyntax.self)!
       let barIdentSyntax = identSyntax.with(\.tokenKind, .keyword(.open))
       let barIdent = barIdentSyntax.raw.as(RawTokenSyntax.self)!
 

--- a/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
+++ b/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
@@ -30,7 +30,7 @@ final class SourceLocationConverterTests: XCTestCase {
         arena: arena
       )
 
-      return Syntax(raw: nodeWithInvalidUtf8.raw).cast(TokenSyntax.self)
+      return Syntax(raw: nodeWithInvalidUtf8.raw, arena: arena).cast(TokenSyntax.self)
     }
 
     let tree = SourceFileSyntax(statements: [], eofToken: eofToken)


### PR DESCRIPTION
Using this to bisect the CI failure in https://github.com/apple/swift-syntax/pull/1708 that I can’t reproduce locally