### PR TITLE
[5.9] Fix SyntaxRewriterFile.swift to generate the expected SyntaxRewriter.swift

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -343,7 +343,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       public func rewrite(_ node: Syntax) -> Syntax {
         let rewritten = self.visit(node)
         return withExtendedLifetime(rewritten) {
-          return Syntax(node.data.replacingSelf(rewritten.raw, arena: rewritten.raw.arena))
+          return Syntax(node.data.replacingSelf(rewritten.raw, arena: SyntaxArena()))
         }
       }
       """


### PR DESCRIPTION
We modified SyntaxRewriter.swift at some point without updating the generating SyntaxRewriterFile.swift. Fix that.