### PR TITLE
Guard `OSLog` calls on all platforms, not just macOS

### DIFF
--- a/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
@@ -27,7 +27,7 @@ extension SyntaxParseable {
   /// are on a platform that supports OSLog, otherwise don't do anything.
   private func logStringInterpolationParsingError() {
     #if canImport(OSLog) && !SWIFTSYNTAX_NO_OSLOG_DEPENDENCY
-    if #available(macOS 11.0, *) {
+    if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *) {
       let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: self)
       let formattedDiagnostics = DiagnosticsFormatter().annotatedSource(tree: self, diags: diagnostics)
       Logger(subsystem: "SwiftSyntax", category: "ParseError").fault(


### PR DESCRIPTION
We only guarded the usage of `Logger` by an OS version on macOS, not on other Apple platforms. Add those platforms the `#available` clause as well.

Fixes https://github.com/apple/swift-syntax/issues/1883 
rdar://111865186