### PR TITLE
add `inheritanceClause` and `genericWhereClause` to `DeclGroupSyntax`’s requirements

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -35,6 +35,8 @@ public let TRAITS: [Trait] = [
     children: [
       Child(name: "Attributes", kind: .node(kind: .attributeList), isOptional: true),
       Child(name: "Modifiers", kind: .node(kind: .modifierList), isOptional: true),
+      Child(name: "InheritanceClause", kind: .node(kind: .typeInheritanceClause), isOptional: true),
+      Child(name: "GenericWhereClause", kind: .node(kind: .genericWhereClause), isOptional: true),
       Child(name: "MemberBlock", kind: .node(kind: .memberDeclBlock)),
     ]
   ),

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -66,6 +66,16 @@ public protocol DeclGroupSyntax: SyntaxProtocol {
     set
   }
   
+  var inheritanceClause: TypeInheritanceClauseSyntax? {
+    get
+    set
+  }
+  
+  var genericWhereClause: GenericWhereClauseSyntax? {
+    get
+    set
+  }
+  
   var memberBlock: MemberDeclBlockSyntax {
     get
     set


### PR DESCRIPTION
In [the `@OptionSet` example ](https://github.com/DougGregor/swift-macro-examples/blob/f61ac7cdca8dc3557e53f86e7e03df1353908d3e/MacroExamplesPlugin/OptionSetMacro.swift#L132-L136) accompanying [SE-0389](https://github.com/apple/swift-evolution/blob/e3fb696bc3c4e8ea72ea18beb2797150912f035a/proposals/0389-attached-macros.md), the macro checks for the lack of an explicit conformance to `OptionSet` at the declaration site before applying one. As part of the check, it must cast the declaration syntax as a `StructDeclSyntax`. This works for `@OptionSet` because it only applies to structs. However, for other conformance macros that work with all kinds of type declarations, they must exhaustively cast to `ActorDeclSyntax`, `ClassDeclSyntax`, etc if they want to check for existing conformance clauses. Adding `inheritanceClause` and `genericWhereClause` to `DeclGroupSyntax`’s requirements solves this problem.