### PR TITLE
Migrate `!currentToken.isStartOfLine` to `TokenSpec(allowStartOfLine: false)`

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1122,7 +1122,7 @@ extension Parser {
     let (unexpectedBeforeDeinitKeyword, deinitKeyword) = self.eat(handle)
     var unexpectedNameAndSignature: [RawSyntax?] = []
     unexpectedNameAndSignature.append(self.consume(if: TokenSpec(.identifier, allowAtStartOfLine: false)).map(RawSyntax.init))
-    if self.at(.leftParen) && !self.currentToken.isAtStartOfLine {
+    if self.at(TokenSpec(.leftParen, allowAtStartOfLine: false)) {
       unexpectedNameAndSignature.append(RawSyntax(parseFunctionSignature()))
     }
     let items = self.parseOptionalCodeBlock()
@@ -1374,7 +1374,7 @@ extension Parser {
             value: value,
             arena: self.arena
           )
-        } else if self.at(.leftParen), !self.currentToken.isAtStartOfLine,
+        } else if self.at(TokenSpec(.leftParen, allowAtStartOfLine: false)),
           let typeAnnotationUnwrapped = typeAnnotation
         {
           // If we have a '(' after the type in the annotation, the type annotation

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -603,7 +603,7 @@ extension Parser {
 
     let beforePeriodWhitespace = previousNode?.raw.trailingTriviaByteLength ?? 0 > 0 || self.currentToken.leadingTriviaByteLength > 0
     let afterPeriodWhitespace = self.currentToken.trailingTriviaByteLength > 0 || self.peek().leadingTriviaByteLength > 0
-    let afterContainsAnyNewline = self.peek().flags.contains(.isAtStartOfLine)
+    let afterContainsAnyNewline = self.peek().isAtStartOfLine
 
     let period = self.consumeAnyToken()
 

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -295,15 +295,13 @@ extension Parser {
         continue
       }
 
-      if !self.currentToken.isAtStartOfLine {
-        if self.at(.postfixQuestionMark) {
-          base = RawTypeSyntax(self.parseOptionalType(base))
-          continue
-        }
-        if self.at(.exclamationMark) {
-          base = RawTypeSyntax(self.parseImplicitlyUnwrappedOptionalType(base))
-          continue
-        }
+      if self.at(TokenSpec(.postfixQuestionMark, allowAtStartOfLine: false)) {
+        base = RawTypeSyntax(self.parseOptionalType(base))
+        continue
+      }
+      if self.at(TokenSpec(.exclamationMark, allowAtStartOfLine: false)) {
+        base = RawTypeSyntax(self.parseImplicitlyUnwrappedOptionalType(base))
+        continue
       }
 
       break
@@ -780,11 +778,9 @@ extension Parser.Lookahead {
         return false
       }
 
-      if !self.currentToken.isAtStartOfLine {
-        if self.at(.postfixQuestionMark) || self.at(.exclamationMark) {
-          self.consumeAnyToken()
-          continue
-        }
+      if self.at(TokenSpec(.postfixQuestionMark, allowAtStartOfLine: false)) || self.at(TokenSpec(.exclamationMark, allowAtStartOfLine: false)) {
+        self.consumeAnyToken()
+        continue
       }
 
       break


### PR DESCRIPTION
`TokenSpec(allowStartOfLine: false)` is the more idiomatic way of checking whether a token is at the start of a line in SwiftParser.