### PR TITLE
Avoid creating binding patterns in a couple more positions

### DIFF
--- a/Tests/SwiftParserTest/PatternTests.swift
+++ b/Tests/SwiftParserTest/PatternTests.swift
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) import SwiftParser
+import XCTest
+
+final class PatternTests: XCTestCase {
+  private var genericArgEnumPattern: Syntax {
+    // let E<Int>.e(y)
+    Syntax(
+      ValueBindingPatternSyntax(
+        bindingKeyword: .keyword(.let),
+        valuePattern: ExpressionPatternSyntax(
+          expression: FunctionCallExprSyntax(
+            calledExpression: MemberAccessExprSyntax(
+              base: SpecializeExprSyntax(
+                expression: IdentifierExprSyntax(identifier: .identifier("E")),
+                genericArgumentClause: GenericArgumentClauseSyntax(
+                  arguments: .init([
+                    .init(argumentType: SimpleTypeIdentifierSyntax(name: .identifier("Int")))
+                  ])
+                )
+              ),
+              name: .identifier("e")
+            ),
+            leftParen: .leftParenToken(),
+            argumentList: TupleExprElementListSyntax([
+              .init(
+                expression: UnresolvedPatternExprSyntax(
+                  pattern: IdentifierPatternSyntax(identifier: .identifier("y"))
+                )
+              )
+            ]),
+            rightParen: .rightParenToken()
+          )
+        )
+      )
+    )
+  }
+
+  func testNonBinding1() {
+    assertParse(
+      """
+      if case let E<Int>.e(y) = x {}
+      """,
+      substructure: genericArgEnumPattern
+    )
+  }
+
+  func testNonBinding2() {
+    assertParse(
+      """
+      switch e {
+      case let E<Int>.e(y):
+        y
+      }
+      """,
+      substructure: genericArgEnumPattern
+    )
+  }
+
+  private var tupleWithSubscriptAndBindingPattern: Syntax {
+    // let (y[0], z)
+    Syntax(
+      ValueBindingPatternSyntax(
+        bindingKeyword: .keyword(.let),
+        valuePattern: ExpressionPatternSyntax(
+          expression: TupleExprSyntax(
+            elements: .init([
+              .init(
+                expression: SubscriptExprSyntax(
+                  calledExpression: IdentifierExprSyntax(identifier: .identifier("y")),
+                  leftBracket: .leftSquareToken(),
+                  argumentList: TupleExprElementListSyntax([
+                    .init(expression: IntegerLiteralExprSyntax(digits: .integerLiteral("0")))
+                  ]),
+                  rightBracket: .rightSquareToken()
+                ),
+                trailingComma: .commaToken()
+              ),
+              .init(
+                expression: UnresolvedPatternExprSyntax(
+                  pattern: IdentifierPatternSyntax(identifier: .identifier("z"))
+                )
+              ),
+            ])
+          )
+        )
+      )
+    )
+  }
+
+  func testNonBinding3() {
+    assertParse(
+      """
+      if case let (y[0], z) = x {}
+      """,
+      substructure: tupleWithSubscriptAndBindingPattern
+    )
+  }
+
+  func testNonBinding4() {
+    assertParse(
+      """
+      switch x {
+      case let (y[0], z):
+        z
+      }
+      """,
+      substructure: tupleWithSubscriptAndBindingPattern
+    )
+  }
+
+  private var subscriptWithBindingPattern: Syntax {
+    // let y[z]
+    Syntax(
+      ValueBindingPatternSyntax(
+        bindingKeyword: .keyword(.let),
+        valuePattern: ExpressionPatternSyntax(
+          expression: SubscriptExprSyntax(
+            calledExpression: IdentifierExprSyntax(identifier: .identifier("y")),
+            leftBracket: .leftSquareToken(),
+            argumentList: TupleExprElementListSyntax([
+              .init(
+                expression: UnresolvedPatternExprSyntax(
+                  pattern: IdentifierPatternSyntax(identifier: .identifier("z"))
+                )
+              )
+            ]),
+            rightBracket: .rightSquareToken()
+          )
+        )
+      )
+    )
+  }
+
+  func testNonBinding5() {
+    assertParse(
+      """
+      if case let y[z] = x {}
+      """,
+      substructure: subscriptWithBindingPattern
+    )
+  }
+
+  func testNonBinding6() {
+    assertParse(
+      """
+      switch 0 {
+      case let y[z]:
+        z
+      case y[z]:
+        0
+      default:
+        0
+      }
+      """,
+      substructure: subscriptWithBindingPattern
+    )
+  }
+}


### PR DESCRIPTION
If we have an identifier followed by either `[` or a generic argument list, avoid turning it into a binding pattern, as that would be invalid. This is similar to the existing rule we have where a following `(` prevents a binding pattern from being formed.

This allows patterns such as `let E<Int>.foo(x)` and `let (y[0], x)` to compile, where `x` is treated as a binding, but no other identifier is.

rdar://108738034