### PR TITLE
[5.9] Guard `OSLog` calls on all platforms, not just macOS

### DIFF
--- a/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
@@ -27,7 +27,7 @@ extension SyntaxParseable {
   /// are on a platform that supports OSLog, otherwise don't do anything.
   private func logStringInterpolationParsingError() {
     #if canImport(OSLog) && !SWIFTSYNTAX_NO_OSLOG_DEPENDENCY
-    if #available(macOS 11.0, *) {
+    if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, macCatalyst 14.0, *) {
       let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: self)
       let formattedDiagnostics = DiagnosticsFormatter().annotatedSource(tree: self, diags: diagnostics)
       Logger(subsystem: "SwiftSyntax", category: "ParseError").fault(


### PR DESCRIPTION
* **Explanation**: We guarded the usage of `Logger` based on whether we can import `OSLog` and the macOS version. This causes SwiftSyntax to not compile for iOS etc. Add those platforms to the availability condition
* **Risk**: Very low
* **Testing**: Locally tested that SwiftSyntax compiles for iOS with this change
* **Issue**: rdar://111865186
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/1884