### PR TITLE
Add support for Musl libc

### DIFF
--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -15,6 +15,8 @@
 @_implementationOnly import Darwin
 #elseif canImport(Glibc)
 @_implementationOnly import Glibc
+#elseif canImport(Musl)
+@_implementationOnly import Musl
 #endif
 #endif
 

--- a/Sources/swift-parser-cli/TerminalUtils.swift
+++ b/Sources/swift-parser-cli/TerminalUtils.swift
@@ -12,6 +12,8 @@
 
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 #else


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires a different import, which now should be applied to files that have `import Glibc` in them.