### PR TITLE
[5.9] Add a compatibility layer for the rename SourceEdit -> IncrementalEdit

### DIFF
--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -42,3 +42,6 @@ public extension EditorPlaceholderDeclSyntax {
     )
   }
 }
+
+@available(*, deprecated, renamed: "IncrementalEdit")
+public typealias SourceEdit = IncrementalEdit

--- a/Tests/SwiftRefactorTest/RefactorTestUtils.swift
+++ b/Tests/SwiftRefactorTest/RefactorTestUtils.swift
@@ -17,6 +17,9 @@ import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 
+// Disambiguate between `SwiftRefactor.SourceEdit` and `SwiftSyntax.SourceEdit`
+typealias SourceEdit = SwiftRefactor.SourceEdit
+
 func assertRefactor<R: EditRefactoringProvider>(
   _ input: R.Input,
   context: R.Context,


### PR DESCRIPTION
* **Explanation**: We renamed `SourceEdit` to `IncrementalEdit`. Add a deprecated `typealias` to keep code that still references `SourceEdit` compiling
* **Risk**: We could get ambiguity warnings if a client imports both `SwiftRefactor` and `SwiftSyntax`, both of which define a `SourceEdit` type. But at the moment, we are relying on clients that still depend on `SourceEdit` existing.
* **Issue**: rdar://111375738
* **Reviewer**:  @bnbarham 