### PR TITLE
[5.9] Allow keywords after `#` in freestanding macro expansions

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -2048,7 +2048,7 @@ extension Parser {
         arena: self.arena
       )
     }
-    let (unexpectedBeforeMacro, macro) = self.expectIdentifier(keywordRecovery: true)
+    let (unexpectedBeforeMacro, macro) = self.expectIdentifier(allowKeywordsAsIdentifier: true)
 
     // Parse the optional generic argument list.
     let generics: RawGenericArgumentClauseSyntax?

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1378,7 +1378,7 @@ extension Parser {
       )
     }
     let poundKeyword = self.consumeAnyToken()
-    let (unexpectedBeforeMacro, macro) = self.expectIdentifier(keywordRecovery: true)
+    let (unexpectedBeforeMacro, macro) = self.expectIdentifier(allowKeywordsAsIdentifier: true)
 
     // Parse the optional generic argument list.
     let generics: RawGenericArgumentClauseSyntax?

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -431,23 +431,31 @@ extension Parser {
     )
   }
 
-  /// If `keywordRecovery` is set to `true` and the parser is currently
-  /// positioned at a keyword instead of an identifier, this method recovers by
-  /// eating the keyword in place of an identifier, recovering if the developer
-  /// incorrectly used a keyword as an identifier.
-  /// This should be set if keywords aren't strong recovery marker at this
-  /// position, e.g. because the parser expects a punctuator next.
-  ///
-  /// If `allowSelfOrCapitalSelfAsIdentifier` is `true`, then `self` and `Self`
-  /// are also accepted and remapped to identifiers. This is exclusively used
-  /// to maintain compatibility with the C++ parser. No new uses of this should
-  /// be introduced.
+  /// - Parameters:
+  ///   - keywordRecovery: If set to `true` and the parser is currently
+  ///     positioned at a keyword instead of an identifier, this method recovers
+  ///     by eating the keyword in place of an identifier, recovering if the
+  ///     developer incorrectly used a keyword as an identifier. This should be
+  ///     set if keywords aren't strong recovery marker at this position, e.g.
+  ///     because the parser expects a punctuator next
+  ///   - allowSelfOrCapitalSelfAsIdentifier: If set to `true`, then `self` and
+  ///     `Self` are also accepted and remapped to identifiers. This is
+  ///     exclusively used to maintain compatibility with the C++ parser. No new
+  ///     uses of this should be introduced.
+  ///   - allowKeywordsAsIdentifier: If set to `true` and the parser is
+  ///     currently positioned at a keyword, consume that keyword and remap it
+  ///     to and identifier.
+  /// - Returns: The consumed token and any unexpected tokens that were skipped.
   mutating func expectIdentifier(
     keywordRecovery: Bool = false,
-    allowSelfOrCapitalSelfAsIdentifier: Bool = false
+    allowSelfOrCapitalSelfAsIdentifier: Bool = false,
+    allowKeywordsAsIdentifier: Bool = false
   ) -> (RawUnexpectedNodesSyntax?, RawTokenSyntax) {
     if let identifier = self.consume(if: .identifier) {
       return (nil, identifier)
+    }
+    if allowKeywordsAsIdentifier, self.currentToken.isLexerClassifiedKeyword {
+      return (nil, self.consumeAnyToken(remapping: .identifier))
     }
     if allowSelfOrCapitalSelfAsIdentifier, let selfOrCapitalSelf = self.consume(if: TokenSpec(.self, remapping: .identifier), TokenSpec(.Self, remapping: .identifier)) {
       return (nil, selfOrCapitalSelf)

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1300,6 +1300,23 @@ final class DeclarationTests: XCTestCase {
     )
   }
 
+  func testMacroExpansionDeclarationWithKeywordName() {
+    assertParse(
+      """
+      struct X {
+        #case
+      }
+      """,
+      substructure: Syntax(
+        MacroExpansionDeclSyntax(
+          poundToken: .poundToken(),
+          macro: .identifier("case"),
+          argumentList: TupleExprElementListSyntax([])
+        )
+      )
+    )
+  }
+
   func testAttributedMacroExpansionDeclaration() {
     assertParse(
       """
@@ -1452,8 +1469,8 @@ final class DeclarationTests: XCTestCase {
     assertParse(
       """
       struct S {
-        @attrib #1️⃣class
-        #2️⃣struct
+        @attrib #class
+        #struct
       }
       """,
       substructure: Syntax(
@@ -1462,43 +1479,19 @@ final class DeclarationTests: XCTestCase {
             decl: MacroExpansionDeclSyntax(
               attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attrib")))],
               poundToken: .poundToken(),
-              /*unexpectedBetweenPoundTokenAndMacro:*/ [
-                TokenSyntax.keyword(.class)
-              ],
-              macro: .identifier("", presence: .missing),
+              macro: .identifier("class"),
               argumentList: []
             )
           ),
           MemberDeclListItemSyntax(
             decl: MacroExpansionDeclSyntax(
               poundToken: .poundToken(),
-              /*unexpectedBetweenPoundTokenAndMacro:*/ [
-                TokenSyntax.keyword(.struct)
-              ],
-              macro: .identifier("", presence: .missing),
+              macro: .identifier("struct"),
               argumentList: []
             )
           ),
         ])
-      ),
-      diagnostics: [
-        DiagnosticSpec(
-          locationMarker: "1️⃣",
-          message: "keyword 'class' cannot be used as an identifier here",
-          fixIts: ["if this name is unavoidable, use backticks to escape it"]
-        ),
-        DiagnosticSpec(
-          locationMarker: "2️⃣",
-          message: "keyword 'struct' cannot be used as an identifier here",
-          fixIts: ["if this name is unavoidable, use backticks to escape it"]
-        ),
-      ],
-      fixedSource: """
-        struct S {
-          @attrib #`class`
-          #`struct`
-        }
-        """
+      )
     )
   }
 

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -948,6 +948,19 @@ final class ExpressionTests: XCTestCase {
     )
   }
 
+  func testMacroExpansionExpressionWithKeywordName() {
+    assertParse(
+      "#case",
+      substructure: Syntax(
+        MacroExpansionExprSyntax(
+          poundToken: .poundToken(),
+          macro: .identifier("case"),
+          argumentList: TupleExprElementListSyntax([])
+        )
+      )
+    )
+  }
+
   func testNewlineInInterpolationOfSingleLineString() {
     assertParse(
       #"""


### PR DESCRIPTION
* **Explanation**: There is no reason why we shouldn’t allow keywords as macro names after `#`.
* **Scope**: Parsing of keyword after `#`
* **Risk**: Low
* **Testing**: Updated test cases to allow keywords after `#`
* **Issue**: https://github.com/apple/swift/issues/66444 rdar://110472060
* **Reviewer**:  @DougGregor on https://github.com/apple/swift-syntax/pull/1778