### PR TITLE
Allow rewrite to detach from the node's parent

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -42,10 +42,13 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      /// Rewrite `node` and anchor, making sure that the rewritten node also has
-      /// a parent if `node` had one.
-      public func rewrite(_ node: some SyntaxProtocol) -> Syntax {
+      /// Rewrite `node`, keeping its parent unless `detach` is `true`.
+      public func rewrite(_ node: some SyntaxProtocol, detach: Bool = false) -> Syntax {
         let rewritten = self.visit(node.data)
+        if detach {
+          return rewritten
+        }
+
         return withExtendedLifetime(rewritten) {
           return Syntax(node.data.replacingSelf(rewritten.raw, rawNodeArena: rewritten.raw.arena, allocationArena: SyntaxArena()))
         }
@@ -100,7 +103,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// Visit any Syntax node.
       ///   - Parameter node: the node that is being visited
       ///   - Returns: the rewritten node
-      @available(*, deprecated, renamed: "rewrite(_:)")
+      @available(*, deprecated, renamed: "rewrite(_:detach:)")
       public func visit(_ node: Syntax) -> Syntax {
         return visit(node.data)
       }

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -78,7 +78,7 @@ extension FixIt.MultiNodeChange {
     guard let node = node else {
       return FixIt.MultiNodeChange(primitiveChanges: [])
     }
-    var changes = [FixIt.Change.replace(oldNode: Syntax(node), newNode: MissingMaker().rewrite(node))]
+    var changes = [FixIt.Change.replace(oldNode: Syntax(node), newNode: MissingMaker().rewrite(node, detach: true))]
     if transferTrivia {
       changes += FixIt.MultiNodeChange.transferTriviaAtSides(from: [node]).primitiveChanges
     }
@@ -123,7 +123,7 @@ extension FixIt.MultiNodeChange {
     leadingTrivia: Trivia? = nil,
     trailingTrivia: Trivia? = nil
   ) -> Self {
-    var presentNode = MissingNodesBasicFormatter(viewMode: .fixedUp).rewrite(node)
+    var presentNode = MissingNodesBasicFormatter(viewMode: .fixedUp).rewrite(node, detach: true)
     presentNode = PresentMaker().rewrite(presentNode)
 
     if let leadingTrivia {

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -28,10 +28,13 @@ open class SyntaxRewriter {
     self.viewMode = viewMode
   }
   
-  /// Rewrite `node` and anchor, making sure that the rewritten node also has
-  /// a parent if `node` had one.
-  public func rewrite(_ node: some SyntaxProtocol) -> Syntax {
+  /// Rewrite `node`, keeping its parent unless `detach` is `true`.
+  public func rewrite(_ node: some SyntaxProtocol, detach: Bool = false) -> Syntax {
     let rewritten = self.visit(node.data)
+    if detach {
+      return rewritten
+    }
+
     return withExtendedLifetime(rewritten) {
       return Syntax(node.data.replacingSelf(rewritten.raw, rawNodeArena: rewritten.raw.arena, allocationArena: SyntaxArena()))
     }
@@ -68,7 +71,7 @@ open class SyntaxRewriter {
   /// Visit any Syntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  @available(*, deprecated, renamed: "rewrite(_:)")
+  @available(*, deprecated, renamed: "rewrite(_:detach:)")
   public func visit(_ node: Syntax) -> Syntax {
     return visit(node.data)
   }


### PR DESCRIPTION
`MissingMaker` and `MissingNodesBasicFormatter` do not require the returned node to have a parent. Avoid re-creating all the parent nodes in this case by detaching the rewritten node (or rather, not re-attaching it).

Resolves rdar://111332992 (#1847).