### PR TITLE
[5.9][Macros] Stop using @_spi for PluginMessage types

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
@@ -12,7 +12,7 @@
 
 // NOTE: Types in this file should be self-contained and should not depend on any non-stdlib types.
 
-@_spi(PluginMessage) public enum HostToPluginMessage: Codable {
+public enum HostToPluginMessage: Codable {
   /// Send capability of the host, and get capability of the plugin.
   case getCapability(
     capability: PluginMessage.HostCapability?
@@ -47,7 +47,7 @@
   )
 }
 
-@_spi(PluginMessage) public enum PluginToHostMessage: Codable {
+public enum PluginToHostMessage: Codable {
   case getCapabilityResult(
     capability: PluginMessage.PluginCapability
   )
@@ -76,7 +76,7 @@
   )
 }
 
-@_spi(PluginMessage) public enum PluginMessage {
+public enum PluginMessage {
   public static var PROTOCOL_VERSION_NUMBER: Int { 7 }  // Pass extension protocol list
 
   public struct HostCapability: Codable {


### PR DESCRIPTION
Cherry-pick #1876 into release/5.9

`swift` repo change https://github.com/apple/swift/pull/67144

* **Explanation**:  Since #67038  `PluginMessage` types are marked as `@_spi(PluginMessage)` which was not necessary, and it caused a failure in a build. Since we don't really need to mark it `@_spi`, just remove it and make it normal `public`
* **Scope**: Macro plugin messaging
* **Risk**: Low. This should be NFC
* **Testing**: Passes the current test suite
* **Issue**: rdar://111748087
* **Reviewer**: Ben Barham (@bnbarham)
