### PR TITLE
Replace `IncrementalParseReusedNodeDelegate` with `ReusedNodeCallback`

### DIFF
--- a/Tests/SwiftParserTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftParserTest/IncrementalParsingTests.swift
@@ -162,7 +162,6 @@ public class IncrementalParsingTests: XCTestCase {
   }
 
   public func testMultiEditMapping() throws {
-    try XCTSkipIf(true, "Swift parser does not handle node reuse yet")
     assertIncrementalParse(
       """
       let one: Int;let two: Int; let three: Int; ⏩️⏸️                      ⏪️⏩️⏸️   ⏪️let found: Int;let five: Int;


### PR DESCRIPTION
Resolves comments in https://github.com/apple/swift-syntax/pull/1685/files#r1254465986