### PR TITLE
Remove outdated docc index

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SwiftSyntaxDoccIndexTemplate.md
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SwiftSyntaxDoccIndexTemplate.md
@@ -67,15 +67,6 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/SourceRange>
 - <doc:SwiftSyntax/SourceLength>
 
-### Incremental Parsing
-
-- <doc:SwiftSyntax/IncrementalParseLookup>
-- <doc:SwiftSyntax/IncrementalParseTransition>
-- <doc:SwiftSyntax/IncrementalParseReusedNodeDelegate>
-- <doc:SwiftSyntax/IncrementalParseReusedNodeCollector>
-- <doc:SwiftSyntax/SourceEdit>
-- <doc:SwiftSyntax/ConcurrentEdits>
-
 ### Internals
 
 - <doc:SwiftSyntax/SyntaxProtocol>

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -395,15 +395,6 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/SourceRange>
 - <doc:SwiftSyntax/SourceLength>
 
-### Incremental Parsing
-
-- <doc:SwiftSyntax/IncrementalParseLookup>
-- <doc:SwiftSyntax/IncrementalParseTransition>
-- <doc:SwiftSyntax/IncrementalParseReusedNodeDelegate>
-- <doc:SwiftSyntax/IncrementalParseReusedNodeCollector>
-- <doc:SwiftSyntax/SourceEdit>
-- <doc:SwiftSyntax/ConcurrentEdits>
-
 ### Internals
 
 - <doc:SwiftSyntax/SyntaxProtocol>


### PR DESCRIPTION
`IncrementalParseTransition.swift` has been moved to `SwiftParser`.