### PR TITLE
[5.9] Generate grammar doc comments for layout nodes

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Generates grammar doc comments for syntax nodes.
+struct GrammarGenerator {
+  private func grammar(for tokenChoice: TokenChoice) -> String {
+    switch tokenChoice {
+    case .keyword(text: let text):
+      return "`'\(text)'`"
+    case .token(tokenKind: let tokenKind):
+      let token = SYNTAX_TOKEN_MAP[tokenKind]!
+      if let tokenText = token.text {
+        return "`'\(tokenText)'`"
+      } else {
+        return "`<\(token.swiftKind)>`"
+      }
+    }
+  }
+
+  private func grammar(for child: Child) -> String {
+    let optionality = child.isOptional ? "?" : ""
+    switch child.kind {
+    case .node(let kind):
+      return "``\(kind)Syntax``\(optionality)"
+    case .nodeChoices(let choices):
+      let choicesDescriptions = choices.map { grammar(for: $0) }
+      return "(\(choicesDescriptions.joined(separator: " | ")))\(optionality)"
+    case .collection(let kind, _):
+      return "``\(kind)Syntax``"
+    case .token(let choices, _, _):
+      if choices.count == 1 {
+        return "\(grammar(for: choices.first!))\(optionality)"
+      } else {
+        let choicesDescriptions = choices.map { grammar(for: $0) }
+        return "(\(choicesDescriptions.joined(separator: " | ")))\(optionality)"
+      }
+    }
+  }
+
+  /// Generates a markdown list containing the children’s names and their
+  /// grammar.
+  ///
+  /// - Parameter children: The children to show in the list
+  static func childrenList(for children: [Child]) -> String {
+    let generator = GrammarGenerator()
+    return
+      children
+      .filter { !$0.isUnexpectedNodes }
+      .map { " - `\($0.swiftName)`: \(generator.grammar(for: $0))" }
+      .joined(separator: "\n")
+  }
+}

--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -87,6 +87,21 @@ public class Node {
     }
   }
 
+  public var grammar: String {
+    guard !children.isEmpty else {
+      return ""
+    }
+
+    return """
+    ### Children
+
+    \(GrammarGenerator.childrenList(for: children))
+    """
+    .split(separator: "\n", omittingEmptySubsequences: false)
+    .map { "/// \($0)" }
+    .joined(separator: "\n")
+  }
+
   init(
     name: String,
     nameForDiagnostics: String?,

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -41,6 +41,8 @@ func syntaxNode(emitKind: String) -> SourceFileSyntax {
         // MARK: - \(raw: node.name)
 
         \(raw: nodeDoc ?? "")
+        \(raw: node.documentation.isEmpty ? "" : "///")
+        \(raw: node.grammar)
         public struct \(raw: node.name): \(raw: node.baseType.syntaxBaseName)Protocol, SyntaxHashable
         """
       ) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -15,6 +15,16 @@
 // MARK: - AccessorDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifier`: ``DeclModifierSyntax``?
+///  - `accessorKind`: (`'get'` | `'set'` | `'didSet'` | `'willSet'` | `'unsafeAddress'` | `'addressWithOwner'` | `'addressWithNativeOwner'` | `'unsafeMutableAddress'` | `'mutableAddressWithOwner'` | `'mutableAddressWithNativeOwner'` | `'_read'` | `'_modify'` | `'init'`)
+///  - `parameter`: ``AccessorParameterSyntax``?
+///  - `effectSpecifiers`: ``AccessorEffectSpecifiersSyntax``?
+///  - `initEffects`: ``AccessorInitEffectsSyntax``?
+///  - `body`: ``CodeBlockSyntax``?
 public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -280,6 +290,17 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - ActorDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `actorKeyword`: `'actor'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -590,6 +611,16 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - AssociatedtypeDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `associatedtypeKeyword`: `'associatedtype'`
+///  - `identifier`: `<identifier>`
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `initializer`: ``TypeInitializerClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -874,6 +905,17 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - ClassDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `classKeyword`: `'class'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1184,6 +1226,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - DeinitializerDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `deinitKeyword`: `'deinit'`
+///  - `body`: ``CodeBlockSyntax``?
 public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1390,6 +1439,12 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - EditorPlaceholderDeclSyntax
 
 /// An editor placeholder, e.g. `<#declaration#>` that is used in a position that expects a declaration.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `placeholder`: `<identifier>`
 public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1573,6 +1628,13 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - EnumCaseDeclSyntax
 
 /// A `case` declaration of a Swift `enum`. It can have 1 or more `EnumCaseElement`s inside, each declaring a different case of the enum.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `caseKeyword`: `'case'`
+///  - `elements`: ``EnumCaseElementListSyntax``
 public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1802,6 +1864,17 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - EnumDeclSyntax
 
 /// A Swift `enum` declaration.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `enumKeyword`: `'enum'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameters`: ``GenericParameterClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2120,6 +2193,16 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - ExtensionDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `extensionKeyword`: `'extension'`
+///  - `extendedType`: ``TypeSyntax``
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2404,6 +2487,17 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `funcKeyword`: `'func'`
+///  - `identifier`: (`<identifier>` | `<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `signature`: ``FunctionSignatureSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `body`: ``CodeBlockSyntax``?
 public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2714,6 +2808,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - IfConfigDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `clauses`: ``IfConfigClauseListSyntax``
+///  - `poundEndif`: `'#endif'`
 public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2849,6 +2948,14 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - ImportDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `importTok`: `'import'`
+///  - `importKind`: (`'typealias'` | `'struct'` | `'class'` | `'enum'` | `'protocol'` | `'var'` | `'let'` | `'func'` | `'inout'`)?
+///  - `path`: ``AccessPathSyntax``
 public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3107,6 +3214,17 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ```
 /// 
 /// The body is optional because this node also represents initializer requirements inside protocols.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `initKeyword`: `'init'`
+///  - `optionalMark`: (`'?'` | `'?'` | `'!'`)?
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `signature`: ``FunctionSignatureSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `body`: ``CodeBlockSyntax``?
 public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3425,6 +3543,17 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - MacroDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `macroKeyword`: `'macro'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `signature`: ``FunctionSignatureSyntax``
+///  - `definition`: ``InitializerClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3735,6 +3864,19 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - MacroExpansionDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `poundToken`: `'#'`
+///  - `macro`: `<identifier>`
+///  - `genericArguments`: ``GenericArgumentClauseSyntax``?
+///  - `leftParen`: `'('`?
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`?
+///  - `trailingClosure`: ``ClosureExprSyntax``?
+///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
 public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4136,6 +4278,12 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingDeclSyntax
 
 /// In case the source code is missing a declaration, this node stands in place of the missing declaration.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `placeholder`: `<identifier>`
 public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4319,6 +4467,14 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - OperatorDeclSyntax
 
 /// A Swift `operator` declaration.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `operatorKeyword`: `'operator'`
+///  - `identifier`: (`<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
+///  - `operatorPrecedenceAndTypes`: ``OperatorPrecedenceAndTypesSyntax``?
 public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4554,6 +4710,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - PoundSourceLocationSyntax
 
 
+
+/// ### Children
+/// 
+///  - `poundSourceLocation`: `'#sourceLocation'`
+///  - `leftParen`: `'('`
+///  - `args`: ``PoundSourceLocationArgsSyntax``?
+///  - `rightParen`: `')'`
 public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4722,6 +4885,16 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - PrecedenceGroupDeclSyntax
 
 /// A Swift `precedencegroup` declaration.
+///
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `precedencegroupKeyword`: `'precedencegroup'`
+///  - `identifier`: `<identifier>`
+///  - `leftBrace`: `'{'`
+///  - `groupAttributes`: ``PrecedenceGroupAttributeListSyntax``
+///  - `rightBrace`: `'}'`
 public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5029,6 +5202,17 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - ProtocolDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `protocolKeyword`: `'protocol'`
+///  - `identifier`: `<identifier>`
+///  - `primaryAssociatedTypeClause`: ``PrimaryAssociatedTypeClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5339,6 +5523,17 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - StructDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `structKeyword`: `'struct'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `inheritanceClause`: ``TypeInheritanceClauseSyntax``?
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `memberBlock`: ``MemberDeclBlockSyntax``
 public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5649,6 +5844,17 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - SubscriptDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `subscriptKeyword`: `'subscript'`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `indices`: ``ParameterClauseSyntax``
+///  - `result`: ``ReturnClauseSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `accessor`: (``AccessorBlockSyntax`` | ``CodeBlockSyntax``)?
 public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public enum Accessor: SyntaxChildChoices {
     case `accessors`(AccessorBlockSyntax)
@@ -6001,6 +6207,16 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - TypealiasDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `typealiasKeyword`: `'typealias'`
+///  - `identifier`: `<identifier>`
+///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
+///  - `initializer`: ``TypeInitializerClauseSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6285,6 +6501,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 // MARK: - VariableDeclSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `bindingKeyword`: (`'let'` | `'var'` | `'inout'`)
+///  - `bindings`: ``PatternBindingListSyntax``
 public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -15,6 +15,12 @@
 // MARK: - ArrayExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquare`: `'['`
+///  - `elements`: ``ArrayElementListSyntax``
+///  - `rightSquare`: `']'`
 public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -176,6 +182,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - ArrowExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `effectSpecifiers`: ``TypeEffectSpecifiersSyntax``?
+///  - `arrowToken`: `'->'`
 public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -292,6 +303,13 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - AsExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `asTok`: `'as'`
+///  - `questionOrExclamationMark`: (`'?'` | `'!'`)?
+///  - `typeName`: ``TypeSyntax``
 public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -460,6 +478,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - AssignmentExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `assignToken`: `'='`
 public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -538,6 +560,11 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - AwaitExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `awaitKeyword`: `'await'`
+///  - `expression`: ``ExprSyntax``
 public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -654,6 +681,10 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - BinaryOperatorExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `operatorToken`: `<binaryOperator>`
 public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -732,6 +763,10 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - BooleanLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `booleanLiteral`: (`'true'` | `'false'`)
 public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -810,6 +845,11 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - BorrowExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `borrowKeyword`: `'_borrow'`
+///  - `expression`: ``ExprSyntax``
 public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -926,6 +966,13 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBrace`: `'{'`
+///  - `signature`: ``ClosureSignatureSyntax``?
+///  - `statements`: ``CodeBlockItemListSyntax``
+///  - `rightBrace`: `'}'`
 public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1113,6 +1160,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - CopyExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `copyKeyword`: `'copy'`
+///  - `expression`: ``ExprSyntax``
 public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1229,6 +1281,12 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - DictionaryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquare`: `'['`
+///  - `content`: (`':'` | ``DictionaryElementListSyntax``)
+///  - `rightSquare`: `']'`
 public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public enum Content: SyntaxChildChoices {
     case `colon`(TokenSyntax)
@@ -1413,6 +1471,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - DiscardAssignmentExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `wildcard`: `'_'`
 public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1491,6 +1553,10 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - EditorPlaceholderExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `identifier`: `<identifier>`
 public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1569,6 +1635,10 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - FloatLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `floatingDigits`: `<floatingLiteral>`
 public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1647,6 +1717,11 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - ForcedValueExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `exclamationMark`: `'!'`
 public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1763,6 +1838,15 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionCallExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `calledExpression`: ``ExprSyntax``
+///  - `leftParen`: `'('`?
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`?
+///  - `trailingClosure`: ``ClosureExprSyntax``?
+///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
 public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2021,6 +2105,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - IdentifierExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `identifier`: (`<identifier>` | `<keyword>` | `<dollarIdentifier>` | `<binaryOperator>`)
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
 public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2137,6 +2226,14 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - IfExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `ifKeyword`: `'if'`
+///  - `conditions`: ``ConditionElementListSyntax``
+///  - `body`: ``CodeBlockSyntax``
+///  - `elseKeyword`: ``ElseTokenSyntax``?
+///  - `elseBody`: (``IfExprSyntax`` | ``CodeBlockSyntax``)?
 public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public enum ElseBody: SyntaxChildChoices {
     case `ifExpr`(IfExprSyntax)
@@ -2392,6 +2489,11 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - InOutExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `ampersand`: `'&'`
+///  - `expression`: ``ExprSyntax``
 public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2508,6 +2610,12 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - InfixOperatorExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftOperand`: ``ExprSyntax``
+///  - `operatorOperand`: ``ExprSyntax``
+///  - `rightOperand`: ``ExprSyntax``
 public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2650,6 +2758,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - IntegerLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `digits`: `<integerLiteral>`
 public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2728,6 +2840,12 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - IsExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `isTok`: `'is'`
+///  - `typeName`: ``TypeSyntax``
 public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2870,6 +2988,12 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `backslash`: `'\'`
+///  - `root`: ``TypeSyntax``?
+///  - `components`: ``KeyPathComponentListSyntax``
 public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3066,6 +3190,17 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - MacroExpansionExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `poundToken`: `'#'`
+///  - `macro`: `<identifier>`
+///  - `genericArguments`: ``GenericArgumentClauseSyntax``?
+///  - `leftParen`: `'('`?
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`?
+///  - `trailingClosure`: ``ClosureExprSyntax``?
+///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
 public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3377,6 +3512,13 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - MemberAccessExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `base`: ``ExprSyntax``?
+///  - `dot`: `'.'`
+///  - `name`: ``TokenSyntax``
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
 public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3584,6 +3726,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingExprSyntax
 
 /// In case the source code is missing a expression, this node stands in place of the missing expression.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3663,6 +3809,11 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - MoveExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `moveKeyword`: (`'_move'` | `'consume'`)
+///  - `expression`: ``ExprSyntax``
 public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3779,6 +3930,10 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - NilLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `nilKeyword`: `'nil'`
 public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3857,6 +4012,11 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - OptionalChainingExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `questionMark`: `'?'`
 public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3973,6 +4133,11 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PackElementExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `eachKeyword`: `'each'`
+///  - `packRefExpr`: ``ExprSyntax``
 public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4089,6 +4254,11 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PackExpansionExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `repeatKeyword`: `'repeat'`
+///  - `patternExpr`: ``ExprSyntax``
 public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4205,6 +4375,11 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PostfixIfConfigExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `base`: ``ExprSyntax``?
+///  - `config`: ``IfConfigDeclSyntax``
 public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4352,6 +4527,11 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PostfixUnaryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `operatorToken`: `<postfixOperator>`
 public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4468,6 +4648,11 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - PrefixOperatorExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `operatorToken`: `<prefixOperator>`?
+///  - `postfixExpression`: ``ExprSyntax``
 public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4584,6 +4769,14 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - RegexLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `openingPounds`: `<extendedRegexDelimiter>`?
+///  - `openSlash`: `'/'`
+///  - `regexPattern`: `<regexLiteralPattern>`
+///  - `closeSlash`: `'/'`
+///  - `closingPounds`: `<extendedRegexDelimiter>`?
 public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4778,6 +4971,10 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SequenceExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `elements`: ``ExprListSyntax``
 public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4875,6 +5072,11 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SpecializeExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``
 public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4991,6 +5193,14 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - StringLiteralExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `openDelimiter`: `<rawStringDelimiter>`?
+///  - `openQuote`: (`'"'` | `'"""'` | `'''`)
+///  - `segments`: ``StringLiteralSegmentsSyntax``
+///  - `closeQuote`: (`'"'` | `'"""'` | `'''`)
+///  - `closeDelimiter`: `<rawStringDelimiter>`?
 public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5204,6 +5414,15 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SubscriptExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `calledExpression`: ``ExprSyntax``
+///  - `leftBracket`: `'['`
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightBracket`: `']'`
+///  - `trailingClosure`: ``ClosureExprSyntax``?
+///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
 public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5462,6 +5681,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SuperRefExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `superKeyword`: `'super'`
 public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5540,6 +5763,14 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - SwitchExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `switchKeyword`: `'switch'`
+///  - `expression`: ``ExprSyntax``
+///  - `leftBrace`: `'{'`
+///  - `cases`: ``SwitchCaseListSyntax``
+///  - `rightBrace`: `'}'`
 public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5753,6 +5984,14 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - TernaryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `conditionExpression`: ``ExprSyntax``
+///  - `questionMark`: `'?'`
+///  - `firstChoice`: ``ExprSyntax``
+///  - `colonMark`: `':'`
+///  - `secondChoice`: ``ExprSyntax``
 public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5947,6 +6186,12 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - TryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `tryKeyword`: `'try'`
+///  - `questionOrExclamationMark`: (`'?'` | `'!'`)?
+///  - `expression`: ``ExprSyntax``
 public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6089,6 +6334,12 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - TupleExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `elementList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`
 public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6250,6 +6501,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - TypeExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `type`: ``TypeSyntax``
 public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6328,6 +6583,11 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - UnresolvedAsExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `asTok`: `'as'`
+///  - `questionOrExclamationMark`: (`'?'` | `'!'`)?
 public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6444,6 +6704,10 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - UnresolvedIsExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `isTok`: `'is'`
 public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6522,6 +6786,10 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - UnresolvedPatternExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `pattern`: ``PatternSyntax``
 public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6600,6 +6868,12 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 // MARK: - UnresolvedTernaryExprSyntax
 
 
+
+/// ### Children
+/// 
+///  - `questionMark`: `'?'`
+///  - `firstChoice`: ``ExprSyntax``
+///  - `colonMark`: `':'`
 public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -15,6 +15,11 @@
 // MARK: - AccessPathComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: (`<identifier>` | `<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
+///  - `trailingDot`: `'.'`?
 public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -131,6 +136,13 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AccessesEffectSyntax
 
 
+
+/// ### Children
+/// 
+///  - `accessesKeyword`: `'accesses'`
+///  - `leftParen`: `'('`
+///  - `propertyList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`
 public struct AccessesEffectSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -318,6 +330,12 @@ public struct AccessesEffectSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AccessorBlockSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBrace`: `'{'`
+///  - `accessors`: ``AccessorListSyntax``
+///  - `rightBrace`: `'}'`
 public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -479,6 +497,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AccessorEffectSpecifiersSyntax
 
 
+
+/// ### Children
+/// 
+///  - `asyncSpecifier`: `'async'`?
+///  - `throwsSpecifier`: `'throws'`?
 public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -595,6 +618,11 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AccessorInitEffectsSyntax
 
 
+
+/// ### Children
+/// 
+///  - `initializesEffect`: ``InitializesEffectSyntax``?
+///  - `accessesEffect`: ``AccessesEffectSyntax``?
 public struct AccessorInitEffectsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -711,6 +739,12 @@ public struct AccessorInitEffectsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AccessorParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `name`: `<identifier>`
+///  - `rightParen`: `')'`
 public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -853,6 +887,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ArrayElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `trailingComma`: `','`?
 public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -969,6 +1008,14 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AttributeSyntax
 
 /// An `@` attribute.
+///
+/// ### Children
+/// 
+///  - `atSignToken`: `'@'`
+///  - `attributeName`: ``TypeSyntax``
+///  - `leftParen`: `'('`?
+///  - `argument`: (``TupleExprElementListSyntax`` | ``TokenSyntax`` | ``StringLiteralExprSyntax`` | ``AvailabilitySpecListSyntax`` | ``SpecializeAttributeSpecListSyntax`` | ``ObjCSelectorSyntax`` | ``ImplementsAttributeArgumentsSyntax`` | ``DifferentiableAttributeArgumentsSyntax`` | ``DerivativeRegistrationAttributeArgumentsSyntax`` | ``BackDeployedAttributeSpecListSyntax`` | ``ConventionAttributeArgumentsSyntax`` | ``ConventionWitnessMethodAttributeArgumentsSyntax`` | ``OpaqueReturnTypeOfAttributeArgumentsSyntax`` | ``ExposeAttributeArgumentsSyntax`` | ``OriginallyDefinedInArgumentsSyntax`` | ``UnderscorePrivateAttributeArgumentsSyntax`` | ``DynamicReplacementArgumentsSyntax`` | ``UnavailableFromAsyncArgumentsSyntax`` | ``EffectsArgumentsSyntax`` | ``DocumentationAttributeArgumentsSyntax``)?
+///  - `rightParen`: `')'`?
 public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Argument: SyntaxChildChoices {
     case `argumentList`(TupleExprElementListSyntax)
@@ -1429,6 +1476,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AvailabilityArgumentSyntax
 
 /// A single argument to an `@available` argument like `*`, `iOS 10.1`, or `message: "This has been deprecated"`.
+///
+/// ### Children
+/// 
+///  - `entry`: ((`<binaryOperator>` | `<identifier>`) | ``AvailabilityVersionRestrictionSyntax`` | ``AvailabilityLabeledArgumentSyntax``)
+///  - `trailingComma`: `','`?
 public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Entry: SyntaxChildChoices {
     case `token`(TokenSyntax)
@@ -1600,6 +1652,13 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AvailabilityConditionSyntax
 
 
+
+/// ### Children
+/// 
+///  - `availabilityKeyword`: (`'#available'` | `'#unavailable'`)
+///  - `leftParen`: `'('`
+///  - `availabilitySpec`: ``AvailabilitySpecListSyntax``
+///  - `rightParen`: `')'`
 public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1787,6 +1846,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AvailabilityEntrySyntax
 
 /// The availability argument for the _specialize attribute
+///
+/// ### Children
+/// 
+///  - `label`: `'availability'`
+///  - `colon`: `':'`
+///  - `availabilityList`: ``AvailabilitySpecListSyntax``
+///  - `semicolon`: `';'`
 public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1976,6 +2042,12 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - AvailabilityLabeledArgumentSyntax
 
 /// A argument to an `@available` attribute that consists of a label and a value, e.g. `message: "This has been deprecated"`.
+///
+/// ### Children
+/// 
+///  - `label`: (`'message'` | `'renamed'` | `'introduced'` | `'obsoleted'` | `'deprecated'`)
+///  - `colon`: `':'`
+///  - `value`: (``StringLiteralExprSyntax`` | ``VersionTupleSyntax``)
 public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Value: SyntaxChildChoices {
     case `string`(StringLiteralExprSyntax)
@@ -2163,6 +2235,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 // MARK: - AvailabilityVersionRestrictionListEntrySyntax
 
 /// A single platform/version pair in an attribute, e.g. `iOS 10.1`.
+///
+/// ### Children
+/// 
+///  - `availabilityVersionRestriction`: ``AvailabilityVersionRestrictionSyntax``
+///  - `trailingComma`: `','`?
 public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2280,6 +2357,11 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
 // MARK: - AvailabilityVersionRestrictionSyntax
 
 /// An argument to `@available` that restricts the availability on a certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
+///
+/// ### Children
+/// 
+///  - `platform`: `<identifier>`
+///  - `version`: ``VersionTupleSyntax``?
 public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2397,6 +2479,12 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
 // MARK: - BackDeployedAttributeSpecListSyntax
 
 /// A collection of arguments for the `@backDeployed` attribute
+///
+/// ### Children
+/// 
+///  - `beforeLabel`: `'before'`
+///  - `colon`: `':'`
+///  - `versionList`: ``AvailabilityVersionRestrictionListSyntax``
 public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2561,6 +2649,12 @@ public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashabl
 // MARK: - CaseItemSyntax
 
 
+
+/// ### Children
+/// 
+///  - `pattern`: ``PatternSyntax``
+///  - `whereClause`: ``WhereClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2703,6 +2797,12 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CatchClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `catchKeyword`: `'catch'`
+///  - `catchItems`: ``CatchItemListSyntax``
+///  - `body`: ``CodeBlockSyntax``
 public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2864,6 +2964,12 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CatchItemSyntax
 
 
+
+/// ### Children
+/// 
+///  - `pattern`: ``PatternSyntax``?
+///  - `whereClause`: ``WhereClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3041,6 +3147,13 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureCaptureItemSpecifierSyntax
 
 
+
+/// ### Children
+/// 
+///  - `specifier`: (`'weak'` | `'unowned'`)
+///  - `leftParen`: `'('`?
+///  - `detail`: (`'safe'` | `'unsafe'`)?
+///  - `rightParen`: `')'`?
 public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3209,6 +3322,14 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
 // MARK: - ClosureCaptureItemSyntax
 
 
+
+/// ### Children
+/// 
+///  - `specifier`: ``ClosureCaptureItemSpecifierSyntax``?
+///  - `name`: `<identifier>`?
+///  - `assignToken`: `'='`?
+///  - `expression`: ``ExprSyntax``
+///  - `trailingComma`: `','`?
 public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3403,6 +3524,12 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureCaptureSignatureSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquare`: `'['`
+///  - `items`: ``ClosureCaptureItemListSyntax``
+///  - `rightSquare`: `']'`
 public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3564,6 +3691,11 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureParamSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: (`<identifier>` | `'_'`)
+///  - `trailingComma`: `','`?
 public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3680,6 +3812,12 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureParameterClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `parameterList`: ``ClosureParameterListSyntax``
+///  - `rightParen`: `')'`
 public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -3844,6 +3982,17 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `firstName`: (`<identifier>` | `'_'`)
+///  - `secondName`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`?
+///  - `type`: ``TypeSyntax``?
+///  - `ellipsis`: `'...'`?
+///  - `trailingComma`: `','`?
 public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4215,6 +4364,15 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ClosureSignatureSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `capture`: ``ClosureCaptureSignatureSyntax``?
+///  - `input`: (``ClosureParamListSyntax`` | ``ClosureParameterClauseSyntax``)?
+///  - `effectSpecifiers`: ``TypeEffectSpecifiersSyntax``?
+///  - `output`: ``ReturnClauseSyntax``?
+///  - `inTok`: `'in'`
 public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Input: SyntaxChildChoices {
     case `simpleInput`(ClosureParamListSyntax)
@@ -4496,6 +4654,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CodeBlockItemSyntax
 
 /// A CodeBlockItem is any Syntax node that appears on its own line inside a CodeBlock.
+///
+/// ### Children
+/// 
+///  - `item`: (``DeclSyntax`` | ``StmtSyntax`` | ``ExprSyntax``)
+///  - `semicolon`: `';'`?
 public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Item: SyntaxChildChoices {
     case `decl`(DeclSyntax)
@@ -4667,6 +4830,12 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CodeBlockSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBrace`: `'{'`
+///  - `statements`: ``CodeBlockItemListSyntax``
+///  - `rightBrace`: `'}'`
 public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4828,6 +4997,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - CompositionTypeElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `type`: ``TypeSyntax``
+///  - `ampersand`: ``TokenSyntax``?
 public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4944,6 +5118,11 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ConditionElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `condition`: (``ExprSyntax`` | ``AvailabilityConditionSyntax`` | ``MatchingPatternConditionSyntax`` | ``OptionalBindingConditionSyntax``)
+///  - `trailingComma`: `','`?
 public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Condition: SyntaxChildChoices {
     case `expression`(ExprSyntax)
@@ -5129,6 +5308,12 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ConformanceRequirementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftTypeIdentifier`: ``TypeSyntax``
+///  - `colon`: `':'`
+///  - `rightTypeIdentifier`: ``TypeSyntax``
 public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5271,6 +5456,14 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ConventionAttributeArgumentsSyntax
 
 /// The arguments for the '@convention(...)'.
+///
+/// ### Children
+/// 
+///  - `conventionLabel`: `<identifier>`
+///  - `comma`: `','`?
+///  - `cTypeLabel`: `'cType'`?
+///  - `colon`: `':'`?
+///  - `cTypeString`: ``StringLiteralExprSyntax``?
 public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5466,6 +5659,12 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 // MARK: - ConventionWitnessMethodAttributeArgumentsSyntax
 
 /// The arguments for the '@convention(witness_method: ...)'.
+///
+/// ### Children
+/// 
+///  - `witnessMethodLabel`: `'witness_method'`
+///  - `colon`: `':'`
+///  - `protocolName`: `<identifier>`
 public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5608,6 +5807,12 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
 // MARK: - DeclModifierDetailSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `detail`: `<identifier>`
+///  - `rightParen`: `')'`
 public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5750,6 +5955,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DeclModifierSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: (`'__consuming'` | `'__setter_access'` | `'_const'` | `'_local'` | `'actor'` | `'async'` | `'borrowing'` | `'class'` | `'consuming'` | `'convenience'` | `'distributed'` | `'dynamic'` | `'fileprivate'` | `'final'` | `'indirect'` | `'infix'` | `'internal'` | `'isolated'` | `'lazy'` | `'mutating'` | `'nonisolated'` | `'nonmutating'` | `'open'` | `'optional'` | `'override'` | `'package'` | `'postfix'` | `'prefix'` | `'private'` | `'public'` | `'reasync'` | `'required'` | `'setter_access'` | `'static'` | `'unowned'` | `'weak'`)
+///  - `detail`: ``DeclModifierDetailSyntax``?
 public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5866,6 +6076,11 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DeclNameArgumentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: ``TokenSyntax``
+///  - `colon`: `':'`
 public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -5982,6 +6197,12 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DeclNameArgumentsSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `arguments`: ``DeclNameArgumentListSyntax``
+///  - `rightParen`: `')'`
 public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6143,6 +6364,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DeclNameSyntax
 
 
+
+/// ### Children
+/// 
+///  - `declBaseName`: (`<identifier>` | `<binaryOperator>` | `'init'` | `'self'` | `'Self'`)
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
 public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6261,6 +6487,16 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DerivativeRegistrationAttributeArgumentsSyntax
 
 /// The arguments for the '@derivative(of:)' and '@transpose(of:)' attributes: the 'of:' label, the original declaration name, and an optional differentiability parameter list.
+///
+/// ### Children
+/// 
+///  - `ofLabel`: `'of'`
+///  - `colon`: `':'`
+///  - `originalDeclName`: ``QualifiedDeclNameSyntax``
+///  - `period`: `'.'`?
+///  - `accessorKind`: (`'get'` | `'set'`)?
+///  - `comma`: `','`?
+///  - `diffParams`: ``DifferentiabilityParamsClauseSyntax``?
 public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6512,6 +6748,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
 // MARK: - DesignatedTypeElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leadingComma`: `','`
+///  - `name`: ``TokenSyntax``
 public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6628,6 +6869,13 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DictionaryElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `keyExpression`: ``ExprSyntax``
+///  - `colon`: `':'`
+///  - `valueExpression`: ``ExprSyntax``
+///  - `trailingComma`: `','`?
 public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6796,6 +7044,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DifferentiabilityParamSyntax
 
 /// A differentiability parameter: either the "self" identifier, a function parameter name, or a function parameter index.
+///
+/// ### Children
+/// 
+///  - `parameter`: (`<identifier>` | `<integerLiteral>` | `<keyword>`)
+///  - `trailingComma`: `','`?
 public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -6912,6 +7165,12 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DifferentiabilityParamsClauseSyntax
 
 /// A clause containing differentiability parameters.
+///
+/// ### Children
+/// 
+///  - `wrtLabel`: `'wrt'`
+///  - `colon`: `':'`
+///  - `parameters`: (``DifferentiabilityParamSyntax`` | ``DifferentiabilityParamsSyntax``)
 public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Parameters: SyntaxChildChoices {
     case `parameter`(DifferentiabilityParamSyntax)
@@ -7098,6 +7357,12 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
 // MARK: - DifferentiabilityParamsSyntax
 
 /// The differentiability parameters.
+///
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `diffParams`: ``DifferentiabilityParamListSyntax``
+///  - `rightParen`: `')'`
 public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -7260,6 +7525,14 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - DifferentiableAttributeArgumentsSyntax
 
 /// The arguments for the `@differentiable` attribute: an optional differentiability kind, an optional differentiability parameter clause, and an optional 'where' clause.
+///
+/// ### Children
+/// 
+///  - `diffKind`: (`'_forward'` | `'reverse'` | `'_linear'`)?
+///  - `diffKindComma`: `','`?
+///  - `diffParams`: ``DifferentiabilityParamsClauseSyntax``?
+///  - `diffParamsComma`: `','`?
+///  - `whereClause`: ``GenericWhereClauseSyntax``?
 public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -7456,6 +7729,13 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
 // MARK: - DocumentationAttributeArgumentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `label`: (`'visibility'` | `'metadata'`)
+///  - `colon`: `':'`
+///  - `value`: ((`<identifier>` | `<keyword>`) | ``StringLiteralExprSyntax``)
+///  - `trailingComma`: `','`?
 public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Value: SyntaxChildChoices {
     case `token`(TokenSyntax)
@@ -7667,6 +7947,12 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
 // MARK: - DynamicReplacementArgumentsSyntax
 
 /// The arguments for the '@_dynamicReplacement' attribute
+///
+/// ### Children
+/// 
+///  - `forLabel`: `'for'`
+///  - `colon`: `':'`
+///  - `declname`: ``DeclNameSyntax``
 public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -7809,6 +8095,13 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
 // MARK: - EnumCaseElementSyntax
 
 /// An element of an enum case, containing the name of the case and, optionally, either associated values or an assignment to a raw value.
+///
+/// ### Children
+/// 
+///  - `identifier`: `<identifier>`
+///  - `associatedValue`: ``EnumCaseParameterClauseSyntax``?
+///  - `rawValue`: ``InitializerClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -7981,6 +8274,12 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - EnumCaseParameterClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `parameterList`: ``EnumCaseParameterListSyntax``
+///  - `rightParen`: `')'`
 public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8145,6 +8444,16 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - EnumCaseParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `firstName`: (`<identifier>` | `'_'`)?
+///  - `secondName`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`?
+///  - `type`: ``TypeSyntax``
+///  - `defaultArgument`: ``InitializerClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8414,6 +8723,12 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ExposeAttributeArgumentsSyntax
 
 /// The arguments for the '@_expose' attribute
+///
+/// ### Children
+/// 
+///  - `language`: ``TokenSyntax``
+///  - `comma`: `','`?
+///  - `cxxName`: ``StringLiteralExprSyntax``?
 public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8556,6 +8871,14 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ExpressionSegmentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `backslash`: `'\'`
+///  - `delimiter`: `<rawStringDelimiter>`?
+///  - `leftParen`: `'('`
+///  - `expressions`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`
 public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8769,6 +9092,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionEffectSpecifiersSyntax
 
 
+
+/// ### Children
+/// 
+///  - `asyncSpecifier`: (`'async'` | `'reasync'`)?
+///  - `throwsSpecifier`: (`'throws'` | `'rethrows'`)?
 public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -8885,6 +9213,18 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `modifiers`: ``ModifierListSyntax``
+///  - `firstName`: (`<identifier>` | `'_'`)
+///  - `secondName`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`
+///  - `type`: ``TypeSyntax``
+///  - `ellipsis`: `'...'`?
+///  - `defaultArgument`: ``InitializerClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9221,6 +9561,12 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionSignatureSyntax
 
 
+
+/// ### Children
+/// 
+///  - `input`: ``ParameterClauseSyntax``
+///  - `effectSpecifiers`: ``FunctionEffectSpecifiersSyntax``?
+///  - `output`: ``ReturnClauseSyntax``?
 public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9363,6 +9709,12 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericArgumentClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftAngleBracket`: `'<'`
+///  - `arguments`: ``GenericArgumentListSyntax``
+///  - `rightAngleBracket`: `'>'`
 public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9524,6 +9876,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericArgumentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `argumentType`: ``TypeSyntax``
+///  - `trailingComma`: `','`?
 public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9640,6 +9997,13 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericParameterClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftAngleBracket`: `'<'`
+///  - `genericParameterList`: ``GenericParameterListSyntax``
+///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
+///  - `rightAngleBracket`: `'>'`
 public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -9827,6 +10191,15 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericParameterSyntax
 
 
+
+/// ### Children
+/// 
+///  - `attributes`: ``AttributeListSyntax``
+///  - `each`: `'each'`?
+///  - `name`: `<identifier>`
+///  - `colon`: `':'`?
+///  - `inheritedType`: ``TypeSyntax``?
+///  - `trailingComma`: `','`?
 public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -10113,6 +10486,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericRequirementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `body`: (``SameTypeRequirementSyntax`` | ``ConformanceRequirementSyntax`` | ``LayoutRequirementSyntax``)
+///  - `trailingComma`: `','`?
 public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Body: SyntaxChildChoices {
     case `sameTypeRequirement`(SameTypeRequirementSyntax)
@@ -10282,6 +10660,11 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - GenericWhereClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `whereKeyword`: `'where'`
+///  - `requirementList`: ``GenericRequirementListSyntax``
 public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -10417,6 +10800,12 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - IfConfigClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `poundKeyword`: (`'#if'` | `'#elseif'` | `'#else'`)
+///  - `condition`: ``ExprSyntax``?
+///  - `elements`: (``CodeBlockItemListSyntax`` | ``SwitchCaseListSyntax`` | ``MemberDeclListSyntax`` | ``ExprSyntax`` | ``AttributeListSyntax``)?
 public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Elements: SyntaxChildChoices {
     case `statements`(CodeBlockItemListSyntax)
@@ -10675,6 +11064,13 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ImplementsAttributeArgumentsSyntax
 
 /// The arguments for the `@_implements` attribute of the form `Type, methodName(arg1Label:arg2Label:)`
+///
+/// ### Children
+/// 
+///  - `type`: ``TypeSyntax``
+///  - `comma`: `','`
+///  - `declBaseName`: ``TokenSyntax``
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
 public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -10847,6 +11243,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 // MARK: - InheritedTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `typeName`: ``TypeSyntax``
+///  - `trailingComma`: `','`?
 public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -10963,6 +11364,11 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - InitializerClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `equal`: `'='`
+///  - `value`: ``ExprSyntax``
 public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11079,6 +11485,13 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - InitializesEffectSyntax
 
 
+
+/// ### Children
+/// 
+///  - `initializesKeyword`: `'initializes'`
+///  - `leftParen`: `'('`
+///  - `propertyList`: ``TupleExprElementListSyntax``
+///  - `rightParen`: `')'`
 public struct InitializesEffectSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11266,6 +11679,11 @@ public struct InitializesEffectSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `period`: `'.'`?
+///  - `component`: (``KeyPathPropertyComponentSyntax`` | ``KeyPathSubscriptComponentSyntax`` | ``KeyPathOptionalComponentSyntax``)
 public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Component: SyntaxChildChoices {
     case `property`(KeyPathPropertyComponentSyntax)
@@ -11435,6 +11853,10 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathOptionalComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `questionOrExclamationMark`: (`'?'` | `'!'`)
 public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11513,6 +11935,12 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathPropertyComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `identifier`: (`<identifier>` | `<keyword>` | `<dollarIdentifier>` | `<binaryOperator>` | `<integerLiteral>`)
+///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
+///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``?
 public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11655,6 +12083,12 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - KeyPathSubscriptComponentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBracket`: `'['`
+///  - `argumentList`: ``TupleExprElementListSyntax``
+///  - `rightBracket`: `']'`
 public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11816,6 +12250,13 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - LabeledSpecializeEntrySyntax
 
 /// A labeled argument for the `@_specialize` attribute like `exported: true`
+///
+/// ### Children
+/// 
+///  - `label`: ``TokenSyntax``
+///  - `colon`: `':'`
+///  - `value`: ``TokenSyntax``
+///  - `trailingComma`: `','`?
 public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -11988,6 +12429,17 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - LayoutRequirementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `typeIdentifier`: ``TypeSyntax``
+///  - `colon`: `':'`
+///  - `layoutConstraint`: (`'_Trivial'` | `'_TrivialAtMost'` | `'_UnknownLayout'` | `'_RefCountedObject'` | `'_NativeRefCountedObject'` | `'_Class'` | `'_NativeClass'`)
+///  - `leftParen`: `'('`?
+///  - `size`: `<integerLiteral>`?
+///  - `comma`: `','`?
+///  - `alignment`: `<integerLiteral>`?
+///  - `rightParen`: `')'`?
 public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12260,6 +12712,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MatchingPatternConditionSyntax
 
 
+
+/// ### Children
+/// 
+///  - `caseKeyword`: `'case'`
+///  - `pattern`: ``PatternSyntax``
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
+///  - `initializer`: ``InitializerClauseSyntax``
 public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12428,6 +12887,12 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MemberDeclBlockSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftBrace`: `'{'`
+///  - `members`: ``MemberDeclListSyntax``
+///  - `rightBrace`: `'}'`
 public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12589,6 +13054,11 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MemberDeclListItemSyntax
 
 /// A member declaration of a type consisting of a declaration and an optional semicolon;
+///
+/// ### Children
+/// 
+///  - `decl`: ``DeclSyntax``
+///  - `semicolon`: `';'`?
 public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12707,6 +13177,10 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MissingSyntax
 
 /// In case the source code is missing a syntax node, this node stands in place of the missing node.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12786,6 +13260,12 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - MultipleTrailingClosureElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `label`: (`<identifier>` | `'_'`)
+///  - `colon`: `':'`
+///  - `closure`: ``ClosureExprSyntax``
 public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -12928,6 +13408,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
 // MARK: - ObjCSelectorPieceSyntax
 
 /// A piece of an Objective-C selector. Either consisting of just an identifier for a nullary selector, an identifier and a colon for a labeled argument or just a colon for an unlabeled argument
+///
+/// ### Children
+/// 
+///  - `name`: ``TokenSyntax``?
+///  - `colon`: `':'`?
 public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13044,6 +13529,12 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - OpaqueReturnTypeOfAttributeArgumentsSyntax
 
 /// The arguments for the '@_opaqueReturnTypeOf()'.
+///
+/// ### Children
+/// 
+///  - `mangledName`: ``StringLiteralExprSyntax``
+///  - `comma`: `','`
+///  - `ordinal`: `<integerLiteral>`
 public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13188,6 +13679,12 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
 // MARK: - OperatorPrecedenceAndTypesSyntax
 
 /// A clause to specify precedence group in infix operator declarations, and designated types in any operator declaration.
+///
+/// ### Children
+/// 
+///  - `colon`: `':'`
+///  - `precedenceGroup`: `<identifier>`
+///  - `designatedTypes`: ``DesignatedTypeListSyntax``
 public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13351,6 +13848,13 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - OptionalBindingConditionSyntax
 
 
+
+/// ### Children
+/// 
+///  - `bindingKeyword`: (`'let'` | `'var'` | `'inout'`)
+///  - `pattern`: ``PatternSyntax``
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
+///  - `initializer`: ``InitializerClauseSyntax``?
 public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13519,6 +14023,14 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - OriginallyDefinedInArgumentsSyntax
 
 /// The arguments for the '@_originallyDefinedIn' attribute
+///
+/// ### Children
+/// 
+///  - `moduleLabel`: `'module'`
+///  - `colon`: `':'`
+///  - `moduleName`: ``StringLiteralExprSyntax``
+///  - `comma`: `','`
+///  - `platforms`: ``AvailabilityVersionRestrictionListSyntax``
 public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13732,6 +14244,12 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 // MARK: - ParameterClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `parameterList`: ``FunctionParameterListSyntax``
+///  - `rightParen`: `')'`
 public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -13893,6 +14411,14 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PatternBindingSyntax
 
 
+
+/// ### Children
+/// 
+///  - `pattern`: ``PatternSyntax``
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
+///  - `initializer`: ``InitializerClauseSyntax``?
+///  - `accessor`: (``AccessorBlockSyntax`` | ``CodeBlockSyntax``)?
+///  - `trailingComma`: `','`?
 public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Accessor: SyntaxChildChoices {
     case `accessors`(AccessorBlockSyntax)
@@ -14129,6 +14655,16 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PoundSourceLocationArgsSyntax
 
 
+
+/// ### Children
+/// 
+///  - `fileArgLabel`: `'file'`
+///  - `fileArgColon`: `':'`
+///  - `fileName`: ``StringLiteralExprSyntax``
+///  - `comma`: `','`
+///  - `lineArgLabel`: `'line'`
+///  - `lineArgColon`: `':'`
+///  - `lineNumber`: `<integerLiteral>`
 public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14375,6 +14911,12 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PrecedenceGroupAssignmentSyntax
 
 /// Specifies the precedence of an operator when used in an operation that includes optional chaining.
+///
+/// ### Children
+/// 
+///  - `assignmentKeyword`: `'assignment'`
+///  - `colon`: `':'`
+///  - `flag`: (`'true'` | `'false'`)
 public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14518,6 +15060,12 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PrecedenceGroupAssociativitySyntax
 
 /// Specifies how a sequence of operators with the same precedence level are grouped together in the absence of grouping parentheses.
+///
+/// ### Children
+/// 
+///  - `associativityKeyword`: `'associativity'`
+///  - `colon`: `':'`
+///  - `value`: (`'left'` | `'right'` | `'none'`)
 public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14661,6 +15209,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 // MARK: - PrecedenceGroupNameElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: `<identifier>`
+///  - `trailingComma`: `','`?
 public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14777,6 +15330,12 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PrecedenceGroupRelationSyntax
 
 /// Specify the new precedence group's relation to existing precedence groups.
+///
+/// ### Children
+/// 
+///  - `higherThanOrLowerThan`: (`'higherThan'` | `'lowerThan'`)
+///  - `colon`: `':'`
+///  - `otherNames`: ``PrecedenceGroupNameListSyntax``
 public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -14940,6 +15499,12 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - PrimaryAssociatedTypeClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftAngleBracket`: `'<'`
+///  - `primaryAssociatedTypeList`: ``PrimaryAssociatedTypeListSyntax``
+///  - `rightAngleBracket`: `'>'`
 public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15101,6 +15666,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
 // MARK: - PrimaryAssociatedTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: `<identifier>`
+///  - `trailingComma`: `','`?
 public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15217,6 +15787,13 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - QualifiedDeclNameSyntax
 
 /// An optionally qualified function declaration name (e.g. `+(_:_:)`, `A.B.C.foo(_:_:)`).
+///
+/// ### Children
+/// 
+///  - `baseType`: ``TypeSyntax``?
+///  - `dot`: `'.'`?
+///  - `name`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<binaryOperator>`)
+///  - `arguments`: ``DeclNameArgumentsSyntax``?
 public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15427,6 +16004,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - ReturnClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `arrow`: `'->'`
+///  - `returnType`: ``TypeSyntax``
 public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15543,6 +16125,12 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SameTypeRequirementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftTypeIdentifier`: ``TypeSyntax``
+///  - `equalityToken`: (`<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
+///  - `rightTypeIdentifier`: ``TypeSyntax``
 public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15685,6 +16273,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SourceFileSyntax
 
 
+
+/// ### Children
+/// 
+///  - `statements`: ``CodeBlockItemListSyntax``
+///  - `eofToken`: ``EOFTokenSyntax``
 public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15820,6 +16413,10 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - StringSegmentSyntax
 
 
+
+/// ### Children
+/// 
+///  - `content`: `<stringSegment>`
 public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15898,6 +16495,12 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SwitchCaseLabelSyntax
 
 
+
+/// ### Children
+/// 
+///  - `caseKeyword`: `'case'`
+///  - `caseItems`: ``CaseItemListSyntax``
+///  - `colon`: `':'`
 public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16059,6 +16662,12 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SwitchCaseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `unknownAttr`: ``AttributeSyntax``?
+///  - `label`: (``SwitchDefaultLabelSyntax`` | ``SwitchCaseLabelSyntax``)
+///  - `statements`: ``CodeBlockItemListSyntax``
 public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Label: SyntaxChildChoices {
     case `default`(SwitchDefaultLabelSyntax)
@@ -16262,6 +16871,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - SwitchDefaultLabelSyntax
 
 
+
+/// ### Children
+/// 
+///  - `defaultKeyword`: `'default'`
+///  - `colon`: `':'`
 public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16378,6 +16992,13 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TargetFunctionEntrySyntax
 
 /// A labeled argument for the `@_specialize` attribute with a function decl value like `target: myFunc(_:)`
+///
+/// ### Children
+/// 
+///  - `label`: `'target'`
+///  - `colon`: `':'`
+///  - `declname`: ``DeclNameSyntax``
+///  - `trailingComma`: `','`?
 public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16550,6 +17171,13 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TupleExprElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `label`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`?
+///  - `expression`: ``ExprSyntax``
+///  - `trailingComma`: `','`?
 public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16718,6 +17346,13 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TuplePatternElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `labelName`: `<identifier>`?
+///  - `labelColon`: `':'`?
+///  - `pattern`: ``PatternSyntax``
+///  - `trailingComma`: `','`?
 public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -16886,6 +17521,17 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TupleTypeElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `inOut`: ``InoutTokenSyntax``?
+///  - `name`: (`<identifier>` | `'_'`)?
+///  - `secondName`: (`<identifier>` | `'_'`)?
+///  - `colon`: `':'`?
+///  - `type`: ``TypeSyntax``
+///  - `ellipsis`: `'...'`?
+///  - `initializer`: ``InitializerClauseSyntax``?
+///  - `trailingComma`: `','`?
 public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17158,6 +17804,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TypeAnnotationSyntax
 
 
+
+/// ### Children
+/// 
+///  - `colon`: `':'`
+///  - `type`: ``TypeSyntax``
 public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17274,6 +17925,11 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TypeEffectSpecifiersSyntax
 
 
+
+/// ### Children
+/// 
+///  - `asyncSpecifier`: `'async'`?
+///  - `throwsSpecifier`: `'throws'`?
 public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17390,6 +18046,11 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TypeInheritanceClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `colon`: `':'`
+///  - `inheritedTypeCollection`: ``InheritedTypeListSyntax``
 public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17525,6 +18186,11 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - TypeInitializerClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `equal`: `'='`
+///  - `value`: ``TypeSyntax``
 public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17641,6 +18307,12 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - UnavailableFromAsyncArgumentsSyntax
 
 /// The arguments for the '@_unavailableFromAsync' attribute
+///
+/// ### Children
+/// 
+///  - `messageLabel`: `'message'`
+///  - `colon`: `':'`
+///  - `message`: ``StringLiteralExprSyntax``
 public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17783,6 +18455,12 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
 // MARK: - UnderscorePrivateAttributeArgumentsSyntax
 
 /// The arguments for the '@_private' attribute
+///
+/// ### Children
+/// 
+///  - `sourceFileLabel`: `'sourceFile'`
+///  - `colon`: `':'`
+///  - `filename`: ``StringLiteralExprSyntax``
 public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -17925,6 +18603,14 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
 // MARK: - VersionTupleSyntax
 
 /// A version number of the form major.minor.patch in which the minor and patch part may be omitted.
+///
+/// ### Children
+/// 
+///  - `major`: `<integerLiteral>`
+///  - `minorPeriod`: `'.'`?
+///  - `minor`: `<integerLiteral>`?
+///  - `patchPeriod`: `'.'`?
+///  - `patch`: `<integerLiteral>`?
 public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -18124,6 +18810,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - WhereClauseSyntax
 
 
+
+/// ### Children
+/// 
+///  - `whereKeyword`: `'where'`
+///  - `guardResult`: ``ExprSyntax``
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -18240,6 +18931,11 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - YieldExprListElementSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
+///  - `comma`: `','`?
 public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -18356,6 +19052,12 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
 // MARK: - YieldListSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `elementList`: ``YieldExprListSyntax``
+///  - `rightParen`: `')'`
 public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -15,6 +15,10 @@
 // MARK: - ExpressionPatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
 public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -93,6 +97,10 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - IdentifierPatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `identifier`: (`<identifier>` | `<keyword>`)
 public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -171,6 +179,11 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - IsTypePatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `isKeyword`: `'is'`
+///  - `type`: ``TypeSyntax``
 public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -287,6 +300,10 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingPatternSyntax
 
 /// In case the source code is missing a pattern, this node stands in place of the missing pattern.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -366,6 +383,12 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - TuplePatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `elements`: ``TuplePatternElementListSyntax``
+///  - `rightParen`: `')'`
 public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -527,6 +550,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - ValueBindingPatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `bindingKeyword`: (`'let'` | `'var'` | `'inout'`)
+///  - `valuePattern`: ``PatternSyntax``
 public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -643,6 +671,11 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 // MARK: - WildcardPatternSyntax
 
 
+
+/// ### Children
+/// 
+///  - `wildcard`: `'_'`
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
 public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -15,6 +15,11 @@
 // MARK: - BreakStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `breakKeyword`: `'break'`
+///  - `label`: `<identifier>`?
 public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -131,6 +136,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ContinueStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `continueKeyword`: `'continue'`
+///  - `label`: `<identifier>`?
 public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -247,6 +257,11 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - DeferStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `deferKeyword`: `'defer'`
+///  - `body`: ``CodeBlockSyntax``
 public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -363,6 +378,11 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - DiscardStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `discardKeyword`: (`'_forget'` | `'discard'`)
+///  - `expression`: ``ExprSyntax``
 public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -479,6 +499,12 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - DoStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `doKeyword`: `'do'`
+///  - `body`: ``CodeBlockSyntax``
+///  - `catchClauses`: ``CatchClauseListSyntax``
 public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -640,6 +666,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ExpressionStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `expression`: ``ExprSyntax``
 public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -718,6 +748,10 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - FallthroughStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `fallthroughKeyword`: `'fallthrough'`
 public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -796,6 +830,19 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ForInStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `forKeyword`: `'for'`
+///  - `tryKeyword`: `'try'`?
+///  - `awaitKeyword`: `'await'`?
+///  - `caseKeyword`: `'case'`?
+///  - `pattern`: ``PatternSyntax``
+///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
+///  - `inKeyword`: `'in'`
+///  - `sequenceExpr`: ``ExprSyntax``
+///  - `whereClause`: ``WhereClauseSyntax``?
+///  - `body`: ``CodeBlockSyntax``
 public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1120,6 +1167,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - GuardStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `guardKeyword`: `'guard'`
+///  - `conditions`: ``ConditionElementListSyntax``
+///  - `elseKeyword`: `'else'`
+///  - `body`: ``CodeBlockSyntax``
 public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1307,6 +1361,12 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - LabeledStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `labelName`: `<identifier>`
+///  - `labelColon`: `':'`
+///  - `statement`: ``StmtSyntax``
 public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1449,6 +1509,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingStmtSyntax
 
 /// In case the source code is missing a statement, this node stands in place of the missing statement.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1528,6 +1592,13 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - RepeatWhileStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `repeatKeyword`: `'repeat'`
+///  - `body`: ``CodeBlockSyntax``
+///  - `whileKeyword`: `'while'`
+///  - `condition`: ``ExprSyntax``
 public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1696,6 +1767,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ReturnStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `returnKeyword`: `'return'`
+///  - `expression`: ``ExprSyntax``?
 public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1843,6 +1919,11 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - ThrowStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `throwKeyword`: `'throw'`
+///  - `expression`: ``ExprSyntax``
 public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1959,6 +2040,12 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - WhileStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `whileKeyword`: `'while'`
+///  - `conditions`: ``ConditionElementListSyntax``
+///  - `body`: ``CodeBlockSyntax``
 public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2120,6 +2207,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 // MARK: - YieldStmtSyntax
 
 
+
+/// ### Children
+/// 
+///  - `yieldKeyword`: `'yield'`
+///  - `yields`: (``YieldListSyntax`` | ``ExprSyntax``)
 public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public enum Yields: SyntaxChildChoices {
     case `yieldList`(YieldListSyntax)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -15,6 +15,12 @@
 // MARK: - ArrayTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquareBracket`: `'['`
+///  - `elementType`: ``TypeSyntax``
+///  - `rightSquareBracket`: `']'`
 public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -157,6 +163,12 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - AttributedTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `specifier`: (`'inout'` | `'__shared'` | `'__owned'` | `'isolated'` | `'_const'` | `'borrowing'` | `'consuming'`)?
+///  - `attributes`: ``AttributeListSyntax``
+///  - `baseType`: ``TypeSyntax``
 public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -318,6 +330,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - ClassRestrictionTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `classKeyword`: `'class'`
 public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -396,6 +412,10 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - CompositionTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `elements`: ``CompositionTypeElementListSyntax``
 public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -493,6 +513,11 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - ConstrainedSugarTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `someOrAnySpecifier`: (`'some'` | `'any'`)
+///  - `baseType`: ``TypeSyntax``
 public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -609,6 +634,14 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - DictionaryTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftSquareBracket`: `'['`
+///  - `keyType`: ``TypeSyntax``
+///  - `colon`: `':'`
+///  - `valueType`: ``TypeSyntax``
+///  - `rightSquareBracket`: `']'`
 public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -803,6 +836,14 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - FunctionTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `arguments`: ``TupleTypeElementListSyntax``
+///  - `rightParen`: `')'`
+///  - `effectSpecifiers`: ``TypeEffectSpecifiersSyntax``?
+///  - `output`: ``ReturnClauseSyntax``
 public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1016,6 +1057,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - ImplicitlyUnwrappedOptionalTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `wrappedType`: ``TypeSyntax``
+///  - `exclamationMark`: `'!'`
 public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1132,6 +1178,13 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 // MARK: - MemberTypeIdentifierSyntax
 
 
+
+/// ### Children
+/// 
+///  - `baseType`: ``TypeSyntax``
+///  - `period`: `'.'`
+///  - `name`: (`<identifier>` | `<keyword>`)
+///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``?
 public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1300,6 +1353,12 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - MetatypeTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `baseType`: ``TypeSyntax``
+///  - `period`: `'.'`
+///  - `typeOrProtocol`: (`'Type'` | `'Protocol'`)
 public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1442,6 +1501,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - MissingTypeSyntax
 
 /// In case the source code is missing a type, this node stands in place of the missing type.
+///
+/// ### Children
+/// 
+///  - `placeholder`: `<identifier>`
 public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1521,6 +1584,11 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - NamedOpaqueReturnTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `genericParameters`: ``GenericParameterClauseSyntax``
+///  - `baseType`: ``TypeSyntax``
 public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1637,6 +1705,11 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - OptionalTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `wrappedType`: ``TypeSyntax``
+///  - `questionMark`: `'?'`
 public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1753,6 +1826,11 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - PackExpansionTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `repeatKeyword`: `'repeat'`
+///  - `patternType`: ``TypeSyntax``
 public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1869,6 +1947,11 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - PackReferenceTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `eachKeyword`: `'each'`
+///  - `packType`: ``TypeSyntax``
 public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1985,6 +2068,11 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - SimpleTypeIdentifierSyntax
 
 
+
+/// ### Children
+/// 
+///  - `name`: (`<identifier>` | `<keyword>` | `'_'`)
+///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``?
 public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2101,6 +2189,11 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - SuppressedTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `withoutTilde`: `<prefixOperator>`
+///  - `patternType`: ``TypeSyntax``
 public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2217,6 +2310,12 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 // MARK: - TupleTypeSyntax
 
 
+
+/// ### Children
+/// 
+///  - `leftParen`: `'('`
+///  - `elements`: ``TupleTypeElementListSyntax``
+///  - `rightParen`: `')'`
 public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   


### PR DESCRIPTION
* **Explanation**: Add a *Children* section to the doc comments of syntax nodes that allows you to see the children of the syntax node at a glance in the source order.
* **Scope**: Adding doc comments to syntax nodes
* **Risk**: Zero, only adds comments
* **Testing**: n/a
* **Issue**: n/a
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/1771