### PR TITLE
Respect indentation in the line for sub-tree in BasicFormat

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -150,6 +150,18 @@ open class BasicFormat: SyntaxRewriter {
 
   // MARK: - Customization points
 
+  /// If we are formatting a subtree and the line that the initial token occurs on is indented,
+  /// use that line indentation for the first token in the subtree to format.
+  ///
+  /// For example, when formatting only the code block in the following,
+  /// then the opening `{` should be indented by four spaces.
+  /// ```
+  ///     func test() {
+  ///         print(1)
+  ///     }
+  /// ```
+  open var inferInitialTokenIndentaiton: Bool { true }
+
   /// Whether a leading newline on `token` should be added.
   open func requiresIndent(_ node: some SyntaxProtocol) -> Bool {
     return node.requiresIndent
@@ -411,6 +423,16 @@ open class BasicFormat: SyntaxRewriter {
       // If the token starts on a new line and does not have indentation, this
       // is the last non-indented token. Store its indentation level
       anchorPoints[token] = currentIndentationLevel
+    }
+
+    if inferInitialTokenIndentaiton
+      && isInitialToken
+      && token.presence == .present
+    {
+      let indentationOfLine = token.indentationOfLine
+      if token.leadingTrivia.pieces.suffix(indentationOfLine.pieces.count) != indentationOfLine.pieces {
+        leadingTrivia += indentationOfLine
+      }
     }
 
     // Add a trailing space to the token unless

--- a/Sources/SwiftBasicFormat/CMakeLists.txt
+++ b/Sources/SwiftBasicFormat/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_swift_host_library(SwiftBasicFormat
   BasicFormat.swift
   generated/BasicFormat+Extensions.swift
+  Syntax+Extensions.swift
   SyntaxProtocol+Formatted.swift
   Trivia+FormatExtensions.swift
 )

--- a/Sources/SwiftBasicFormat/Syntax+Extensions.swift
+++ b/Sources/SwiftBasicFormat/Syntax+Extensions.swift
@@ -12,7 +12,7 @@
 
 import SwiftSyntax
 
-public extension TokenSyntax {
+extension TokenSyntax {
   /// The indentation of this token
   ///
   /// In contrast to `indentationOfLine`, this does not walk to previous tokens to
@@ -23,7 +23,7 @@ public extension TokenSyntax {
   }
 
   /// Returns the indentation of the line this token occurs on
-  var indentationOfLine: Trivia {
+  public var indentationOfLine: Trivia {
     var token: TokenSyntax = self
     if let indentation = token.indentation {
       return indentation

--- a/Sources/SwiftBasicFormat/Syntax+Extensions.swift
+++ b/Sources/SwiftBasicFormat/Syntax+Extensions.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public extension TokenSyntax {
+  /// The indentation of this token
+  ///
+  /// In contrast to `indentationOfLine`, this does not walk to previous tokens to
+  /// find the indentation of the line this token occurs on.
+  private var indentation: Trivia? {
+    let previous = self.previousToken(viewMode: .sourceAccurate)
+    return ((previous?.trailingTrivia ?? []) + leadingTrivia).indentation(isOnNewline: false)
+  }
+
+  /// Returns the indentation of the line this token occurs on
+  var indentationOfLine: Trivia {
+    var token: TokenSyntax = self
+    if let indentation = token.indentation {
+      return indentation
+    }
+    while let previous = token.previousToken(viewMode: .sourceAccurate) {
+      token = previous
+      if let indentation = token.indentation {
+        return indentation
+      }
+    }
+
+    return []
+  }
+}

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -22,6 +22,8 @@ fileprivate func findCommonAncestor(_ nodes: [Syntax]) -> Syntax? {
 }
 
 class NoNewlinesFormat: BasicFormat {
+  override var inferInitialTokenIndentaiton: Bool { false }
+
   override func requiresNewline(between first: TokenSyntax?, and second: TokenSyntax?) -> Bool {
     return false
   }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -51,31 +51,6 @@ fileprivate func getTokens(between first: TokenSyntax, and second: TokenSyntax) 
 }
 
 fileprivate extension TokenSyntax {
-  /// The indentation of this token
-  ///
-  /// In contrast to `indentation`, this does not walk to previous tokens to
-  /// find the indentation of the line this token occurs on.
-  private var indentation: Trivia? {
-    let previous = self.previousToken(viewMode: .sourceAccurate)
-    return ((previous?.trailingTrivia ?? []) + leadingTrivia).indentation(isOnNewline: false)
-  }
-
-  /// Returns the indentation of the line this token occurs on
-  var indentationOfLine: Trivia {
-    var token: TokenSyntax = self
-    if let indentation = token.indentation {
-      return indentation
-    }
-    while let previous = token.previousToken(viewMode: .sourceAccurate) {
-      token = previous
-      if let indentation = token.indentation {
-        return indentation
-      }
-    }
-
-    return []
-  }
-
   /// Assuming this token is a `poundAvailableKeyword` or `poundUnavailableKeyword`
   /// returns the opposite keyword.
   var negatedAvailabilityKeyword: TokenSyntax {

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -374,7 +374,7 @@ final class BasicFormatTest: XCTestCase {
     assertFormatted(
       tree: body,
       expected: """
-        {
+            {
                 print(1)
             }
         """

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -351,7 +351,7 @@ final class BasicFormatTest: XCTestCase {
     let body = decl.cast(FunctionDeclSyntax.self).body!
 
     assertFormatted(
-      source: body.formatted().description,
+      tree: body,
       expected: """
         {
             print(1)
@@ -372,7 +372,7 @@ final class BasicFormatTest: XCTestCase {
     let body = decl.cast(StructDeclSyntax.self).memberBlock.members.first!.decl.cast(FunctionDeclSyntax.self).body!
 
     assertFormatted(
-      source: body.formatted().description,
+      tree: body,
       expected: """
         {
                 print(1)


### PR DESCRIPTION
The pull request at https://github.com/apple/swift-syntax/pull/1791 emphasizes the need to indent sub-tree nodes while formatting.

I attempted to address another sub-tree indentation based on the comment in https://github.com/apple/swift-syntax/pull/1791#discussion_r1231314001.