### PR TITLE
[5.9] Remove spacing between `Any` and `.`

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -205,6 +205,7 @@ open class BasicFormat: SyntaxRewriter {
       (.identifier, .leftSquareBracket),  // myArray[1]
       (.identifier, .period),  // a.b
       (.integerLiteral, .period),  // macOS 11.2.1
+      (.keyword(.Any), .period),  // Any.Type
       (.keyword(.`init`), .leftAngle),  // init<T>()
       (.keyword(.`init`), .leftParen),  // init()
       (.keyword(.self), .period),  // self.someProperty

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -349,4 +349,17 @@ final class VariableTests: XCTestCase {
       assertBuildResult(builder, expected, line: line)
     }
   }
+
+  // https://github.com/apple/swift-syntax/issues/1815
+  func testSpacingInDictionaryType() throws {
+    let buildable = try VariableDeclSyntax("static var mirror: Dictionary<String, Any.Type>") {}
+
+    assertBuildResult(
+      buildable,
+      """
+      static var mirror: Dictionary<String, Any.Type> {
+      }
+      """
+    )
+  }
 }


### PR DESCRIPTION
* **Explanation**: This fixes a space after the `Any` keyword if it's followed by a `.`.
* **Scope**: Basic format and a macro testcase in the Swift repo
* **Risk**: Low
* **Testing**: Added a test case to support this
* **Issue**: [#1815 ](rdar://111017063)
* **Reviewer**: @ahoppen on #1820