### PR TITLE
Deprecate manipulation functions on  SyntaxCollection

### DIFF
--- a/Sources/SwiftSyntax/SyntaxCollection.swift
+++ b/Sources/SwiftSyntax/SyntaxCollection.swift
@@ -33,7 +33,7 @@ extension SyntaxCollection {
     self.init(Syntax(data))!
   }
 
-  public init(_ children: [Element]) {
+  public init<Children: Sequence>(_ children: Children) where Children.Element == Element {
     let arena = SyntaxArena()
     // Extend the lifetime of children so their arenas don't get destroyed
     // before they can be added as children of the new arena.
@@ -70,6 +70,7 @@ extension SyntaxCollection {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new collection with that element appended to the end.
+  @available(*, deprecated, message: "Create a new array of elements and construct a new collection type from those elements")
   public func appending(_ syntax: Element) -> Self {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
@@ -82,6 +83,7 @@ extension SyntaxCollection {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new collection with that element prepended to the
   ///            beginning.
+  @available(*, deprecated, message: "Create a new array of elements and construct a new collection type from those elements")
   public func prepending(_ syntax: Element) -> Self {
     return inserting(syntax, at: 0)
   }
@@ -94,6 +96,7 @@ extension SyntaxCollection {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new collection with that element appended to the end.
+  @available(*, deprecated, message: "Create a new array of elements and construct a new collection type from those elements")
   public func inserting(_ syntax: Element, at index: Int) -> Self {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
@@ -130,6 +133,7 @@ extension SyntaxCollection {
   /// - Parameter index: The index of the element to remove from the collection.
   /// - Returns: A new collection with the element at the provided index
   ///            removed.
+  @available(*, deprecated, message: "Use filter to remove unwanted elements and construct a new collection type from the filtered elements")
   public func removing(childAt index: Int) -> Self {
     var newLayout = layoutView.formLayoutArray()
     newLayout.remove(at: index)
@@ -139,6 +143,7 @@ extension SyntaxCollection {
   /// Creates a new collection by removing the first element.
   ///
   /// - Returns: A new collection with the first element removed.
+  @available(*, deprecated, message: "Use CollectionType(node.dropFirst())")
   public func removingFirst() -> Self {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeFirst()
@@ -148,6 +153,7 @@ extension SyntaxCollection {
   /// Creates a new collection by removing the last element.
   ///
   /// - Returns: A new collection with the last element removed.
+  @available(*, deprecated, message: "Use CollectionType(node.dropLast())")
   public func removingLast() -> Self {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -497,7 +497,7 @@ extension MacroApplication {
     }
 
     let newAttributes = attributes.reduce(attributedDecl.attributes ?? .init([])) {
-      $0.appending(AttributeListSyntax.Element($1))
+      AttributeListSyntax($0 + [AttributeListSyntax.Element($1)])
     }
 
     let newDecl = attributedDecl.with(\.attributes, newAttributes).as(DeclSyntax.self)!

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -52,9 +52,9 @@ class ExplicitParenFolder: SyntaxRewriter {
       let sequenceExpr = firstNode.expression.as(SequenceExprSyntax.self),
       sequenceExpr.elements.count == 3,
       let leftOperand = sequenceExpr.elements.first,
-      let middleExpr = sequenceExpr.elements.removingFirst().first,
+      let middleExpr = sequenceExpr.elements.dropFirst().first,
       let rightOperand =
-        sequenceExpr.elements.removingFirst().removingFirst().first
+        sequenceExpr.elements.dropFirst(2).first
     else {
       return ExprSyntax(node)
     }

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
@@ -351,16 +351,20 @@ public struct AddCompletionHandler: PeerMacro {
     let newParameterList: FunctionParameterListSyntax
     if let lastParam = parameterList.last {
       // We need to add a trailing comma to the preceding list.
-      newParameterList = parameterList.removingLast()
-        .appending(
+      let newParameterListElements =
+        parameterList.dropLast()
+        + [
           lastParam.with(
             \.trailingComma,
             .commaToken(trailingTrivia: .space)
-          )
-        )
-        .appending(completionHandlerParam)
+          ),
+          completionHandlerParam,
+        ]
+      newParameterList = FunctionParameterListSyntax(newParameterListElements)
     } else {
-      newParameterList = parameterList.appending(completionHandlerParam)
+      newParameterList = FunctionParameterListSyntax(
+        parameterList + [completionHandlerParam]
+      )
     }
 
     let callArguments: [String] = parameterList.map { param in

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -28,7 +28,7 @@ public class SyntaxCollectionsTests: XCTestCase {
       integerLiteralElement(0)
     ])
 
-    let newArrayElementList = arrayElementList.appending(integerLiteralElement(1))
+    let newArrayElementList = ArrayElementListSyntax(arrayElementList + [integerLiteralElement(1)])
     XCTAssert(newArrayElementList.kind.isSyntaxCollection)
     XCTAssertEqual(newArrayElementList.count, 2)
     XCTAssertNotNil(newArrayElementList.child(at: 1))
@@ -41,13 +41,13 @@ public class SyntaxCollectionsTests: XCTestCase {
       integerLiteralElement(1)
     ])
 
-    var newArrayElementList = arrayElementList.inserting(integerLiteralElement(0), at: 0)
+    var newArrayElementList = ArrayElementListSyntax([integerLiteralElement(0)] + arrayElementList)
 
     XCTAssertEqual(newArrayElementList.count, 2)
     XCTAssertNotNil(newArrayElementList.child(at: 0))
     XCTAssertEqual("\(newArrayElementList.child(at: 0)!)", "0")
 
-    newArrayElementList = newArrayElementList.inserting(integerLiteralElement(2), at: 2)
+    newArrayElementList = ArrayElementListSyntax(newArrayElementList + [integerLiteralElement(2)])
 
     XCTAssertEqual(newArrayElementList.count, 3)
     XCTAssertNotNil(newArrayElementList.child(at: 2))
@@ -59,7 +59,7 @@ public class SyntaxCollectionsTests: XCTestCase {
       integerLiteralElement(1)
     ])
 
-    let newArrayElementList = arrayElementList.prepending(integerLiteralElement(0))
+    let newArrayElementList = ArrayElementListSyntax([integerLiteralElement(0)] + arrayElementList)
 
     XCTAssertEqual(newArrayElementList.count, 2)
     XCTAssertNotNil(newArrayElementList.child(at: 0))
@@ -72,7 +72,7 @@ public class SyntaxCollectionsTests: XCTestCase {
       integerLiteralElement(1),
     ])
 
-    let newArrayElementList = arrayElementList.removingFirst()
+    let newArrayElementList = ArrayElementListSyntax(arrayElementList.dropFirst())
 
     XCTAssertEqual(newArrayElementList.count, 1)
     XCTAssertNotNil(newArrayElementList.child(at: 0))
@@ -85,7 +85,7 @@ public class SyntaxCollectionsTests: XCTestCase {
       integerLiteralElement(1),
     ])
 
-    let newArrayElementList = arrayElementList.removingLast()
+    let newArrayElementList = ArrayElementListSyntax(arrayElementList.dropLast())
 
     XCTAssertEqual(newArrayElementList.count, 1)
     XCTAssertNotNil(newArrayElementList.child(at: 0))
@@ -97,7 +97,7 @@ public class SyntaxCollectionsTests: XCTestCase {
       integerLiteralElement(0)
     ])
 
-    let newArrayElementList = arrayElementList.removing(childAt: 0)
+    let newArrayElementList = ArrayElementListSyntax(arrayElementList.dropFirst())
 
     XCTAssertEqual(newArrayElementList.count, 0)
     XCTAssertNil(newArrayElementList.child(at: 0))


### PR DESCRIPTION
Instead of re-inventing the wheel and providing hand-written `appending` etc. functions on `SyntaxCollection`, clients should use the methods on `Array` to manipulate the elements of a `SyntaxCollection` and create a new collection node once the manipulation is done.