### PR TITLE
[5.9] assertMacroExpansion should assert if there are errors

### DIFF
--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -14,6 +14,7 @@ import _SwiftSyntaxTestSupport
 import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftParser
+import SwiftParserDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
 import XCTest
@@ -279,11 +280,27 @@ public func assertMacroExpansion(
   let context = BasicMacroExpansionContext(
     sourceFiles: [origSourceFile: .init(moduleName: testModuleName, fullFilePath: testFileName)]
   )
-  let expandedSourceFile = origSourceFile.expand(macros: macros, in: context).formatted(using: BasicFormat(indentationWidth: indentationWidth))
 
+  let expandedSourceFile = origSourceFile.expand(macros: macros, in: context)
+  let diags = ParseDiagnosticsGenerator.diagnostics(for: expandedSourceFile)
+  if !diags.isEmpty {
+    XCTFail(
+      """
+      Expanded source should not contain any syntax errors, but contains:
+      \(DiagnosticsFormatter.annotatedSource(tree: expandedSourceFile, diags: diags))
+
+      Expanded syntax tree was:
+      \(expandedSourceFile.debugDescription)
+      """,
+      file: file,
+      line: line
+    )
+  }
+
+  let formattedSourceFile = expandedSourceFile.formatted(using: BasicFormat(indentationWidth: indentationWidth))
   assertStringsEqualWithDiff(
-    expandedSourceFile.description.trimmingTrailingWhitespace().trimmingCharacters(in: .newlines),
-    expandedSource.trimmingTrailingWhitespace().trimmingCharacters(in: .newlines),
+    formattedSourceFile.description.trimmingCharacters(in: .newlines),
+    expandedSource.trimmingCharacters(in: .newlines),
     additionalInfo: """
       Actual expanded source:
       \(expandedSource)


### PR DESCRIPTION
* Explanation: `assertMacroExpansion` is used for testing macro expansions. It should check that the expanded macro is itself valid.
* Scope: Macro unit testing
* Risk: Very low. It's possible some existing tests may now fail, but that means that the underlying expansion needs to be updated.
* Original PR: https://github.com/apple/swift-syntax/pull/1758