### PR TITLE
Rename eof to endOfFile

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -2033,7 +2033,7 @@ public let DECL_NODES: [Node] = [
     ]
   ),
 
-  // source-file = code-block-item-list eof
+  // source-file = code-block-item-list endOfFile
   Node(
     kind: .sourceFile,
     base: .syntax,
@@ -2048,7 +2048,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "EndOfFileToken",
         deprecatedName: "EOFToken",
-        kind: .token(choices: [.token(tokenKind: "EOFToken")])
+        kind: .token(choices: [.token(tokenKind: "EndOfFileToken")])
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
@@ -183,6 +183,7 @@ public let SYNTAX_TOKENS: [TokenSpec] = [
   PunctuatorSpec(name: "Comma", kind: "comma", text: ",", requiresTrailingSpace: true),
   MiscSpec(name: "DollarIdentifier", kind: "dollarident", nameForDiagnostics: "dollar identifier", classification: "DollarIdentifier"),
   PunctuatorSpec(name: "Ellipsis", kind: "ellipsis", text: "..."),
+  MiscSpec(name: "EndOfFile", kind: "eof", nameForDiagnostics: "end of file", text: ""),
   PunctuatorSpec(name: "Equal", kind: "equal", text: "=", requiresLeadingSpace: true, requiresTrailingSpace: true),
   PunctuatorSpec(name: "ExclamationMark", kind: "exclaim_postfix", text: "!"),
   MiscSpec(name: "ExtendedRegexDelimiter", kind: "extended_regex_delimiter", nameForDiagnostics: "extended delimiter", classification: "RegexLiteral"),
@@ -222,7 +223,6 @@ public let SYNTAX_TOKENS: [TokenSpec] = [
   MiscSpec(name: "StringSegment", kind: "string_segment", nameForDiagnostics: "string segment", classification: "StringLiteral"),
   MiscSpec(name: "Unknown", kind: "unknown", nameForDiagnostics: "token"),
   MiscSpec(name: "Wildcard", kind: "_", nameForDiagnostics: "wildcard", text: "_"),
-  MiscSpec(name: "EndOfFile", kind: "eof", nameForDiagnostics: "end of file", text: "")
 ]
 
 public let SYNTAX_TOKEN_MAP = Dictionary(

--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
@@ -222,10 +222,9 @@ public let SYNTAX_TOKENS: [TokenSpec] = [
   MiscSpec(name: "StringSegment", kind: "string_segment", nameForDiagnostics: "string segment", classification: "StringLiteral"),
   MiscSpec(name: "Unknown", kind: "unknown", nameForDiagnostics: "token"),
   MiscSpec(name: "Wildcard", kind: "_", nameForDiagnostics: "wildcard", text: "_"),
+  MiscSpec(name: "EndOfFile", kind: "eof", nameForDiagnostics: "end of file", text: "")
 ]
 
-// FIXME: Generate the EOF token as part of the normal SYNTAX_TOKENS and remove the special handling for it.
 public let SYNTAX_TOKEN_MAP = Dictionary(
-  uniqueKeysWithValues: (SYNTAX_TOKENS + [MiscSpec(name: "EOF", kind: "eof", nameForDiagnostics: "end of file", text: "")])
-    .map { ("\($0.name)Token", $0) }
+  uniqueKeysWithValues: SYNTAX_TOKENS.map { ("\($0.name)Token", $0) }
 )

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -74,9 +74,6 @@ public extension Child {
     if token.isKeyword {
       return InitializerClauseSyntax(value: ExprSyntax(".\(raw: token.swiftKind)()"))
     }
-    if token.name == "EOF" {
-      return InitializerClauseSyntax(value: ExprSyntax(".eof()"))
-    }
     if token.text != nil {
       return InitializerClauseSyntax(value: ExprSyntax(".\(raw: token.swiftKind)Token()"))
     }

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -68,8 +68,6 @@ public struct SyntaxBuildableType: Hashable {
       } else if token.text != nil {
         return ExprSyntax(".\(raw: lowercaseFirstWord(name: token.name))Token()")
       }
-    } else if case .token("EOFToken") = kind {
-      return ExprSyntax(".eof()")
     }
     return nil
   }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/ideutils/SyntaxClassificationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/ideutils/SyntaxClassificationFile.swift
@@ -77,12 +77,9 @@ let syntaxClassificationFile = SourceFileSyntax(leadingTrivia: copyrightHeader) 
             if let classification = token.classification {
               StmtSyntax("return .\(raw: classification.swiftName)")
             } else {
-              StmtSyntax("return .none)")
+              StmtSyntax("return .none")
             }
           }
-        }
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax("return .none")
         }
       }
     }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/IsLexerClassifiedFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/IsLexerClassifiedFile.swift
@@ -58,10 +58,6 @@ let isLexerClassifiedFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch self") {
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax("return false")
-        }
-
         for token in SYNTAX_TOKENS where token.isKeyword {
           SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
             StmtSyntax("return true")

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TokenSpecStaticMembersFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TokenSpecStaticMembersFile.swift
@@ -19,8 +19,6 @@ let tokenSpecStaticMembersFile = SourceFileSyntax(leadingTrivia: copyrightHeader
   DeclSyntax("@_spi(RawSyntax) import SwiftSyntax")
 
   try! ExtensionDeclSyntax("extension TokenSpec") {
-    DeclSyntax("static var eof: TokenSpec { return TokenSpec(.eof) }")
-
     for token in SYNTAX_TOKENS where token.swiftKind != "keyword" {
       DeclSyntax("static var \(raw: token.swiftKind): TokenSpec { return TokenSpec(.\(raw: token.swiftKind)) }")
     }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
@@ -21,10 +21,6 @@ let tokenNameForDiagnosticFile = SourceFileSyntax(leadingTrivia: copyrightHeader
   try! ExtensionDeclSyntax("extension TokenKind") {
     try! VariableDeclSyntax("var nameForDiagnostics: String") {
       try! SwitchExprSyntax("switch self") {
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax(#"return "end of file""#)
-        }
-
         for token in SYNTAX_TOKENS where token.swiftKind != "keyword" {
           SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
             StmtSyntax("return #\"\(raw: token.nameForDiagnostics)\"#")

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -22,8 +22,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     public enum TokenKind: Hashable
     """
   ) {
-    DeclSyntax("case eof")
-
     for token in SYNTAX_TOKENS {
       // Tokens that don't have a set text have an associated value that
       // contains their text.
@@ -59,10 +57,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           }
         }
-
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax(#"return """#)
-        }
       }
     }
 
@@ -85,10 +79,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           }
         }
-
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax(#"return """#)
-        }
+          
         SwitchCaseSyntax("default:") {
           StmtSyntax(#"return """#)
         }
@@ -106,10 +97,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try SwitchExprSyntax("switch self") {
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax("return false")
-        }
-
         for token in SYNTAX_TOKENS {
           SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
             StmtSyntax("return \(raw: type(of: token) == PunctuatorSpec.self)")
@@ -122,10 +109,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! ExtensionDeclSyntax("extension TokenKind: Equatable") {
     try FunctionDeclSyntax("public static func ==(lhs: TokenKind, rhs: TokenKind) -> Bool") {
       try SwitchExprSyntax("switch (lhs, rhs)") {
-        SwitchCaseSyntax("case (.eof, .eof):") {
-          StmtSyntax("return true")
-        }
-
         for token in SYNTAX_TOKENS {
           if token.text != nil {
             SwitchCaseSyntax("case (.\(raw: token.swiftKind), .\(raw: token.swiftKind)):") {
@@ -156,8 +139,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     public enum RawTokenKind: UInt8, Equatable, Hashable
     """
   ) {
-    DeclSyntax("case eof")
-
     for token in SYNTAX_TOKENS {
       DeclSyntax("case \(raw: token.swiftKind)")
     }
@@ -169,10 +150,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch self") {
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax(#"return """#)
-        }
-
         for token in SYNTAX_TOKENS {
           if let text = token.text {
             SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
@@ -198,10 +175,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch self") {
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax("return false")
-        }
-
         for token in SYNTAX_TOKENS {
           SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
             StmtSyntax("return \(raw: type(of: token) == PunctuatorSpec.self)")
@@ -220,10 +193,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch rawKind") {
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax("return .eof")
-        }
-
         for token in SYNTAX_TOKENS {
           if token.swiftKind == "keyword" {
             SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
@@ -259,10 +228,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch self") {
-        SwitchCaseSyntax("case .eof:") {
-          StmtSyntax("return (.eof, nil)")
-        }
-
         for token in SYNTAX_TOKENS {
           if token.swiftKind == "keyword" {
             SwitchCaseSyntax("case .\(raw: token.swiftKind)(let keyword):") {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -79,7 +79,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           }
         }
-          
+
         SwitchCaseSyntax("default:") {
           StmtSyntax(#"return """#)
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
@@ -90,21 +90,5 @@ let tokensFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         )
       }
     }
-
-    DeclSyntax(
-      """
-      public static func eof(
-        leadingTrivia: Trivia = [],
-        presence: SourcePresence = .present
-      ) -> TokenSyntax {
-        return TokenSyntax(
-          .eof,
-          leadingTrivia: leadingTrivia,
-          trailingTrivia: [],
-          presence: presence
-        )
-      }
-      """
-    )
   }
 }

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -236,6 +236,8 @@ class ValidateSyntaxNodes: XCTestCase {
           message: "child 'ClosingPounds' has a token as its only token choice and should thus be named 'ExtendedRegexDelimiter'"
             // There are the opening and closing ExtendedRegexDelimiter in the node
         ),
+        // We should explicitly mention token here because it’s not obvious that the end of a file is represented by a token
+        ValidationFailure(node: .sourceFile, message: "child 'EndOfFileToken' has a token as its only token choice and should thus be named 'EndOfFile'"),
         ValidationFailure(
           node: .stringLiteralExpr,
           message: "child 'OpenDelimiter' has a token as its only token choice and should thus be named 'RawStringDelimiter'"
@@ -281,11 +283,6 @@ class ValidateSyntaxNodes: XCTestCase {
         ValidationFailure(
           node: .importPathComponent,
           message: "child 'TrailingPeriod' has a token as its only token choice and should thus be named 'Period'"
-        ),
-        // We should explicitly mention token here because it’s not obvious that the end of a file is represented by a token
-        ValidationFailure(
-          node: .sourceFile,
-          message: "child 'EndOfFileToken' has a token as its only token choice and should thus be named 'EOF'"
         ),
         // `~` is the only operator that’s allowed here
         ValidationFailure(

--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -208,7 +208,7 @@ open class BasicFormat: SyntaxRewriter {
       (.backslash, _),
       (.backtick, _),
       (.dollarIdentifier, .period),  // a.b
-      (.eof, _),
+      (.endOfFile, _),
       (.exclamationMark, .leftParen),  // myOptionalClosure!()
       (.exclamationMark, .period),  // myOptionalBar!.foo()
       (.extendedRegexDelimiter, .leftParen),  // opening extended regex delimiter should never be separate by a space
@@ -254,7 +254,7 @@ open class BasicFormat: SyntaxRewriter {
       (.stringSegment, _),
       (_, .comma),
       (_, .ellipsis),
-      (_, .eof),
+      (_, .endOfFile),
       (_, .exclamationMark),
       (_, .postfixOperator),
       (_, .postfixQuestionMark),

--- a/Sources/SwiftIDEUtils/generated/SyntaxClassification.swift
+++ b/Sources/SwiftIDEUtils/generated/SyntaxClassification.swift
@@ -122,6 +122,8 @@ extension RawTokenKind {
       return .dollarIdentifier
     case .ellipsis:
       return .none
+    case .endOfFile:
+      return .none
     case .equal:
       return .none
     case .exclamationMark:
@@ -199,8 +201,6 @@ extension RawTokenKind {
     case .unknown:
       return .none
     case .wildcard:
-      return .none
-    case .endOfFile:
       return .none
     }
   }

--- a/Sources/SwiftIDEUtils/generated/SyntaxClassification.swift
+++ b/Sources/SwiftIDEUtils/generated/SyntaxClassification.swift
@@ -200,7 +200,7 @@ extension RawTokenKind {
       return .none
     case .wildcard:
       return .none
-    case .eof:
+    case .endOfFile:
       return .none
     }
   }

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -287,7 +287,7 @@ extension Parser {
         // The contents of the @_effects attribute are parsed in SIL, we just
         // represent the contents as a list of tokens in SwiftSyntax.
         var tokens: [RawTokenSyntax] = []
-        while !parser.at(.rightParen, .eof) {
+        while !parser.at(.rightParen, .endOfFile) {
           tokens.append(parser.consumeAnyToken())
         }
         return .effectsArguments(RawEffectsArgumentsSyntax(elements: tokens, arena: parser.arena))
@@ -453,7 +453,7 @@ extension Parser {
 
     var elements = [RawDifferentiabilityParamSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !self.at(.eof, .rightParen) && loopProgress.evaluate(currentToken) {
+    while !self.at(.endOfFile, .rightParen) && loopProgress.evaluate(currentToken) {
       guard let param = self.parseDifferentiabilityParameter() else {
         break
       }
@@ -676,7 +676,7 @@ extension Parser {
     var elements = [RawSpecializeAttributeSpecListSyntax.Element]()
     // Parse optional "exported" and "kind" labeled parameters.
     var loopProgress = LoopProgressCondition()
-    while !self.at(.eof, .rightParen, .keyword(.where)) && loopProgress.evaluate(currentToken) {
+    while !self.at(.endOfFile, .rightParen, .keyword(.where)) && loopProgress.evaluate(currentToken) {
       switch self.at(anyIn: SpecializeParameter.self) {
       case (.target, let handle)?:
         let ident = self.eat(handle)

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -85,7 +85,7 @@ extension TokenConsumer {
     }
 
     if hasAttribute {
-      if subparser.at(.rightBrace) || subparser.at(.eof) || subparser.at(.poundEndifKeyword) {
+      if subparser.at(.rightBrace) || subparser.at(.endOfFile) || subparser.at(.poundEndifKeyword) {
         return true
       }
     }
@@ -776,7 +776,7 @@ extension Parser {
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof, .rightBrace) && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightBrace) && loopProgress.evaluate(currentToken) {
         let newItemAtStartOfLine = self.currentToken.isAtStartOfLine
         guard let newElement = self.parseMemberDeclListItem() else {
           break
@@ -1539,7 +1539,7 @@ extension Parser {
     var elements = [RawAccessorDeclSyntax]()
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof, .rightBrace) && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightBrace) && loopProgress.evaluate(currentToken) {
         guard let introducer = self.parseAccessorIntroducer() else {
           // There can only be an implicit getter if no other accessors were
           // seen before this one.
@@ -1758,7 +1758,7 @@ extension Parser {
     var loopProgress = LoopProgressCondition()
     while (identifiersAfterOperatorName.last ?? name).trailingTriviaByteLength == 0,
       self.currentToken.leadingTriviaByteLength == 0,
-      !self.at(.colon, .leftBrace, .eof),
+      !self.at(.colon, .leftBrace, .endOfFile),
       loopProgress.evaluate(self.currentToken)
     {
       identifiersAfterOperatorName.append(consumeAnyToken())
@@ -1906,7 +1906,7 @@ extension Parser {
     var elements = [RawPrecedenceGroupAttributeListSyntax.Element]()
     do {
       var attributesProgress = LoopProgressCondition()
-      LOOP: while !self.at(.eof, .rightBrace) && attributesProgress.evaluate(currentToken) {
+      LOOP: while !self.at(.endOfFile, .rightBrace) && attributesProgress.evaluate(currentToken) {
         switch self.at(anyIn: LabelText.self) {
         case (.associativity, let handle)?:
           let associativity = self.eat(handle)

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -205,7 +205,7 @@ extension Parser {
   ) -> [Element] {
     var elements = [Element]()
     var elementsProgress = LoopProgressCondition()
-    while !self.at(.eof)
+    while !self.at(.endOfFile)
       && !self.at(.poundElseKeyword, .poundElseifKeyword, .poundEndifKeyword)
       && !self.atElifTypo()
       && elementsProgress.evaluate(currentToken)

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -924,7 +924,7 @@ extension Parser {
           var loopProgress = LoopProgressCondition()
           repeat {
             backtrack.eat(.poundIfKeyword)
-            while !backtrack.at(.eof) && !backtrack.currentToken.isAtStartOfLine {
+            while !backtrack.at(.endOfFile) && !backtrack.currentToken.isAtStartOfLine {
               backtrack.skipSingle()
             }
           } while backtrack.at(.poundIfKeyword) && loopProgress.evaluate(backtrack.currentToken)
@@ -1713,12 +1713,12 @@ extension Parser {
         // If we saw a comma, that's a strong indicator we have more elements
         // to process. If that's not the case, we have to do some legwork to
         // determine if we should bail out.
-        guard comma == nil || self.at(.rightSquare, .eof) else {
+        guard comma == nil || self.at(.rightSquare, .endOfFile) else {
           continue
         }
 
         // If we found EOF or the closing square bracket, bailout.
-        if self.at(.rightSquare, .eof) {
+        if self.at(.rightSquare, .endOfFile) {
           break
         }
 
@@ -1924,7 +1924,7 @@ extension Parser {
       }
       // We were promised a right square bracket, so we're going to get it.
       var unexpectedNodes = [RawSyntax]()
-      while !self.at(.eof) && !self.at(.rightSquare) && !self.at(.keyword(.in)) {
+      while !self.at(.endOfFile) && !self.at(.rightSquare) && !self.at(.keyword(.in)) {
         unexpectedNodes.append(RawSyntax(self.consumeAnyToken()))
       }
       let (unexpectedBeforeRSquare, rsquare) = self.expect(.rightSquare)
@@ -2230,7 +2230,7 @@ extension Parser.Lookahead {
     var backtrack = self.lookahead()
     backtrack.eat(.leftBrace)
     var loopProgress = LoopProgressCondition()
-    while !backtrack.at(.eof, .rightBrace)
+    while !backtrack.at(.endOfFile, .rightBrace)
       && !backtrack.at(.poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword)
       && loopProgress.evaluate(backtrack.currentToken)
     {
@@ -2383,7 +2383,7 @@ extension Parser {
   mutating func parseSwitchCases(allowStandaloneStmtRecovery: Bool) -> RawSwitchCaseListSyntax {
     var elements = [RawSwitchCaseListSyntax.Element]()
     var elementsProgress = LoopProgressCondition()
-    while !self.at(.eof, .rightBrace) && !self.at(.poundEndifKeyword, .poundElseifKeyword, .poundElseKeyword)
+    while !self.at(.endOfFile, .rightBrace) && !self.at(.poundEndifKeyword, .poundElseifKeyword, .poundElseKeyword)
       && elementsProgress.evaluate(currentToken)
     {
       if self.withLookahead({ $0.isAtStartOfSwitchCase(allowRecovery: false) }) {
@@ -2691,7 +2691,7 @@ extension Parser.Lookahead {
 
       // While we don't have '->' or ')', eat balanced tokens.
       var skipProgress = LoopProgressCondition()
-      while !lookahead.at(.eof, .rightParen) && skipProgress.evaluate(lookahead.currentToken) {
+      while !lookahead.at(.endOfFile, .rightParen) && skipProgress.evaluate(lookahead.currentToken) {
         lookahead.skipSingle()
       }
 

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -972,7 +972,7 @@ extension Lexer.Cursor {
     case UInt8(ascii: "`"):
       return self.lexEscapedIdentifier()
     case nil:
-      return Lexer.Result(.eof)
+      return Lexer.Result(.endOfFile)
     default:
       var tmp = self
       if tmp.advance(if: { Unicode.Scalar($0).isValidIdentifierStartCodePoint }) {
@@ -1000,7 +1000,7 @@ extension Lexer.Cursor {
     case UInt8(ascii: #"'"#), UInt8(ascii: #"""#):
       return self.lexStringQuote(isOpening: true, leadingDelimiterLength: delimiterLength)
     case nil:
-      return Lexer.Result(.eof)
+      return Lexer.Result(.endOfFile)
     default:
       preconditionFailure("state 'afterRawStringDelimiter' expects to be positioned at a quote")
     }
@@ -1011,7 +1011,7 @@ extension Lexer.Cursor {
     case UInt8(ascii: #"'"#), UInt8(ascii: #"""#):
       return self.lexStringQuote(isOpening: false, leadingDelimiterLength: 0)
     case nil:
-      return Lexer.Result(.eof)
+      return Lexer.Result(.endOfFile)
     default:
       preconditionFailure("state 'isAfterStringLiteral' expects to be positioned at a quote")
     }
@@ -1023,7 +1023,7 @@ extension Lexer.Cursor {
       self.advance(while: { $0 == Unicode.Scalar("#") })
       return Lexer.Result(.rawStringDelimiter, stateTransition: .pop)
     case nil:
-      return Lexer.Result(.eof)
+      return Lexer.Result(.endOfFile)
     default:
       preconditionFailure("state 'afterClosingStringQuote' expects to be positioned at a '#'")
     }
@@ -1045,7 +1045,7 @@ extension Lexer.Cursor {
       _ = self.advance()
       return Lexer.Result(.leftParen, stateTransition: .replace(newState: .inStringInterpolation(stringLiteralKind: stringLiteralKind, parenCount: 0)))
     case nil:
-      return Lexer.Result(.eof)
+      return Lexer.Result(.endOfFile)
     default:
       preconditionFailure("state 'afterBackslashOfStringInterpolation' expects to be positioned at '#' or '('")
     }
@@ -1884,7 +1884,7 @@ extension Lexer.Cursor {
   }
 
   mutating func lexInStringLiteral(stringLiteralKind: StringLiteralKind, delimiterLength: Int) -> Lexer.Result {
-    if self.isAtEndOfFile { return .init(.eof) }
+    if self.isAtEndOfFile { return .init(.endOfFile) }
 
     var error: LexingDiagnostic? = nil
 

--- a/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
+++ b/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
@@ -602,7 +602,7 @@ extension Lexer.Cursor {
       return true
 
     // Cannot lex at the end of the buffer.
-    case .eof:
+    case .endOfFile:
       return false
 
     // Prefix grammar that appears before an expression.

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -196,7 +196,7 @@ extension Parser.Lookahead {
       } while self.consume(if: .period) != nil
 
       if self.consume(if: .leftParen) != nil {
-        while !self.at(.eof, .rightParen, .poundEndifKeyword) {
+        while !self.at(.endOfFile, .rightParen, .poundEndifKeyword) {
           self.skipSingle()
         }
         self.consume(if: .rightParen)
@@ -291,7 +291,7 @@ extension Parser.Lookahead {
   }
 
   mutating func skipUntilEndOfLine() {
-    while !self.at(.eof) && !self.currentToken.isAtStartOfLine {
+    while !self.at(.endOfFile) && !self.currentToken.isAtStartOfLine {
       self.skipSingle()
     }
   }
@@ -393,7 +393,7 @@ extension Parser.Lookahead {
           return
         }
       case .skipUntil(let t1, let t2):
-        if !self.at(.eof, t1, t2) && !self.at(.poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword) {
+        if !self.at(.endOfFile, t1, t2) && !self.at(.poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword) {
           stack += [.skipUntil(t1, t2), .skipSingle]
         }
       }

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -115,7 +115,7 @@ extension Parser {
     var elements = [RawDeclNameArgumentSyntax]()
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof, .rightParen) && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightParen) && loopProgress.evaluate(currentToken) {
         // Check to see if there is an argument label.
         precondition(self.currentToken.canBeArgumentLabel() && self.peek().rawTokenKind == .colon)
         let name = self.consumeAnyToken()
@@ -240,7 +240,7 @@ extension Parser.Lookahead {
     }
 
     var loopProgress = LoopProgressCondition()
-    while !lookahead.at(.eof, .rightParen) && loopProgress.evaluate(lookahead.currentToken) {
+    while !lookahead.at(.endOfFile, .rightParen) && loopProgress.evaluate(lookahead.currentToken) {
       // Check to see if there is an argument label.
       guard lookahead.currentToken.canBeArgumentLabel() && lookahead.peek().rawTokenKind == .colon else {
         return false

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -376,7 +376,7 @@ extension Parser {
     return self.withLookahead {
       $0.consume(if: .leftParen)
       guard $0.canParseType() else { return false }
-      return $0.at(.rightParen, .keyword(.where), .leftBrace) || $0.at(.eof)
+      return $0.at(.rightParen, .keyword(.where), .leftBrace) || $0.at(.endOfFile)
     }
   }
 }

--- a/Sources/SwiftParser/Parameters.swift
+++ b/Sources/SwiftParser/Parameters.swift
@@ -284,7 +284,7 @@ extension Parser {
     if !shouldSkipParameterParsing {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof, .rightParen)
+      while !self.at(.endOfFile, .rightParen)
         && keepGoing
         && loopProgress.evaluate(currentToken)
       {

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -90,7 +90,7 @@ public struct Parser {
   var arena: ParsingSyntaxArena
   /// A view of the sequence of lexemes in the input.
   var lexemes: Lexer.LexemeSequence
-  /// The current token. If there was no input, this token will have a kind of `.eof`.
+  /// The current token. If there was no input, this token will have a kind of `.endOfFile`.
   var currentToken: Lexer.Lexeme
 
   /// The current nesting level, i.e. the number of tokens that

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -266,7 +266,7 @@ extension Parser {
 
     var unexpectedTokens = [RawTokenSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !self.at(.eof), !currentToken.isAtStartOfLine, loopProgress.evaluate(self.currentToken) {
+    while !self.at(.endOfFile), !currentToken.isAtStartOfLine, loopProgress.evaluate(self.currentToken) {
       unexpectedTokens += [self.consumeAnyToken()]
     }
 

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -215,7 +215,7 @@ extension Parser {
     do {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
         // If the tuple element has a label, parse it.
         let labelAndColon = self.consume(if: .identifier, followedBy: .colon)
         var (label, colon) = (labelAndColon?.0, labelAndColon?.1)

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -76,7 +76,7 @@ extension Parser.Lookahead {
     let recoveryPrecedence = min(spec1.recoveryPrecedence, spec2.recoveryPrecedence, spec3.recoveryPrecedence)
     let shouldSkipOverNewlines = recoveryPrecedence.shouldSkipOverNewlines && spec1.allowAtStartOfLine && spec2.allowAtStartOfLine && spec3.allowAtStartOfLine
 
-    while !self.at(.eof) {
+    while !self.at(.endOfFile) {
       if !shouldSkipOverNewlines, self.currentToken.isAtStartOfLine {
         break
       }
@@ -139,7 +139,7 @@ extension Parser.Lookahead {
         return $0.spec.recoveryPrecedence
       }).min()!
     var loopProgress = LoopProgressCondition()
-    while !self.at(.eof) && loopProgress.evaluate(self.currentToken) {
+    while !self.at(.endOfFile) && loopProgress.evaluate(self.currentToken) {
       if !recoveryPrecedence.shouldSkipOverNewlines,
         self.currentToken.isAtStartOfLine
       {

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -694,7 +694,7 @@ extension Parser {
       case poundEndifKeyword
       case poundElseKeyword
       case poundElseifKeyword
-      case eof
+      case endOfFile
 
       init?(lexeme: Lexer.Lexeme) {
         switch PrepareForKeywordMatch(lexeme) {
@@ -706,7 +706,7 @@ extension Parser {
         case TokenSpec(.poundEndifKeyword): self = .poundEndifKeyword
         case TokenSpec(.poundElseKeyword): self = .poundElseKeyword
         case TokenSpec(.poundElseifKeyword): self = .poundElseifKeyword
-        case TokenSpec(.eof): self = .eof
+        case TokenSpec(.endOfFile): self = .endOfFile
         default: return nil
         }
       }
@@ -721,7 +721,7 @@ extension Parser {
         case .poundEndifKeyword: return .poundEndifKeyword
         case .poundElseKeyword: return .poundElseKeyword
         case .poundElseifKeyword: return .poundElseifKeyword
-        case .eof: return .eof
+        case .endOfFile: return .endOfFile
         }
       }
     }
@@ -798,7 +798,7 @@ extension Parser {
         var keepGoing = true
         var elementList = [RawYieldExprListElementSyntax]()
         var loopProgress = LoopProgressCondition()
-        while !self.at(.eof, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
+        while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
           let expr = self.parseExpression()
           let comma = self.consume(if: .comma)
           elementList.append(

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -503,7 +503,7 @@ extension Parser {
         // This allows us to skip over extraneous identifiers etc. in an unterminated string interpolation.
         var unexpectedBeforeRightParen: [RawTokenSyntax] = []
         var unexpectedProgress = LoopProgressCondition()
-        while !self.at(.rightParen, .stringSegment, .backslash) && !self.at(TokenSpec(openQuoteKind), .eof) && unexpectedProgress.evaluate(self.currentToken) {
+        while !self.at(.rightParen, .stringSegment, .backslash) && !self.at(TokenSpec(openQuoteKind), .endOfFile) && unexpectedProgress.evaluate(self.currentToken) {
           unexpectedBeforeRightParen.append(self.consumeAnyToken())
         }
         // Consume the right paren if present, ensuring that it's on the same

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -503,7 +503,9 @@ extension Parser {
         // This allows us to skip over extraneous identifiers etc. in an unterminated string interpolation.
         var unexpectedBeforeRightParen: [RawTokenSyntax] = []
         var unexpectedProgress = LoopProgressCondition()
-        while !self.at(.rightParen, .stringSegment, .backslash) && !self.at(TokenSpec(openQuoteKind), .endOfFile) && unexpectedProgress.evaluate(self.currentToken) {
+        while !self.at(.rightParen, .stringSegment, .backslash) && !self.at(TokenSpec(openQuoteKind), .endOfFile)
+          && unexpectedProgress.evaluate(self.currentToken)
+        {
           unexpectedBeforeRightParen.append(self.consumeAnyToken())
         }
         // Consume the right paren if present, ensuring that it's on the same

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -169,7 +169,7 @@ enum TokenPrecedence: Comparable {
     .semicolon,
       // Arrow is a strong indicator in a function type that we are now in the return type
       .arrow,
-      // EOF is here because it is a very strong marker and doesn't belong anywhere else
+      // endOfFile is here because it is a very strong marker and doesn't belong anywhere else
       .endOfFile:
       self = .strongPunctuator
 

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -170,7 +170,7 @@ enum TokenPrecedence: Comparable {
       // Arrow is a strong indicator in a function type that we are now in the return type
       .arrow,
       // EOF is here because it is a very strong marker and doesn't belong anywhere else
-      .eof:
+      .endOfFile:
       self = .strongPunctuator
 
     // MARK: Strong bracket close

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -46,12 +46,12 @@ extension Parser {
   ///     source-file → top-level-declaration?
   mutating func parseSourceFile() -> RawSourceFileSyntax {
     let items = self.parseTopLevelCodeBlockItems()
-    let unexpectedBeforeEof = consumeRemainingTokens()
-    let eof = self.consume(if: .endOfFile)!
+    let unexpectedBeforeEndOfFileToken = consumeRemainingTokens()
+    let endOfFile = self.consume(if: .endOfFile)!
     return .init(
       statements: items,
-      RawUnexpectedNodesSyntax(unexpectedBeforeEof, arena: self.arena),
-      endOfFileToken: eof,
+      RawUnexpectedNodesSyntax(unexpectedBeforeEndOfFileToken, arena: self.arena),
+      endOfFileToken: endOfFile,
       arena: self.arena
     )
   }

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -16,7 +16,7 @@ extension Parser {
   /// Consumes and returns all remaining tokens in the source file.
   mutating func consumeRemainingTokens() -> [RawSyntax] {
     var extraneousTokens = [RawSyntax]()
-    while !self.at(.eof) {
+    while !self.at(.endOfFile) {
       extraneousTokens.append(RawSyntax(consumeAnyToken()))
     }
     return extraneousTokens
@@ -26,7 +26,7 @@ extension Parser {
   /// as unexpected nodes that have the `isMaximumNestingLevelOverflow` bit set.
   /// Check this in places that are likely to cause deep recursion and if this returns non-nil, abort parsing.
   mutating func remainingTokensIfMaximumNestingLevelReached() -> RawUnexpectedNodesSyntax? {
-    if nestingLevel > self.maximumNestingLevel && self.currentToken.rawTokenKind != .eof {
+    if nestingLevel > self.maximumNestingLevel && self.currentToken.rawTokenKind != .endOfFile {
       let remainingTokens = self.consumeRemainingTokens()
       return RawUnexpectedNodesSyntax(elements: remainingTokens, isMaximumNestingLevelOverflow: true, arena: self.arena)
     } else {
@@ -47,7 +47,7 @@ extension Parser {
   mutating func parseSourceFile() -> RawSourceFileSyntax {
     let items = self.parseTopLevelCodeBlockItems()
     let unexpectedBeforeEof = consumeRemainingTokens()
-    let eof = self.consume(if: .eof)!
+    let eof = self.consume(if: .endOfFile)!
     return .init(
       statements: items,
       RawUnexpectedNodesSyntax(unexpectedBeforeEof, arena: self.arena),

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -494,7 +494,7 @@ extension Parser {
     do {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
         let unexpectedBeforeFirst: RawUnexpectedNodesSyntax?
         let first: RawTokenSyntax?
         let unexpectedBeforeSecond: RawUnexpectedNodesSyntax?
@@ -825,7 +825,7 @@ extension Parser.Lookahead {
         // better if we skip over them.
         if self.consume(if: .equal) != nil {
           var skipProgress = LoopProgressCondition()
-          while !self.at(.eof)
+          while !self.at(.endOfFile)
             && !self.at(.rightParen, .rightBrace, .comma)
             && !self.atContextualPunctuator("...")
             && !self.atStartOfDeclaration()
@@ -1089,7 +1089,7 @@ extension Lexer.Lexeme {
       .period,
       .comma,
       .semicolon,
-      .eof,
+      .endOfFile,
       .exclamationMark,
       .postfixQuestionMark,
       .colon:

--- a/Sources/SwiftParser/generated/IsLexerClassified.swift
+++ b/Sources/SwiftParser/generated/IsLexerClassified.swift
@@ -140,8 +140,6 @@ extension TokenKind {
   @_spi(Diagnostics) @_spi(Testing)
   public var isLexerClassifiedKeyword: Bool {
     switch self {
-    case .eof:
-      return false
     case .poundAvailableKeyword:
       return true
     case .poundElseKeyword:

--- a/Sources/SwiftParser/generated/TokenSpecStaticMembers.swift
+++ b/Sources/SwiftParser/generated/TokenSpecStaticMembers.swift
@@ -15,10 +15,6 @@
 @_spi(RawSyntax) import SwiftSyntax
 
 extension TokenSpec {
-  static var eof: TokenSpec {
-    return TokenSpec(.eof)
-  }
-  
   static var arrow: TokenSpec {
     return TokenSpec(.arrow)
   }
@@ -205,6 +201,10 @@ extension TokenSpec {
   
   static var wildcard: TokenSpec {
     return TokenSpec(.wildcard)
+  }
+  
+  static var endOfFile: TokenSpec {
+    return TokenSpec(.endOfFile)
   }
   
   static func keyword(_ keyword: Keyword) -> TokenSpec {

--- a/Sources/SwiftParser/generated/TokenSpecStaticMembers.swift
+++ b/Sources/SwiftParser/generated/TokenSpecStaticMembers.swift
@@ -51,6 +51,10 @@ extension TokenSpec {
     return TokenSpec(.ellipsis)
   }
   
+  static var endOfFile: TokenSpec {
+    return TokenSpec(.endOfFile)
+  }
+  
   static var equal: TokenSpec {
     return TokenSpec(.equal)
   }
@@ -201,10 +205,6 @@ extension TokenSpec {
   
   static var wildcard: TokenSpec {
     return TokenSpec(.wildcard)
-  }
-  
-  static var endOfFile: TokenSpec {
-    return TokenSpec(.endOfFile)
   }
   
   static func keyword(_ keyword: Keyword) -> TokenSpec {

--- a/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
@@ -17,8 +17,6 @@
 extension TokenKind {
   var nameForDiagnostics: String {
     switch self {
-    case .eof:
-      return "end of file"
     case .arrow:
       return #"->"#
     case .atSign:
@@ -113,6 +111,8 @@ extension TokenKind {
       return #"token"#
     case .wildcard:
       return #"wildcard"#
+    case .endOfFile:
+      return #"end of file"#
     case .keyword(let keyword):
       return String(syntaxText: keyword.defaultText)
     }

--- a/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
@@ -35,6 +35,8 @@ extension TokenKind {
       return #"dollar identifier"#
     case .ellipsis:
       return #"..."#
+    case .endOfFile:
+      return #"end of file"#
     case .equal:
       return #"="#
     case .exclamationMark:
@@ -111,8 +113,6 @@ extension TokenKind {
       return #"token"#
     case .wildcard:
       return #"wildcard"#
-    case .endOfFile:
-      return #"end of file"#
     case .keyword(let keyword):
       return String(syntaxText: keyword.defaultText)
     }

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -51,7 +51,7 @@ public extension TokenKind {
   static var rightSquareBracket: TokenKind {
     return .rightSquare
   }
-  
+
   @available(*, deprecated, renamed: "endOfFile")
   static var eof: TokenKind { .endOfFile }
 }
@@ -82,7 +82,7 @@ public extension TokenSyntax {
       presence: presence
     )
   }
-    
+
   @available(*, deprecated, renamed: "endOfFileToken")
   static func eof(
     leadingTrivia: Trivia = [],

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -51,6 +51,9 @@ public extension TokenKind {
   static var rightSquareBracket: TokenKind {
     return .rightSquare
   }
+  
+  @available(*, deprecated, renamed: "endOfFile")
+  static var eof: TokenKind { .endOfFile }
 }
 
 public extension TokenSyntax {
@@ -74,6 +77,19 @@ public extension TokenSyntax {
     presence: SourcePresence = .present
   ) -> TokenSyntax {
     return .rightSquareToken(
+      leadingTrivia: leadingTrivia,
+      trailingTrivia: trailingTrivia,
+      presence: presence
+    )
+  }
+    
+  @available(*, deprecated, renamed: "endOfFileToken")
+  static func eof(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [],
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return .endOfFileToken(
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -3446,7 +3446,7 @@ extension SourceFileSyntax {
       _ unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil,
       statements: CodeBlockItemListSyntax,
       _ unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? = nil,
-      eofToken: TokenSyntax = .eof(),
+      eofToken: TokenSyntax = .endOfFileToken(),
       _ unexpectedAfterEOFToken: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -14,7 +14,6 @@
 
 /// Enumerates the kinds of tokens in the Swift language.
 public enum TokenKind: Hashable {
-  case eof
   case arrow
   case atSign
   case backslash
@@ -63,6 +62,7 @@ public enum TokenKind: Hashable {
   case stringSegment(String)
   case unknown(String)
   case wildcard
+  case endOfFile
   
   /// The textual representation of this token kind.
   @_spi(Testing)
@@ -164,8 +164,8 @@ public enum TokenKind: Hashable {
       return text
     case .wildcard:
       return #"_"#
-    case .eof:
-      return ""
+    case .endOfFile:
+      return #""#
     }
   }
   
@@ -245,8 +245,8 @@ public enum TokenKind: Hashable {
       return #"""#
     case .wildcard:
       return #"_"#
-    case .eof:
-      return ""
+    case .endOfFile:
+      return #""#
     default:
       return ""
     }
@@ -259,8 +259,6 @@ public enum TokenKind: Hashable {
   /// quote characters in a string literal.
   public var isPunctuation: Bool {
     switch self {
-    case .eof:
-      return false
     case .arrow:
       return true
     case .atSign:
@@ -357,6 +355,8 @@ public enum TokenKind: Hashable {
       return false
     case .wildcard:
       return false
+    case .endOfFile:
+      return false
     }
   }
 }
@@ -364,8 +364,6 @@ public enum TokenKind: Hashable {
 extension TokenKind: Equatable {
   public static func == (lhs: TokenKind, rhs: TokenKind) -> Bool {
     switch (lhs, rhs) {
-    case (.eof, .eof):
-      return true
     case (.arrow, .arrow):
       return true
     case (.atSign, .atSign):
@@ -462,6 +460,8 @@ extension TokenKind: Equatable {
       return lhsText == rhsText
     case (.wildcard, .wildcard):
       return true
+    case (.endOfFile, .endOfFile):
+      return true
     default:
       return false
     }
@@ -475,7 +475,6 @@ extension TokenKind: Equatable {
 @frozen // FIXME: Not actually stable, works around a miscompile
 @_spi(RawSyntax)
 public enum RawTokenKind: UInt8, Equatable, Hashable {
-  case eof
   case arrow
   case atSign
   case backslash
@@ -524,12 +523,11 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
   case stringSegment
   case unknown
   case wildcard
+  case endOfFile
   
   @_spi(RawSyntax)
   public var defaultText: SyntaxText? {
     switch self {
-    case .eof:
-      return ""
     case .arrow:
       return #"->"#
     case .atSign:
@@ -600,6 +598,8 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
       return #"""#
     case .wildcard:
       return #"_"#
+    case .endOfFile:
+      return #""#
     default:
       return nil
     }
@@ -612,8 +612,6 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
   /// quote characters in a string literal.
   public var isPunctuation: Bool {
     switch self {
-    case .eof:
-      return false
     case .arrow:
       return true
     case .atSign:
@@ -710,6 +708,8 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
       return false
     case .wildcard:
       return false
+    case .endOfFile:
+      return false
     }
   }
 }
@@ -719,8 +719,6 @@ extension TokenKind {
   @_spi(RawSyntax)
   public static func fromRaw(kind rawKind: RawTokenKind, text: String) -> TokenKind {
     switch rawKind {
-    case .eof:
-      return .eof
     case .arrow:
       precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .arrow
@@ -855,6 +853,9 @@ extension TokenKind {
     case .wildcard:
       precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .wildcard
+    case .endOfFile:
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      return .endOfFile
     }
   }
   
@@ -863,8 +864,6 @@ extension TokenKind {
   @_spi(RawSyntax)
   public func decomposeToRaw() -> (rawKind: RawTokenKind, string: String?) {
     switch self {
-    case .eof:
-      return (.eof, nil)
     case .arrow:
       return (.arrow, nil)
     case .atSign:
@@ -961,6 +960,8 @@ extension TokenKind {
       return (.unknown, str)
     case .wildcard:
       return (.wildcard, nil)
+    case .endOfFile:
+      return (.endOfFile, nil)
     }
   }
 }

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -23,6 +23,7 @@ public enum TokenKind: Hashable {
   case comma
   case dollarIdentifier(String)
   case ellipsis
+  case endOfFile
   case equal
   case exclamationMark
   case extendedRegexDelimiter(String)
@@ -62,7 +63,6 @@ public enum TokenKind: Hashable {
   case stringSegment(String)
   case unknown(String)
   case wildcard
-  case endOfFile
   
   /// The textual representation of this token kind.
   @_spi(Testing)
@@ -86,6 +86,8 @@ public enum TokenKind: Hashable {
       return text
     case .ellipsis:
       return #"..."#
+    case .endOfFile:
+      return #""#
     case .equal:
       return #"="#
     case .exclamationMark:
@@ -164,8 +166,6 @@ public enum TokenKind: Hashable {
       return text
     case .wildcard:
       return #"_"#
-    case .endOfFile:
-      return #""#
     }
   }
   
@@ -187,6 +187,8 @@ public enum TokenKind: Hashable {
       return #","#
     case .ellipsis:
       return #"..."#
+    case .endOfFile:
+      return #""#
     case .equal:
       return #"="#
     case .exclamationMark:
@@ -245,8 +247,6 @@ public enum TokenKind: Hashable {
       return #"""#
     case .wildcard:
       return #"_"#
-    case .endOfFile:
-      return #""#
     default:
       return ""
     }
@@ -277,6 +277,8 @@ public enum TokenKind: Hashable {
       return false
     case .ellipsis:
       return true
+    case .endOfFile:
+      return false
     case .equal:
       return true
     case .exclamationMark:
@@ -355,8 +357,6 @@ public enum TokenKind: Hashable {
       return false
     case .wildcard:
       return false
-    case .endOfFile:
-      return false
     }
   }
 }
@@ -381,6 +381,8 @@ extension TokenKind: Equatable {
     case (.dollarIdentifier(let lhsText), .dollarIdentifier(let rhsText)):
       return lhsText == rhsText
     case (.ellipsis, .ellipsis):
+      return true
+    case (.endOfFile, .endOfFile):
       return true
     case (.equal, .equal):
       return true
@@ -460,8 +462,6 @@ extension TokenKind: Equatable {
       return lhsText == rhsText
     case (.wildcard, .wildcard):
       return true
-    case (.endOfFile, .endOfFile):
-      return true
     default:
       return false
     }
@@ -484,6 +484,7 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
   case comma
   case dollarIdentifier
   case ellipsis
+  case endOfFile
   case equal
   case exclamationMark
   case extendedRegexDelimiter
@@ -523,7 +524,6 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
   case stringSegment
   case unknown
   case wildcard
-  case endOfFile
   
   @_spi(RawSyntax)
   public var defaultText: SyntaxText? {
@@ -542,6 +542,8 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
       return #","#
     case .ellipsis:
       return #"..."#
+    case .endOfFile:
+      return #""#
     case .equal:
       return #"="#
     case .exclamationMark:
@@ -598,8 +600,6 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
       return #"""#
     case .wildcard:
       return #"_"#
-    case .endOfFile:
-      return #""#
     default:
       return nil
     }
@@ -630,6 +630,8 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
       return false
     case .ellipsis:
       return true
+    case .endOfFile:
+      return false
     case .equal:
       return true
     case .exclamationMark:
@@ -708,8 +710,6 @@ public enum RawTokenKind: UInt8, Equatable, Hashable {
       return false
     case .wildcard:
       return false
-    case .endOfFile:
-      return false
     }
   }
 }
@@ -744,6 +744,9 @@ extension TokenKind {
     case .ellipsis:
       precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .ellipsis
+    case .endOfFile:
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      return .endOfFile
     case .equal:
       precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .equal
@@ -853,9 +856,6 @@ extension TokenKind {
     case .wildcard:
       precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .wildcard
-    case .endOfFile:
-      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
-      return .endOfFile
     }
   }
   
@@ -882,6 +882,8 @@ extension TokenKind {
       return (.dollarIdentifier, str)
     case .ellipsis:
       return (.ellipsis, nil)
+    case .endOfFile:
+      return (.endOfFile, nil)
     case .equal:
       return (.equal, nil)
     case .exclamationMark:
@@ -960,8 +962,6 @@ extension TokenKind {
       return (.unknown, str)
     case .wildcard:
       return (.wildcard, nil)
-    case .endOfFile:
-      return (.endOfFile, nil)
     }
   }
 }

--- a/Sources/SwiftSyntax/generated/Tokens.swift
+++ b/Sources/SwiftSyntax/generated/Tokens.swift
@@ -143,6 +143,20 @@ extension TokenSyntax {
     )
   }
   
+  public static func endOfFileToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [],
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .endOfFile,
+      leadingTrivia: leadingTrivia,
+      trailingTrivia: trailingTrivia,
+      presence: presence
+      
+    )
+  }
+  
   public static func equalToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
@@ -704,20 +718,6 @@ extension TokenSyntax {
   ) -> TokenSyntax {
     return TokenSyntax(
       .wildcard,
-      leadingTrivia: leadingTrivia,
-      trailingTrivia: trailingTrivia,
-      presence: presence
-      
-    )
-  }
-  
-  public static func endOfFileToken(
-    leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = [],
-    presence: SourcePresence = .present
-  ) -> TokenSyntax {
-    return TokenSyntax(
-      .endOfFile,
       leadingTrivia: leadingTrivia,
       trailingTrivia: trailingTrivia,
       presence: presence

--- a/Sources/SwiftSyntax/generated/Tokens.swift
+++ b/Sources/SwiftSyntax/generated/Tokens.swift
@@ -711,14 +711,15 @@ extension TokenSyntax {
     )
   }
   
-  public static func eof(
+  public static func endOfFileToken(
     leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
   ) -> TokenSyntax {
     return TokenSyntax(
-      .eof,
+      .endOfFile,
       leadingTrivia: leadingTrivia,
-      trailingTrivia: [],
+      trailingTrivia: trailingTrivia,
       presence: presence
       
     )

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2293,7 +2293,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawCodeBlockItemListSyntax.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.eof)]))
+    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.endOfFile)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   case .specializeAttributeSpecList:
     for (index, element) in layout.enumerated() {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -16687,7 +16687,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil,
       statements: CodeBlockItemListSyntax,
       _ unexpectedBetweenStatementsAndEndOfFileToken: UnexpectedNodesSyntax? = nil,
-      endOfFileToken: TokenSyntax = .eof(),
+      endOfFileToken: TokenSyntax = .endOfFileToken(),
       _ unexpectedAfterEndOfFileToken: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     

--- a/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
@@ -38,7 +38,7 @@ extension Trivia {
     self = trivia
     if pieces.contains(where: { $0.isUnexpected }) {
       var diagnostics: [Diagnostic] = []
-      let tree = SourceFileSyntax(statements: [], endOfFileToken: .eof(leadingTrivia: self))
+      let tree = SourceFileSyntax(statements: [], endOfFileToken: .endOfFileToken(leadingTrivia: self))
       var offset = 0
       for piece in pieces {
         if case .unexpectedText(let contents) = piece {

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -1222,7 +1222,7 @@ extension SourceFileSyntax {
       leadingTrivia: Trivia? = nil, 
       unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil, 
       unexpectedBetweenStatementsAndEndOfFileToken: UnexpectedNodesSyntax? = nil, 
-      endOfFileToken: TokenSyntax = .eof(), 
+      endOfFileToken: TokenSyntax = .endOfFileToken(), 
       unexpectedAfterEndOfFileToken: UnexpectedNodesSyntax? = nil, 
       @CodeBlockItemListBuilder statementsBuilder: () throws -> CodeBlockItemListSyntax, 
       trailingTrivia: Trivia? = nil

--- a/Sources/SwiftSyntaxBuilder/generated/RenamedChildrenBuilderCompatibility.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/RenamedChildrenBuilderCompatibility.swift
@@ -381,7 +381,7 @@ extension SourceFileSyntax {
       leadingTrivia: Trivia? = nil, 
       unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil, 
       unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? = nil, 
-      eofToken: TokenSyntax = .eof(), 
+      eofToken: TokenSyntax = .endOfFileToken(), 
       unexpectedAfterEOFToken: UnexpectedNodesSyntax? = nil, 
       @CodeBlockItemListBuilder statementsBuilder: () throws -> CodeBlockItemListSyntax, 
       trailingTrivia: Trivia? = nil

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -153,7 +153,7 @@ extension SyntaxProtocol {
       if case .keyword(let keyword) = tokenKind {
         tokenInitializerName = "keyword"
         tokenKindArgument = ExprSyntax(".\(raw: keyword)")
-      } else if tokenKind.isLexerClassifiedKeyword || tokenKind == .eof {
+      } else if tokenKind.isLexerClassifiedKeyword {
         tokenInitializerName = String(describing: tokenKind)
         tokenKindArgument = nil
       } else if tokenKind.decomposeToRaw().rawKind.defaultText != nil {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -184,15 +184,15 @@ func assertLexemes(
   var (markerLocations, source) = extractMarkers(markedSource)
   markerLocations["START"] = 0
   var expectedLexemes = expectedLexemes
-  if expectedLexemes.last?.rawTokenKind != .eof {
-    expectedLexemes.append(LexemeSpec(.eof, text: ""))
+  if expectedLexemes.last?.rawTokenKind != .endOfFile {
+    expectedLexemes.append(LexemeSpec(.endOfFile, text: ""))
   }
   source.withUTF8 { buf in
     var lexemes = [Lexer.Lexeme]()
     for token in Lexer.tokenize(buf, from: 0) {
       lexemes.append(token)
 
-      if token.rawTokenKind == .eof {
+      if token.rawTokenKind == .endOfFile {
         break
       }
     }

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -20,7 +20,7 @@ fileprivate func lex(_ sourceBytes: [UInt8], body: ([Lexer.Lexeme]) throws -> Vo
     for token in Lexer.tokenize(buf, from: 0) {
       lexemes.append(token)
 
-      if token.rawTokenKind == .eof {
+      if token.rawTokenKind == .endOfFile {
         break
       }
     }
@@ -100,7 +100,7 @@ public class LexerTests: XCTestCase {
       /* /* */ */
       """,
       lexemes: [
-        LexemeSpec(.eof, leading: "/* */\n/**/\n/* /* */ */", text: "", flags: [.isAtStartOfLine])
+        LexemeSpec(.endOfFile, leading: "/* */\n/**/\n/* /* */ */", text: "", flags: [.isAtStartOfLine])
       ]
     )
   }
@@ -294,7 +294,7 @@ public class LexerTests: XCTestCase {
         LexemeSpec(.identifier, text: "x"),
         LexemeSpec(.colon, text: ":", trailing: " "),
         LexemeSpec(.identifier, text: "Int"),
-        LexemeSpec(.eof, leading: "\n/* regular comment */", text: "", flags: [.isAtStartOfLine]),
+        LexemeSpec(.endOfFile, leading: "\n/* regular comment */", text: "", flags: [.isAtStartOfLine]),
       ]
     )
   }
@@ -608,7 +608,7 @@ public class LexerTests: XCTestCase {
       """,
       lexemes: [
         LexemeSpec(
-          .eof,
+          .endOfFile,
           leading:
             """
             // diff3-style conflict markers
@@ -646,7 +646,7 @@ public class LexerTests: XCTestCase {
       """,
       lexemes: [
         LexemeSpec(
-          .eof,
+          .endOfFile,
           leading:
             """
             // Perforce-style conflict markers
@@ -722,7 +722,7 @@ public class LexerTests: XCTestCase {
         LexemeSpec(.binaryOperator, text: "/"),
         LexemeSpec(.identifier, leading: "\n         ", text: "x", flags: [.isAtStartOfLine]),
         LexemeSpec(.rightBrace, leading: "\n", text: "}", flags: [.isAtStartOfLine]),
-        LexemeSpec(.eof, leading: "\n\n///", text: "", flags: [.isAtStartOfLine]),
+        LexemeSpec(.endOfFile, leading: "\n\n///", text: "", flags: [.isAtStartOfLine]),
       ]
     )
 
@@ -975,7 +975,7 @@ public class LexerTests: XCTestCase {
 
       assertRawBytesLexeme(
         lexemes[0],
-        kind: .eof,
+        kind: .endOfFile,
         leadingTrivia: sourceBytes,
         text: []
       )
@@ -1022,7 +1022,7 @@ public class LexerTests: XCTestCase {
       }
       assertRawBytesLexeme(
         lexemes[0],
-        kind: .eof,
+        kind: .endOfFile,
         leadingTrivia: sourceBytes,
         text: [],
         error: TokenDiagnostic(.invalidUtf8, byteOffset: 0)
@@ -1039,7 +1039,7 @@ public class LexerTests: XCTestCase {
       }
       assertRawBytesLexeme(
         lexemes[0],
-        kind: .eof,
+        kind: .endOfFile,
         leadingTrivia: sourceBytes,
         text: [],
         error: TokenDiagnostic(.invalidUtf8, byteOffset: 0)
@@ -1129,7 +1129,7 @@ public class LexerTests: XCTestCase {
       lexemes: [
         LexemeSpec(.stringQuote, text: #"""#),
         LexemeSpec(.stringSegment, text: "bar"),
-        LexemeSpec(.eof, leading: "\n", text: "", flags: [.isAtStartOfLine]),
+        LexemeSpec(.endOfFile, leading: "\n", text: "", flags: [.isAtStartOfLine]),
       ]
     )
   }
@@ -1146,7 +1146,7 @@ public class LexerTests: XCTestCase {
         LexemeSpec(.backslash, text: "\\"),
         LexemeSpec(.leftParen, text: "("),
         LexemeSpec(.stringSegment, text: ""),
-        LexemeSpec(.eof, leading: "\n", text: "", flags: .isAtStartOfLine),
+        LexemeSpec(.endOfFile, leading: "\n", text: "", flags: .isAtStartOfLine),
       ]
     )
   }
@@ -1466,7 +1466,7 @@ public class LexerTests: XCTestCase {
     assertLexemes(
       "1️⃣/*",
       lexemes: [
-        LexemeSpec(.eof, leading: "/*", text: "", diagnostic: "unterminated '/*' comment")
+        LexemeSpec(.endOfFile, leading: "/*", text: "", diagnostic: "unterminated '/*' comment")
       ]
     )
   }
@@ -1475,7 +1475,7 @@ public class LexerTests: XCTestCase {
     assertLexemes(
       "1️⃣/*/",
       lexemes: [
-        LexemeSpec(.eof, leading: "/*/", text: "", diagnostic: "unterminated '/*' comment")
+        LexemeSpec(.endOfFile, leading: "/*/", text: "", diagnostic: "unterminated '/*' comment")
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
@@ -49,7 +49,7 @@ final class HashbangLibraryTests: XCTestCase {
               )
             )
           ]),
-          endOfFileToken: .eof()
+          endOfFileToken: .endOfFileToken()
         )
       ),
       options: [.substructureCheckTrivia]

--- a/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
@@ -31,7 +31,7 @@ public class AbsolutePositionTests: XCTestCase {
     }
     let root = SourceFileSyntax(
       statements: CodeBlockItemListSyntax(l),
-      endOfFileToken: .eof()
+      endOfFileToken: .endOfFileToken()
     )
     _ = root.statements[idx].position
     _ = root.statements[idx].byteSize
@@ -67,7 +67,7 @@ public class AbsolutePositionTests: XCTestCase {
       )
     return SourceFileSyntax(
       statements: CodeBlockItemListSyntax(items),
-      endOfFileToken: .eof()
+      endOfFileToken: .endOfFileToken()
     )
   }
 

--- a/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
+++ b/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
@@ -195,7 +195,7 @@ public class DebugDescriptionTests: XCTestCase {
                         rightParen: .rightParenToken()
                       )))
               ]),
-          endOfFileToken: .eof()
+          endOfFileToken: .endOfFileToken()
         )
       """
     )
@@ -218,7 +218,7 @@ public class DebugDescriptionTests: XCTestCase {
                         rightParen: .rightParenToken()
                       )))
               ]),
-          endOfFileToken: .eof()
+          endOfFileToken: .endOfFileToken()
         )
       """
     )

--- a/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
+++ b/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
@@ -42,7 +42,7 @@ final class SourceLocationConverterTests: XCTestCase {
       }
 
       let nodeWithInvalidUtf8 = RawTokenSyntax(
-        kind: .eof,
+        kind: .endOfFile,
         text: "",
         leadingTriviaPieces: [
           .unexpectedText(leadingTriviaText)


### PR DESCRIPTION
Resolves https://github.com/apple/swift-syntax/issues/1837
rdar://111217077

This PR renames eof(or EOF) to endOfFile.

I've also noticed there was a FIXME where `eof` was treated specially in `SYNTAX_TOKENS`. I changed the TokenSpec to include `EndOfFile` as a regular `SYNTAX_TOKENS`, and fixed places where eof was handled individually. In most cases, these special handlings could be covered with existing logic for other tokens. 


This is my first PR in swift-syntax, so please let me know if there's a better way to land these kind of changes. 