### PR TITLE
Improve diagnostics for invalid version tuples

### DIFF
--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -1893,14 +1893,22 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       return .skipChildren
     }
 
-    if let trailingComponents = node.unexpectedAfterComponents,
-      let components = node.components
-    {
-      addDiagnostic(
-        trailingComponents,
-        TrailingVersionAreIgnored(major: node.major, components: components),
-        handledNodes: [trailingComponents.id]
-      )
+    if let unexpectedAfterComponents = node.unexpectedAfterComponents {
+      if let components = node.components,
+        unexpectedAfterComponents.allSatisfy({ $0.is(VersionComponentSyntax.self) })
+      {
+        addDiagnostic(
+          unexpectedAfterComponents,
+          TrailingVersionAreIgnored(major: node.major, components: components),
+          handledNodes: [unexpectedAfterComponents.id]
+        )
+      } else {
+        addDiagnostic(
+          unexpectedAfterComponents,
+          CannotParseVersionTuple(versionTuple: unexpectedAfterComponents),
+          handledNodes: [node.major.id, node.components?.id, unexpectedAfterComponents.id].compactMap { $0 }
+        )
+      }
     }
 
     return .visitChildren

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -286,7 +286,7 @@ public struct CannotParseVersionTuple: ParserError {
   public let versionTuple: UnexpectedNodesSyntax
 
   public var message: String {
-    return "cannot parse version \(versionTuple)"
+    return "cannot parse version component \(versionTuple.shortSingleLineContentDescription)"
   }
 }
 

--- a/Tests/SwiftParserTest/AvailabilityTests.swift
+++ b/Tests/SwiftParserTest/AvailabilityTests.swift
@@ -144,17 +144,19 @@ final class AvailabilityTests: XCTestCase {
 
     assertParse(
       """
+      @available(OSX 10.0.1, *)
+      func test() {}
+      """
+    )
+
+    assertParse(
+      """
       @available(OSX 1️⃣10e10)
       func test() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected version tuple in version restriction", fixIts: ["insert version tuple"]),
-        DiagnosticSpec(message: "unexpected code '10e10' in attribute"),
-      ],
-      fixedSource: """
-        @available(OSX <#integer literal#>10e10)
-        func test() {}
-        """
+        DiagnosticSpec(message: "cannot parse version component code '10e10'")
+      ]
     )
 
     assertParse(
@@ -163,13 +165,8 @@ final class AvailabilityTests: XCTestCase {
       func test() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected integer literal in version tuple", fixIts: ["insert integer literal"]),
-        DiagnosticSpec(message: "unexpected code '0e10' in attribute"),
-      ],
-      fixedSource: """
-        @available(OSX 10.<#integer literal#>0e10)
-        func test() {}
-        """
+        DiagnosticSpec(message: "cannot parse version component code '0e10'")
+      ]
     )
 
     assertParse(
@@ -178,13 +175,8 @@ final class AvailabilityTests: XCTestCase {
       func test() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected version tuple in version restriction", fixIts: ["insert version tuple"]),
-        DiagnosticSpec(message: "unexpected code '0xff' in attribute"),
-      ],
-      fixedSource: """
-        @available(OSX <#integer literal#>0xff)
-        func test() {}
-        """
+        DiagnosticSpec(message: "cannot parse version component code '0xff'")
+      ]
     )
 
     assertParse(
@@ -193,13 +185,28 @@ final class AvailabilityTests: XCTestCase {
       func test() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected integer literal in version tuple", fixIts: ["insert integer literal"]),
-        DiagnosticSpec(message: "unexpected code '0xff' in attribute"),
-      ],
-      fixedSource: """
-        @available(OSX 1.0.<#integer literal#>0xff)
-        func test() {}
-        """
+        DiagnosticSpec(message: "cannot parse version component code '0xff'")
+      ]
+    )
+
+    assertParse(
+      """
+      @available(OSX 1.0.1️⃣0xff, *)
+      func test() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "cannot parse version component code '0xff'")
+      ]
+    )
+
+    assertParse(
+      """
+      @available(OSX 1.0.1️⃣asdf)
+      func test() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "cannot parse version component code 'asdf'")
+      ]
     )
   }
 }

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -388,7 +388,7 @@ final class IfconfigExprTests: XCTestCase {
       #endif
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "cannot parse version \"\"")
+        DiagnosticSpec(message: #"cannot parse version component code '""'"#)
       ]
     )
   }
@@ -401,7 +401,7 @@ final class IfconfigExprTests: XCTestCase {
       #endif
       """,
       diagnostics: [
-        DiagnosticSpec(message: "cannot parse version >=2.2")
+        DiagnosticSpec(message: "cannot parse version component code '>=2.2'")
       ]
     )
   }
@@ -414,7 +414,7 @@ final class IfconfigExprTests: XCTestCase {
       #endif
       """,
       diagnostics: [
-        DiagnosticSpec(message: "cannot parse version 20A301")
+        DiagnosticSpec(message: "cannot parse version component code '20A301'")
       ]
     )
   }
@@ -427,7 +427,7 @@ final class IfconfigExprTests: XCTestCase {
       #endif
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "cannot parse version \"20A301\"")
+        DiagnosticSpec(message: #"cannot parse version component code '"20A301"'"#)
       ]
     )
   }


### PR DESCRIPTION
Resolve #1613 

During the process of rebasing the changes from the main branch, an issue arose, leading to the closure and reopening of the previous PR(#1717).
I sincerely apologize for the inconvenience caused.

Based on the feedback provided in the comment here(https://github.com/apple/swift-syntax/pull/1717#discussion_r1221876190), I have made the necessary revisions and added several relevant test cases.