### PR TITLE
Allow keywords after `#` in freestanding macro expansions

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -2107,7 +2107,7 @@ extension Parser {
     var unexpectedBeforeMacro: RawUnexpectedNodesSyntax?
     var macro: RawTokenSyntax
     if !self.currentToken.isAtStartOfLine {
-      (unexpectedBeforeMacro, macro) = self.expectIdentifier(keywordRecovery: true)
+      (unexpectedBeforeMacro, macro) = self.expectIdentifier(allowKeywordsAsIdentifier: true)
       if macro.leadingTriviaByteLength != 0 {
         unexpectedBeforeMacro = RawUnexpectedNodesSyntax(combining: unexpectedBeforeMacro, macro, arena: self.arena)
         pound = self.missingToken(.identifier, text: macro.tokenText)

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1420,7 +1420,7 @@ extension Parser {
     var unexpectedBeforeMacro: RawUnexpectedNodesSyntax?
     var macro: RawTokenSyntax
     if !self.currentToken.isAtStartOfLine {
-      (unexpectedBeforeMacro, macro) = self.expectIdentifier(keywordRecovery: true)
+      (unexpectedBeforeMacro, macro) = self.expectIdentifier(allowKeywordsAsIdentifier: true)
       if macro.leadingTriviaByteLength != 0 {
         // If there're whitespaces after '#' diagnose.
         unexpectedBeforeMacro = RawUnexpectedNodesSyntax(combining: unexpectedBeforeMacro, macro, arena: self.arena)

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -431,23 +431,31 @@ extension Parser {
     )
   }
 
-  /// If `keywordRecovery` is set to `true` and the parser is currently
-  /// positioned at a keyword instead of an identifier, this method recovers by
-  /// eating the keyword in place of an identifier, recovering if the developer
-  /// incorrectly used a keyword as an identifier.
-  /// This should be set if keywords aren't strong recovery marker at this
-  /// position, e.g. because the parser expects a punctuator next.
-  ///
-  /// If `allowSelfOrCapitalSelfAsIdentifier` is `true`, then `self` and `Self`
-  /// are also accepted and remapped to identifiers. This is exclusively used
-  /// to maintain compatibility with the C++ parser. No new uses of this should
-  /// be introduced.
+  /// - Parameters:
+  ///   - keywordRecovery: If set to `true` and the parser is currently
+  ///     positioned at a keyword instead of an identifier, this method recovers
+  ///     by eating the keyword in place of an identifier, recovering if the
+  ///     developer incorrectly used a keyword as an identifier. This should be
+  ///     set if keywords aren't strong recovery marker at this position, e.g.
+  ///     because the parser expects a punctuator next
+  ///   - allowSelfOrCapitalSelfAsIdentifier: If set to `true`, then `self` and
+  ///     `Self` are also accepted and remapped to identifiers. This is
+  ///     exclusively used to maintain compatibility with the C++ parser. No new
+  ///     uses of this should be introduced.
+  ///   - allowKeywordsAsIdentifier: If set to `true` and the parser is
+  ///     currently positioned at a keyword, consume that keyword and remap it
+  ///     to and identifier.
+  /// - Returns: The consumed token and any unexpected tokens that were skipped.
   mutating func expectIdentifier(
     keywordRecovery: Bool = false,
-    allowSelfOrCapitalSelfAsIdentifier: Bool = false
+    allowSelfOrCapitalSelfAsIdentifier: Bool = false,
+    allowKeywordsAsIdentifier: Bool = false
   ) -> (RawUnexpectedNodesSyntax?, RawTokenSyntax) {
     if let identifier = self.consume(if: .identifier) {
       return (nil, identifier)
+    }
+    if allowKeywordsAsIdentifier, self.currentToken.isLexerClassifiedKeyword {
+      return (nil, self.consumeAnyToken(remapping: .identifier))
     }
     if allowSelfOrCapitalSelfAsIdentifier,
       let selfOrCapitalSelf = self.consume(if: TokenSpec(.self, remapping: .identifier), TokenSpec(.Self, remapping: .identifier))

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1653,6 +1653,23 @@ final class DeclarationTests: XCTestCase {
     )
   }
 
+  func testMacroExpansionDeclarationWithKeywordName() {
+    assertParse(
+      """
+      struct X {
+        #case
+      }
+      """,
+      substructure: Syntax(
+        MacroExpansionDeclSyntax(
+          poundToken: .poundToken(),
+          macro: .identifier("case"),
+          argumentList: TupleExprElementListSyntax([])
+        )
+      )
+    )
+  }
+
   func testAttributedMacroExpansionDeclaration() {
     assertParse(
       """
@@ -1806,60 +1823,32 @@ final class DeclarationTests: XCTestCase {
     assertParse(
       """
       struct S {
-        @attrib #1️⃣class
+        @attrib #class
       }
       """,
       substructure: Syntax(
         MacroExpansionDeclSyntax(
           attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attrib")))],
           poundToken: .poundToken(),
-          /*unexpectedBetweenPoundTokenAndMacro:*/ [
-            TokenSyntax.keyword(.class)
-          ],
-          macro: .identifier("", presence: .missing),
+          macro: .identifier("class"),
           argumentList: []
         )
-      ),
-      diagnostics: [
-        DiagnosticSpec(
-          message: "keyword 'class' cannot be used as an identifier here",
-          fixIts: ["if this name is unavoidable, use backticks to escape it"]
-        )
-      ],
-      fixedSource: """
-        struct S {
-          @attrib #`class`
-        }
-        """
+      )
     )
 
     assertParse(
       """
       struct S {
-        #1️⃣struct
+        #struct
       }
       """,
       substructure: Syntax(
         MacroExpansionDeclSyntax(
           poundToken: .poundToken(),
-          /*unexpectedBetweenPoundTokenAndMacro:*/ [
-            TokenSyntax.keyword(.struct)
-          ],
-          macro: .identifier("", presence: .missing),
+          macro: .identifier("struct"),
           argumentList: []
         )
-      ),
-      diagnostics: [
-        DiagnosticSpec(
-          message: "keyword 'struct' cannot be used as an identifier here",
-          fixIts: ["if this name is unavoidable, use backticks to escape it"]
-        )
-      ],
-      fixedSource: """
-        struct S {
-          #`struct`
-        }
-        """
+      )
     )
   }
 

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -1151,6 +1151,19 @@ final class ExpressionTests: XCTestCase {
     )
   }
 
+  func testMacroExpansionExpressionWithKeywordName() {
+    assertParse(
+      "#case",
+      substructure: Syntax(
+        MacroExpansionExprSyntax(
+          poundToken: .poundToken(),
+          macro: .identifier("case"),
+          argumentList: TupleExprElementListSyntax([])
+        )
+      )
+    )
+  }
+
   func testNewlineInInterpolationOfSingleLineString() {
     assertParse(
       #"""


### PR DESCRIPTION
There is no reason why we shouldn’t allow keywords here.

I also thought about allowing keywords after `@` but things become tricky here for two reasons:
- In the parser, we parse a type after the `@`, which could start with a keyword itself (e.g. `any`). If we want to keep the parser logic to parse a type after `@` (which I think we should), then it becomes unclear what `@any T` should parse as.
- We allow a space between `@` and the type name. This makes it very hard for recovery to tell whether `@ struct` refers to an attribute with name `struct` or if the user forgot to write the attribute name after `@`.

Since almost all keywords are lowercase and attached member macros are usually spelled with an uppercase name, there are a lot fewer chances for clashes here, so I don’t think it’s worth allowing keywords after `@`.

https://github.com/apple/swift/issues/66444
rdar://110472060

I will work on a corresponding compiler PR tomorrow.