### PR TITLE
[5.9] Add missing trait conformances

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -187,6 +187,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     nameForDiagnostics: "version",
     description: "A single platform/version pair in an attribute, e.g. `iOS 10.1`.",
     kind: "Syntax",
+    traits: ["WithTrailingComma"],
     children: [
       Child(
         name: "AvailabilityVersionRestriction",

--- a/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
@@ -21,6 +21,7 @@ public let AVAILABILITY_NODES: [Node] = [
     nameForDiagnostics: "availability argument",
     description: "A single argument to an `@available` argument like `*`, `iOS 10.1`, or `message: \"This has been deprecated\"`.",
     kind: "Syntax",
+    traits: ["WithTrailingComma"],
     children: [
       Child(
         name: "Entry",

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -1779,6 +1779,7 @@ public let DECL_NODES: [Node] = [
     name: "PrecedenceGroupNameElement",
     nameForDiagnostics: nil,
     kind: "Syntax",
+    traits: ["WithTrailingComma"],
     children: [
       Child(
         name: "Name",
@@ -2095,6 +2096,7 @@ public let DECL_NODES: [Node] = [
     traits: [
       "IdentifiedDecl",
       "WithAttributes",
+      "WithModifiers",
     ],
     children: [
       Child(

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -499,6 +499,10 @@ extension AssociatedtypeDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, 
 
 extension AttributedTypeSyntax: WithAttributesSyntax {}
 
+extension AvailabilityArgumentSyntax: WithTrailingCommaSyntax {}
+
+extension AvailabilityVersionRestrictionListEntrySyntax: WithTrailingCommaSyntax {}
+
 extension CaseItemSyntax: WithTrailingCommaSyntax {}
 
 extension CatchClauseSyntax: WithCodeBlockSyntax {}
@@ -603,6 +607,8 @@ extension PoundSourceLocationSyntax: ParenthesizedSyntax {}
 
 extension PrecedenceGroupDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
+extension PrecedenceGroupNameElementSyntax: WithTrailingCommaSyntax {}
+
 extension PrimaryAssociatedTypeSyntax: WithTrailingCommaSyntax {}
 
 extension ProtocolDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
@@ -635,7 +641,7 @@ extension TupleTypeSyntax: ParenthesizedSyntax {}
 
 extension TypeEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
-extension TypealiasDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax {}
+extension TypealiasDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
 extension VariableDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -419,7 +419,10 @@ public struct AvailabilitySpecListBuilder {
   /// If declared, this will be called on the partial result from the outermost
   /// block statement to produce the final returned result.
   public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+    let lastIndex = component.count - 1
+    return .init(component.enumerated().map { index, source in
+      return index < lastIndex ? source.ensuringTrailingComma() : source
+      })
   }
 }
 
@@ -499,7 +502,10 @@ public struct AvailabilityVersionRestrictionListBuilder {
   /// If declared, this will be called on the partial result from the outermost
   /// block statement to produce the final returned result.
   public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+    let lastIndex = component.count - 1
+    return .init(component.enumerated().map { index, source in
+      return index < lastIndex ? source.ensuringTrailingComma() : source
+      })
   }
 }
 
@@ -3128,7 +3134,10 @@ public struct PrecedenceGroupNameListBuilder {
   /// If declared, this will be called on the partial result from the outermost
   /// block statement to produce the final returned result.
   public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+    let lastIndex = component.count - 1
+    return .init(component.enumerated().map { index, source in
+      return index < lastIndex ? source.ensuringTrailingComma() : source
+      })
   }
 }
 

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -1112,7 +1112,7 @@ final class MacroSystemTests: XCTestCase {
       expandedSource: #"""
         struct S {
           @attr static var value1 = 1
-          @attr typealias A = B
+          @attr static typealias A = B
         }
         """#,
       macros: ["decls": DeclsFromStringsMacro.self],


### PR DESCRIPTION
* **Explanation**: `TypealiasDeclSyntax` is missing conformance to `WithAttributesSyntax`. We should add it. Same for a couple more types that should conform to `WithTrailingComma`.
* **Risk**: Low, these conformances should have always existed
* **Testing**: Ran unit tests
* **Issue**: rdar://110818997
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/1784