### PR TITLE
Move `IncrementalParseTransition` to `SwiftParser`

### DIFF
--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -13,6 +13,7 @@ add_swift_host_library(SwiftParser
   Declarations.swift
   Directives.swift
   Expressions.swift
+  IncrementalParseTransition.swift
   Lookahead.swift
   LoopProgressCondition.swift
   Modifiers.swift

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -11,7 +11,6 @@ add_swift_host_library(SwiftSyntax
   Assert.swift
   BumpPtrAllocator.swift
   CommonAncestor.swift
-  IncrementalParseTransition.swift
   MemoryLayout.swift
   MissingNodeInitializers.swift
   Trivia.swift

--- a/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
+++ b/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
@@ -12,6 +12,7 @@
 
 import XCTest
 import SwiftSyntax
+import SwiftParser
 import _SwiftSyntaxTestSupport
 
 let longString = """


### PR DESCRIPTION
Also move `ConcurrentEdits` to `SwiftSyntax/Utils.swift`, since it might have its own value other than incremental parse in the future.