### PR TITLE
Detect `attached` attributes using a contextual keyword instead of string matching

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -95,6 +95,7 @@ public let KEYWORDS: [KeywordSpec] = [
   KeywordSpec("associatedtype", isLexerClassified: true, requiresTrailingSpace: true),
   KeywordSpec("associativity"),
   KeywordSpec("async", requiresTrailingSpace: true),
+  KeywordSpec("attached"),
   KeywordSpec("autoclosure"),
   KeywordSpec("availability"),
   KeywordSpec("available"),

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -54,6 +54,7 @@ extension Parser {
     case _typeEraser
     case _unavailableFromAsync
     case `rethrows`
+    case attached
     case available
     case backDeployed
     case derivative
@@ -88,6 +89,7 @@ extension Parser {
       case TokenSpec(._typeEraser): self = ._typeEraser
       case TokenSpec(._unavailableFromAsync): self = ._unavailableFromAsync
       case TokenSpec(.`rethrows`): self = .rethrows
+      case TokenSpec(.attached): self = .attached
       case TokenSpec(.available): self = .available
       case TokenSpec(.backDeployed): self = .backDeployed
       case TokenSpec(.derivative): self = .derivative
@@ -126,6 +128,7 @@ extension Parser {
       case ._typeEraser: return .keyword(._typeEraser)
       case ._unavailableFromAsync: return .keyword(._unavailableFromAsync)
       case .`rethrows`: return .keyword(.rethrows)
+      case .attached: return .keyword(.attached)
       case .available: return .keyword(.available)
       case .backDeployed: return .keyword(.backDeployed)
       case .derivative: return .keyword(.derivative)
@@ -313,6 +316,11 @@ extension Parser {
       return parseAttribute(argumentMode: .optional) { parser in
         return .unavailableFromAsyncArguments(parser.parseUnavailableFromAsyncArguments())
       }
+    case .attached:
+      return parseAttribute(argumentMode: .customAttribute) { parser in
+        let arguments = parser.parseAttachedArguments()
+        return .argumentList(RawTupleExprElementListSyntax(elements: arguments, arena: parser.arena))
+      }
     case .rethrows:
       let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
       let (unexpectedBeforeAttributeName, attributeName) = self.expect(TokenSpec(.rethrows, remapping: .identifier))
@@ -329,15 +337,8 @@ extension Parser {
         )
       )
     case nil:
-      let isAttached = self.peek().isAttachedKeyword
       return parseAttribute(argumentMode: .customAttribute) { parser in
-        let arguments: [RawTupleExprElementSyntax]
-        if isAttached {
-          arguments = parser.parseAttachedArguments()
-        } else {
-          arguments = parser.parseArgumentListElements(pattern: .none)
-        }
-
+        let arguments = parser.parseArgumentListElements(pattern: .none)
         return .argumentList(RawTupleExprElementListSyntax(elements: arguments, arena: parser.arena))
       }
     }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -1076,10 +1076,6 @@ extension Lexer.Lexeme {
       || self.rawTokenKind == .prefixOperator
   }
 
-  var isAttachedKeyword: Bool {
-    return self.rawTokenKind == .identifier && self.tokenText == "attached"
-  }
-
   var isEllipsis: Bool {
     return self.isAnyOperator && self.tokenText == "..."
   }

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -71,6 +71,7 @@ public enum Keyword: UInt8, Hashable {
   case `associatedtype`
   case associativity
   case async
+  case attached
   case autoclosure
   case availability
   case available
@@ -478,6 +479,8 @@ public enum Keyword: UInt8, Hashable {
         self = ._version
       case "accesses":
         self = .accesses
+      case "attached":
+        self = .attached
       case "compiler":
         self = .compiler
       case "continue":
@@ -817,6 +820,7 @@ public enum Keyword: UInt8, Hashable {
       "associatedtype", 
       "associativity", 
       "async", 
+      "attached", 
       "autoclosure", 
       "availability", 
       "available", 


### PR DESCRIPTION
We don’t want to do any string-matching based on token texts in SwiftParser. The correct design here is to add `attached` as a contextual keyword.