### PR TITLE
[5.9] Avoid creating binding patterns in a couple more positions

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1210,10 +1210,10 @@ extension Parser {
         )
       )
     case (.identifier, let handle)?, (.selfKeyword, let handle)?, (.initKeyword, let handle)?:
-      // If we have "case let x." or "case let x(", we parse x as a normal
-      // name, not a binding, because it is the start of an enum pattern or
-      // call pattern.
-      if pattern.admitsBinding && !self.lookahead().isNextTokenCallPattern() {
+      // If we have "case let x" followed by ".", "(", "[", or a generic
+      // argument list, we parse x as a normal name, not a binding, because it
+      // is the start of an enum or expr pattern.
+      if pattern.admitsBinding && self.lookahead().isInBindingPatternPosition() {
         let identifier = self.eat(handle)
         let pattern = RawPatternSyntax(
           RawIdentifierPatternSyntax(
@@ -2658,13 +2658,21 @@ extension Parser.Lookahead {
     return self.peek().isLexerClassifiedKeyword || TokenSpec(.identifier) ~= self.peek()
   }
 
-  fileprivate func isNextTokenCallPattern() -> Bool {
+  fileprivate func isInBindingPatternPosition() -> Bool {
+    // Cannot form a binding pattern if a generic argument list follows, this
+    // is something like 'case let E<Int>.foo(x)'.
+    if self.peek().isContextualPunctuator("<") {
+      var lookahead = self.lookahead()
+      lookahead.consumeAnyToken()
+      return !lookahead.canParseAsGenericArgumentList()
+    }
     switch self.peek().rawTokenKind {
-    case .period,
-      .leftParen:
-      return true
-    default:
+    // A '.' indicates a member access, '(' and '[' indicate a function call or
+    // subscript. We can't form a binding pattern as the base of these.
+    case .period, .leftParen, .leftSquareBracket:
       return false
+    default:
+      return true
     }
   }
 }

--- a/Tests/SwiftParserTest/PatternTests.swift
+++ b/Tests/SwiftParserTest/PatternTests.swift
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) import SwiftParser
+import XCTest
+
+final class PatternTests: XCTestCase {
+  private var genericArgEnumPattern: Syntax {
+    // let E<Int>.e(y)
+    Syntax(
+      ValueBindingPatternSyntax(
+        bindingKeyword: .keyword(.let),
+        valuePattern: ExpressionPatternSyntax(
+          expression: FunctionCallExprSyntax(
+            calledExpression: MemberAccessExprSyntax(
+              base: SpecializeExprSyntax(
+                expression: IdentifierExprSyntax(identifier: .identifier("E")),
+                genericArgumentClause: GenericArgumentClauseSyntax(
+                  arguments: .init([
+                    .init(argumentType: SimpleTypeIdentifierSyntax(name: .identifier("Int")))
+                  ])
+                )
+              ),
+              name: .identifier("e")
+            ),
+            leftParen: .leftParenToken(),
+            argumentList: TupleExprElementListSyntax([
+              .init(
+                expression: UnresolvedPatternExprSyntax(
+                  pattern: IdentifierPatternSyntax(identifier: .identifier("y"))
+                )
+              )
+            ]),
+            rightParen: .rightParenToken()
+          )
+        )
+      )
+    )
+  }
+
+  func testNonBinding1() {
+    assertParse(
+      """
+      if case let E<Int>.e(y) = x {}
+      """,
+      substructure: genericArgEnumPattern
+    )
+  }
+
+  func testNonBinding2() {
+    assertParse(
+      """
+      switch e {
+      case let E<Int>.e(y):
+        y
+      }
+      """,
+      substructure: genericArgEnumPattern
+    )
+  }
+
+  private var tupleWithSubscriptAndBindingPattern: Syntax {
+    // let (y[0], z)
+    Syntax(
+      ValueBindingPatternSyntax(
+        bindingKeyword: .keyword(.let),
+        valuePattern: ExpressionPatternSyntax(
+          expression: TupleExprSyntax(
+            elementList: .init([
+              .init(
+                expression: SubscriptExprSyntax(
+                  calledExpression: IdentifierExprSyntax(identifier: .identifier("y")),
+                  leftBracket: .leftSquareBracketToken(),
+                  argumentList: TupleExprElementListSyntax([
+                    .init(expression: IntegerLiteralExprSyntax(digits: .integerLiteral("0")))
+                  ]),
+                  rightBracket: .rightSquareBracketToken()
+                ),
+                trailingComma: .commaToken()
+              ),
+              .init(
+                expression: UnresolvedPatternExprSyntax(
+                  pattern: IdentifierPatternSyntax(identifier: .identifier("z"))
+                )
+              ),
+            ])
+          )
+        )
+      )
+    )
+  }
+
+  func testNonBinding3() {
+    assertParse(
+      """
+      if case let (y[0], z) = x {}
+      """,
+      substructure: tupleWithSubscriptAndBindingPattern
+    )
+  }
+
+  func testNonBinding4() {
+    assertParse(
+      """
+      switch x {
+      case let (y[0], z):
+        z
+      }
+      """,
+      substructure: tupleWithSubscriptAndBindingPattern
+    )
+  }
+
+  private var subscriptWithBindingPattern: Syntax {
+    // let y[z]
+    Syntax(
+      ValueBindingPatternSyntax(
+        bindingKeyword: .keyword(.let),
+        valuePattern: ExpressionPatternSyntax(
+          expression: SubscriptExprSyntax(
+            calledExpression: IdentifierExprSyntax(identifier: .identifier("y")),
+            leftBracket: .leftSquareBracketToken(),
+            argumentList: TupleExprElementListSyntax([
+              .init(
+                expression: UnresolvedPatternExprSyntax(
+                  pattern: IdentifierPatternSyntax(identifier: .identifier("z"))
+                )
+              )
+            ]),
+            rightBracket: .rightSquareBracketToken()
+          )
+        )
+      )
+    )
+  }
+
+  func testNonBinding5() {
+    assertParse(
+      """
+      if case let y[z] = x {}
+      """,
+      substructure: subscriptWithBindingPattern
+    )
+  }
+
+  func testNonBinding6() {
+    assertParse(
+      """
+      switch 0 {
+      case let y[z]:
+        z
+      case y[z]:
+        0
+      default:
+        0
+      }
+      """,
+      substructure: subscriptWithBindingPattern
+    )
+  }
+}


### PR DESCRIPTION
*5.9 cherry-pick of #1804*

- Explanation: Allows the parser to correctly parse the patterns `case let E<Int>.foo(x)` and `case let (y[0], x)`, where only `x` becomes a binding. Previously we would attempt to treat `E` and `y` as bindings.
- Scope: Affects parsing of patterns
- Issue: rdar://108738034
- Risk: Low, only affects code that was previously invalid
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen