### PR TITLE
[5.9][Macros] Opaque params in expansion functions in macro protocols

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroProtocols/AccessorMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/AccessorMacro.swift
@@ -14,12 +14,9 @@ public protocol AccessorMacro: AttachedMacro {
   /// Expand a macro that's expressed as a custom attribute attached to
   /// the given declaration. The result is a set of accessors for the
   /// declaration.
-  static func expansion<
-    Context: MacroExpansionContext,
-    Declaration: DeclSyntaxProtocol
-  >(
+  static func expansion(
     of node: AttributeSyntax,
-    providingAccessorsOf declaration: Declaration,
-    in context: Context
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
   ) throws -> [AccessorDeclSyntax]
 }

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/CodeItemMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/CodeItemMacro.swift
@@ -13,11 +13,8 @@ import SwiftSyntax
 public protocol CodeItemMacro: FreestandingMacro {
   /// Expand a macro described by the given freestanding macro expansion
   /// declaration within the given context to produce a set of declarations.
-  static func expansion<
-    Node: FreestandingMacroExpansionSyntax,
-    Context: MacroExpansionContext
-  >(
-    of node: Node,
-    in context: Context
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
   ) throws -> [CodeBlockItemSyntax]
 }

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/ConformanceMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/ConformanceMacro.swift
@@ -25,12 +25,9 @@ public protocol ConformanceMacro: AttachedMacro {
   /// - Returns: the set of `(type, where-clause?)` pairs that each provide the
   ///   protocol type to which the declared type conforms, along with
   ///   an optional where clause.
-  static func expansion<
-    Declaration: DeclGroupSyntax,
-    Context: MacroExpansionContext
-  >(
+  static func expansion(
     of node: AttributeSyntax,
-    providingConformancesOf declaration: Declaration,
-    in context: Context
+    providingConformancesOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
   ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)]
 }

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/DeclarationMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/DeclarationMacro.swift
@@ -13,12 +13,9 @@ import SwiftSyntax
 public protocol DeclarationMacro: FreestandingMacro {
   /// Expand a macro described by the given freestanding macro expansion
   /// declaration within the given context to produce a set of declarations.
-  static func expansion<
-    Node: FreestandingMacroExpansionSyntax,
-    Context: MacroExpansionContext
-  >(
-    of node: Node,
-    in context: Context
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
   ) throws -> [DeclSyntax]
 
   /// Whether to copy attributes on the expansion syntax to expanded declarations,

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/ExpressionMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/ExpressionMacro.swift
@@ -16,11 +16,8 @@ import SwiftSyntax
 public protocol ExpressionMacro: FreestandingMacro {
   /// Expand a macro described by the given freestanding macro expansion
   /// within the given context to produce a replacement expression.
-  static func expansion<
-    Node: FreestandingMacroExpansionSyntax,
-    Context: MacroExpansionContext
-  >(
-    of node: Node,
-    in context: Context
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
   ) throws -> ExprSyntax
 }

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/MemberAttributeMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/MemberAttributeMacro.swift
@@ -25,14 +25,10 @@ public protocol MemberAttributeMacro: AttachedMacro {
   ///   - context: The context in which to perform the macro expansion.
   ///
   /// - Returns: the set of attributes to apply to the given member.
-  static func expansion<
-    Declaration: DeclGroupSyntax,
-    MemberDeclaration: DeclSyntaxProtocol,
-    Context: MacroExpansionContext
-  >(
+  static func expansion(
     of node: AttributeSyntax,
-    attachedTo declaration: Declaration,
-    providingAttributesFor member: MemberDeclaration,
-    in context: Context
+    attachedTo declaration: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
   ) throws -> [AttributeSyntax]
 }

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
@@ -23,12 +23,9 @@ public protocol MemberMacro: AttachedMacro {
   ///
   /// - Returns: the set of member declarations introduced by this macro, which
   /// are nested inside the `attachedTo` declaration.
-  static func expansion<
-    Declaration: DeclGroupSyntax,
-    Context: MacroExpansionContext
-  >(
+  static func expansion(
     of node: AttributeSyntax,
-    providingMembersOf declaration: Declaration,
-    in context: Context
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
   ) throws -> [DeclSyntax]
 }

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/PeerMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/PeerMacro.swift
@@ -16,12 +16,9 @@ public protocol PeerMacro: AttachedMacro {
   ///
   /// The macro expansion can introduce "peer" declarations that sit alongside
   /// the given declaration.
-  static func expansion<
-    Context: MacroExpansionContext,
-    Declaration: DeclSyntaxProtocol
-  >(
+  static func expansion(
     of node: AttributeSyntax,
-    providingPeersOf declaration: Declaration,
-    in context: Context
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
   ) throws -> [DeclSyntax]
 }


### PR DESCRIPTION
Cherry-pick #1774 into `release/5.9`

* **Explanation**: In [macro](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md) [evolution](https://github.com/apple/swift-evolution/blob/main/proposals/0389-attached-macros.md) [proposals](https://github.com/apple/swift-evolution/blob/main/proposals/0397-freestanding-declaration-macros.md), each `Macro` protocol has `static func expansion()` requirement that uses several `some` parameters. But the actual declarations used to use generic parameters instead of `some`. This change fix that.
* **Scope**: Macro implementation
* **Risk**: Low, This should be NFC for compilations. SourceKit functionalities e.g. code completion are affected by this.
* **Testing**: Current test suite passed
* **Issue**: rdar://110733340
* **Reviewer**: Ben Barham (@bnbarham)