### PR TITLE
Replace `offset(of: )` with `getOffsetToStart`

### DIFF
--- a/Sources/SwiftParser/IncrementalParseTransition.swift
+++ b/Sources/SwiftParser/IncrementalParseTransition.swift
@@ -18,7 +18,7 @@ extension Parser {
       return nil
     }
 
-    let currentOffset = self.lexemes.getOffsetToStart(self.currentToken)
+    let currentOffset = self.lexemes.offsetToStart(self.currentToken)
     if let node = parseLookup!.lookUp(currentOffset, kind: kind) {
       self.lexemes.advance(by: node.byteSize, currentToken: &self.currentToken)
       return node
@@ -30,7 +30,7 @@ extension Parser {
   mutating func registerNodeForIncrementalParse(node: RawSyntax, startToken: Lexer.Lexeme) {
     lookaheadRanges.registerNodeForIncrementalParse(
       node: node,
-      lookaheadLength: lexemes.lookaheadTracker.pointee.furthestOffset - self.lexemes.getOffsetToStart(startToken)
+      lookaheadLength: lexemes.lookaheadTracker.pointee.furthestOffset - self.lexemes.offsetToStart(startToken)
     )
   }
 }

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -34,7 +34,7 @@ extension Lexer {
 
     /// The offset of the trailing trivia end of `nextToken` relative to the source buffer’s start.
     var offsetToNextTokenEnd: Int {
-      self.getOffsetToStart(self.nextToken) + self.nextToken.byteLength
+      self.offsetToStart(self.nextToken) + self.nextToken.byteLength
     }
 
     /// See doc comments in ``LookaheadTracker``
@@ -70,7 +70,7 @@ extension Lexer {
     }
 
     /// Get the offset of the leading trivia start of `token` relative to `sourceBufferStart`.
-    func getOffsetToStart(_ token: Lexer.Lexeme) -> Int {
+    func offsetToStart(_ token: Lexer.Lexeme) -> Int {
       return self.sourceBufferStart.distance(to: token.cursor)
     }
 
@@ -122,20 +122,6 @@ extension Lexer {
         return remainingText
       }
     }
-
-    #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
-    /// If `pointer` is in the source buffer of this ``LexemeSequence``, return
-    /// its offset, otherwise `nil`. Should only be used for the parser's
-    /// alternate token introspection
-    func offset(of pointer: UnsafePointer<UInt8>) -> Int? {
-      let offset = pointer - self.sourceBufferStart.input.baseAddress!
-      if offset <= self.sourceBufferStart.input.count {
-        return offset
-      } else {
-        return nil
-      }
-    }
-    #endif
   }
 
   @_spi(Testing)

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -250,11 +250,7 @@ public struct Parser {
   public var alternativeTokenChoices: [Int: [TokenSpec]] = [:]
 
   mutating func recordAlternativeTokenChoice(for lexeme: Lexer.Lexeme, choices: [TokenSpec]) {
-    guard let lexemeBaseAddress = lexeme.tokenText.baseAddress,
-      let offset = lexemes.offset(of: lexemeBaseAddress)
-    else {
-      return
-    }
+    let offset = lexemes.offsetToStart(lexeme)
     alternativeTokenChoices[offset, default: []].append(contentsOf: choices)
   }
   #endif


### PR DESCRIPTION
`LexemeSequence.offset(of: )` and `LexemeSequence.getOffsetToStart` perform the same function and this should make the usage more consistent.