### PR TITLE
Fix compile error on tutorial

### DIFF
--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step10.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step10.swift
@@ -55,7 +55,7 @@ import Foundation
     }
     return
       sourceFile
-      .with(\.statements, CodeBlockItemSyntax(formattedStatements))
+      .with(\.statements, CodeBlockItemListSyntax(formattedStatements))
   }
 
   enum Item {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
@@ -58,7 +58,7 @@ import Foundation
     }
     return
       sourceFile
-      .with(\.statements, CodeBlockItemSyntax(formattedStatements))
+      .with(\.statements, CodeBlockItemListSyntax(formattedStatements))
   }
 
   enum Item {


### PR DESCRIPTION
I've recently taken an interest in Swift macros and have been getting started with swift-syntax. The Tutorial provided in this repository was very beneficial, thank you!
While following along with the Tutorial, I encountered a portion of code that causes a compile error. I am proposing a fix for the error in this PR.