### PR TITLE
Add missing trait conformances

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -184,6 +184,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     base: .syntax,
     nameForDiagnostics: "version",
     documentation: "A single platform/version pair in an attribute, e.g. `iOS 10.1`.",
+    traits: ["WithTrailingComma"],
     children: [
       Child(
         name: "AvailabilityVersionRestriction",

--- a/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
@@ -21,6 +21,7 @@ public let AVAILABILITY_NODES: [Node] = [
     base: .syntax,
     nameForDiagnostics: "availability argument",
     documentation: "A single argument to an `@available` argument like `*`, `iOS 10.1`, or `message: \"This has been deprecated\"`.",
+    traits: ["WithTrailingComma"],
     children: [
       Child(
         name: "Entry",

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -1871,6 +1871,7 @@ public let DECL_NODES: [Node] = [
     kind: .precedenceGroupNameElement,
     base: .syntax,
     nameForDiagnostics: nil,
+    traits: ["WithTrailingComma"],
     children: [
       Child(
         name: "Name",
@@ -2268,6 +2269,7 @@ public let DECL_NODES: [Node] = [
     traits: [
       "IdentifiedDecl",
       "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -499,6 +499,10 @@ extension AssociatedtypeDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, 
 
 extension AttributedTypeSyntax: WithAttributesSyntax {}
 
+extension AvailabilityArgumentSyntax: WithTrailingCommaSyntax {}
+
+extension AvailabilityVersionRestrictionListEntrySyntax: WithTrailingCommaSyntax {}
+
 extension CaseItemSyntax: WithTrailingCommaSyntax {}
 
 extension CatchClauseSyntax: WithCodeBlockSyntax {}
@@ -603,6 +607,8 @@ extension PoundSourceLocationSyntax: ParenthesizedSyntax {}
 
 extension PrecedenceGroupDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
+extension PrecedenceGroupNameElementSyntax: WithTrailingCommaSyntax {}
+
 extension PrimaryAssociatedTypeSyntax: WithTrailingCommaSyntax {}
 
 extension ProtocolDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
@@ -635,7 +641,7 @@ extension TupleTypeSyntax: ParenthesizedSyntax {}
 
 extension TypeEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
-extension TypealiasDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax {}
+extension TypealiasDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension VariableDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -339,7 +339,10 @@ public struct AvailabilitySpecListBuilder {
   /// If declared, this will be called on the partial result from the outermost
   /// block statement to produce the final returned result.
   public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+    let lastIndex = component.count - 1
+    return .init(component.enumerated().map { index, source in
+      return index < lastIndex ? source.ensuringTrailingComma() : source
+      })
   }
 }
 
@@ -419,7 +422,10 @@ public struct AvailabilityVersionRestrictionListBuilder {
   /// If declared, this will be called on the partial result from the outermost
   /// block statement to produce the final returned result.
   public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+    let lastIndex = component.count - 1
+    return .init(component.enumerated().map { index, source in
+      return index < lastIndex ? source.ensuringTrailingComma() : source
+      })
   }
 }
 
@@ -3128,7 +3134,10 @@ public struct PrecedenceGroupNameListBuilder {
   /// If declared, this will be called on the partial result from the outermost
   /// block statement to produce the final returned result.
   public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+    let lastIndex = component.count - 1
+    return .init(component.enumerated().map { index, source in
+      return index < lastIndex ? source.ensuringTrailingComma() : source
+      })
   }
 }
 

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -1112,7 +1112,7 @@ final class MacroSystemTests: XCTestCase {
       expandedSource: #"""
         struct S {
           @attr static var value1 = 1
-          @attr typealias A = B
+          @attr static typealias A = B
         }
         """#,
       macros: ["decls": DeclsFromStringsMacro.self],


### PR DESCRIPTION
These trait conformances were simply missing. Add them.

I added a validation rule to check that all nodes that can conform to a trait do so in https://github.com/apple/swift-syntax/pull/1748.