### PR TITLE
[5.9] Fix macro expansion order in compiler_plugin_basic.swift

### DIFF
--- a/lit_tests/compiler_plugin_basic.swift
+++ b/lit_tests/compiler_plugin_basic.swift
@@ -59,11 +59,6 @@ struct MyStruct {
 // CHECK-NEXT: }
 // CHECK-NEXT: ------------------------------
 
-// CHECK: @__swiftmacro_7TestApp8MyStruct9EquatablefMc_.swift
-// CHECK-NEXT: ------------------------------
-// CHECK-NEXT: extension MyStruct : Equatable  {}
-// CHECK-NEXT: ------------------------------
-
 // CHECK: @__swiftmacro_7TestApp8MyStruct8MetadatafMm_.swift
 // CHECK-NEXT: ------------------------------
 // CHECK-NEXT: static var __metadata__: [String: String] {
@@ -79,6 +74,11 @@ struct MyStruct {
 // CHECK: @__swiftmacro_7TestApp8MyStructV5_test16MemberDeprecatedfMr0_.swift
 // CHECK-NEXT: ------------------------------
 // CHECK-NEXT: @available(*, deprecated)
+// CHECK-NEXT: ------------------------------
+
+// CHECK: @__swiftmacro_7TestApp8MyStruct9EquatablefMc_.swift
+// CHECK-NEXT: ------------------------------
+// CHECK-NEXT: extension MyStruct : Equatable  {}
 // CHECK-NEXT: ------------------------------
 
 // CHECK: @__swiftmacro_7TestApp8MyStructV5value11DidSetPrintfMa_.swift


### PR DESCRIPTION
* **Explanation**: https://github.com/apple/swift/pull/66956 changes the expansion order of macros so that conformance macros always appear last. This requires a test fix in compiler_plugin_basic.swift.
* **Risk**: None. This is just a test fix.
* **Testing**: Fixed compiler_plugin_basic.swift.
* **Reviewer**: @ahoppen
* **Main branch PR**: https://github.com/apple/swift-syntax/pull/1855