### PR TITLE
Rename TokenKind.eof to TokenKind.endOfFile

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -208,7 +208,7 @@ open class BasicFormat: SyntaxRewriter {
       (.backslash, _),
       (.backtick, _),
       (.dollarIdentifier, .period),  // a.b
-      (.eof, _),
+      (.endOfFile, _),
       (.exclamationMark, .leftParen),  // myOptionalClosure!()
       (.exclamationMark, .period),  // myOptionalBar!.foo()
       (.extendedRegexDelimiter, .leftParen),  // opening extended regex delimiter should never be separate by a space
@@ -254,7 +254,7 @@ open class BasicFormat: SyntaxRewriter {
       (.stringSegment, _),
       (_, .comma),
       (_, .ellipsis),
-      (_, .eof),
+      (_, .endOfFile),
       (_, .exclamationMark),
       (_, .postfixOperator),
       (_, .postfixQuestionMark),

--- a/Sources/SwiftParser/generated/IsLexerClassified.swift
+++ b/Sources/SwiftParser/generated/IsLexerClassified.swift
@@ -140,7 +140,7 @@ extension TokenKind {
   @_spi(Diagnostics) @_spi(Testing)
   public var isLexerClassifiedKeyword: Bool {
     switch self {
-    case .eof:
+    case .endOfFile:
       return false
     case .poundAvailableKeyword:
       return true

--- a/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
@@ -17,7 +17,7 @@
 extension TokenKind {
   var nameForDiagnostics: String {
     switch self {
-    case .eof:
+    case .endOfFile:
       return "end of file"
     case .arrow:
       return #"->"#

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -14,7 +14,7 @@
 
 /// Enumerates the kinds of tokens in the Swift language.
 public enum TokenKind: Hashable {
-  case eof
+  case endOfFile
   case arrow
   case atSign
   case backslash
@@ -164,7 +164,7 @@ public enum TokenKind: Hashable {
       return text
     case .wildcard:
       return #"_"#
-    case .eof:
+    case .endOfFile:
       return ""
     }
   }
@@ -245,7 +245,7 @@ public enum TokenKind: Hashable {
       return #"""#
     case .wildcard:
       return #"_"#
-    case .eof:
+    case .endOfFile:
       return ""
     default:
       return ""
@@ -259,7 +259,7 @@ public enum TokenKind: Hashable {
   /// quote characters in a string literal.
   public var isPunctuation: Bool {
     switch self {
-    case .eof:
+    case .endOfFile:
       return false
     case .arrow:
       return true
@@ -364,7 +364,7 @@ public enum TokenKind: Hashable {
 extension TokenKind: Equatable {
   public static func == (lhs: TokenKind, rhs: TokenKind) -> Bool {
     switch (lhs, rhs) {
-    case (.eof, .eof):
+    case (.endOfFile, .endOfFile):
       return true
     case (.arrow, .arrow):
       return true
@@ -720,7 +720,7 @@ extension TokenKind {
   public static func fromRaw(kind rawKind: RawTokenKind, text: String) -> TokenKind {
     switch rawKind {
     case .eof:
-      return .eof
+      return .endOfFile
     case .arrow:
       precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .arrow
@@ -863,7 +863,7 @@ extension TokenKind {
   @_spi(RawSyntax)
   public func decomposeToRaw() -> (rawKind: RawTokenKind, string: String?) {
     switch self {
-    case .eof:
+    case .endOfFile:
       return (.eof, nil)
     case .arrow:
       return (.arrow, nil)

--- a/Sources/SwiftSyntax/generated/Tokens.swift
+++ b/Sources/SwiftSyntax/generated/Tokens.swift
@@ -711,12 +711,12 @@ extension TokenSyntax {
     )
   }
   
-  public static func eof(
+  public static func endOfFile(
     leadingTrivia: Trivia = [],
     presence: SourcePresence = .present
   ) -> TokenSyntax {
     return TokenSyntax(
-      .eof,
+      .endOfFile,
       leadingTrivia: leadingTrivia,
       trailingTrivia: [],
       presence: presence

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2293,7 +2293,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawCodeBlockItemListSyntax.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.eof)]))
+    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.endOfFile)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   case .specializeAttributeSpecList:
     for (index, element) in layout.enumerated() {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -16327,7 +16327,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil,
       statements: CodeBlockItemListSyntax,
       _ unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? = nil,
-      eofToken: TokenSyntax = .eof(),
+      eofToken: TokenSyntax = .endOfFile(),
       _ unexpectedAfterEOFToken: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     

--- a/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
@@ -38,7 +38,7 @@ extension Trivia {
     self = trivia
     if pieces.contains(where: { $0.isUnexpected }) {
       var diagnostics: [Diagnostic] = []
-      let tree = SourceFileSyntax(statements: [], eofToken: .eof(leadingTrivia: self))
+      let tree = SourceFileSyntax(statements: [], eofToken: .endOfFile(leadingTrivia: self))
       var offset = 0
       for piece in pieces {
         if case .unexpectedText(let contents) = piece {

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -1222,7 +1222,7 @@ extension SourceFileSyntax {
       leadingTrivia: Trivia? = nil, 
       unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil, 
       unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? = nil, 
-      eofToken: TokenSyntax = .eof(), 
+      eofToken: TokenSyntax = .endOfFile(), 
       unexpectedAfterEOFToken: UnexpectedNodesSyntax? = nil, 
       @CodeBlockItemListBuilder statementsBuilder: () throws -> CodeBlockItemListSyntax, 
       trailingTrivia: Trivia? = nil

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -153,7 +153,7 @@ extension SyntaxProtocol {
       if case .keyword(let keyword) = tokenKind {
         tokenInitializerName = "keyword"
         tokenKindArgument = ExprSyntax(".\(raw: keyword)")
-      } else if tokenKind.isLexerClassifiedKeyword || tokenKind == .eof {
+      } else if tokenKind.isLexerClassifiedKeyword || tokenKind == .endOfFile {
         tokenInitializerName = String(describing: tokenKind)
         tokenKindArgument = nil
       } else if tokenKind.decomposeToRaw().rawKind.defaultText != nil {

--- a/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
@@ -49,7 +49,7 @@ final class HashbangLibraryTests: XCTestCase {
               )
             )
           ]),
-          eofToken: .eof()
+          eofToken: .endOfFile()
         )
       ),
       options: [.substructureCheckTrivia]

--- a/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
@@ -31,7 +31,7 @@ public class AbsolutePositionTests: XCTestCase {
     }
     let root = SourceFileSyntax(
       statements: CodeBlockItemListSyntax(l),
-      eofToken: .eof()
+      eofToken: .endOfFile()
     )
     _ = root.statements[idx].position
     _ = root.statements[idx].byteSize
@@ -67,7 +67,7 @@ public class AbsolutePositionTests: XCTestCase {
       )
     return SourceFileSyntax(
       statements: CodeBlockItemListSyntax(items),
-      eofToken: .eof()
+      eofToken: .endOfFile()
     )
   }
 

--- a/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
+++ b/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
@@ -195,7 +195,7 @@ public class DebugDescriptionTests: XCTestCase {
                         rightParen: .rightParenToken()
                       )))
               ]),
-          eofToken: .eof()
+          eofToken: .endOfFile()
         )
       """
     )
@@ -218,7 +218,7 @@ public class DebugDescriptionTests: XCTestCase {
                         rightParen: .rightParenToken()
                       )))
               ]),
-          eofToken: .eof()
+          eofToken: .endOfFile()
         )
       """
     )


### PR DESCRIPTION
Resolves https://github.com/apple/swift-syntax/issues/1837
rdar://111217077

This PR renames `TokenKind.eof` to `TokenKind.endOfFile` and `TokenSyntax.eof()` to `TokenSyntax.endOfFile()`