### PR TITLE
[Macros] Implement function body macros

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -56,6 +56,7 @@ public let COMMON_NODES: [Node] = [
     kind: .codeBlock,
     base: .syntax,
     nameForDiagnostics: "code block",
+    parserFunction: "parseCodeBlock",
     traits: [
       "Braced",
       "WithStatements",

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -82,7 +82,10 @@ public let DECL_NODES: [Node] = [
     base: .decl,
     nameForDiagnostics: "accessor",
     parserFunction: "parseAccessorDecl",
-    traits: ["WithAttributes"],
+    traits: [
+      "WithOptionalCodeBlock",
+      "WithAttributes",
+    ],
     children: [
       Child(
         name: "attributes",
@@ -493,6 +496,7 @@ public let DECL_NODES: [Node] = [
     traits: [
       "WithAttributes",
       "WithModifiers",
+      "WithOptionalCodeBlock",
     ],
     children: [
       Child(
@@ -879,6 +883,7 @@ public let DECL_NODES: [Node] = [
       "WithAttributes",
       "WithGenericParameters",
       "WithModifiers",
+      "WithOptionalCodeBlock",
     ],
     children: [
       Child(
@@ -1217,6 +1222,7 @@ public let DECL_NODES: [Node] = [
       "WithAttributes",
       "WithGenericParameters",
       "WithModifiers",
+      "WithOptionalCodeBlock",
     ],
     children: [
       Child(

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -152,6 +152,12 @@ public let TRAITS: [Trait] = [
     ]
   ),
   Trait(
+    traitName: "WithOptionalCodeBlock",
+    children: [
+      Child(name: "body", kind: .node(kind: .codeBlock), isOptional: true)
+    ]
+  ),
+  Trait(
     traitName: "WithStatements",
     children: [
       Child(name: "statements", kind: .node(kind: .codeBlockItemList))

--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -20,6 +20,10 @@
   - Description: Enum to exhaustively switch over all different syntax nodes of each base type.
   - Pull Request: https://github.com/apple/swift-syntax/pull/2351
 
+- `WithOptionalCodeBlock`
+  - Description: A trait for syntax nodes that have an optional code block, such as `FunctionDeclSyntax` and `InitializerDeclSyntax`.
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2359
+
 ## API Behavior Changes
 
 ## Deprecations

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -14,8 +14,8 @@ import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntax
-import SwiftSyntaxMacroExpansion
-import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacroExpansion
+@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
 
 extension CompilerPluginMessageHandler {
   /// Get concrete macro type from a pair of module name and type name.

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -166,6 +166,8 @@ private extension MacroRole {
     case .conformance: self = .extension
     case .codeItem: self = .codeItem
     case .extension: self = .extension
+    case .preamble: self = .preamble
+    case .body: self = .body
     }
   }
 }

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
@@ -124,8 +124,8 @@ public enum PluginMessage {
     case conformance
     case codeItem
     case `extension`
-    case preamble
-    case body
+    @_spi(ExperimentalLanguageFeature) case preamble
+    @_spi(ExperimentalLanguageFeature) case body
   }
 
   public struct SourceLocation: Codable {

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
@@ -124,6 +124,8 @@ public enum PluginMessage {
     case conformance
     case codeItem
     case `extension`
+    case preamble
+    case body
   }
 
   public struct SourceLocation: Codable {

--- a/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
+++ b/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
@@ -126,6 +126,24 @@ extension CodeBlockItemSyntax: SyntaxParseable {
   }
 }
 
+extension CodeBlockSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
+    let node = parser.parseCodeBlock()
+    let raw = RawSyntax(parser.parseRemainder(into: node))
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
+  }
+}
+
 extension DeclSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
     // Keep the parser alive so that the arena in which `raw` is allocated

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -401,6 +401,7 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/WithCodeBlockSyntax>
 - <doc:SwiftSyntax/WithGenericParametersSyntax>
 - <doc:SwiftSyntax/WithModifiersSyntax>
+- <doc:SwiftSyntax/WithOptionalCodeBlockSyntax>
 - <doc:SwiftSyntax/WithStatementsSyntax>
 - <doc:SwiftSyntax/WithTrailingCommaSyntax>
 

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -570,6 +570,43 @@ public extension SyntaxProtocol {
   }
 }
 
+// MARK: - WithOptionalCodeBlockSyntax
+
+
+public protocol WithOptionalCodeBlockSyntax: SyntaxProtocol {
+  var body: CodeBlockSyntax? {
+    get
+    set
+  }
+}
+
+public extension WithOptionalCodeBlockSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<WithOptionalCodeBlockSyntax, T>, _ newChild: T) -> WithOptionalCodeBlockSyntax {
+    var copy: WithOptionalCodeBlockSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
+}
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to
+  /// `WithOptionalCodeBlockSyntax`.
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: WithOptionalCodeBlockSyntax.Protocol) -> Bool {
+    return self.asProtocol(WithOptionalCodeBlockSyntax.self) != nil
+  }
+  
+  /// Return the non-type erased version of this syntax node if it conforms to
+  /// `WithOptionalCodeBlockSyntax`. Otherwise return `nil`.
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: WithOptionalCodeBlockSyntax.Protocol) -> WithOptionalCodeBlockSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithOptionalCodeBlockSyntax
+  }
+}
+
 // MARK: - WithStatementsSyntax
 
 
@@ -649,7 +686,7 @@ public extension SyntaxProtocol {
 
 extension AccessorBlockSyntax: BracedSyntax {}
 
-extension AccessorDeclSyntax: WithAttributesSyntax {}
+extension AccessorDeclSyntax: WithOptionalCodeBlockSyntax, WithAttributesSyntax {}
 
 extension AccessorEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
@@ -693,7 +730,7 @@ extension DeclNameArgumentsSyntax: ParenthesizedSyntax {}
 
 extension DeferStmtSyntax: WithCodeBlockSyntax {}
 
-extension DeinitializerDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
+extension DeinitializerDeclSyntax: WithAttributesSyntax, WithModifiersSyntax, WithOptionalCodeBlockSyntax {}
 
 extension DictionaryElementSyntax: WithTrailingCommaSyntax {}
 
@@ -723,7 +760,7 @@ extension ExtensionDeclSyntax: DeclGroupSyntax, WithAttributesSyntax, WithModifi
 
 extension ForStmtSyntax: WithCodeBlockSyntax {}
 
-extension FunctionDeclSyntax: NamedDeclSyntax, WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
+extension FunctionDeclSyntax: NamedDeclSyntax, WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax, WithOptionalCodeBlockSyntax {}
 
 extension FunctionEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
@@ -747,7 +784,7 @@ extension ImportDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension InheritedTypeSyntax: WithTrailingCommaSyntax {}
 
-extension InitializerDeclSyntax: WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
+extension InitializerDeclSyntax: WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax, WithOptionalCodeBlockSyntax {}
 
 extension LabeledExprSyntax: WithTrailingCommaSyntax {}
 

--- a/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
@@ -40,11 +40,9 @@ extension SyntaxStringInterpolation {
   }
 }
 
-// MARK: - HasCodeBlock
+// MARK: - HasTrailingCodeBlock
 
-public protocol HasTrailingCodeBlock {
-  var body: CodeBlockSyntax { get set }
-
+public protocol HasTrailingCodeBlock: WithCodeBlockSyntax {
   /// Constructs a syntax node where `header` builds the text of the node before the body in braces and `bodyBuilder` is used to build the node’s body.
   ///
   /// For example, you can construct
@@ -90,11 +88,9 @@ extension ForStmtSyntax: HasTrailingCodeBlock {}
 extension GuardStmtSyntax: HasTrailingCodeBlock {}
 extension WhileStmtSyntax: HasTrailingCodeBlock {}
 
-// MARK: - HasOptionalCodeBlock
+// MARK: - WithOptionalCodeBlockSyntax
 
-public protocol HasTrailingOptionalCodeBlock {
-  var body: CodeBlockSyntax? { get set }
-
+public extension WithOptionalCodeBlockSyntax where Self: DeclSyntaxProtocol {
   /// Constructs a syntax node where `header` builds the text of the node before the body in braces and `bodyBuilder` is used to build the node’s body.
   ///
   /// For example, you can construct
@@ -114,10 +110,6 @@ public protocol HasTrailingOptionalCodeBlock {
   /// ```
   ///
   /// Throws an error if `header` defines a different node type than the type the initializer is called on. E.g. if calling `try FunctionDeclSyntax("init") {}`
-  init(_ header: SyntaxNodeString, @CodeBlockItemListBuilder bodyBuilder: () throws -> CodeBlockItemListSyntax) throws
-}
-
-public extension HasTrailingOptionalCodeBlock where Self: DeclSyntaxProtocol {
   init(_ header: SyntaxNodeString, @CodeBlockItemListBuilder bodyBuilder: () throws -> CodeBlockItemListSyntax) throws {
     let decl = DeclSyntax("\(header) {}")
     guard let castedDecl = decl.as(Self.self) else {
@@ -127,11 +119,6 @@ public extension HasTrailingOptionalCodeBlock where Self: DeclSyntaxProtocol {
     self.body = try CodeBlockSyntax(statements: bodyBuilder())
   }
 }
-
-extension AccessorDeclSyntax: HasTrailingOptionalCodeBlock {}
-extension DeinitializerDeclSyntax: HasTrailingOptionalCodeBlock {}
-extension FunctionDeclSyntax: HasTrailingOptionalCodeBlock {}
-extension InitializerDeclSyntax: HasTrailingOptionalCodeBlock {}
 
 // MARK: HasTrailingMemberDeclBlock
 

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -26,6 +26,8 @@ extension ClosureParameterSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension CodeBlockItemSyntax: SyntaxExpressibleByStringInterpolation {}
 
+extension CodeBlockSyntax: SyntaxExpressibleByStringInterpolation {}
+
 extension DeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension EnumCaseParameterSyntax: SyntaxExpressibleByStringInterpolation {}

--- a/Sources/SwiftSyntaxMacroExpansion/FunctionParameterUtils.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/FunctionParameterUtils.swift
@@ -9,7 +9,8 @@ extension FunctionParameterSyntax {
   ///
   /// The parameter names for these three parameters are `a`, `b`, and `see`,
   /// respectively.
-  var parameterName: TokenSyntax? {
+  @_spi(Testing)
+  public var parameterName: TokenSyntax? {
     // If there were two names, the second is the parameter name.
     if let secondName {
       if secondName.text == "_" {

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -12,7 +12,7 @@
 
 import SwiftBasicFormat
 import SwiftSyntax
-@_spi(MacroExpansion) import SwiftSyntaxMacros
+@_spi(MacroExpansion) @_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
 
 public enum MacroRole {
   case expression
@@ -24,8 +24,8 @@ public enum MacroRole {
   case conformance
   case codeItem
   case `extension`
-  case preamble
-  case body
+  @_spi(ExperimentalLanguageFeature) case preamble
+  @_spi(ExperimentalLanguageFeature) case body
 }
 
 extension MacroRole {
@@ -55,7 +55,7 @@ enum MacroExpansionError: Error, CustomStringConvertible {
   case declarationHasNoBody
   case noExtendedTypeSyntax
   case noFreestandingMacroRoles(Macro.Type)
-  case tooManyBodyMacros
+  case moreThanOneBodyMacro
   case preambleWithoutBody
 
   var description: String {
@@ -81,7 +81,7 @@ enum MacroExpansionError: Error, CustomStringConvertible {
     case .noFreestandingMacroRoles(let type):
       return "macro implementation type '\(type)' does not conform to any freestanding macro protocol"
 
-    case .tooManyBodyMacros:
+    case .moreThanOneBodyMacro:
       return "function can not have more than one body macro applied to it"
 
     case .preambleWithoutBody:

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -24,6 +24,8 @@ public enum MacroRole {
   case conformance
   case codeItem
   case `extension`
+  case preamble
+  case body
 }
 
 extension MacroRole {
@@ -38,18 +40,23 @@ extension MacroRole {
     case .conformance: return "ConformanceMacro"
     case .codeItem: return "CodeItemMacro"
     case .extension: return "ExtensionMacro"
+    case .preamble: return "PreambleMacro"
+    case .body: return "BodyMacro"
     }
   }
 }
 
 /// Simple diagnostic message
-private enum MacroExpansionError: Error, CustomStringConvertible {
+enum MacroExpansionError: Error, CustomStringConvertible {
   case unmatchedMacroRole(Macro.Type, MacroRole)
   case parentDeclGroupNil
   case declarationNotDeclGroup
   case declarationNotIdentified
+  case declarationHasNoBody
   case noExtendedTypeSyntax
   case noFreestandingMacroRoles(Macro.Type)
+  case tooManyBodyMacros
+  case preambleWithoutBody
 
   var description: String {
     switch self {
@@ -65,12 +72,20 @@ private enum MacroExpansionError: Error, CustomStringConvertible {
     case .declarationNotIdentified:
       return "declaration is not a 'Identified' syntax"
 
+    case .declarationHasNoBody:
+      return "declaration is not a type with an optional code block"
+
     case .noExtendedTypeSyntax:
       return "no extended type for extension macro"
 
     case .noFreestandingMacroRoles(let type):
       return "macro implementation type '\(type)' does not conform to any freestanding macro protocol"
 
+    case .tooManyBodyMacros:
+      return "function can not have more than one body macro applied to it"
+
+    case .preambleWithoutBody:
+      return "preamble macro cannot be applied to a function with no body"
     }
   }
 }
@@ -125,7 +140,7 @@ public func expandFreestandingMacro(
       expandedSyntax = Syntax(CodeBlockItemListSyntax(rewritten))
 
     case (.accessor, _), (.memberAttribute, _), (.member, _), (.peer, _), (.conformance, _), (.extension, _), (.expression, _), (.declaration, _),
-      (.codeItem, _):
+      (.codeItem, _), (.preamble, _), (.body, _):
       throw MacroExpansionError.unmatchedMacroRole(definition, macroRole)
     }
     return expandedSyntax.formattedExpansion(definition.formatMode, indentationWidth: indentationWidth)
@@ -285,6 +300,38 @@ public func expandAttachedMacroWithoutCollapsing<Context: MacroExpansionContext>
 
       // Form a buffer of peer declarations to return to the caller.
       return extensions.map {
+        $0.formattedExpansion(definition.formatMode, indentationWidth: indentationWidth)
+      }
+
+    case (let attachedMacro as PreambleMacro.Type, .preamble):
+      guard let declToPass = Syntax(declarationNode).asProtocol(SyntaxProtocol.self) as? (DeclSyntaxProtocol & WithOptionalCodeBlockSyntax)
+      else {
+        // Compiler error: declaration must have a body.
+        throw MacroExpansionError.declarationHasNoBody
+      }
+
+      let preamble = try attachedMacro.expansion(
+        of: attributeNode,
+        providingPreambleFor: declToPass,
+        in: context
+      )
+      return preamble.map {
+        $0.formattedExpansion(definition.formatMode, indentationWidth: indentationWidth)
+      }
+
+    case (let attachedMacro as BodyMacro.Type, .body):
+      guard let declToPass = Syntax(declarationNode).asProtocol(SyntaxProtocol.self) as? (DeclSyntaxProtocol & WithOptionalCodeBlockSyntax)
+      else {
+        // Compiler error: declaration must have a body.
+        throw MacroExpansionError.declarationHasNoBody
+      }
+
+      let body = try attachedMacro.expansion(
+        of: attributeNode,
+        providingBodyFor: declToPass,
+        in: context
+      )
+      return body.map {
         $0.formattedExpansion(definition.formatMode, indentationWidth: indentationWidth)
       }
 

--- a/Sources/SwiftSyntaxMacros/CMakeLists.txt
+++ b/Sources/SwiftSyntaxMacros/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_swift_syntax_library(SwiftSyntaxMacros
   MacroProtocols/AccessorMacro.swift
   MacroProtocols/AttachedMacro.swift
+  MacroProtocols/BodyMacro.swift
   MacroProtocols/CodeItemMacro.swift
   MacroProtocols/DeclarationMacro.swift
   MacroProtocols/ExpressionMacro.swift
@@ -19,6 +20,7 @@ add_swift_syntax_library(SwiftSyntaxMacros
   MacroProtocols/MemberAttributeMacro.swift
   MacroProtocols/MemberMacro.swift
   MacroProtocols/PeerMacro.swift
+  MacroProtocols/PreambleMacro.swift
 
   AbstractSourceLocation.swift
   MacroExpansionContext.swift

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/BodyMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/BodyMacro.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Describes a macro that can create the body for a function that does not
+/// have one.
+public protocol BodyMacro: AttachedMacro {
+  /// Expand a macro described by the given custom attribute and
+  /// attached to the given declaration and evaluated within a
+  /// particular expansion context.
+  ///
+  /// The macro expansion can introduce a body for the given function.
+  static func expansion(
+    of node: AttributeSyntax,
+    providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax]
+}

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/BodyMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/BodyMacro.swift
@@ -11,6 +11,7 @@ import SwiftSyntax
 
 /// Describes a macro that can create the body for a function that does not
 /// have one.
+@_spi(ExperimentalLanguageFeature)
 public protocol BodyMacro: AttachedMacro {
   /// Expand a macro described by the given custom attribute and
   /// attached to the given declaration and evaluated within a

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/PreambleMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/PreambleMacro.swift
@@ -11,6 +11,7 @@ import SwiftSyntax
 
 /// Describes a macro that can introduce "preamble" code into an existing
 /// function body.
+@_spi(ExperimentalLanguageFeature)
 public protocol PreambleMacro: AttachedMacro {
   /// Expand a macro described by the given custom attribute and
   /// attached to the given declaration and evaluated within a

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/PreambleMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/PreambleMacro.swift
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Describes a macro that can introduce "preamble" code into an existing
+/// function body.
+public protocol PreambleMacro: AttachedMacro {
+  /// Expand a macro described by the given custom attribute and
+  /// attached to the given declaration and evaluated within a
+  /// particular expansion context.
+  ///
+  /// The macro expansion can introduce code items that form a preamble to
+  /// the body of the given function. The code items produced by this macro
+  /// expansion will be inserted at the beginning of the function body.
+  static func expansion(
+    of node: AttributeSyntax,
+    providingPreambleFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax]
+}

--- a/Tests/SwiftSyntaxMacroExpansionTest/BodyMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/BodyMacroTests.swift
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//==========================================================================//
+// IMPORTANT: The macros defined in this file are intended to test the      //
+// behavior of MacroSystem. Many of them do not serve as good examples of   //
+// how macros should be written. In particular, they often lack error       //
+// handling because it is not needed in the few test cases in which these   //
+// macros are invoked.                                                      //
+//==========================================================================//
+
+import SwiftDiagnostics
+import SwiftSyntax
+@_spi(Testing) import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+struct RemoteBodyMacro: BodyMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax] {
+    // FIXME: Should be able to support (de-)initializers and accessors as
+    // well, but this is a lazy implementation.
+    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+      return []
+    }
+
+    let funcBaseName = funcDecl.name.text
+    let paramNames = funcDecl.signature.parameterClause.parameters.map { param in
+      if let name = param.parameterName {
+        return name
+      } else {
+        return TokenSyntax(.wildcard, presence: .present)
+      }
+    }
+
+    let passedArgs = DictionaryExprSyntax(
+      content: .elements(
+        DictionaryElementListSyntax {
+          for paramName in paramNames {
+            DictionaryElementSyntax(
+              key: ExprSyntax("\(literal: paramName.text)"),
+              value: DeclReferenceExprSyntax(baseName: paramName)
+            )
+          }
+        }
+      )
+    )
+
+    return [
+      """
+      return try await remoteCall(function: \(literal: funcBaseName), arguments: \(passedArgs))
+      """
+    ]
+  }
+}
+
+final class BodyMacroTests: XCTestCase {
+  private let indentationWidth: Trivia = .spaces(2)
+
+  func testBodyExpansion() {
+    assertMacroExpansion(
+      """
+      @Remote
+      func f(a: Int, b: String) async throws -> String
+      """,
+      expandedSource: """
+
+        func f(a: Int, b: String) async throws -> String {
+          return try await remoteCall(function: "f", arguments: ["a": a, "b": b])
+        }
+        """,
+      macros: ["Remote": RemoteBodyMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
+  func testBodyExpansionTwice() {
+    assertMacroExpansion(
+      """
+      @Remote @Remote
+      func f(a: Int, b: String) async throws -> String
+      """,
+      expandedSource: """
+
+        func f(a: Int, b: String) async throws -> String {
+          return try await remoteCall(function: "f", arguments: ["a": a, "b": b])
+        }
+        """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "function can not have more than one body macro applied to it",
+          line: 1,
+          column: 1
+        )
+      ],
+      macros: ["Remote": RemoteBodyMacro.self],
+      indentationWidth: indentationWidth
+    )
+
+  }
+}

--- a/Tests/SwiftSyntaxMacroExpansionTest/PreambleMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PreambleMacroTests.swift
@@ -21,7 +21,7 @@
 import SwiftDiagnostics
 import SwiftSyntax
 @_spi(Testing) import SwiftSyntaxMacroExpansion
-import SwiftSyntaxMacros
+@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
@@ -39,17 +39,13 @@ struct TracedPreambleMacro: PreambleMacro {
 
     let funcBaseName = funcDecl.name
     let paramNames = funcDecl.signature.parameterClause.parameters.map { param in
-      if let name = param.parameterName {
-        return name.text
-      } else {
-        return "_"
-      }
+      param.parameterName?.text ?? "_"
     }
 
     let passedArgs = paramNames.map { "\($0): \\(\($0))" }.joined(separator: ", ")
 
     let entry: CodeBlockItemSyntax = """
-      log("Entering \(raw: funcBaseName)(\(raw: passedArgs))")
+      log("Entering \(funcBaseName)(\(raw: passedArgs))")
       """
 
     let argLabels = paramNames.map { "\($0):" }.joined()

--- a/Tests/SwiftSyntaxMacroExpansionTest/PreambleMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PreambleMacroTests.swift
@@ -1,0 +1,176 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//==========================================================================//
+// IMPORTANT: The macros defined in this file are intended to test the      //
+// behavior of MacroSystem. Many of them do not serve as good examples of   //
+// how macros should be written. In particular, they often lack error       //
+// handling because it is not needed in the few test cases in which these   //
+// macros are invoked.                                                      //
+//==========================================================================//
+
+import SwiftDiagnostics
+import SwiftSyntax
+@_spi(Testing) import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+struct TracedPreambleMacro: PreambleMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingPreambleFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax] {
+    // FIXME: Should be able to support (de-)initializers and accessors as
+    // well, but this is a lazy implementation.
+    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+      return []
+    }
+
+    let funcBaseName = funcDecl.name
+    let paramNames = funcDecl.signature.parameterClause.parameters.map { param in
+      if let name = param.parameterName {
+        return name.text
+      } else {
+        return "_"
+      }
+    }
+
+    let passedArgs = paramNames.map { "\($0): \\(\($0))" }.joined(separator: ", ")
+
+    let entry: CodeBlockItemSyntax = """
+      log("Entering \(raw: funcBaseName)(\(raw: passedArgs))")
+      """
+
+    let argLabels = paramNames.map { "\($0):" }.joined()
+
+    let exit: CodeBlockItemSyntax = """
+      log("Exiting \(funcBaseName)(\(raw: argLabels))")
+      """
+
+    return [
+      entry,
+      """
+      defer {
+        \(exit)
+      }
+      """,
+    ]
+  }
+}
+
+final class PreambleMacroTests: XCTestCase {
+  private let indentationWidth: Trivia = .spaces(2)
+
+  func testPreambleExpansion() {
+    assertMacroExpansion(
+      """
+      @Traced
+      func doSomethingDangerous(operation: String) {
+        print("This is the operation: \\(operation)")
+      }
+      """,
+      expandedSource: """
+
+        func doSomethingDangerous(operation: String) {
+          log("Entering doSomethingDangerous(operation: \\(operation))")
+
+          defer {
+            log("Exiting doSomethingDangerous(operation:)")
+          }
+          print("This is the operation: \\(operation)")
+        }
+        """,
+      macros: ["Traced": TracedPreambleMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
+  func testPreambleExpansionTwice() {
+    assertMacroExpansion(
+      """
+      @Traced @Traced
+      func doSomethingDangerous(operation: String) {
+        print("This is the operation: \\(operation)")
+      }
+      """,
+      expandedSource: """
+
+        func doSomethingDangerous(operation: String) {
+          log("Entering doSomethingDangerous(operation: \\(operation))")
+
+          defer {
+            log("Exiting doSomethingDangerous(operation:)")
+          }
+          log("Entering doSomethingDangerous(operation: \\(operation))")
+
+          defer {
+            log("Exiting doSomethingDangerous(operation:)")
+          }
+          print("This is the operation: \\(operation)")
+        }
+        """,
+      macros: ["Traced": TracedPreambleMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
+  func testBodyAndPreambleExpansion() {
+    assertMacroExpansion(
+      """
+      @Remote @Traced
+      func f(a: Int, b: String) async throws -> String
+      """,
+      expandedSource: """
+
+        func f(a: Int, b: String) async throws -> String {
+          log("Entering f(a: \\(a), b: \\(b))")
+
+          defer {
+            log("Exiting f(a:b:)")
+          }
+          return try await remoteCall(function: "f", arguments: ["a": a, "b": b])
+        }
+        """,
+      macros: [
+        "Remote": RemoteBodyMacro.self,
+        "Traced": TracedPreambleMacro.self,
+      ],
+      indentationWidth: indentationWidth
+    )
+  }
+
+  func testPreambleExpansionWithoutBody() {
+    assertMacroExpansion(
+      """
+      @Traced
+      func f(a: Int, b: String) async throws -> String
+      """,
+      expandedSource: """
+
+        func f(a: Int, b: String) async throws -> String
+        """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "preamble macro cannot be applied to a function with no body",
+          line: 1,
+          column: 1
+        )
+      ],
+      macros: [
+        "Traced": TracedPreambleMacro.self
+      ],
+      indentationWidth: indentationWidth
+    )
+  }
+}


### PR DESCRIPTION
Introduce function body macros, which are comprised of two similar macro roles:

- Preamble macros introduce "preamble" code into a user-written function body, e.g., to perform tracing, logging, check additional preconditions, etc.
- Body macros: introduce a function body into a function that has none or replace the existing function body 