### PR TITLE
[5.9] Plugin should keep handling the conformance macro role

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -168,7 +168,7 @@ private extension MacroRole {
     case .memberAttribute: self = .memberAttribute
     case .member: self = .member
     case .peer: self = .peer
-    case .conformance: self = .conformance
+    case .conformance: self = .extension
     case .codeItem: self = .codeItem
     case .extension: self = .extension
     }

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -273,7 +273,13 @@ public func expandAttachedMacroWithoutCollapsing<Context: MacroExpansionContext>
         throw MacroExpansionError.declarationNotDeclGroup
       }
 
-      guard let extendedType = extendedType else {
+      let extensionOf: TypeSyntax
+      if let extendedType {
+        extensionOf = extendedType
+      } else if let identified = declarationNode.asProtocol(IdentifiedDeclSyntax.self) {
+        // Fallback for old compilers with a new plugin, where
+        extensionOf = TypeSyntax(SimpleTypeIdentifierSyntax(name: identified.identifier))
+      } else {
         throw MacroExpansionError.noExtendedTypeSyntax
       }
 
@@ -287,7 +293,7 @@ public func expandAttachedMacroWithoutCollapsing<Context: MacroExpansionContext>
         return try attachedMacro.expansion(
           of: attributeNode,
           attachedTo: node,
-          providingExtensionsOf: extendedType,
+          providingExtensionsOf: extensionOf,
           conformingTo: protocols,
           in: context
         )

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/ConformanceMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/ConformanceMacro.swift
@@ -51,13 +51,13 @@ extension ConformanceMacro {
     for (proto, whereClause) in newConformances {
       let decl: DeclSyntax =
         """
-        extension \(type.trimmed): \(proto) {}
+        extension \(type.trimmed): \(proto.trimmed) {}
         """
 
       var extensionDecl = decl.cast(ExtensionDeclSyntax.self)
 
       if let whereClause {
-        extensionDecl = extensionDecl.with(\.genericWhereClause, whereClause)
+        extensionDecl = extensionDecl.with(\.genericWhereClause, whereClause.trimmed)
       }
 
       extensions.append(extensionDecl)


### PR DESCRIPTION
* **Explanation**: New compilers will never send conformance as a role (only extension), but swift-syntax should keep handling them until support for older compilers has dropped.
* **Scope**: Conformance expansions
* **Risk**: Low
* **Testing**: Tested swift-macro-examples with an old compiler and new swift-syntax.
* **Issue**: rdar://111911487
* **Original PR**: https://github.com/apple/swift-syntax/pull/1887