### PR TITLE
Deprecate `SyntaxCollection.replacing(childAt:with:)` in favor of a writable subscript

### DIFF
--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -14,7 +14,7 @@
 
 /// The data for an index in a syntax children collection that is not the end
 /// index. See ``SyntaxChildrenIndex`` for the representation of the end index.
-struct SyntaxChildrenIndexData: Comparable {
+struct SyntaxChildrenIndexData: Hashable, Comparable {
   /// The UTF-8 offset of the item at this index in the source file
   /// See `AbsoluteSyntaxPosition.offset`
   let offset: UInt32
@@ -50,7 +50,7 @@ struct SyntaxChildrenIndexData: Comparable {
 }
 
 /// An index in a syntax children collection.
-public struct SyntaxChildrenIndex: Comparable, ExpressibleByNilLiteral {
+public struct SyntaxChildrenIndex: Hashable, Comparable, ExpressibleByNilLiteral {
   /// Construct the `endIndex` of a ``SyntaxChildren`` collection.
   public init(nilLiteral: ()) {
     self.data = nil

--- a/Sources/SwiftSyntax/SyntaxCollection.swift
+++ b/Sources/SwiftSyntax/SyntaxCollection.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public protocol SyntaxCollection: SyntaxProtocol, BidirectionalCollection where Element: SyntaxProtocol {
+public protocol SyntaxCollection: SyntaxProtocol, BidirectionalCollection, MutableCollection where Element: SyntaxProtocol {
   associatedtype Iterator = SyntaxCollectionIterator<Element>
 
   /// The ``SyntaxKind`` of the syntax node that conforms to ``SyntaxCollection``.
@@ -113,6 +113,7 @@ extension SyntaxCollection {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new collection with the new element at the provided index.
+  @available(*, deprecated, message: "Use .with(\\.[index], newValue) instead")
   public func replacing(childAt index: Int, with syntax: Element) -> Self {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
@@ -211,9 +212,24 @@ extension SyntaxCollection {
   }
 
   public subscript(position: SyntaxChildrenIndex) -> Element {
-    let (raw, info) = rawChildren[position]
-    let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
-    let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return Syntax(data).cast(Element.self)
+    get {
+      let (raw, info) = rawChildren[position]
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
+      let data = SyntaxData(absoluteRaw, parent: Syntax(self))
+      return Syntax(data).cast(Element.self)
+    }
+    set {
+      guard let indexToReplace = (position.data?.indexInParent).map(Int.init) else {
+        preconditionFailure("Cannot replace element at the end index")
+      }
+      var newLayout = layoutView.formLayoutArray()
+      /// Make sure the index is a valid index for replacing
+      precondition(
+        (newLayout.startIndex..<newLayout.endIndex).contains(indexToReplace),
+        "replacing node at invalid index \(index)"
+      )
+      newLayout[indexToReplace] = newValue.raw
+      self = replacingLayout(newLayout)
+    }
   }
 }

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -340,9 +340,9 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
     return DeclSyntax(
       visitedVarDecl.with(
         \.bindings,
-        visitedVarDecl.bindings.replacing(
-          childAt: 0,
-          with: binding.with(
+        visitedVarDecl.bindings.with(
+          \.[visitedVarDecl.bindings.startIndex],
+          binding.with(
             \.accessor,
             .accessors(
               .init(

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
@@ -58,9 +58,9 @@ private func replaceFirstLabel(
     return tuple
   }
 
-  return tuple.replacing(
-    childAt: 0,
-    with: firstElement.with(\.label, .identifier(newLabel))
+  return tuple.with(
+    \.[tuple.startIndex],
+    firstElement.with(\.label, .identifier(newLabel))
   )
 }
 

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -110,9 +110,11 @@ public class SyntaxCollectionsTests: XCTestCase {
       integerLiteralElement(2),
     ])
 
-    let newArrayElementList = arrayElementList.replacing(
-      childAt: 2,
-      with: integerLiteralElement(3)
+    let lastElementIndex = arrayElementList.index(arrayElementList.startIndex, offsetBy: 2)
+
+    let newArrayElementList = arrayElementList.with(
+      \.[lastElementIndex],
+      integerLiteralElement(3)
     )
 
     XCTAssertNotNil(newArrayElementList.child(at: 2))


### PR DESCRIPTION
The writable subscript fits much better into the current API design of SwiftSyntax instead of the hand-written `replacing` function, especially if we deprecate all the other hand-written manipulation methods in https://github.com/apple/swift-syntax/pull/1879.