### PR TITLE
Fixes wrong escape when creating a string literal where a pound sign follows a sequence of double quotes or backslashes

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -287,6 +287,9 @@ extension StringLiteralExprSyntax {
       case (true, _) where c.unicodeScalars.contains("#"):
         consecutivePounds += 1
         maxPounds = max(maxPounds, consecutivePounds)
+      case (true, "\""), (true, "\\"):
+        countingPounds = true
+        requiresEscaping = true
       case (true, _):
         countingPounds = false
         consecutivePounds = 0

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -288,8 +288,7 @@ extension StringLiteralExprSyntax {
         consecutivePounds += 1
         maxPounds = max(maxPounds, consecutivePounds)
       case (true, "\""), (true, "\\"):
-        countingPounds = true
-        requiresEscaping = true
+        continue
       case (true, _):
         countingPounds = false
         consecutivePounds = 0

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralExprSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralExprSyntaxTests.swift
@@ -71,6 +71,24 @@ final class StringLiteralExprSyntaxTests: XCTestCase {
     )
   }
 
+  func testEscapePoundsAfterConsecutiveQuotes() {
+    assertBuildResult(
+      StringLiteralExprSyntax(content: ##"foobar""#"##),
+      """
+      ##"foobar""#"##
+      """
+    )
+  }
+
+  func testEscapePoundsAfterConsecutiveBackslashes() {
+    assertBuildResult(
+      StringLiteralExprSyntax(content: ##"foobar\\#"##),
+      ##"""
+      ##"foobar\\#"##
+      """##
+    )
+  }
+
   func testEscapePoundEmojis() {
     assertBuildResult(
       StringLiteralExprSyntax(content: ##"foo"#️⃣"bar"##),


### PR DESCRIPTION
This pull request fixes a problem where escaping fails when a pound sign follows a sequence of double quotes or backslashes.

As shown in the added test case, `foobar""#` and `foobar\\#` require two pound signs as delimiter for escaping, but the current implementation only adds one pound sign, resulting in an incorrect string literal.

The reason for this is that a sequence of double quotes or backslashes will stop counting pound signs if they are not followed by a pound sign.

If a double quotation mark or backslash is followed by a double quotation mark or backslash, it must continue in pound sign counting mode.