### PR TITLE
When creation of a syntax node using string interpolation failed, log the diagnostics

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
@@ -17,41 +17,8 @@ import Utils
 
 let syntaxExpressibleByStringInterpolationConformancesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   DeclSyntax("import SwiftSyntax")
-  DeclSyntax("import SwiftParser")
-  DeclSyntax("import SwiftParserDiagnostics")
-
-  try! ExtensionDeclSyntax("extension SyntaxParseable") {
-    DeclSyntax("public typealias StringInterpolation = SyntaxStringInterpolation")
-
-    DeclSyntax(
-      """
-      public init(stringInterpolation: SyntaxStringInterpolation) {
-        self = performParse(source: stringInterpolation.sourceText, parse: { parser in
-          return Self.parse(from: &parser)
-        })
-      }
-      """
-    )
-  }
 
   for node in SYNTAX_NODES where node.parserFunction != nil {
     DeclSyntax("extension \(node.kind.syntaxType): SyntaxExpressibleByStringInterpolation {}")
   }
-
-  DeclSyntax(
-    """
-    // TODO: This should be inlined in SyntaxParseable.init(stringInterpolation:),
-    // but is currently used in `ConvenienceInitializers.swift`.
-    // See the corresponding TODO there.
-    func performParse<SyntaxType: SyntaxProtocol>(source: [UInt8], parse: (inout Parser) -> SyntaxType) -> SyntaxType {
-      return source.withUnsafeBufferPointer { buffer in
-        var parser = Parser(buffer)
-        // FIXME: When the parser supports incremental parsing, put the
-        // interpolatedSyntaxNodes in so we don't have to parse them again.
-        let result = parse(&parser)
-        return result
-      }
-    }
-    """
-  )
 }

--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,12 @@
 import PackageDescription
 import Foundation
 
+var swiftSyntaxSwiftSettings: [SwiftSetting] = []
+var swiftSyntaxBuilderSwiftSettings: [SwiftSetting] = []
+var swiftParserSwiftSettings: [SwiftSetting] = []
+
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
-var swiftSyntaxSwiftSettings: [SwiftSetting] = []
 if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil {
   let groupFile = URL(fileURLWithPath: #file)
     .deletingLastPathComponent()
@@ -21,14 +24,20 @@ if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil 
       "-enforce-exclusivity=unchecked",
     ]),
   ]
+  swiftSyntaxBuilderSwiftSettings += [
+    .define("SWIFTSYNTAX_NO_OSLOG_DEPENDENCY")
+  ]
+  swiftParserSwiftSettings += [
+    .define("SWIFTSYNTAX_NO_OSLOG_DEPENDENCY")
+  ]
 }
+
 if ProcessInfo.processInfo.environment["SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION"] != nil {
   swiftSyntaxSwiftSettings += [
     .define("SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION")
   ]
 }
 
-var swiftParserSwiftSettings: [SwiftSetting] = []
 if ProcessInfo.processInfo.environment["SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION"] != nil {
   swiftParserSwiftSettings += [
     .define("SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION")
@@ -162,8 +171,9 @@ let package = Package(
 
     .target(
       name: "SwiftSyntaxBuilder",
-      dependencies: ["SwiftBasicFormat", "SwiftParser", "SwiftParserDiagnostics", "SwiftSyntax"],
-      exclude: ["CMakeLists.txt"]
+      dependencies: ["SwiftBasicFormat", "SwiftParser", "SwiftDiagnostics", "SwiftParserDiagnostics", "SwiftSyntax"],
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: swiftSyntaxBuilderSwiftSettings
     ),
 
     .testTarget(

--- a/Sources/SwiftSyntaxBuilder/CMakeLists.txt
+++ b/Sources/SwiftSyntaxBuilder/CMakeLists.txt
@@ -12,6 +12,7 @@ add_swift_host_library(SwiftSyntaxBuilder
   ResultBuilderExtensions.swift
   Syntax+StringInterpolation.swift
   SyntaxNodeWithBody.swift
+  SyntaxParsable+ExpressibleByStringInterpolation.swift
   ValidatingSyntaxNodes.swift
   WithTrailingCommaSyntax+EnsuringTrailingComma.swift
 
@@ -21,6 +22,11 @@ add_swift_host_library(SwiftSyntaxBuilder
   generated/ResultBuilders.swift
   generated/SyntaxExpressibleByStringInterpolationConformances.swift
 )
+
+# Don't depend on OSLog when we are building for the compiler.
+# In that case we don't want any dependencies on the SDK.
+target_compile_options(SwiftSyntaxBuilder PRIVATE
+  $<$<COMPILE_LANGUAGE:Swift>:-D;SWIFTSYNTAX_NO_OSLOG_DEPENDENCY>)
 
 target_link_libraries(SwiftSyntaxBuilder PUBLIC
   SwiftBasicFormat

--- a/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftParser
+import SwiftParserDiagnostics
+// Don't introduce a dependency on OSLog when building SwiftSyntax using CMake
+// for the compiler.
+#if canImport(OSLog) && !SWIFTSYNTAX_NO_OSLOG_DEPENDENCY
+import OSLog
+#endif
+
+extension SyntaxParseable {
+  public typealias StringInterpolation = SyntaxStringInterpolation
+
+  /// Assuming that this node contains a syntax error, log it using OSLog if we
+  /// are on a platform that supports OSLog, otherwise don't do anything.
+  private func logStringInterpolationParsingError() {
+    #if canImport(OSLog) && !SWIFTSYNTAX_NO_OSLOG_DEPENDENCY
+    if #available(macOS 11.0, *) {
+      let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: self)
+      let formattedDiagnostics = DiagnosticsFormatter().annotatedSource(tree: self, diags: diagnostics)
+      Logger(subsystem: "SwiftSyntax", category: "ParseError").fault(
+        """
+        Parsing a `\(Self.self)` node from string interpolation produced the following parsing errors.
+        Set a breakpoint in `SyntaxParseable.logStringInterpolationParsingError()` to debug the failure.
+        \(formattedDiagnostics)
+        """
+      )
+    }
+    #endif
+  }
+
+  /// Initialize the syntax node from a string interpolation.
+  ///
+  /// - Important: This asssumes that the string interpolation produces a valid
+  ///              syntax tree. If the syntax tree is not valid, a fault will
+  ///              be logged using OSLog on Darwin platforms.
+  public init(stringInterpolation: SyntaxStringInterpolation) {
+    self = stringInterpolation.sourceText.withUnsafeBufferPointer { buffer in
+      var parser = Parser(buffer)
+      // FIXME: When the parser supports incremental parsing, put the
+      // interpolatedSyntaxNodes in so we don't have to parse them again.
+      let result = Self.parse(from: &parser)
+      return result
+    }
+    if self.hasError {
+      self.logStringInterpolationParsingError()
+    }
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -13,18 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-import SwiftParser
-import SwiftParserDiagnostics
-
-extension SyntaxParseable {
-  public typealias StringInterpolation = SyntaxStringInterpolation
-  
-  public init(stringInterpolation: SyntaxStringInterpolation) {
-    self = performParse(source: stringInterpolation.sourceText, parse: { parser in
-      return Self.parse(from: &parser)
-    })
-  }
-}
 
 extension AccessorDeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
@@ -57,16 +45,3 @@ extension StmtSyntax: SyntaxExpressibleByStringInterpolation {}
 extension SwitchCaseSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension TypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-// TODO: This should be inlined in SyntaxParseable.init(stringInterpolation:),
-// but is currently used in `ConvenienceInitializers.swift`.
-// See the corresponding TODO there.
-func performParse<SyntaxType: SyntaxProtocol>(source: [UInt8], parse: (inout Parser) -> SyntaxType) -> SyntaxType {
-  return source.withUnsafeBufferPointer { buffer in
-    var parser = Parser(buffer)
-    // FIXME: When the parser supports incremental parsing, put the
-    // interpolatedSyntaxNodes in so we don't have to parse them again.
-    let result = parse(&parser)
-    return result
-  }
-}

--- a/Tests/SwiftParserTest/StringLiteralRepresentedLiteralValueTests.swift
+++ b/Tests/SwiftParserTest/StringLiteralRepresentedLiteralValueTests.swift
@@ -250,7 +250,8 @@ public class StringLiteralRepresentedLiteralValueTests: XCTestCase {
   // MARK: literal value not available
 
   func testMissingQuoteStringLiteral() throws {
-    let stringLiteral = StringLiteralExprSyntax(#""a"# as ExprSyntax)!
+    var parser = Parser(#""a"#)
+    let stringLiteral = StringLiteralExprSyntax(ExprSyntax.parse(from: &parser))!
     XCTAssertNil(stringLiteral.representedLiteralValue, "only fully parsed string literals should produce a literal value")
   }
 
@@ -260,7 +261,8 @@ public class StringLiteralRepresentedLiteralValueTests: XCTestCase {
   }
 
   func testMalformedMultiLineStringLiteral() throws {
-    let stringLiteral = StringLiteralExprSyntax(#""""a""""# as ExprSyntax)!
+    var parser = Parser(#""""a""""#)
+    let stringLiteral = StringLiteralExprSyntax(ExprSyntax.parse(from: &parser))!
     XCTAssertNil(stringLiteral.representedLiteralValue, "missing newline in multiline string literal cannot produce a literal value")
   }
 

--- a/Tests/SwiftRefactorTest/ExpandEditorPlaceholderTests.swift
+++ b/Tests/SwiftRefactorTest/ExpandEditorPlaceholderTests.swift
@@ -12,6 +12,7 @@
 
 import SwiftBasicFormat
 import SwiftRefactor
+import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import XCTest
@@ -100,7 +101,8 @@ fileprivate func assertRefactorPlaceholder(
   if wrap {
     token = "\(raw: ExpandEditorPlaceholder.wrapInPlaceholder(placeholder))"
   } else {
-    let expr: ExprSyntax = "\(raw: placeholder)"
+    var parser = Parser(placeholder)
+    let expr = ExprSyntax.parse(from: &parser)
     token = try XCTUnwrap(expr.as(EditorPlaceholderExprSyntax.self)?.identifier, file: file, line: line)
   }
 

--- a/Tests/SwiftRefactorTest/ExpandEditorPlaceholdersTests.swift
+++ b/Tests/SwiftRefactorTest/ExpandEditorPlaceholdersTests.swift
@@ -109,7 +109,8 @@ fileprivate func assertRefactorPlaceholderCall(
   file: StaticString = #file,
   line: UInt = #line
 ) throws {
-  let call = try XCTUnwrap(ExprSyntax("\(raw: expr)").as(FunctionCallExprSyntax.self), file: file, line: line)
+  var parser = Parser(expr)
+  let call = try XCTUnwrap(ExprSyntax.parse(from: &parser).as(FunctionCallExprSyntax.self), file: file, line: line)
   let arg = try XCTUnwrap(call.argumentList[placeholder].as(TupleExprElementSyntax.self), file: file, line: line)
   let token: TokenSyntax = try XCTUnwrap(arg.expression.as(EditorPlaceholderExprSyntax.self), file: file, line: line).identifier
 
@@ -123,7 +124,8 @@ fileprivate func assertRefactorPlaceholderToken(
   file: StaticString = #file,
   line: UInt = #line
 ) throws {
-  let call = try XCTUnwrap(ExprSyntax("\(raw: expr)").as(FunctionCallExprSyntax.self), file: file, line: line)
+  var parser = Parser(expr)
+  let call = try XCTUnwrap(ExprSyntax.parse(from: &parser).as(FunctionCallExprSyntax.self), file: file, line: line)
   let arg = try XCTUnwrap(call.argumentList[placeholder].as(TupleExprElementSyntax.self), file: file, line: line)
   let token: TokenSyntax = try XCTUnwrap(arg.expression.as(EditorPlaceholderExprSyntax.self), file: file, line: line).identifier
 

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -446,10 +446,11 @@ final class StringInterpolationTests: XCTestCase {
   }
 
   func testInvalidSyntax() {
-    let invalid = DeclSyntax("return 1")
+    var parser = Parser("return 1")
+    let invalid = DeclSyntax.parse(from: &parser)
     XCTAssert(invalid.hasError)
 
-    XCTAssertThrowsError(try DeclSyntax(validating: "return 1")) { error in
+    XCTAssertThrowsError(try DeclSyntax(validating: invalid)) { error in
       assertStringsEqualWithDiff(
         String(describing: error),
         """
@@ -464,10 +465,11 @@ final class StringInterpolationTests: XCTestCase {
   }
 
   func testInvalidSyntax2() {
-    let invalid = StmtSyntax("struct Foo {}")
+    var parser = Parser("struct Foo {}")
+    let invalid = StmtSyntax.parse(from: &parser)
     XCTAssert(invalid.hasError)
 
-    XCTAssertThrowsError(try StmtSyntax(validating: "struct Foo {}")) { error in
+    XCTAssertThrowsError(try StmtSyntax(validating: invalid)) { error in
       assertStringsEqualWithDiff(
         String(describing: error),
         """
@@ -482,10 +484,11 @@ final class StringInterpolationTests: XCTestCase {
   }
 
   func testInvalidSyntax3() {
-    let invalid: CodeBlockItemSyntax = " "
+    var parser = Parser(" ")
+    let invalid = CodeBlockItemSyntax.parse(from: &parser)
 
     XCTAssert(invalid.hasError)
-    XCTAssertThrowsError(try CodeBlockItemSyntax(validating: " ")) { error in
+    XCTAssertThrowsError(try CodeBlockItemSyntax(validating: invalid)) { error in
       assertStringsEqualWithDiff(
         String(describing: error),
         """

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralExprSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralExprSyntaxTests.swift
@@ -232,7 +232,7 @@ final class StringLiteralExprSyntaxTests: XCTestCase {
         StringSegmentSyntax(content: .stringSegment(#"Validation failures:"#), trailingTrivia: .newline)
         ExpressionSegmentSyntax(
           expressions: TupleExprElementListSyntax {
-            TupleExprElementSyntax(expression: ExprSyntax(#"nonNilErrors.map({ "- \($0.description)" }).joined(separator: "\n"))"#))
+            TupleExprElementSyntax(expression: ExprSyntax(#"nonNilErrors.map({ "- \($0.description)" }).joined(separator: "\n")"#))
           }
         )
       },
@@ -246,7 +246,7 @@ final class StringLiteralExprSyntaxTests: XCTestCase {
       Error validating child at index \(index) of \(nodeKind):
       Node did not satisfy any node choice requirement.
       Validation failures:
-      \(nonNilErrors.map({ "- \($0.description)" }).joined(separator: "\n")))
+      \(nonNilErrors.map({ "- \($0.description)" }).joined(separator: "\n"))
       """
       """#
     )


### PR DESCRIPTION
From the first feedback of developers starting to build macros, the number one mistake was to build incorrect syntax nodes, e.g. build an `ExprSyntax` for a declaration. For example

- https://github.com/apple/swift-syntax/issues/1792
- https://github.com/apple/swift-syntax/issues/1786

Up until recently, these errors weren’t diagnosed at all. By now we at least issue an XCTest assertion if the expanded macro code contains syntax errors. But I think the issues are a lot easier to debug if we can emit an error at the location where the incorrect syntax node is being created.

Since we can’t throw an error from string interpolation, use OSLog to log the parsing error to Xcode or OS console. When OSLog is not available or we are building using CMake (and thus don’t want to introduce any dependency on the SDK), silently accept the error as we do right now. Logging to stderr might be too fragile in case some application is expecting to populate stderr itself.