### PR TITLE
Add a GitHub issue template to file actionable BasicFormat bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/BASICFORMAT_BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BASICFORMAT_BUG.yml
@@ -1,0 +1,39 @@
+name: BasicFormat Bug
+description: A bug in the BasicFormat module
+labels: [bug, BasicFormat]
+body:
+ - type: markdown
+   attributes:
+     value: Thanks for taking the time to fill out this bug report! We would really appreciate if you could take the time to reduce the issue as described in [Filing BasicFormat Bug Reports](https://swiftpackageindex.com/apple/swift-syntax/main/documentation/swiftbasicformat/filingbugreports).
+ - type: textarea
+   id: source
+   attributes:
+     label: Source Code
+     description: The source code that, when formatted, produces incorrectly formatted code.
+     value: |
+       ```swift
+       ```
+ - type: textarea
+   id: source
+   attributes:
+     label: Actual Formatted Code
+     description: The way that `BasicFormat` formats the above code
+     value: |
+       ```swift
+       ```
+  - type: textarea
+   id: source
+   attributes:
+     label: Expected Formatted Code
+     description: The way that you think `BasicFormat` should format the code
+     value: |
+       ```swift
+       ```
+ - type: textarea
+   id: description
+   attributes:
+     label: Description
+     description: |
+       Any additional information you can provide for this issue, like
+        - Has this issue started occurring recently?
+        - Is the issue only happening under certain circumstances?

--- a/.github/ISSUE_TEMPLATE/PARSER_BUG.yml
+++ b/.github/ISSUE_TEMPLATE/PARSER_BUG.yml
@@ -4,12 +4,12 @@ labels: [bug, SwiftParser]
 body:
  - type: markdown
    attributes:
-     value: Thanks for taking the time to fill out this bug report! If you could take the time to reduce the issue as described in [FilingBugReports.md](https://github.com/apple/swift-syntax/blob/main/Sources/SwiftParser/SwiftParser.docc/FilingBugReports.md), we would really appreciate that.
+     value: Thanks for taking the time to fill out this bug report! We would really appreciate if you could take the time to reduce the issue as described in [Filing Parser Bug Reports](https://swiftpackageindex.com/apple/swift-syntax/main/documentation/swiftparser/filingbugreports).
  - type: dropdown
    id: issue-type
    attributes:
      label: Issue Kind
-     description: What kind of issue is this? See [FilingBugReports.md](https://github.com/apple/swift-syntax/blob/main/Sources/SwiftParser/SwiftParser.docc/FilingBugReports.md) for more details.
+     description: What kind of issue is this? See [Filing Parser Bug Reports](https://swiftpackageindex.com/apple/swift-syntax/main/documentation/swiftparser/filingbugreports) for more details.
      options:
        - Round-Trip Failure
        - Parser Crash

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxKindFile.swift
@@ -19,7 +19,7 @@ let syntaxKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
     /// Enumerates the known kinds of Syntax represented in the Syntax tree.
-    public enum SyntaxKind
+    public enum SyntaxKind: CaseIterable
     """
   ) {
     DeclSyntax("case token")

--- a/Package.swift
+++ b/Package.swift
@@ -263,7 +263,7 @@ let package = Package(
     .executableTarget(
       name: "swift-parser-cli",
       dependencies: [
-        "_InstructionCounter", "SwiftDiagnostics", "SwiftOperators", "SwiftParser", "SwiftParserDiagnostics", "SwiftSyntax",
+        "_InstructionCounter", "SwiftBasicFormat", "SwiftDiagnostics", "SwiftOperators", "SwiftParser", "SwiftParserDiagnostics", "SwiftSyntax",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),

--- a/Sources/SwiftBasicFormat/SwiftBasicFormat.docc/FilingBugReports.md
+++ b/Sources/SwiftBasicFormat/SwiftBasicFormat.docc/FilingBugReports.md
@@ -1,0 +1,18 @@
+# Filing BasicFormat Bug Reports
+
+Guide to provide steps for filing actionable bug reports for `BasicFormat` failures.
+
+- Attention: Keep in mind that the primary goal of BasicFormat is to add trivia to a SwiftSyntax tree in a way that allows the parser to parse the same tree again, e.g. making sure that a keyword and an identifier are separated by a space. BasicFormat intentionally has no functionality to e.g. split lines.
+
+Reducing a failure requires the `swift-parser-cli` utility that you can build by checking out `swift-syntax` and running 
+```
+swift build --product swift-parser-cli
+```
+or building the `swift-parser-cli` target in Xcode.
+
+1. After you have built `swift-parse-cli`, you can format a single source file using BasicFormat by running the following command. If you are only experiencing the issue while formatting a single node, e.g. while creating an `AccessorDeclSyntax` inside a macro, you can additionally pass the type of the node as `--node-type AccessorDeclSyntax` 
+```
+swift-parser-cli basic-format /path/to/file/that/formats/incorrectly.swift
+```
+2. Remove as much code from your source file while still experiencing the formatting issue.
+3. File a bug report on <https://github.com/apple/swift-syntax/issues/new/choose> with the reduced source code.

--- a/Sources/SwiftBasicFormat/SwiftBasicFormat.docc/Info.plist
+++ b/Sources/SwiftBasicFormat/SwiftBasicFormat.docc/Info.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>SwiftBasicFormat</string>
+	<key>CFBundleDisplayName</key>
+	<string>SwiftBasicFormat</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.apple.swift-basic-format</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleIconFile</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundleIconName</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundlePackageType</key>
+	<string>DOCS</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CDDefaultCodeListingLanguage</key>
+	<string>swift</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CDAppleDefaultAvailability</key>
+	<dict>
+		<key>SwiftParser</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>macOS</string>
+				<key>version</key>
+				<string>10.15</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>Mac Catalyst</string>
+				<key>version</key>
+				<string>13.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>iOS</string>
+				<key>version</key>
+				<string>13.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>tvOS</string>
+				<key>version</key>
+				<string>13.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>watchOS</string>
+				<key>version</key>
+				<string>6.0</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
-public enum SyntaxKind {
+public enum SyntaxKind: CaseIterable {
   case token
   case accessesEffect
   case accessorBlock

--- a/Sources/swift-parser-cli/BasicFormat.swift
+++ b/Sources/swift-parser-cli/BasicFormat.swift
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import SwiftBasicFormat
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftParser
+import SwiftParserDiagnostics
+
+struct BasicFormat: ParsableCommand, ParseCommand {
+  enum Error: Swift.Error, CustomStringConvertible {
+    case unknownSyntaxNodeType(nodeType: String, parsableTypes: [String])
+
+    var description: String {
+      switch self {
+      case .unknownSyntaxNodeType(nodeType: let nodeType, parsableTypes: let parsableTypes):
+        return """
+          '\(nodeType)' is not a SwiftSyntax node type that conforms to SyntaxParsable. Possible options are:
+          \(parsableTypes.map {" - \($0)" }.joined(separator: "\n"))
+          """
+      }
+    }
+  }
+
+  static var configuration = CommandConfiguration(
+    commandName: "basic-format",
+    abstract: "Format a source file using BasicFormat"
+  )
+
+  @OptionGroup
+  var arguments: ParseArguments
+
+  @Option(help: "The number of spaces to use for indentation")
+  var indentationWidth: Int = 4
+
+  @Option(help: "The type that the node should be parsed as")
+  var nodeType: String = "SourceFileSyntax"
+
+  func run() throws {
+    let parsableMetatypes = SyntaxKind.allCases.compactMap {
+      $0.syntaxNodeType as? SyntaxParseable.Type
+    }
+    let parsableMetatypesByName = Dictionary(
+      parsableMetatypes.map {
+        (String(reflecting: $0).replacingOccurrences(of: "SwiftSyntax.", with: ""), $0)
+      },
+      uniquingKeysWith: { l, r in l }
+    )
+
+    guard let parseType = parsableMetatypesByName[nodeType] else {
+      throw Error.unknownSyntaxNodeType(nodeType: nodeType, parsableTypes: parsableMetatypesByName.keys.sorted())
+    }
+
+    let tree = try sourceFileContents.withUnsafeBufferPointer { sourceBuffer in
+      var parser = Parser(sourceBuffer)
+      return parseType.parse(from: &parser)
+    }
+
+    let resultTree: Syntax
+    if foldSequences {
+      resultTree = foldAllSequences(tree).0
+    } else {
+      resultTree = Syntax(tree)
+    }
+
+    if resultTree.hasError {
+      let diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
+      printerr(
+        """
+        Source input contained syntax errors. Formatting might be incorrect due to these errors:
+        \(DiagnosticsFormatter(colorize: TerminalHelper.isConnectedToTerminal).annotatedSource(tree: tree, diags: diags))
+        ----------------------------------------
+        """
+      )
+    }
+
+    let formattedTree = resultTree.formatted(using: SwiftBasicFormat.BasicFormat(indentationWidth: .spaces(indentationWidth)))
+
+    print(formattedTree.description)
+  }
+}

--- a/Sources/swift-parser-cli/Commands/Reduce.swift
+++ b/Sources/swift-parser-cli/Commands/Reduce.swift
@@ -16,11 +16,6 @@ import Foundation
 import WinSDK
 #endif
 
-/// Print the given message to stderr
-fileprivate func printerr(_ message: String, terminator: String = "\n") {
-  FileHandle.standardError.write((message + terminator).data(using: .utf8)!)
-}
-
 fileprivate func withTemporaryFile<T>(contents: [UInt8], body: (URL) throws -> T) throws -> T {
   var tempFileURL = FileManager.default.temporaryDirectory
   tempFileURL.appendPathComponent("swift-parser-cli-\(UUID().uuidString).swift")

--- a/Sources/swift-parser-cli/SyntaxUtils.swift
+++ b/Sources/swift-parser-cli/SyntaxUtils.swift
@@ -15,14 +15,16 @@ import SwiftOperators
 import SwiftSyntax
 
 /// Fold all of the sequences in the given source file.
-func foldAllSequences(_ tree: SourceFileSyntax) -> (Syntax, [Diagnostic]) {
+func foldAllSequences(_ tree: some SyntaxProtocol) -> (Syntax, [Diagnostic]) {
   var diags: [Diagnostic] = []
 
   let recordOperatorError: (OperatorError) -> Void = { error in
     diags.append(error.asDiagnostic)
   }
   var operatorTable = OperatorTable.standardOperators
-  operatorTable.addSourceFile(tree, errorHandler: recordOperatorError)
+  if let sourceFile = tree as? SourceFileSyntax {
+    operatorTable.addSourceFile(sourceFile, errorHandler: recordOperatorError)
+  }
   let resultTree = operatorTable.foldAll(tree, errorHandler: recordOperatorError)
   return (resultTree, diags)
 }

--- a/Sources/swift-parser-cli/Utils.swift
+++ b/Sources/swift-parser-cli/Utils.swift
@@ -22,3 +22,8 @@ func getContentsOfSourceFile(at path: String?) throws -> [UInt8] {
   }
   return [UInt8](source)
 }
+
+/// Print the given message to stderr
+func printerr(_ message: String, terminator: String = "\n") {
+  FileHandle.standardError.write((message + terminator).data(using: .utf8)!)
+}

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -29,6 +29,7 @@ class SwiftParserCli: ParsableCommand {
   static var configuration = CommandConfiguration(
     abstract: "Utility to test SwiftSyntax syntax tree creation.",
     subcommands: [
+      BasicFormat.self,
       PerformanceTest.self,
       PrintDiags.self,
       PrintTree.self,


### PR DESCRIPTION
This adds
- A new subcommand to `swift-parser-cli` to run BasicFormat on a source file
- A documentation articile of how to use `swift-parser-cli basic-format`
- A GitHub issue template that has text fields for input, actual formatted and expected formatted.