### PR TITLE
[5.9] BasicFormat should not format unexpected nodes

### DIFF
--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -1,6 +1,7 @@
 // swift-tools-version:5.7
 
 import PackageDescription
+import Foundation
 
 let package = Package(
   name: "CodeGeneration",
@@ -11,8 +12,7 @@ let package = Package(
     .executable(name: "generate-swiftsyntax", targets: ["generate-swiftsyntax"])
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", revision: "c7087adb193b26f02b59d21cd06d17ec202d1bf5"),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
+    .package(url: "..", revision: "HEAD")
   ],
   targets: [
     .executableTarget(
@@ -41,3 +41,14 @@ let package = Package(
     ),
   ]
 )
+
+if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+  // Building standalone.
+  package.dependencies += [
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.2"))
+  ]
+} else {
+  package.dependencies += [
+    .package(path: "../../swift-argument-parser")
+  ]
+}

--- a/CodeGeneration/Sources/Utils/CodeGenerationFormat.swift
+++ b/CodeGeneration/Sources/Utils/CodeGenerationFormat.swift
@@ -108,7 +108,7 @@ public class CodeGenerationFormat: BasicFormat {
   private func formatChildrenSeparatedByNewline<SyntaxType: SyntaxProtocol>(children: SyntaxChildren, elementType: SyntaxType.Type) -> [SyntaxType] {
     increaseIndentationLevel()
     var formattedChildren = children.map {
-      self.visit($0).as(SyntaxType.self)!
+      self.rewrite($0.cast(SyntaxType.self)).cast(SyntaxType.self)
     }
     formattedChildren = formattedChildren.map {
       if $0.leadingTrivia.first?.isNewline == true {

--- a/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
+++ b/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
@@ -36,6 +36,7 @@ final class SourceEditorCommand: NSObject, XCSourceEditorCommand {
 
       init(provider: any RefactoringProvider.Type) {
         self.provider = provider
+        super.init(viewMode: .sourceAccurate)
       }
 
       override func visitAny(_ node: Syntax) -> Syntax? {

--- a/Sources/SwiftBasicFormat/SyntaxProtocol+Formatted.swift
+++ b/Sources/SwiftBasicFormat/SyntaxProtocol+Formatted.swift
@@ -3,6 +3,6 @@ import SwiftSyntax
 public extension SyntaxProtocol {
   /// Build a syntax node from this `Buildable` and format it with the given format.
   func formatted(using format: BasicFormat = BasicFormat()) -> Syntax {
-    return format.visit(Syntax(self))
+    return format.rewrite(self)
   }
 }

--- a/Sources/SwiftOperators/OperatorTable+Folding.swift
+++ b/Sources/SwiftOperators/OperatorTable+Folding.swift
@@ -475,6 +475,7 @@ extension OperatorTable {
     ) {
       self.opPrecedence = opPrecedence
       self.errorHandler = errorHandler
+      super.init(viewMode: .fixedUp)
     }
 
     override func visitAny(_ node: Syntax) -> Syntax? {
@@ -538,7 +539,7 @@ extension OperatorTable {
         opPrecedence: self,
         errorHandler: errorHandler
       )
-      let result = folder.visit(Syntax(node))
+      let result = folder.rewrite(node)
 
       // If the sequence folder encountered an error that caused the error
       // handler to throw, invoke the error handler again with the original

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -93,7 +93,7 @@ extension FixIt.MultiNodeChange {
     guard let node = node else {
       return FixIt.MultiNodeChange(primitiveChanges: [])
     }
-    var changes = [FixIt.Change.replace(oldNode: Syntax(node), newNode: MissingMaker().visit(Syntax(node)))]
+    var changes = [FixIt.Change.replace(oldNode: Syntax(node), newNode: MissingMaker().rewrite(node))]
     if transferTrivia {
       changes += FixIt.MultiNodeChange.transferTriviaAtSides(from: [node]).primitiveChanges
     }
@@ -138,7 +138,7 @@ extension FixIt.MultiNodeChange {
     leadingTrivia: Trivia? = nil,
     trailingTrivia: Trivia? = nil
   ) -> Self {
-    var presentNode = MissingNodesBasicFormatter(viewMode: .fixedUp).visit(Syntax(node))
+    var presentNode = MissingNodesBasicFormatter(viewMode: .fixedUp).rewrite(node)
     presentNode = PresentMaker().rewrite(presentNode)
 
     if let leadingTrivia = leadingTrivia {

--- a/Sources/SwiftParserDiagnostics/PresenceUtils.swift
+++ b/Sources/SwiftParserDiagnostics/PresenceUtils.swift
@@ -45,6 +45,10 @@ extension SyntaxProtocol {
 
 /// Transforms a syntax tree by making all missing tokens present.
 class PresentMaker: SyntaxRewriter {
+  init() {
+    super.init(viewMode: .fixedUp)
+  }
+
   override func visit(_ token: TokenSyntax) -> TokenSyntax {
     if token.presence == .missing {
       let presentToken: TokenSyntax
@@ -62,7 +66,12 @@ class PresentMaker: SyntaxRewriter {
   }
 }
 
+/// Transforms a syntax tree by making all present tokens missing.
 class MissingMaker: SyntaxRewriter {
+  init() {
+    super.init(viewMode: .sourceAccurate)
+  }
+
   override func visit(_ node: TokenSyntax) -> TokenSyntax {
     guard node.presence == .present else {
       return node

--- a/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
+++ b/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
@@ -125,7 +125,7 @@ public struct OpaqueParameterToGeneric: SyntaxRefactoringProvider {
     in params: ParameterClauseSyntax,
     augmenting genericParams: GenericParameterClauseSyntax?
   ) -> (ParameterClauseSyntax, GenericParameterClauseSyntax)? {
-    let rewriter = SomeParameterRewriter()
+    let rewriter = SomeParameterRewriter(viewMode: .sourceAccurate)
     let rewrittenParams = rewriter.visit(params.parameterList)
 
     if rewriter.rewrittenSomeParameters.isEmpty {

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -60,8 +60,8 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -229,7 +229,7 @@ extension AccessPathSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -269,8 +269,8 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -438,7 +438,7 @@ extension AccessorListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -478,8 +478,8 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -647,7 +647,7 @@ extension ArrayElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -730,8 +730,8 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -899,7 +899,7 @@ extension AttributeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -939,8 +939,8 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1108,7 +1108,7 @@ extension AvailabilitySpecListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -1148,8 +1148,8 @@ public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, Syntax
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityVersionRestrictionList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1317,7 +1317,7 @@ extension AvailabilityVersionRestrictionListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -1357,8 +1357,8 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1526,7 +1526,7 @@ extension CaseItemListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -1566,8 +1566,8 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1735,7 +1735,7 @@ extension CatchClauseListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -1775,8 +1775,8 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1944,7 +1944,7 @@ extension CatchItemListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -1984,8 +1984,8 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2153,7 +2153,7 @@ extension ClosureCaptureItemListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -2193,8 +2193,8 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParamList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2362,7 +2362,7 @@ extension ClosureParamListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -2402,8 +2402,8 @@ public struct ClosureParameterListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParameterList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2571,7 +2571,7 @@ extension ClosureParameterListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -2611,8 +2611,8 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2780,7 +2780,7 @@ extension CodeBlockItemListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -2820,8 +2820,8 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2989,7 +2989,7 @@ extension CompositionTypeElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -3029,8 +3029,8 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3198,7 +3198,7 @@ extension ConditionElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -3238,8 +3238,8 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3407,7 +3407,7 @@ extension DeclNameArgumentListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -3447,8 +3447,8 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3616,7 +3616,7 @@ extension DesignatedTypeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -3656,8 +3656,8 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3825,7 +3825,7 @@ extension DictionaryElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -3865,8 +3865,8 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4034,7 +4034,7 @@ extension DifferentiabilityParamListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -4071,8 +4071,8 @@ public struct DocumentationAttributeArgumentsSyntax: SyntaxCollection, SyntaxHas
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.documentationAttributeArguments,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4240,7 +4240,7 @@ extension DocumentationAttributeArgumentsSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -4277,8 +4277,8 @@ public struct EffectsArgumentsSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.effectsArguments,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4446,7 +4446,7 @@ extension EffectsArgumentsSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -4483,8 +4483,8 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4652,7 +4652,7 @@ extension EnumCaseElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -4692,8 +4692,8 @@ public struct EnumCaseParameterListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseParameterList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4861,7 +4861,7 @@ extension EnumCaseParameterListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -4898,8 +4898,8 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5067,7 +5067,7 @@ extension ExprListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -5107,8 +5107,8 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5276,7 +5276,7 @@ extension FunctionParameterListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -5316,8 +5316,8 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5485,7 +5485,7 @@ extension GenericArgumentListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -5525,8 +5525,8 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5694,7 +5694,7 @@ extension GenericParameterListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -5734,8 +5734,8 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5903,7 +5903,7 @@ extension GenericRequirementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -5943,8 +5943,8 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6112,7 +6112,7 @@ extension IfConfigClauseListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -6152,8 +6152,8 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6321,7 +6321,7 @@ extension InheritedTypeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -6361,8 +6361,8 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponentList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6530,7 +6530,7 @@ extension KeyPathComponentListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -6570,8 +6570,8 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6739,7 +6739,7 @@ extension MemberDeclListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -6779,8 +6779,8 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6948,7 +6948,7 @@ extension ModifierListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -6988,8 +6988,8 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7157,7 +7157,7 @@ extension MultipleTrailingClosureElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -7197,8 +7197,8 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelector,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7366,7 +7366,7 @@ extension ObjCSelectorSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -7406,8 +7406,8 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7575,7 +7575,7 @@ extension PatternBindingListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -7670,8 +7670,8 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7839,7 +7839,7 @@ extension PrecedenceGroupAttributeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -7879,8 +7879,8 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8048,7 +8048,7 @@ extension PrecedenceGroupNameListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -8088,8 +8088,8 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8257,7 +8257,7 @@ extension PrimaryAssociatedTypeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -8362,8 +8362,8 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeAttributeSpecList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8531,7 +8531,7 @@ extension SpecializeAttributeSpecListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -8614,8 +8614,8 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8783,7 +8783,7 @@ extension StringLiteralSegmentsSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -8866,8 +8866,8 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9035,7 +9035,7 @@ extension SwitchCaseListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -9075,8 +9075,8 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9244,7 +9244,7 @@ extension TupleExprElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -9284,8 +9284,8 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9453,7 +9453,7 @@ extension TuplePatternElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -9493,8 +9493,8 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9662,7 +9662,7 @@ extension TupleTypeElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -9699,8 +9699,8 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.unexpectedNodes,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9868,7 +9868,7 @@ extension UnexpectedNodesSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
@@ -9908,8 +9908,8 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
       let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
                                      from: children.map {
-            $0.raw
-          }, arena: arena)
+          $0.raw
+        }, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -10077,7 +10077,7 @@ extension YieldExprListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
   
-  public subscript (position: SyntaxChildrenIndex) -> Element {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -22,7 +22,59 @@
 //===----------------------------------------------------------------------===//
 
 open class SyntaxRewriter {
-  public init() {
+  public let viewMode: SyntaxTreeViewMode
+  
+  public init(viewMode: SyntaxTreeViewMode = .sourceAccurate) {
+    self.viewMode = viewMode
+  }
+  
+  /// Rewrite `node` and anchor, making sure that the rewritten node also has
+  /// a parent if `node` had one.
+  public func rewrite<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) -> Syntax {
+    let rewritten = self.visit(node.data)
+    return withExtendedLifetime(rewritten) {
+      return Syntax(node.data.replacingSelf(rewritten.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  /// Visit a ``TokenSyntax``.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ token: TokenSyntax) -> TokenSyntax {
+    return token
+  }
+  
+  /// The function called before visiting the node and its descendents.
+  ///   - node: the node we are about to visit.
+  open func visitPre(_ node: Syntax) {
+  }
+  
+  /// Override point to choose custom visitation dispatch instead of the
+  /// specialized `visit(_:)` methods. Use this instead of those methods if
+  /// you intend to dynamically dispatch rewriting behavior.
+  /// - note: If this method returns a non-nil result, the specialized
+  ///         `visit(_:)` methods will not be called for this node and the
+  ///         visited node will be replaced by the returned node in the
+  ///         rewritten tree.
+  open func visitAny(_ node: Syntax) -> Syntax? {
+    return nil
+  }
+  
+  /// The function called after visiting the node and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: Syntax) {
+  }
+  
+  /// Visit any Syntax node.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  @available(*, deprecated, renamed: "rewrite(_:)")
+  public func visit(_ node: Syntax) -> Syntax {
+    return visit(node.data)
+  }
+  
+  public func visit<T: SyntaxChildChoices>(_ node: T) -> T {
+    return visit(node.data).cast(T.self)
   }
   
   /// Visit a `AccessPathComponentSyntax`.
@@ -1934,45 +1986,6 @@ open class SyntaxRewriter {
   ///   - Returns: the rewritten node
   open func visit(_ node: YieldStmtSyntax) -> StmtSyntax {
     return StmtSyntax(visitChildren(node))
-  }
-  
-  /// Visit a `TokenSyntax`.
-  ///   - Parameter node: the node that is being visited
-  ///   - Returns: the rewritten node
-  open func visit(_ token: TokenSyntax) -> TokenSyntax {
-    return token
-  }
-  
-  /// The function called before visiting the node and its descendents.
-  ///   - node: the node we are about to visit.
-  open func visitPre(_ node: Syntax) {
-  }
-  
-  /// Override point to choose custom visitation dispatch instead of the
-  /// specialized `visit(_:)` methods. Use this instead of those methods if
-  /// you intend to dynamically dispatch rewriting behavior.
-  /// - note: If this method returns a non-nil result, the specialized
-  ///         `visit(_:)` methods will not be called for this node and the
-  ///         visited node will be replaced by the returned node in the
-  ///         rewritten tree.
-  open func visitAny(_ node: Syntax) -> Syntax? {
-    return nil
-  }
-  
-  /// The function called after visiting the node and its descendents.
-  ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: Syntax) {
-  }
-  
-  /// Visit any Syntax node.
-  ///   - Parameter node: the node that is being visited
-  ///   - Returns: the rewritten node
-  public func visit(_ node: Syntax) -> Syntax {
-    return visit(node.data)
-  }
-  
-  public func visit<T: SyntaxChildChoices>(_ node: T) -> T {
-    return visit(Syntax(node)).cast(T.self)
   }
   
   /// Visit any DeclSyntax node.
@@ -7004,13 +7017,15 @@ open class SyntaxRewriter {
     var childIndex = 0
     for (raw, info) in RawSyntaxChildren(syntaxNode) {
       defer {
-          childIndex += 1
-        }
-      guard let child = raw else {
-        // Node does not exist. If we are collecting rewritten nodes, we need to
-        // collect this one as well, otherwise we can ignore it.
+        childIndex += 1
+      }
+
+      guard let child = raw, viewMode.shouldTraverse(node: child) else {
+        // Node does not exist or should not be visited. If we are collecting
+        // rewritten nodes, we need to collect this one as well, otherwise we
+        // can ignore it.
         if newLayout != nil {
-          newLayout!.append(nil)
+          newLayout!.append(raw)
         }
         continue
       }
@@ -7064,15 +7079,6 @@ open class SyntaxRewriter {
     } else {
       // No child node was rewritten. So no need to change this node as well.
       return node
-    }
-  }
-  
-  /// Rewrite `node` and anchor, making sure that the rewritten node also has
-  /// a parent if `node` had one.
-  public func rewrite(_ node: Syntax) -> Syntax {
-    let rewritten = self.visit(node)
-    return withExtendedLifetime(rewritten) {
-      return Syntax(node.data.replacingSelf(rewritten.raw, arena: SyntaxArena()))
     }
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -37,7 +37,7 @@ open class SyntaxRewriter {
     }
   }
   
-  /// Visit a ``TokenSyntax``.
+  /// Visit a `TokenSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ token: TokenSyntax) -> TokenSyntax {

--- a/Sources/SwiftSyntax/generated/Tokens.swift
+++ b/Sources/SwiftSyntax/generated/Tokens.swift
@@ -23,7 +23,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -37,7 +37,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -51,7 +51,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -65,7 +65,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -81,7 +81,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -95,7 +95,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -109,7 +109,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -125,7 +125,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -139,7 +139,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -153,7 +153,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -167,7 +167,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -183,7 +183,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -199,7 +199,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -215,7 +215,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -229,7 +229,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -245,7 +245,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -261,7 +261,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -275,7 +275,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -289,7 +289,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -303,7 +303,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -317,7 +317,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -331,7 +331,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -345,7 +345,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -361,7 +361,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -375,7 +375,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -389,7 +389,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -403,7 +403,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -417,7 +417,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -431,7 +431,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -445,7 +445,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -459,7 +459,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -473,7 +473,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -487,7 +487,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -501,7 +501,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -517,7 +517,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -533,7 +533,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -549,7 +549,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -563,7 +563,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -577,7 +577,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -591,7 +591,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -605,7 +605,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -619,7 +619,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -633,7 +633,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -647,7 +647,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -661,7 +661,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -677,7 +677,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -693,7 +693,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -707,7 +707,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence
-        
+      
     )
   }
   
@@ -720,7 +720,7 @@ extension TokenSyntax {
       leadingTrivia: leadingTrivia,
       trailingTrivia: [],
       presence: presence
-        
+      
     )
   }
 }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -130,8 +130,8 @@ public struct RawAccessPathSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .accessPath, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -626,8 +626,8 @@ public struct RawAccessorListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .accessorList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -900,8 +900,8 @@ public struct RawArrayElementListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .arrayElementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -1567,8 +1567,8 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .attributeList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -2371,8 +2371,8 @@ public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .availabilitySpecList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -2491,8 +2491,8 @@ public struct RawAvailabilityVersionRestrictionListSyntax: RawSyntaxNodeProtocol
     let raw = RawSyntax.makeLayout(
       kind: .availabilityVersionRestrictionList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -3019,8 +3019,8 @@ public struct RawCaseItemListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .caseItemList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -3151,8 +3151,8 @@ public struct RawCatchClauseListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .catchClauseList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -3283,8 +3283,8 @@ public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .catchItemList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -3615,8 +3615,8 @@ public struct RawClosureCaptureItemListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .closureCaptureItemList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -4041,8 +4041,8 @@ public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .closureParamList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -4243,8 +4243,8 @@ public struct RawClosureParameterListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .closureParameterList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -4584,8 +4584,8 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .codeBlockItemList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -4824,8 +4824,8 @@ public struct RawCompositionTypeElementListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .compositionTypeElementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -5002,8 +5002,8 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .conditionElementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -5799,8 +5799,8 @@ public struct RawDeclNameArgumentListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .declNameArgumentList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -6474,8 +6474,8 @@ public struct RawDesignatedTypeListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .designatedTypeList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -6524,8 +6524,8 @@ public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .dictionaryElementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -6887,8 +6887,8 @@ public struct RawDifferentiabilityParamListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .differentiabilityParamList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -7643,8 +7643,8 @@ public struct RawDocumentationAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .documentationAttributeArguments, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -7915,8 +7915,8 @@ public struct RawEffectsArgumentsSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .effectsArguments, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -8059,8 +8059,8 @@ public struct RawEnumCaseElementListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .enumCaseElementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -8285,8 +8285,8 @@ public struct RawEnumCaseParameterListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .enumCaseParameterList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -8689,8 +8689,8 @@ public struct RawExprListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .exprList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -9812,8 +9812,8 @@ public struct RawFunctionParameterListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .functionParameterList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -10286,8 +10286,8 @@ public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .genericArgumentList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -10500,8 +10500,8 @@ public struct RawGenericParameterListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .genericParameterList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -10668,8 +10668,8 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .genericRequirementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -11118,8 +11118,8 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .ifConfigClauseList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -11931,8 +11931,8 @@ public struct RawInheritedTypeListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .inheritedTypeList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -12567,8 +12567,8 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .keyPathComponentList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -14137,8 +14137,8 @@ public struct RawMemberDeclListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .memberDeclList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -14735,8 +14735,8 @@ public struct RawModifierListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .modifierList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -14855,8 +14855,8 @@ public struct RawMultipleTrailingClosureElementListSyntax: RawSyntaxNodeProtocol
     let raw = RawSyntax.makeLayout(
       kind: .multipleTrailingClosureElementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -15185,8 +15185,8 @@ public struct RawObjCSelectorSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .objCSelector, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -16207,8 +16207,8 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .patternBindingList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -16999,8 +16999,8 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupAttributeList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -17249,8 +17249,8 @@ public struct RawPrecedenceGroupNameListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupNameList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -17533,8 +17533,8 @@ public struct RawPrimaryAssociatedTypeListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .primaryAssociatedTypeList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -18554,8 +18554,8 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .specializeAttributeSpecList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -18850,8 +18850,8 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .stringLiteralSegments, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -19632,8 +19632,8 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .switchCaseList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -20323,8 +20323,8 @@ public struct RawTupleExprElementListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .tupleExprElementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -20549,8 +20549,8 @@ public struct RawTuplePatternElementListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .tuplePatternElementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -20775,8 +20775,8 @@ public struct RawTupleTypeElementListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .tupleTypeElementList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -21720,8 +21720,8 @@ public struct RawUnexpectedNodesSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .unexpectedNodes, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1
@@ -22600,8 +22600,8 @@ public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .yieldExprList, uninitializedCount: elements.count, arena: arena) { layout in
         guard var ptr = layout.baseAddress else {
-            return
-          }
+          return
+        }
         for elem in elements {
           ptr.initialize(to: elem.raw)
           ptr += 1

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -43,19 +43,19 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       case .expectedNonNil(expectedKind: let expectedKind, file: _, line: _):
         return "Expected non-nil node of type \(expectedKind) but received nil"
       case .kindMismatch(
-            expectedKind: let expectedKind, 
-            actualKind: let actualKind, 
-            file: _, 
-            line: _
-          ):
+          expectedKind: let expectedKind, 
+          actualKind: let actualKind, 
+          file: _, 
+          line: _
+        ):
         return "Expected node of type \(expectedKind) but received \(actualKind)"
       case .tokenMismatch(
-            expectedTokenChoices: let tokenChoices, 
-            actualKind: let actualKind, 
-            actualText: let actualText, 
-            file: _, 
-            line: _
-          ):
+          expectedTokenChoices: let tokenChoices, 
+          actualKind: let actualKind, 
+          actualText: let actualText, 
+          file: _, 
+          line: _
+        ):
         return "Expected token with one of \(tokenChoices) but received \(actualKind) with text '\(actualText)'"
       }
     }
@@ -66,19 +66,19 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       case .expectedNonNil(expectedKind: _, file: let file, line: let line):
         return (file, line)
       case .kindMismatch(
-            expectedKind: _, 
-            actualKind: _, 
-            file: let file, 
-            line: let line
-          ):
+          expectedKind: _, 
+          actualKind: _, 
+          file: let file, 
+          line: let line
+        ):
         return (file, line)
       case .tokenMismatch(
-            expectedTokenChoices: _, 
-            actualKind: _, 
-            actualText: _, 
-            file: let file, 
-            line: let line
-          ):
+          expectedTokenChoices: _, 
+          actualKind: _, 
+          actualText: _, 
+          file: let file, 
+          line: let line
+        ):
         return (file, line)
       }
     }
@@ -94,11 +94,11 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     guard Node.isKindOf(raw) else {
       return .kindMismatch(
-            expectedKind: Node.self, 
-            actualKind: raw.kind, 
-            file: file, 
-            line: line
-          )
+          expectedKind: Node.self, 
+          actualKind: raw.kind, 
+          file: file, 
+          line: line
+        )
     }
     return nil
   }
@@ -110,11 +110,11 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     ) -> ValidationError? {
     if raw != nil {
       return verify(
-            raw, 
-            as: Node.self, 
-            file: file, 
-            line: line
-          )
+          raw, 
+          as: Node.self, 
+          file: file, 
+          line: line
+        )
     }
     return nil
   }
@@ -131,12 +131,12 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     // regarding it are fixed.
     if raw != nil {
       return verify(
-            raw, 
-            as: RawTokenSyntax.self, 
-            tokenChoices: tokenChoices, 
-            file: file, 
-            line: line
-          )
+          raw, 
+          as: RawTokenSyntax.self, 
+          tokenChoices: tokenChoices, 
+          file: file, 
+          line: line
+        )
     }
     return nil
   }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -71,7 +71,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenInitEffectsAndBody, 
             body, 
             unexpectedAfterBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -340,7 +340,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndMemberBlock, 
             memberBlock, 
             unexpectedAfterMemberBlock
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -646,7 +646,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenInitializerAndGenericWhereClause, 
             genericWhereClause, 
             unexpectedAfterGenericWhereClause
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -934,7 +934,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndMemberBlock, 
             memberBlock, 
             unexpectedAfterMemberBlock
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -1228,7 +1228,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDeinitKeywordAndBody, 
             body, 
             unexpectedAfterBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -1430,7 +1430,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenModifiersAndPlaceholder, 
             placeholder, 
             unexpectedAfterPlaceholder
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -1617,7 +1617,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenCaseKeywordAndElements, 
             elements, 
             unexpectedAfterElements
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -1862,7 +1862,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndMemberBlock, 
             memberBlock, 
             unexpectedAfterMemberBlock
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -2176,7 +2176,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndMemberBlock, 
             memberBlock, 
             unexpectedAfterMemberBlock
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -2464,7 +2464,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndBody, 
             body, 
             unexpectedAfterBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -2750,7 +2750,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenClausesAndPoundEndif, 
             poundEndif, 
             unexpectedAfterPoundEndif
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeClauses?.raw, 
           clauses.raw, 
@@ -2897,7 +2897,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenImportKindAndPath, 
             path, 
             unexpectedAfterPath
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -3167,7 +3167,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndBody, 
             body, 
             unexpectedAfterBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -3485,7 +3485,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDefinitionAndGenericWhereClause, 
             genericWhereClause, 
             unexpectedAfterGenericWhereClause
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -3803,7 +3803,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
             additionalTrailingClosures, 
             unexpectedAfterAdditionalTrailingClosures
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -4176,7 +4176,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenModifiersAndPlaceholder, 
             placeholder, 
             unexpectedAfterPlaceholder
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -4367,7 +4367,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes, 
             operatorPrecedenceAndTypes, 
             unexpectedAfterOperatorPrecedenceAndTypes
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -4598,7 +4598,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenArgsAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforePoundSourceLocation?.raw, 
           poundSourceLocation.raw, 
@@ -4778,7 +4778,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGroupAttributesAndRightBrace, 
             rightBrace, 
             unexpectedAfterRightBrace
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -5089,7 +5089,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndMemberBlock, 
             memberBlock, 
             unexpectedAfterMemberBlock
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -5399,7 +5399,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndMemberBlock, 
             memberBlock, 
             unexpectedAfterMemberBlock
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -5751,7 +5751,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndAccessor, 
             accessor, 
             unexpectedAfterAccessor
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -6057,7 +6057,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenInitializerAndGenericWhereClause, 
             genericWhereClause, 
             unexpectedAfterGenericWhereClause
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -6329,7 +6329,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenBindingKeywordAndBindings, 
             bindings, 
             unexpectedAfterBindings
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -55,7 +55,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenElementsAndRightSquare, 
             rightSquare, 
             unexpectedAfterRightSquare
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftSquare?.raw, 
           leftSquare.raw, 
@@ -212,7 +212,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEffectSpecifiersAndArrowToken, 
             arrowToken, 
             unexpectedAfterArrowToken
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeEffectSpecifiers?.raw, 
           effectSpecifiers?.raw, 
@@ -336,7 +336,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenQuestionOrExclamationMarkAndTypeName, 
             typeName, 
             unexpectedAfterTypeName
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeExpression?.raw, 
           expression.raw, 
@@ -488,7 +488,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAssignToken, assignToken, unexpectedAfterAssignToken))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAssignToken, assignToken, unexpectedAfterAssignToken))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeAssignToken?.raw, assignToken.raw, unexpectedAfterAssignToken?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.assignmentExpr,
@@ -574,7 +574,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAwaitKeywordAndExpression, 
             expression, 
             unexpectedAfterExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAwaitKeyword?.raw, 
           awaitKeyword.raw, 
@@ -682,7 +682,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeOperatorToken, operatorToken, unexpectedAfterOperatorToken))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeOperatorToken, operatorToken, unexpectedAfterOperatorToken))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeOperatorToken?.raw, operatorToken.raw, unexpectedAfterOperatorToken?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.binaryOperatorExpr,
@@ -760,7 +760,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBooleanLiteral, booleanLiteral, unexpectedAfterBooleanLiteral))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBooleanLiteral, booleanLiteral, unexpectedAfterBooleanLiteral))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeBooleanLiteral?.raw, booleanLiteral.raw, unexpectedAfterBooleanLiteral?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.booleanLiteralExpr,
@@ -846,7 +846,7 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenBorrowKeywordAndExpression, 
             expression, 
             unexpectedAfterExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBorrowKeyword?.raw, 
           borrowKeyword.raw, 
@@ -970,7 +970,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenStatementsAndRightBrace, 
             rightBrace, 
             unexpectedAfterRightBrace
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftBrace?.raw, 
           leftBrace.raw, 
@@ -1149,7 +1149,7 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenCopyKeywordAndExpression, 
             expression, 
             unexpectedAfterExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeCopyKeyword?.raw, 
           copyKeyword.raw, 
@@ -1311,7 +1311,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenContentAndRightSquare, 
             rightSquare, 
             unexpectedAfterRightSquare
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftSquare?.raw, 
           leftSquare.raw, 
@@ -1441,7 +1441,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWildcard, wildcard, unexpectedAfterWildcard))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWildcard, wildcard, unexpectedAfterWildcard))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeWildcard?.raw, wildcard.raw, unexpectedAfterWildcard?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.discardAssignmentExpr,
@@ -1519,7 +1519,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedAfterIdentifier))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedAfterIdentifier))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeIdentifier?.raw, identifier.raw, unexpectedAfterIdentifier?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.editorPlaceholderExpr,
@@ -1597,7 +1597,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeFloatingDigits, floatingDigits, unexpectedAfterFloatingDigits))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeFloatingDigits, floatingDigits, unexpectedAfterFloatingDigits))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeFloatingDigits?.raw, floatingDigits.raw, unexpectedAfterFloatingDigits?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.floatLiteralExpr,
@@ -1683,7 +1683,7 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenExpressionAndExclamationMark, 
             exclamationMark, 
             unexpectedAfterExclamationMark
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeExpression?.raw, 
           expression.raw, 
@@ -1815,7 +1815,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
             additionalTrailingClosures, 
             unexpectedAfterAdditionalTrailingClosures
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeCalledExpression?.raw, 
           calledExpression.raw, 
@@ -2057,7 +2057,7 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenIdentifierAndDeclNameArguments, 
             declNameArguments, 
             unexpectedAfterDeclNameArguments
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeIdentifier?.raw, 
           identifier.raw, 
@@ -2227,7 +2227,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenElseKeywordAndElseBody, 
             elseBody, 
             unexpectedAfterElseBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeIfKeyword?.raw, 
           ifKeyword.raw, 
@@ -2428,7 +2428,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAmpersandAndExpression, 
             expression, 
             unexpectedAfterExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAmpersand?.raw, 
           ampersand.raw, 
@@ -2548,7 +2548,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenOperatorOperandAndRightOperand, 
             rightOperand, 
             unexpectedAfterRightOperand
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftOperand?.raw, 
           leftOperand.raw, 
@@ -2678,7 +2678,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDigits, digits, unexpectedAfterDigits))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDigits, digits, unexpectedAfterDigits))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeDigits?.raw, digits.raw, unexpectedAfterDigits?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.integerLiteralExpr,
@@ -2768,7 +2768,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenIsTokAndTypeName, 
             typeName, 
             unexpectedAfterTypeName
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeExpression?.raw, 
           expression.raw, 
@@ -2910,7 +2910,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenRootAndComponents, 
             components, 
             unexpectedAfterComponents
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBackslash?.raw, 
           backslash.raw, 
@@ -2960,7 +2960,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
         unexpectedBeforeBackslash,
         backslash: backslash,
         unexpectedBetweenBackslashAndRoot,
-        root: Optional<TypeSyntax>.none,
+        root: Optional<TypeSyntax> .none,
         unexpectedBetweenRootAndComponents,
         components: components,
         unexpectedAfterComponents, 
@@ -3126,7 +3126,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
             additionalTrailingClosures, 
             unexpectedAfterAdditionalTrailingClosures
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforePoundToken?.raw, 
           poundToken.raw, 
@@ -3421,7 +3421,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndDeclNameArguments, 
             declNameArguments, 
             unexpectedAfterDeclNameArguments
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBase?.raw, 
           base?.raw, 
@@ -3473,7 +3473,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self.init(
         leadingTrivia: leadingTrivia,
         unexpectedBeforeBase,
-        base: Optional<ExprSyntax>.none,
+        base: Optional<ExprSyntax> .none,
         unexpectedBetweenBaseAndDot,
         dot: dot,
         unexpectedBetweenDotAndName,
@@ -3612,7 +3612,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforePlaceholder?.raw, placeholder.raw, unexpectedAfterPlaceholder?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.missingExpr,
@@ -3699,7 +3699,7 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenMoveKeywordAndExpression, 
             expression, 
             unexpectedAfterExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeMoveKeyword?.raw, 
           moveKeyword.raw, 
@@ -3807,7 +3807,7 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeNilKeyword, nilKeyword, unexpectedAfterNilKeyword))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeNilKeyword, nilKeyword, unexpectedAfterNilKeyword))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeNilKeyword?.raw, nilKeyword.raw, unexpectedAfterNilKeyword?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.nilLiteralExpr,
@@ -3893,7 +3893,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenExpressionAndQuestionMark, 
             questionMark, 
             unexpectedAfterQuestionMark
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeExpression?.raw, 
           expression.raw, 
@@ -4009,7 +4009,7 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEachKeywordAndPackRefExpr, 
             packRefExpr, 
             unexpectedAfterPackRefExpr
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeEachKeyword?.raw, 
           eachKeyword.raw, 
@@ -4125,7 +4125,7 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenRepeatKeywordAndPatternExpr, 
             patternExpr, 
             unexpectedAfterPatternExpr
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeRepeatKeyword?.raw, 
           repeatKeyword.raw, 
@@ -4241,7 +4241,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenBaseAndConfig, 
             config, 
             unexpectedAfterConfig
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBase?.raw, 
           base?.raw, 
@@ -4285,7 +4285,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self.init(
         leadingTrivia: leadingTrivia,
         unexpectedBeforeBase,
-        base: Optional<ExprSyntax>.none,
+        base: Optional<ExprSyntax> .none,
         unexpectedBetweenBaseAndConfig,
         config: config,
         unexpectedAfterConfig, 
@@ -4388,7 +4388,7 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenExpressionAndOperatorToken, 
             operatorToken, 
             unexpectedAfterOperatorToken
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeExpression?.raw, 
           expression.raw, 
@@ -4504,7 +4504,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenOperatorTokenAndPostfixExpression, 
             postfixExpression, 
             unexpectedAfterPostfixExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeOperatorToken?.raw, 
           operatorToken?.raw, 
@@ -4632,7 +4632,7 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenCloseSlashAndClosingPounds, 
             closingPounds, 
             unexpectedAfterClosingPounds
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeOpeningPounds?.raw, 
           openingPounds?.raw, 
@@ -4806,7 +4806,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeElements, elements, unexpectedAfterElements))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeElements, elements, unexpectedAfterElements))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeElements?.raw, elements.raw, unexpectedAfterElements?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.sequenceExpr,
@@ -4911,7 +4911,7 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenExpressionAndGenericArgumentClause, 
             genericArgumentClause, 
             unexpectedAfterGenericArgumentClause
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeExpression?.raw, 
           expression.raw, 
@@ -5039,7 +5039,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenCloseQuoteAndCloseDelimiter, 
             closeDelimiter, 
             unexpectedAfterCloseDelimiter
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeOpenDelimiter?.raw, 
           openDelimiter?.raw, 
@@ -5256,7 +5256,7 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, 
             additionalTrailingClosures, 
             unexpectedAfterAdditionalTrailingClosures
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeCalledExpression?.raw, 
           calledExpression.raw, 
@@ -5490,7 +5490,7 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeSuperKeyword, superKeyword, unexpectedAfterSuperKeyword))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeSuperKeyword, superKeyword, unexpectedAfterSuperKeyword))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeSuperKeyword?.raw, superKeyword.raw, unexpectedAfterSuperKeyword?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.superRefExpr,
@@ -5588,7 +5588,7 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenCasesAndRightBrace, 
             rightBrace, 
             unexpectedAfterRightBrace
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeSwitchKeyword?.raw, 
           switchKeyword.raw, 
@@ -5801,7 +5801,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenColonMarkAndSecondChoice, 
             secondChoice, 
             unexpectedAfterSecondChoice
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeConditionExpression?.raw, 
           conditionExpression.raw, 
@@ -5987,7 +5987,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenQuestionOrExclamationMarkAndExpression, 
             expression, 
             unexpectedAfterExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeTryKeyword?.raw, 
           tryKeyword.raw, 
@@ -6129,7 +6129,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenElementListAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -6278,7 +6278,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeType, type, unexpectedAfterType))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeType, type, unexpectedAfterType))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeType?.raw, type.raw, unexpectedAfterType?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.typeExpr,
@@ -6364,7 +6364,7 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAsTokAndQuestionOrExclamationMark, 
             questionOrExclamationMark, 
             unexpectedAfterQuestionOrExclamationMark
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAsTok?.raw, 
           asTok.raw, 
@@ -6472,7 +6472,7 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIsTok, isTok, unexpectedAfterIsTok))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIsTok, isTok, unexpectedAfterIsTok))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeIsTok?.raw, isTok.raw, unexpectedAfterIsTok?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.unresolvedIsExpr,
@@ -6550,7 +6550,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePattern, pattern, unexpectedAfterPattern))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePattern, pattern, unexpectedAfterPattern))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforePattern?.raw, pattern.raw, unexpectedAfterPattern?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.unresolvedPatternExpr,
@@ -6640,7 +6640,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenFirstChoiceAndColonMark, 
             colonMark, 
             unexpectedAfterColonMark
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeQuestionMark?.raw, 
           questionMark.raw, 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -51,7 +51,7 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndTrailingDot, 
             trailingDot, 
             unexpectedAfterTrailingDot
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeName?.raw, 
           name.raw, 
@@ -175,7 +175,7 @@ public struct AccessesEffectSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenPropertyListAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAccessesKeyword?.raw, 
           accessesKeyword.raw, 
@@ -358,7 +358,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAccessorsAndRightBrace, 
             rightBrace, 
             unexpectedAfterRightBrace
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftBrace?.raw, 
           leftBrace.raw, 
@@ -515,7 +515,7 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAsyncSpecifierAndThrowsSpecifier, 
             throwsSpecifier, 
             unexpectedAfterThrowsSpecifier
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAsyncSpecifier?.raw, 
           asyncSpecifier?.raw, 
@@ -631,7 +631,7 @@ public struct AccessorInitEffectsSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenInitializesEffectAndAccessesEffect, 
             accessesEffect, 
             unexpectedAfterAccessesEffect
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeInitializesEffect?.raw, 
           initializesEffect?.raw, 
@@ -751,7 +751,7 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -889,7 +889,7 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenExpressionAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeExpression?.raw, 
           expression.raw, 
@@ -1278,7 +1278,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenArgumentAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAtSignToken?.raw, 
           atSignToken.raw, 
@@ -1518,7 +1518,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEntryAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeEntry?.raw, 
           entry.raw, 
@@ -1644,7 +1644,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAvailabilitySpecAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAvailabilityKeyword?.raw, 
           availabilityKeyword.raw, 
@@ -1831,7 +1831,7 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAvailabilityListAndSemicolon, 
             semicolon, 
             unexpectedAfterSemicolon
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLabel?.raw, 
           label.raw, 
@@ -2058,7 +2058,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
             unexpectedBetweenColonAndValue, 
             value, 
             unexpectedAfterValue
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLabel?.raw, 
           label.raw, 
@@ -2199,7 +2199,7 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
             unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAvailabilityVersionRestriction?.raw, 
           availabilityVersionRestriction.raw, 
@@ -2316,7 +2316,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
             unexpectedBetweenPlatformAndVersion, 
             version, 
             unexpectedAfterVersion
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforePlatform?.raw, 
           platform.raw, 
@@ -2437,7 +2437,7 @@ public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashabl
             unexpectedBetweenColonAndVersionList, 
             versionList, 
             unexpectedAfterVersionList
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBeforeLabel?.raw, 
           beforeLabel.raw, 
@@ -2601,7 +2601,7 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenWhereClauseAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforePattern?.raw, 
           pattern.raw, 
@@ -2743,7 +2743,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenCatchItemsAndBody, 
             body, 
             unexpectedAfterBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeCatchKeyword?.raw, 
           catchKeyword.raw, 
@@ -2904,7 +2904,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenWhereClauseAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforePattern?.raw, 
           pattern?.raw, 
@@ -2952,7 +2952,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     self.init(
         leadingTrivia: leadingTrivia,
         unexpectedBeforePattern,
-        pattern: Optional<PatternSyntax>.none,
+        pattern: Optional<PatternSyntax> .none,
         unexpectedBetweenPatternAndWhereClause,
         whereClause: whereClause,
         unexpectedBetweenWhereClauseAndTrailingComma,
@@ -3085,7 +3085,7 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
             unexpectedBetweenDetailAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeSpecifier?.raw, 
           specifier.raw, 
@@ -3257,7 +3257,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenExpressionAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeSpecifier?.raw, 
           specifier?.raw, 
@@ -3443,7 +3443,7 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenItemsAndRightSquare, 
             rightSquare, 
             unexpectedAfterRightSquare
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftSquare?.raw, 
           leftSquare.raw, 
@@ -3600,7 +3600,7 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeName?.raw, 
           name.raw, 
@@ -3720,7 +3720,7 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenParameterListAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -3904,7 +3904,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEllipsisAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -3982,7 +3982,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
         unexpectedBetweenSecondNameAndColon,
         colon: colon,
         unexpectedBetweenColonAndType,
-        type: Optional<TypeSyntax>.none,
+        type: Optional<TypeSyntax> .none,
         unexpectedBetweenTypeAndEllipsis,
         ellipsis: ellipsis,
         unexpectedBetweenEllipsisAndTrailingComma,
@@ -4309,7 +4309,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenOutputAndInTok, 
             inTok, 
             unexpectedAfterInTok
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -4585,7 +4585,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenItemAndSemicolon, 
             semicolon, 
             unexpectedAfterSemicolon
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeItem?.raw, 
           item.raw, 
@@ -4707,7 +4707,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenStatementsAndRightBrace, 
             rightBrace, 
             unexpectedAfterRightBrace
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftBrace?.raw, 
           leftBrace.raw, 
@@ -4864,7 +4864,7 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenTypeAndAmpersand, 
             ampersand, 
             unexpectedAfterAmpersand
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeType?.raw, 
           type.raw, 
@@ -5049,7 +5049,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenConditionAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeCondition?.raw, 
           condition.raw, 
@@ -5169,7 +5169,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenColonAndRightTypeIdentifier, 
             rightTypeIdentifier, 
             unexpectedAfterRightTypeIdentifier
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftTypeIdentifier?.raw, 
           leftTypeIdentifier.raw, 
@@ -5319,7 +5319,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
             unexpectedBetweenColonAndCTypeString, 
             cTypeString, 
             unexpectedAfterCTypeString
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeConventionLabel?.raw, 
           conventionLabel.raw, 
@@ -5506,7 +5506,7 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
             unexpectedBetweenColonAndProtocolName, 
             protocolName, 
             unexpectedAfterProtocolName
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeWitnessMethodLabel?.raw, 
           witnessMethodLabel.raw, 
@@ -5648,7 +5648,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDetailAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -5786,7 +5786,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndDetail, 
             detail, 
             unexpectedAfterDetail
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeName?.raw, 
           name.raw, 
@@ -5902,7 +5902,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndColon, 
             colon, 
             unexpectedAfterColon
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeName?.raw, 
           name.raw, 
@@ -6022,7 +6022,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenArgumentsAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -6179,7 +6179,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDeclBaseNameAndDeclNameArguments, 
             declNameArguments, 
             unexpectedAfterDeclNameArguments
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeDeclBaseName?.raw, 
           declBaseName.raw, 
@@ -6317,7 +6317,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
             unexpectedBetweenCommaAndDiffParams, 
             diffParams, 
             unexpectedAfterDiffParams
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeOfLabel?.raw, 
           ofLabel.raw, 
@@ -6548,7 +6548,7 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenLeadingCommaAndName, 
             name, 
             unexpectedAfterName
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeadingComma?.raw, 
           leadingComma.raw, 
@@ -6672,7 +6672,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenValueExpressionAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeKeyExpression?.raw, 
           keyExpression.raw, 
@@ -6832,7 +6832,7 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenParameterAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeParameter?.raw, 
           parameter.raw, 
@@ -6994,7 +6994,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
             unexpectedBetweenColonAndParameters, 
             parameters, 
             unexpectedAfterParameters
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeWrtLabel?.raw, 
           wrtLabel.raw, 
@@ -7138,7 +7138,7 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDiffParamsAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -7308,7 +7308,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
             unexpectedBetweenDiffParamsCommaAndWhereClause, 
             whereClause, 
             unexpectedAfterWhereClause
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeDiffKind?.raw, 
           diffKind?.raw, 
@@ -7542,7 +7542,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
             unexpectedBetweenValueAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLabel?.raw, 
           label.raw, 
@@ -7707,7 +7707,7 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
             unexpectedBetweenColonAndDeclname, 
             declname, 
             unexpectedAfterDeclname
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeForLabel?.raw, 
           forLabel.raw, 
@@ -7853,7 +7853,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenRawValueAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeIdentifier?.raw, 
           identifier.raw, 
@@ -8021,7 +8021,7 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenParameterListAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -8201,7 +8201,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDefaultArgumentAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeModifiers?.raw, 
           modifiers?.raw, 
@@ -8454,7 +8454,7 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenCommaAndCxxName, 
             cxxName, 
             unexpectedAfterCxxName
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLanguage?.raw, 
           language.raw, 
@@ -8604,7 +8604,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenExpressionsAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBackslash?.raw, 
           backslash.raw, 
@@ -8805,7 +8805,7 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAsyncSpecifierAndThrowsSpecifier, 
             throwsSpecifier, 
             unexpectedAfterThrowsSpecifier
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAsyncSpecifier?.raw, 
           asyncSpecifier?.raw, 
@@ -8949,7 +8949,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDefaultArgumentAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -9261,7 +9261,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEffectSpecifiersAndOutput, 
             output, 
             unexpectedAfterOutput
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeInput?.raw, 
           input.raw, 
@@ -9403,7 +9403,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenArgumentsAndRightAngleBracket, 
             rightAngleBracket, 
             unexpectedAfterRightAngleBracket
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftAngleBracket?.raw, 
           leftAngleBracket.raw, 
@@ -9560,7 +9560,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenArgumentTypeAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeArgumentType?.raw, 
           argumentType.raw, 
@@ -9684,7 +9684,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericWhereClauseAndRightAngleBracket, 
             rightAngleBracket, 
             unexpectedAfterRightAngleBracket
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftAngleBracket?.raw, 
           leftAngleBracket.raw, 
@@ -9879,7 +9879,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenInheritedTypeAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
           attributes?.raw, 
@@ -9947,7 +9947,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
         unexpectedBetweenNameAndColon,
         colon: colon,
         unexpectedBetweenColonAndInheritedType,
-        inheritedType: Optional<TypeSyntax>.none,
+        inheritedType: Optional<TypeSyntax> .none,
         unexpectedBetweenInheritedTypeAndTrailingComma,
         trailingComma: trailingComma,
         unexpectedAfterTrailingComma, 
@@ -10202,7 +10202,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenBodyAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBody?.raw, 
           body.raw, 
@@ -10318,7 +10318,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenWhereKeywordAndRequirementList, 
             requirementList, 
             unexpectedAfterRequirementList
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeWhereKeyword?.raw, 
           whereKeyword.raw, 
@@ -10538,7 +10538,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenConditionAndElements, 
             elements, 
             unexpectedAfterElements
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforePoundKeyword?.raw, 
           poundKeyword.raw, 
@@ -10588,7 +10588,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
         unexpectedBeforePoundKeyword,
         poundKeyword: poundKeyword,
         unexpectedBetweenPoundKeywordAndCondition,
-        condition: Optional<ExprSyntax>.none,
+        condition: Optional<ExprSyntax> .none,
         unexpectedBetweenConditionAndElements,
         elements: elements,
         unexpectedAfterElements, 
@@ -10719,7 +10719,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
             unexpectedBetweenDeclBaseNameAndDeclNameArguments, 
             declNameArguments, 
             unexpectedAfterDeclNameArguments
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeType?.raw, 
           type.raw, 
@@ -10883,7 +10883,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenTypeNameAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeTypeName?.raw, 
           typeName.raw, 
@@ -10999,7 +10999,7 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEqualAndValue, 
             value, 
             unexpectedAfterValue
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeEqual?.raw, 
           equal.raw, 
@@ -11123,7 +11123,7 @@ public struct InitializesEffectSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenPropertyListAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeInitializesKeyword?.raw, 
           initializesKeyword.raw, 
@@ -11355,7 +11355,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenPeriodAndComponent, 
             component, 
             unexpectedAfterComponent
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforePeriod?.raw, 
           period?.raw, 
@@ -11463,7 +11463,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeQuestionOrExclamationMark, questionOrExclamationMark, unexpectedAfterQuestionOrExclamationMark))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeQuestionOrExclamationMark, questionOrExclamationMark, unexpectedAfterQuestionOrExclamationMark))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeQuestionOrExclamationMark?.raw, questionOrExclamationMark.raw, unexpectedAfterQuestionOrExclamationMark?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.keyPathOptionalComponent,
@@ -11553,7 +11553,7 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause, 
             genericArgumentClause, 
             unexpectedAfterGenericArgumentClause
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeIdentifier?.raw, 
           identifier.raw, 
@@ -11695,7 +11695,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenArgumentListAndRightBracket, 
             rightBracket, 
             unexpectedAfterRightBracket
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftBracket?.raw, 
           leftBracket.raw, 
@@ -11860,7 +11860,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenValueAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLabel?.raw, 
           label.raw, 
@@ -12048,7 +12048,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAlignmentAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeTypeIdentifier?.raw, 
           typeIdentifier.raw, 
@@ -12304,7 +12304,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenTypeAnnotationAndInitializer, 
             initializer, 
             unexpectedAfterInitializer
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeCaseKeyword?.raw, 
           caseKeyword.raw, 
@@ -12468,7 +12468,7 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenMembersAndRightBrace, 
             rightBrace, 
             unexpectedAfterRightBrace
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftBrace?.raw, 
           leftBrace.raw, 
@@ -12625,7 +12625,7 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDeclAndSemicolon, 
             semicolon, 
             unexpectedAfterSemicolon
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeDecl?.raw, 
           decl.raw, 
@@ -12735,7 +12735,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforePlaceholder?.raw, placeholder.raw, unexpectedAfterPlaceholder?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.missing,
@@ -12826,7 +12826,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
             unexpectedBetweenColonAndClosure, 
             closure, 
             unexpectedAfterClosure
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLabel?.raw, 
           label.raw, 
@@ -12964,7 +12964,7 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndColon, 
             colon, 
             unexpectedAfterColon
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeName?.raw, 
           name?.raw, 
@@ -13084,7 +13084,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
             unexpectedBetweenCommaAndOrdinal, 
             ordinal, 
             unexpectedAfterOrdinal
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeMangledName?.raw, 
           mangledName.raw, 
@@ -13228,7 +13228,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenPrecedenceGroupAndDesignatedTypes, 
             designatedTypes, 
             unexpectedAfterDesignatedTypes
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeColon?.raw, 
           colon.raw, 
@@ -13395,7 +13395,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenTypeAnnotationAndInitializer, 
             initializer, 
             unexpectedAfterInitializer
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBindingKeyword?.raw, 
           bindingKeyword.raw, 
@@ -13567,7 +13567,7 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
             unexpectedBetweenCommaAndPlatforms, 
             platforms, 
             unexpectedAfterPlatforms
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeModuleLabel?.raw, 
           moduleLabel.raw, 
@@ -13772,7 +13772,7 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenParameterListAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -13983,7 +13983,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAccessorAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforePattern?.raw, 
           pattern.raw, 
@@ -14185,7 +14185,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenLineArgColonAndLineNumber, 
             lineNumber, 
             unexpectedAfterLineNumber
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeFileArgLabel?.raw, 
           fileArgLabel.raw, 
@@ -14415,7 +14415,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenColonAndFlag, 
             flag, 
             unexpectedAfterFlag
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAssignmentKeyword?.raw, 
           assignmentKeyword.raw, 
@@ -14558,7 +14558,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
             unexpectedBetweenColonAndValue, 
             value, 
             unexpectedAfterValue
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAssociativityKeyword?.raw, 
           associativityKeyword.raw, 
@@ -14697,7 +14697,7 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeName?.raw, 
           name.raw, 
@@ -14817,7 +14817,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenColonAndOtherNames, 
             otherNames, 
             unexpectedAfterOtherNames
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeHigherThanOrLowerThan?.raw, 
           higherThanOrLowerThan.raw, 
@@ -14980,7 +14980,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
             unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket, 
             rightAngleBracket, 
             unexpectedAfterRightAngleBracket
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftAngleBracket?.raw, 
           leftAngleBracket.raw, 
@@ -15137,7 +15137,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeName?.raw, 
           name.raw, 
@@ -15261,7 +15261,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndArguments, 
             arguments, 
             unexpectedAfterArguments
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBaseType?.raw, 
           baseType?.raw, 
@@ -15313,7 +15313,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     self.init(
         leadingTrivia: leadingTrivia,
         unexpectedBeforeBaseType,
-        baseType: Optional<TypeSyntax>.none,
+        baseType: Optional<TypeSyntax> .none,
         unexpectedBetweenBaseTypeAndDot,
         dot: dot,
         unexpectedBetweenDotAndName,
@@ -15463,7 +15463,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenArrowAndReturnType, 
             returnType, 
             unexpectedAfterReturnType
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeArrow?.raw, 
           arrow.raw, 
@@ -15583,7 +15583,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEqualityTokenAndRightTypeIdentifier, 
             rightTypeIdentifier, 
             unexpectedAfterRightTypeIdentifier
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftTypeIdentifier?.raw, 
           leftTypeIdentifier.raw, 
@@ -15721,7 +15721,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenStatementsAndEOFToken, 
             eofToken, 
             unexpectedAfterEOFToken
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeStatements?.raw, 
           statements.raw, 
@@ -15848,7 +15848,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeContent, content, unexpectedAfterContent))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeContent, content, unexpectedAfterContent))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeContent?.raw, content.raw, unexpectedAfterContent?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.stringSegment,
@@ -15938,7 +15938,7 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenCaseItemsAndColon, 
             colon, 
             unexpectedAfterColon
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeCaseKeyword?.raw, 
           caseKeyword.raw, 
@@ -16141,7 +16141,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenLabelAndStatements, 
             statements, 
             unexpectedAfterStatements
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeUnknownAttr?.raw, 
           unknownAttr?.raw, 
@@ -16298,7 +16298,7 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDefaultKeywordAndColon, 
             colon, 
             unexpectedAfterColon
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeDefaultKeyword?.raw, 
           defaultKeyword.raw, 
@@ -16422,7 +16422,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDeclnameAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLabel?.raw, 
           label.raw, 
@@ -16594,7 +16594,7 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenExpressionAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLabel?.raw, 
           label?.raw, 
@@ -16762,7 +16762,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenPatternAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLabelName?.raw, 
           labelName?.raw, 
@@ -16946,7 +16946,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenInitializerAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeInOut?.raw, 
           inOut?.raw, 
@@ -17194,7 +17194,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenColonAndType, 
             type, 
             unexpectedAfterType
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeColon?.raw, 
           colon.raw, 
@@ -17310,7 +17310,7 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAsyncSpecifierAndThrowsSpecifier, 
             throwsSpecifier, 
             unexpectedAfterThrowsSpecifier
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeAsyncSpecifier?.raw, 
           asyncSpecifier?.raw, 
@@ -17426,7 +17426,7 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenColonAndInheritedTypeCollection, 
             inheritedTypeCollection, 
             unexpectedAfterInheritedTypeCollection
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeColon?.raw, 
           colon.raw, 
@@ -17561,7 +17561,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEqualAndValue, 
             value, 
             unexpectedAfterValue
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeEqual?.raw, 
           equal.raw, 
@@ -17681,7 +17681,7 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
             unexpectedBetweenColonAndMessage, 
             message, 
             unexpectedAfterMessage
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeMessageLabel?.raw, 
           messageLabel.raw, 
@@ -17823,7 +17823,7 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
             unexpectedBetweenColonAndFilename, 
             filename, 
             unexpectedAfterFilename
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeSourceFileLabel?.raw, 
           sourceFileLabel.raw, 
@@ -17973,7 +17973,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenPatchPeriodAndPatch, 
             patch, 
             unexpectedAfterPatch
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeMajor?.raw, 
           major.raw, 
@@ -18160,7 +18160,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenWhereKeywordAndGuardResult, 
             guardResult, 
             unexpectedAfterGuardResult
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeWhereKeyword?.raw, 
           whereKeyword.raw, 
@@ -18276,7 +18276,7 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenExpressionAndComma, 
             comma, 
             unexpectedAfterComma
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeExpression?.raw, 
           expression.raw, 
@@ -18396,7 +18396,7 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
             unexpectedBetweenElementListAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -43,7 +43,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedAfterExpression))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedAfterExpression))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeExpression?.raw, expression.raw, unexpectedAfterExpression?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.expressionPattern,
@@ -121,7 +121,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedAfterIdentifier))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedAfterIdentifier))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeIdentifier?.raw, identifier.raw, unexpectedAfterIdentifier?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.identifierPattern,
@@ -207,7 +207,7 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenIsKeywordAndType, 
             type, 
             unexpectedAfterType
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeIsKeyword?.raw, 
           isKeyword.raw, 
@@ -315,7 +315,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforePlaceholder?.raw, placeholder.raw, unexpectedAfterPlaceholder?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.missingPattern,
@@ -406,7 +406,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenElementsAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -563,7 +563,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenBindingKeywordAndValuePattern, 
             valuePattern, 
             unexpectedAfterValuePattern
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBindingKeyword?.raw, 
           bindingKeyword.raw, 
@@ -679,7 +679,7 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenWildcardAndTypeAnnotation, 
             typeAnnotation, 
             unexpectedAfterTypeAnnotation
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeWildcard?.raw, 
           wildcard.raw, 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -51,7 +51,7 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenBreakKeywordAndLabel, 
             label, 
             unexpectedAfterLabel
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBreakKeyword?.raw, 
           breakKeyword.raw, 
@@ -167,7 +167,7 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenContinueKeywordAndLabel, 
             label, 
             unexpectedAfterLabel
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeContinueKeyword?.raw, 
           continueKeyword.raw, 
@@ -283,7 +283,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDeferKeywordAndBody, 
             body, 
             unexpectedAfterBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeDeferKeyword?.raw, 
           deferKeyword.raw, 
@@ -399,7 +399,7 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenDiscardKeywordAndExpression, 
             expression, 
             unexpectedAfterExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeDiscardKeyword?.raw, 
           discardKeyword.raw, 
@@ -519,7 +519,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenBodyAndCatchClauses, 
             catchClauses, 
             unexpectedAfterCatchClauses
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeDoKeyword?.raw, 
           doKeyword.raw, 
@@ -668,7 +668,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedAfterExpression))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedAfterExpression))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeExpression?.raw, expression.raw, unexpectedAfterExpression?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.expressionStmt,
@@ -746,7 +746,7 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeFallthroughKeyword, fallthroughKeyword, unexpectedAfterFallthroughKeyword))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeFallthroughKeyword, fallthroughKeyword, unexpectedAfterFallthroughKeyword))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeFallthroughKeyword?.raw, fallthroughKeyword.raw, unexpectedAfterFallthroughKeyword?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.fallthroughStmt,
@@ -864,7 +864,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenWhereClauseAndBody, 
             body, 
             unexpectedAfterBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeForKeyword?.raw, 
           forKeyword.raw, 
@@ -1164,7 +1164,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenElseKeywordAndBody, 
             body, 
             unexpectedAfterBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeGuardKeyword?.raw, 
           guardKeyword.raw, 
@@ -1347,7 +1347,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenLabelColonAndStatement, 
             statement, 
             unexpectedAfterStatement
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLabelName?.raw, 
           labelName.raw, 
@@ -1477,7 +1477,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforePlaceholder?.raw, placeholder.raw, unexpectedAfterPlaceholder?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.missingStmt,
@@ -1572,7 +1572,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenWhileKeywordAndCondition, 
             condition, 
             unexpectedAfterCondition
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeRepeatKeyword?.raw, 
           repeatKeyword.raw, 
@@ -1732,7 +1732,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenReturnKeywordAndExpression, 
             expression, 
             unexpectedAfterExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeReturnKeyword?.raw, 
           returnKeyword.raw, 
@@ -1778,7 +1778,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
         unexpectedBeforeReturnKeyword,
         returnKeyword: returnKeyword,
         unexpectedBetweenReturnKeywordAndExpression,
-        expression: Optional<ExprSyntax>.none,
+        expression: Optional<ExprSyntax> .none,
         unexpectedAfterExpression, 
         trailingTrivia: trailingTrivia
       )
@@ -1879,7 +1879,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenThrowKeywordAndExpression, 
             expression, 
             unexpectedAfterExpression
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeThrowKeyword?.raw, 
           throwKeyword.raw, 
@@ -1999,7 +1999,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenConditionsAndBody, 
             body, 
             unexpectedAfterBody
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeWhileKeyword?.raw, 
           whileKeyword.raw, 
@@ -2198,7 +2198,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenYieldKeywordAndYields, 
             yields, 
             unexpectedAfterYields
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeYieldKeyword?.raw, 
           yieldKeyword.raw, 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -55,7 +55,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenElementTypeAndRightSquareBracket, 
             rightSquareBracket, 
             unexpectedAfterRightSquareBracket
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftSquareBracket?.raw, 
           leftSquareBracket.raw, 
@@ -197,7 +197,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenAttributesAndBaseType, 
             baseType, 
             unexpectedAfterBaseType
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeSpecifier?.raw, 
           specifier?.raw, 
@@ -346,7 +346,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeClassKeyword, classKeyword, unexpectedAfterClassKeyword))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeClassKeyword, classKeyword, unexpectedAfterClassKeyword))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeClassKeyword?.raw, classKeyword.raw, unexpectedAfterClassKeyword?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.classRestrictionType,
@@ -424,7 +424,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeElements, elements, unexpectedAfterElements))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeElements, elements, unexpectedAfterElements))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforeElements?.raw, elements.raw, unexpectedAfterElements?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.compositionType,
@@ -529,7 +529,7 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenSomeOrAnySpecifierAndBaseType, 
             baseType, 
             unexpectedAfterBaseType
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeSomeOrAnySpecifier?.raw, 
           someOrAnySpecifier.raw, 
@@ -657,7 +657,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenValueTypeAndRightSquareBracket, 
             rightSquareBracket, 
             unexpectedAfterRightSquareBracket
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftSquareBracket?.raw, 
           leftSquareBracket.raw, 
@@ -851,7 +851,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEffectSpecifiersAndOutput, 
             output, 
             unexpectedAfterOutput
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 
@@ -1052,7 +1052,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
             unexpectedBetweenWrappedTypeAndExclamationMark, 
             exclamationMark, 
             unexpectedAfterExclamationMark
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeWrappedType?.raw, 
           wrappedType.raw, 
@@ -1176,7 +1176,7 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndGenericArgumentClause, 
             genericArgumentClause, 
             unexpectedAfterGenericArgumentClause
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBaseType?.raw, 
           baseType.raw, 
@@ -1340,7 +1340,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenPeriodAndTypeOrProtocol, 
             typeOrProtocol, 
             unexpectedAfterTypeOrProtocol
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBaseType?.raw, 
           baseType.raw, 
@@ -1470,7 +1470,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) {(arena, _) in
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlaceholder, placeholder, unexpectedAfterPlaceholder))) { (arena, _) in
       let layout: [RawSyntax?] = [unexpectedBeforePlaceholder?.raw, placeholder.raw, unexpectedAfterPlaceholder?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.missingType,
@@ -1557,7 +1557,7 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenGenericParametersAndBaseType, 
             baseType, 
             unexpectedAfterBaseType
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeGenericParameters?.raw, 
           genericParameters.raw, 
@@ -1673,7 +1673,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenWrappedTypeAndQuestionMark, 
             questionMark, 
             unexpectedAfterQuestionMark
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeWrappedType?.raw, 
           wrappedType.raw, 
@@ -1789,7 +1789,7 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenRepeatKeywordAndPatternType, 
             patternType, 
             unexpectedAfterPatternType
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeRepeatKeyword?.raw, 
           repeatKeyword.raw, 
@@ -1905,7 +1905,7 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenEachKeywordAndPackType, 
             packType, 
             unexpectedAfterPackType
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeEachKeyword?.raw, 
           eachKeyword.raw, 
@@ -2021,7 +2021,7 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenNameAndGenericArgumentClause, 
             genericArgumentClause, 
             unexpectedAfterGenericArgumentClause
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeName?.raw, 
           name.raw, 
@@ -2137,7 +2137,7 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenWithoutTildeAndPatternType, 
             patternType, 
             unexpectedAfterPatternType
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeWithoutTilde?.raw, 
           withoutTilde.raw, 
@@ -2257,7 +2257,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
             unexpectedBetweenElementsAndRightParen, 
             rightParen, 
             unexpectedAfterRightParen
-          ))) {(arena, _) in
+          ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeLeftParen?.raw, 
           leftParen.raw, 

--- a/Sources/SwiftSyntaxBuilder/Indenter.swift
+++ b/Sources/SwiftSyntaxBuilder/Indenter.swift
@@ -30,6 +30,7 @@ class Indenter: SyntaxRewriter {
 
   init(indentation: Trivia) {
     self.indentation = indentation
+    super.init(viewMode: .sourceAccurate)
   }
 
   /// Adds `indentation` after all newlines in the syntax tree.
@@ -37,7 +38,7 @@ class Indenter: SyntaxRewriter {
     _ node: SyntaxType,
     indentation: Trivia
   ) -> SyntaxType {
-    return Indenter(indentation: indentation).visit(Syntax(node)).as(SyntaxType.self)!
+    return Indenter(indentation: indentation).rewrite(node).as(SyntaxType.self)!
   }
 
   public override func visit(_ token: TokenSyntax) -> TokenSyntax {

--- a/Sources/SwiftSyntaxMacros/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacros/MacroReplacement.swift
@@ -231,6 +231,7 @@ private final class MacroExpansionRewriter: SyntaxRewriter {
   init(parameterReplacements: [IdentifierExprSyntax: Int], arguments: [ExprSyntax]) {
     self.parameterReplacements = parameterReplacements
     self.arguments = arguments
+    super.init(viewMode: .sourceAccurate)
   }
 
   override func visit(_ node: IdentifierExprSyntax) -> ExprSyntax {

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -74,6 +74,7 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
   ) {
     self.macroSystem = macroSystem
     self.context = context
+    super.init(viewMode: .sourceAccurate)
   }
 
   override func visitAny(_ node: Syntax) -> Syntax? {
@@ -582,6 +583,6 @@ extension SyntaxProtocol {
       context: context
     )
 
-    return applier.visit(Syntax(self))
+    return applier.rewrite(self)
   }
 }

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -23,7 +23,7 @@ private class InitializerExprFormat: BasicFormat {
   private func formatChildrenSeparatedByNewline<SyntaxType: SyntaxProtocol>(children: SyntaxChildren, elementType: SyntaxType.Type) -> [SyntaxType] {
     increaseIndentationLevel()
     var formattedChildren = children.map {
-      self.visit($0).as(SyntaxType.self)!
+      self.rewrite($0.cast(SyntaxType.self)).cast(SyntaxType.self)
     }
     formattedChildren = formattedChildren.map {
       if $0.leadingTrivia.first?.isNewline == true {

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -257,7 +257,7 @@ func performClassifySyntax(args: CommandLineArguments) throws {
   let result = ClassifiedSyntaxTreePrinter.print(Syntax(tree))
   do {
     // Sanity check that we get the same result if the tree has constructed nodes.
-    let ctorTree = TreeReconstructor().visit(tree)
+    let ctorTree = TreeReconstructor(viewMode: .sourceAccurate).visit(tree)
     let ctorResult = ClassifiedSyntaxTreePrinter.print(Syntax(ctorTree))
     if ctorResult != result {
       throw TestingError.classificationVerificationFailed(result, ctorResult)

--- a/Tests/PerformanceTest/VisitorPerformanceTests.swift
+++ b/Tests/PerformanceTest/VisitorPerformanceTests.swift
@@ -48,7 +48,7 @@ public class VisitorPerformanceTests: XCTestCase {
       try {
         let parsed = Parser.parse(source: try String(contentsOf: inputFile))
 
-        let emptyRewriter = EmptyRewriter()
+        let emptyRewriter = EmptyRewriter(viewMode: .sourceAccurate)
 
         measure {
           _ = emptyRewriter.visit(parsed)

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -341,4 +341,17 @@ final class BasicFormatTest: XCTestCase {
         """
     )
   }
+
+  func testUnexpectedIsNotFormatted() {
+    let expr: ExprSyntax = """
+      let foo=1
+      """
+
+    assertFormatted(
+      tree: expr,
+      expected: """
+        let foo=1
+        """
+    )
+  }
 }

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -60,9 +60,9 @@ class ExplicitParenFolder: SyntaxRewriter {
     }
 
     return OperatorTable.makeBinaryOperationExpr(
-      lhs: visit(Syntax(leftOperand)).as(ExprSyntax.self)!,
-      op: visit(Syntax(middleExpr)).as(ExprSyntax.self)!,
-      rhs: visit(Syntax(rightOperand)).as(ExprSyntax.self)!
+      lhs: visit(leftOperand),
+      op: visit(middleExpr),
+      rhs: visit(rightOperand)
     )
   }
 }
@@ -86,7 +86,7 @@ extension OperatorTable {
 
     // Parse and "fold" the parenthesized version.
     let parenthesizedParsed = Parser.parse(source: fullyParenthesizedSource)
-    let parenthesizedSyntax = ExplicitParenFolder().visit(parenthesizedParsed)
+    let parenthesizedSyntax = ExplicitParenFolder(viewMode: .sourceAccurate).visit(parenthesizedParsed)
     XCTAssertFalse(parenthesizedSyntax.containsExprSequence)
 
     // Make sure the two have the same structure.

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -286,6 +286,8 @@ class FixItApplier: SyntaxRewriter {
         }
       }
       .flatMap { $0.changes }
+
+    super.init(viewMode: .all)
   }
 
   public override func visitAny(_ node: Syntax) -> Syntax? {
@@ -319,7 +321,7 @@ class FixItApplier: SyntaxRewriter {
   /// If `messages` is not `nil`, applies only Fix-Its whose message is in `messages`.
   public static func applyFixes<T: SyntaxProtocol>(in diagnostics: [Diagnostic], withMessages messages: [String]?, to tree: T) -> Syntax {
     let applier = FixItApplier(diagnostics: diagnostics, withMessages: messages)
-    return applier.visit(Syntax(tree))
+    return applier.rewrite(tree)
   }
 }
 
@@ -477,6 +479,8 @@ class TokenPresenceFlipper: SyntaxRewriter {
 
   init(flipTokenAtIndex: Int) {
     self.flipTokenAtIndex = flipTokenAtIndex
+
+    super.init(viewMode: .all)
   }
 
   override func visit(_ token: TokenSyntax) -> TokenSyntax {
@@ -723,8 +727,8 @@ func assertBasicFormat<S: SyntaxProtocol>(
   line: UInt = #line
 ) {
   var parser = Parser(source)
-  let sourceTree = Syntax(parse(&parser))
-  let withoutTrivia = TriviaRemover().visit(sourceTree)
+  let sourceTree = parse(&parser)
+  let withoutTrivia = TriviaRemover(viewMode: .sourceAccurate).rewrite(sourceTree)
   let formatted = withoutTrivia.formatted()
 
   var formattedParser = Parser(formatted.description)

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -235,7 +235,7 @@ final class StringInterpolationTests: XCTestCase {
         return DeclSyntax(newFunc)
       }
     }
-    let rewrittenSourceFile = Rewriter().visit(sourceFile)
+    let rewrittenSourceFile = Rewriter(viewMode: .sourceAccurate).visit(sourceFile)
     XCTAssertEqual(
       rewrittenSourceFile.description,
       """

--- a/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
@@ -14,14 +14,6 @@ import _SwiftSyntaxTestSupport
 import SwiftSyntax
 import XCTest
 
-fileprivate class FuncRenamer: SyntaxRewriter {
-  override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
-    let rewritten = super.visit(node).as(FunctionDeclSyntax.self)!
-    let modifiedFunctionDecl = rewritten.with(\.identifier, .identifier("anotherName"))
-    return DeclSyntax(modifiedFunctionDecl)
-  }
-}
-
 public class AbsolutePositionTests: XCTestCase {
   public func testRecursion() {
     var l = [CodeBlockItemSyntax]()

--- a/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
@@ -158,7 +158,7 @@ public class SyntaxVisitorTests: XCTestCase {
     let closure = ClosureExprSyntax(
       statements: CodeBlockItemListSyntax([])
     )
-    let rewriter = ClosureRewriter()
+    let rewriter = ClosureRewriter(viewMode: .sourceAccurate)
     let rewritten = rewriter.visit(closure)
     XCTAssertEqual(closure.description, rewritten.description)
   }
@@ -168,6 +168,7 @@ public class SyntaxVisitorTests: XCTestCase {
       let transform: (TokenSyntax) -> TokenSyntax
       init(transform: @escaping (TokenSyntax) -> TokenSyntax) {
         self.transform = transform
+        super.init(viewMode: .sourceAccurate)
       }
       override func visitAny(_ node: Syntax) -> Syntax? {
         if let tok = node.as(TokenSyntax.self) {
@@ -235,7 +236,7 @@ public class SyntaxVisitorTests: XCTestCase {
       ])
     )
     XCTAssertEqual(source.description, "let a = 5")
-    let visitor = TriviaRemover()
+    let visitor = TriviaRemover(viewMode: .sourceAccurate)
     let rewritten = visitor.visit(source)
     XCTAssertEqual(rewritten.description, "leta=5")
   }

--- a/Tests/SwiftSyntaxTest/VisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTests.swift
@@ -142,8 +142,8 @@ public class VisitorTests: XCTestCase {
       }
 
       static func print<Tree: SyntaxProtocol>(_ tree: Tree, viewMode: SyntaxTreeViewMode) -> String {
-        let printer = TreePrinter(viewMode: viewMode)
-        printer.walk(tree)
+        let printer = RewritingTreePrinter(viewMode: viewMode)
+        _ = printer.rewrite(Syntax(tree))
         return printer.out
       }
     }


### PR DESCRIPTION
* **Explanation**: Updates BasicFormat to not format unexpected nodes, which has been a constant source of new issues for swift-syntax. Also included here is Kim's patch to use HEAD For CodeGeneration + re-running it (there were a number of conflicts in the generated code and re-running codegen is far simpler than trying to fix them).
* **Scope**: Macro expansion formatting
* **Risk**: Low
* **Testing**: Added a test case for the unexpected case
* **Original PR**: https://github.com/apple/swift-syntax/pull/1759