### PR TITLE
Conform `MessageID` and `DiagnosticSeverity` to `Sendable`

### DIFF
--- a/Sources/SwiftDiagnostics/Message.swift
+++ b/Sources/SwiftDiagnostics/Message.swift
@@ -16,7 +16,7 @@
 /// Two diagnostics with the same ID don’t need to necessarily have the exact
 /// same wording. Eg. it’s possible that the message contains more context when
 /// available.
-public struct MessageID: Hashable {
+public struct MessageID: Hashable, Sendable {
   private let domain: String
   private let id: String
 
@@ -26,7 +26,7 @@ public struct MessageID: Hashable {
   }
 }
 
-public enum DiagnosticSeverity {
+public enum DiagnosticSeverity: Sendable {
   case error
   case warning
   case note


### PR DESCRIPTION
I have a project with concurrency warnings turned on and am getting warnings when introducing a custom diagnostics message error:

```swift
struct SimpleDiagnosticMessage: DiagnosticMessage, Error {
  let message: String
  let diagnosticID: MessageID       // ⚠️
  let severity: DiagnosticSeverity  // ⚠️
}
```

> **Warning**: Stored property 'diagnosticID' of 'Sendable'-conforming struct 'SimpleDiagnosticMessage' has non-sendable type 'MessageID'
>
> **Warning**: Stored property 'severity' of 'Sendable'-conforming struct 'SimpleDiagnosticMessage' has non-sendable type 'DiagnosticSeverity'