### PR TITLE
When handling a missing layout node, only make the placeholder present

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -160,6 +160,7 @@ public let COMMON_NODES: [Node] = [
     nameForDiagnostics: "declaration",
     documentation: "In case the source code is missing a declaration, this node stands in place of the missing declaration.",
     traits: [
+      "MissingNode",
       "WithAttributes",
       "WithModifiers",
     ],
@@ -192,6 +193,9 @@ public let COMMON_NODES: [Node] = [
     base: .expr,
     nameForDiagnostics: "expression",
     documentation: "In case the source code is missing an expression, this node stands in place of the missing expression.",
+    traits: [
+      "MissingNode"
+    ],
     children: [
       Child(
         name: "Placeholder",
@@ -209,6 +213,9 @@ public let COMMON_NODES: [Node] = [
     base: .pattern,
     nameForDiagnostics: "pattern",
     documentation: "In case the source code is missing a pattern, this node stands in place of the missing pattern.",
+    traits: [
+      "MissingNode"
+    ],
     children: [
       Child(
         name: "Placeholder",
@@ -226,6 +233,9 @@ public let COMMON_NODES: [Node] = [
     base: .stmt,
     nameForDiagnostics: "statement",
     documentation: "In case the source code is missing a statement, this node stands in place of the missing statement.",
+    traits: [
+      "MissingNode"
+    ],
     children: [
       Child(
         name: "Placeholder",
@@ -243,6 +253,9 @@ public let COMMON_NODES: [Node] = [
     base: .syntax,
     nameForDiagnostics: nil,
     documentation: "In case the source code is missing a syntax node, this node stands in place of the missing node.",
+    traits: [
+      "MissingNode"
+    ],
     children: [
       Child(
         name: "Placeholder",
@@ -260,6 +273,9 @@ public let COMMON_NODES: [Node] = [
     base: .type,
     nameForDiagnostics: "type",
     documentation: "In case the source code is missing a type, this node stands in place of the missing type.",
+    traits: [
+      "MissingNode"
+    ],
     children: [
       Child(
         name: "Placeholder",

--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -180,7 +180,7 @@ public let COMMON_NODES: [Node] = [
         name: "Placeholder",
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
-          A placeholder, i.e. `<#decl#>` that can be inserted into the source code to represent the missing declaration.
+          A placeholder, i.e. `<#decl#>`, that can be inserted into the source code to represent the missing declaration.
           This token should always have `presence = .missing`.
           """
       ),
@@ -197,7 +197,7 @@ public let COMMON_NODES: [Node] = [
         name: "Placeholder",
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
-          A placeholder, i.e. `<#expression#>` that can be inserted into the source code to represent the missing expression.
+          A placeholder, i.e. `<#expression#>`, that can be inserted into the source code to represent the missing expression.
           This token should always have `presence = .missing`.
           """
       )
@@ -214,7 +214,7 @@ public let COMMON_NODES: [Node] = [
         name: "Placeholder",
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
-          A placeholder, i.e. `<#pattern#>` that can be inserted into the source code to represent the missing pattern.
+          A placeholder, i.e. `<#pattern#>`, that can be inserted into the source code to represent the missing pattern.
           This token should always have `presence = .missing`.
           """
       )
@@ -231,7 +231,7 @@ public let COMMON_NODES: [Node] = [
         name: "Placeholder",
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
-          A placeholder, i.e. `<#statement#>` that can be inserted into the source code to represent the missing pattern.
+          A placeholder, i.e. `<#statement#>`, that can be inserted into the source code to represent the missing pattern.
           This token should always have `presence = .missing`.
           """
       )
@@ -248,7 +248,7 @@ public let COMMON_NODES: [Node] = [
         name: "Placeholder",
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
-          A placeholder, i.e. `<#syntax#>` that can be inserted into the source code to represent the missing pattern.
+          A placeholder, i.e. `<#syntax#>`, that can be inserted into the source code to represent the missing pattern.
           This token should always have `presence = .missing`
           """
       )
@@ -265,7 +265,7 @@ public let COMMON_NODES: [Node] = [
         name: "Placeholder",
         kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
-          A placeholder, i.e. `<#type#>` that can be inserted into the source code to represent the missing type. This token should always have `presence = .missing`.
+          A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type. This token should always have `presence = .missing`.
           """
       )
     ]

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -110,4 +110,21 @@ public let TRAITS: [Trait] = [
       Child(name: "TrailingComma", kind: .token(choices: [.token(tokenKind: "CommaToken")]), isOptional: true)
     ]
   ),
+  Trait(
+    traitName: "MissingNode",
+    documentation: """
+      Represents a layout node that is missing in the source file.
+
+      See the types conforming to this protocol for examples of where missing nodes can occur.
+      """,
+    children: [
+      Child(
+        name: "Placeholder",
+        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        documentation: """
+          A placeholder, i.e. `<#placeholder#>`, that can be inserted into the source code to represent the missing node.
+          """
+      )
+    ]
+  ),
 ]

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -10,15 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftSyntax
+
 public class Trait {
   public let traitName: String
+  public let protocolName: TokenSyntax
+  public let documentation: SwiftSyntax.Trivia
   public let children: [Child]
-  public let description: String?
 
-  init(traitName: String, children: [Child], description: String? = nil) {
+  init(traitName: String, documentation: String? = nil, children: [Child]) {
     self.traitName = traitName
+    self.protocolName = .identifier("\(traitName)Syntax")
+    self.documentation = docCommentTrivia(from: documentation)
     self.children = children
-    self.description = description
   }
 }
 

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SwiftSyntaxDoccIndex.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SwiftSyntaxDoccIndex.swift
@@ -61,7 +61,7 @@ let nodesSections: String = {
 
   addSection(heading: "Miscellaneous Syntax", types: SYNTAX_NODES.map(\.kind.syntaxType.description).filter({ !handledSyntaxTypes.contains($0) }))
 
-  addSection(heading: "Traits", types: TRAITS.map { "\($0.traitName)Syntax" })
+  addSection(heading: "Traits", types: TRAITS.map { "\($0.protocolName)" })
 
   return result
 }()

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -19,24 +19,30 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   for trait in TRAITS {
     try! ProtocolDeclSyntax(
       """
-      // MARK: - \(raw: trait.traitName)Syntax
+      // MARK: - \(trait.protocolName)
 
-      public protocol \(raw: trait.traitName)Syntax: SyntaxProtocol
+      \(raw: trait.documentation)
+      public protocol \(trait.protocolName): SyntaxProtocol
       """
     ) {
       for child in trait.children {
-        DeclSyntax("var \(raw: child.varName): \(child.syntaxNodeKind.syntaxType)\(raw: child.isOptional ? "?" : "") { get set }")
+        DeclSyntax(
+          """
+          \(raw: child.docComment)
+          var \(raw: child.varName): \(child.syntaxNodeKind.syntaxType)\(raw: child.isOptional ? "?" : "") { get set }
+          """
+        )
       }
     }
 
-    try! ExtensionDeclSyntax("public extension \(raw: trait.traitName)Syntax") {
+    try! ExtensionDeclSyntax("public extension \(trait.protocolName)") {
       DeclSyntax(
         """
         /// Without this function, the `with` function defined on `SyntaxProtocol`
         /// does not work on existentials of this protocol type.
         @_disfavoredOverload
-        func with<T>(_ keyPath: WritableKeyPath<\(raw: trait.traitName)Syntax, T>, _ newChild: T) -> \(raw: trait.traitName)Syntax {
-          var copy: \(raw: trait.traitName)Syntax = self
+        func with<T>(_ keyPath: WritableKeyPath<\(trait.protocolName), T>, _ newChild: T) -> \(trait.protocolName) {
+          var copy: \(trait.protocolName) = self
           copy[keyPath: keyPath] = newChild
           return copy
         }
@@ -48,10 +54,10 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Check whether the non-type erased version of this syntax node conforms to
-        /// `\(raw: trait.traitName)Syntax`.
+        /// `\(trait.protocolName)`.
         /// Note that this will incur an existential conversion.
-        func isProtocol(_: \(raw: trait.traitName)Syntax.Protocol) -> Bool {
-          return self.asProtocol(\(raw: trait.traitName)Syntax.self) != nil
+        func isProtocol(_: \(trait.protocolName).Protocol) -> Bool {
+          return self.asProtocol(\(trait.protocolName).self) != nil
         }
         """
       )
@@ -59,10 +65,10 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Return the non-type erased version of this syntax node if it conforms to
-        /// `\(raw: trait.traitName)Syntax`. Otherwise return `nil`.
+        /// `\(trait.protocolName)`. Otherwise return `nil`.
         /// Note that this will incur an existential conversion.
-        func asProtocol(_: \(raw: trait.traitName)Syntax.Protocol) -> \(raw: trait.traitName)Syntax? {
-          return Syntax(self).asProtocol(SyntaxProtocol.self) as? \(raw: trait.traitName)Syntax
+        func asProtocol(_: \(trait.protocolName).Protocol) -> \(trait.protocolName)? {
+          return Syntax(self).asProtocol(SyntaxProtocol.self) as? \(trait.protocolName)
         }
         """
       )

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -540,6 +540,7 @@ class ValidateSyntaxNodes: XCTestCase {
         ValidationFailure(node: .availabilityCondition, message: "could conform to trait 'Parenthesized' but does not"),
         ValidationFailure(node: .canImportExpr, message: "could conform to trait 'Parenthesized' but does not"),
         ValidationFailure(node: .differentiabilityParams, message: "could conform to trait 'Parenthesized' but does not"),
+        ValidationFailure(node: .editorPlaceholderDecl, message: "could conform to trait 'MissingNode' but does not"),
         ValidationFailure(node: .editorPlaceholderExpr, message: "could conform to trait 'IdentifiedDecl' but does not"),
         ValidationFailure(node: .enumCaseElement, message: "could conform to trait 'IdentifiedDecl' but does not"),
         ValidationFailure(node: .initializesEffect, message: "could conform to trait 'Parenthesized' but does not"),

--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -70,7 +70,7 @@ public struct Diagnostic: CustomDebugStringConvertible {
   public var debugDescription: String {
     let locationConverter = SourceLocationConverter(file: "", tree: node.root)
     let location = location(converter: locationConverter)
-    return "\(location): \(message)"
+    return "\(location.line):\(location.column): \(message)"
   }
 }
 

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -388,7 +388,15 @@ extension ParseDiagnosticsGenerator {
       }
     }
 
-    let changes = missingNodes.map { FixIt.MultiNodeChange.makePresent($0) }
+    let changes = missingNodes.map { node in
+      if let missing = node.asProtocol(MissingNodeSyntax.self) {
+        // For missing nodes, only make the placeholder present. Don’t make any
+        // missing nodes, e.g. in a malformed attribute, present.
+        return FixIt.MultiNodeChange.makePresent(missing.placeholder)
+      } else {
+        return FixIt.MultiNodeChange.makePresent(node)
+      }
+    }
     let fixIt = FixIt(
       message: InsertTokenFixIt(missingNodes: missingNodes),
       changes: additionalChanges + changes

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -383,6 +383,7 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/WithModifiersSyntax>
 - <doc:SwiftSyntax/WithStatementsSyntax>
 - <doc:SwiftSyntax/WithTrailingCommaSyntax>
+- <doc:SwiftSyntax/MissingNodeSyntax>
 
 
 

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -504,6 +504,46 @@ public extension SyntaxProtocol {
   }
 }
 
+// MARK: - MissingNodeSyntax
+
+/// Represents a layout node that is missing in the source file.
+/// 
+/// See the types conforming to this protocol for examples of where missing nodes can occur.
+public protocol MissingNodeSyntax: SyntaxProtocol {
+  /// A placeholder, i.e. `<#placeholder#>`, that can be inserted into the source code to represent the missing node.
+  var placeholder: TokenSyntax {
+    get
+    set
+  }
+}
+
+public extension MissingNodeSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<MissingNodeSyntax, T>, _ newChild: T) -> MissingNodeSyntax {
+    var copy: MissingNodeSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
+}
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to
+  /// `MissingNodeSyntax`.
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: MissingNodeSyntax.Protocol) -> Bool {
+    return self.asProtocol(MissingNodeSyntax.self) != nil
+  }
+  
+  /// Return the non-type erased version of this syntax node if it conforms to
+  /// `MissingNodeSyntax`. Otherwise return `nil`.
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: MissingNodeSyntax.Protocol) -> MissingNodeSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? MissingNodeSyntax
+  }
+}
+
 extension AccessorBlockSyntax: BracedSyntax {}
 
 extension AccessorDeclSyntax: WithAttributesSyntax {}
@@ -616,7 +656,17 @@ extension MacroExpansionExprSyntax: FreestandingMacroExpansionSyntax {}
 
 extension MemberDeclBlockSyntax: BracedSyntax {}
 
-extension MissingDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
+extension MissingDeclSyntax: MissingNodeSyntax, WithAttributesSyntax, WithModifiersSyntax {}
+
+extension MissingExprSyntax: MissingNodeSyntax {}
+
+extension MissingPatternSyntax: MissingNodeSyntax {}
+
+extension MissingStmtSyntax: MissingNodeSyntax {}
+
+extension MissingSyntax: MissingNodeSyntax {}
+
+extension MissingTypeSyntax: MissingNodeSyntax {}
 
 extension OperatorDeclSyntax: IdentifiedDeclSyntax {}
 

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -14,6 +14,7 @@
 
 // MARK: - BracedSyntax
 
+
 public protocol BracedSyntax: SyntaxProtocol {
   var leftBrace: TokenSyntax {
     get
@@ -54,6 +55,7 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - DeclGroupSyntax
+
 
 public protocol DeclGroupSyntax: SyntaxProtocol {
   var attributes: AttributeListSyntax? {
@@ -111,6 +113,7 @@ public extension SyntaxProtocol {
 
 // MARK: - EffectSpecifiersSyntax
 
+
 public protocol EffectSpecifiersSyntax: SyntaxProtocol {
   var unexpectedBeforeAsyncSpecifier: UnexpectedNodesSyntax? {
     get
@@ -166,6 +169,7 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - FreestandingMacroExpansionSyntax
+
 
 public protocol FreestandingMacroExpansionSyntax: SyntaxProtocol {
   var poundToken: TokenSyntax {
@@ -238,6 +242,7 @@ public extension SyntaxProtocol {
 
 // MARK: - IdentifiedDeclSyntax
 
+
 public protocol IdentifiedDeclSyntax: SyntaxProtocol {
   var identifier: TokenSyntax {
     get
@@ -273,6 +278,7 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - ParenthesizedSyntax
+
 
 public protocol ParenthesizedSyntax: SyntaxProtocol {
   var leftParen: TokenSyntax {
@@ -315,6 +321,7 @@ public extension SyntaxProtocol {
 
 // MARK: - WithAttributesSyntax
 
+
 public protocol WithAttributesSyntax: SyntaxProtocol {
   var attributes: AttributeListSyntax? {
     get
@@ -350,6 +357,7 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - WithCodeBlockSyntax
+
 
 public protocol WithCodeBlockSyntax: SyntaxProtocol {
   var body: CodeBlockSyntax {
@@ -387,6 +395,7 @@ public extension SyntaxProtocol {
 
 // MARK: - WithModifiersSyntax
 
+
 public protocol WithModifiersSyntax: SyntaxProtocol {
   var modifiers: ModifierListSyntax? {
     get
@@ -423,6 +432,7 @@ public extension SyntaxProtocol {
 
 // MARK: - WithStatementsSyntax
 
+
 public protocol WithStatementsSyntax: SyntaxProtocol {
   var statements: CodeBlockItemListSyntax {
     get
@@ -458,6 +468,7 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - WithTrailingCommaSyntax
+
 
 public protocol WithTrailingCommaSyntax: SyntaxProtocol {
   var trailingComma: TokenSyntax? {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -4661,7 +4661,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - attributes: If there were standalone attributes without a declaration to attach them to, the ``MissingDeclSyntax`` will contain these.
   ///   - modifiers: If there were standalone modifiers without a declaration to attach them to, the ``MissingDeclSyntax`` will contain these.
-  ///   - placeholder: A placeholder, i.e. `<#decl#>` that can be inserted into the source code to represent the missing declaration.
+  ///   - placeholder: A placeholder, i.e. `<#decl#>`, that can be inserted into the source code to represent the missing declaration.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -4803,7 +4803,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#decl#>` that can be inserted into the source code to represent the missing declaration./// This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#decl#>`, that can be inserted into the source code to represent the missing declaration./// This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -4187,7 +4187,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - placeholder: A placeholder, i.e. `<#expression#>` that can be inserted into the source code to represent the missing expression.
+  ///   - placeholder: A placeholder, i.e. `<#expression#>`, that can be inserted into the source code to represent the missing expression.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -4223,7 +4223,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#expression#>` that can be inserted into the source code to represent the missing expression./// This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#expression#>`, that can be inserted into the source code to represent the missing expression./// This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -13529,7 +13529,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - placeholder: A placeholder, i.e. `<#syntax#>` that can be inserted into the source code to represent the missing pattern.
+  ///   - placeholder: A placeholder, i.e. `<#syntax#>`, that can be inserted into the source code to represent the missing pattern.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -13565,7 +13565,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#syntax#>` that can be inserted into the source code to represent the missing pattern./// This token should always have `presence = .missing`
+  /// A placeholder, i.e. `<#syntax#>`, that can be inserted into the source code to represent the missing pattern./// This token should always have `presence = .missing`
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -333,7 +333,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - placeholder: A placeholder, i.e. `<#pattern#>` that can be inserted into the source code to represent the missing pattern.
+  ///   - placeholder: A placeholder, i.e. `<#pattern#>`, that can be inserted into the source code to represent the missing pattern.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -369,7 +369,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#pattern#>` that can be inserted into the source code to represent the missing pattern./// This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#pattern#>`, that can be inserted into the source code to represent the missing pattern./// This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -1573,7 +1573,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - placeholder: A placeholder, i.e. `<#statement#>` that can be inserted into the source code to represent the missing pattern.
+  ///   - placeholder: A placeholder, i.e. `<#statement#>`, that can be inserted into the source code to represent the missing pattern.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -1609,7 +1609,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#statement#>` that can be inserted into the source code to represent the missing pattern./// This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#statement#>`, that can be inserted into the source code to represent the missing pattern./// This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -1570,7 +1570,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - placeholder: A placeholder, i.e. `<#type#>` that can be inserted into the source code to represent the missing type. This token should always have `presence = .missing`.
+  ///   - placeholder: A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type. This token should always have `presence = .missing`.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -1606,7 +1606,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// A placeholder, i.e. `<#type#>` that can be inserted into the source code to represent the missing type. This token should always have `presence = .missing`.
+  /// A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type. This token should always have `presence = .missing`.
   public var placeholder: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -107,7 +107,7 @@ final class AttributeTests: XCTestCase {
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected declaration after attribute", fixIts: ["insert declaration"]),
       ],
       fixedSource: """
-        @_specialize(e:, exported: false)  <#declaration#>
+        @_specialize(e:, exported: false) <#declaration#>
         """
     )
   }
@@ -343,7 +343,7 @@ final class AttributeTests: XCTestCase {
       "@resultBuilder1️⃣",
       diagnostics: [DiagnosticSpec(message: "expected declaration after attribute", fixIts: ["insert declaration"])],
       fixedSource: """
-        @resultBuilder  <#declaration#>
+        @resultBuilder <#declaration#>
         """
     )
   }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -730,7 +730,7 @@ final class DeclarationTests: XCTestCase {
       ],
       fixedSource: """
         struct a {
-          public  <#declaration#>
+          public <#declaration#>
         }
         """
     )


### PR DESCRIPTION
This fixes a couple of formatting issues and resolves the question raised in https://github.com/apple/swift-syntax/pull/1727#discussion_r1254270178.

While at it do the following
- Add a syntax trait for all missing nodes (because we’re using it for diagnostic generation)
- Improve the generation of Traits.swift
- Add missing comma in doc comments of missing nodes
- Improve `debugDescription` of `Diagnostic`
  - Since `SourceLocation` is no longer `ExpressibleByDebugDescription` due to the addition of `presumedFile` and `presumedLine`, we need to manually print just line and column here.