### PR TITLE
Add `Children` section to `SyntaxCollection` nodes

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -270,4 +270,21 @@ public struct CollectionNode {
       return choices
     }
   }
+
+  public var grammar: SwiftSyntax.Trivia {
+    let grammar: String
+    if let onlyElement = elementChoices.only {
+      grammar = "``\(onlyElement.syntaxType)`` `*`"
+    } else {
+      grammar = "(\(elementChoices.map { "``\($0.syntaxType)``" }.joined(separator: " | "))) `*`"
+    }
+
+    return docCommentTrivia(
+      from: """
+        ### Children
+
+        \(grammar)
+        """
+    )
+  }
 }

--- a/CodeGeneration/Sources/SyntaxSupport/Utils.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Utils.swift
@@ -54,3 +54,14 @@ public func docCommentTrivia(from string: String?) -> SwiftSyntax.Trivia {
   }
   return SwiftSyntax.Trivia(pieces: pieces)
 }
+
+public extension Collection {
+  /// If the collection contains a single element, return it, otherwise `nil`.
+  var only: Element? {
+    if !isEmpty && index(after: startIndex) == endIndex {
+      return self.first!
+    } else {
+      return nil
+    }
+  }
+}

--- a/CodeGeneration/Sources/Utils/Utils.swift
+++ b/CodeGeneration/Sources/Utils/Utils.swift
@@ -10,28 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Trims leading and trailing whitespace from each line.
-public func dedented<Lines: Sequence>(lines: Lines) -> [String] where Lines.Element: StringProtocol {
-  lines.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-}
+extension String {
+  /// Creates a single-line documentation string from indented
+  /// documentation as written in `CodeGeneration`.
+  public var flattened: String {
+    self
+      .replacingOccurrences(of: "\n", with: "")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
 
-/// Trims leading and trailing whitespace from each line.
-public func dedented(string: String) -> String {
-  dedented(lines: string.split(separator: "\n"))
-    .joined(separator: "\n")
-}
-
-/// Creates a single-line documentation string from indented
-/// documentation as written in `CodeGeneration`.
-public func flattened(indentedDocumentation: String) -> String {
-  dedented(string: indentedDocumentation)
-    .replacingOccurrences(of: "\n", with: "")
-    .trimmingCharacters(in: .whitespacesAndNewlines)
-}
-
-/// Removes all empty lines from a multi-line string.
-public func removedEmptyLines(string: String) -> String {
-  string.split(whereSeparator: \.isNewline)
-    .filter { !$0.allSatisfy(\.isWhitespace) }
-    .joined(separator: "\n")
+  /// Removes all empty lines from a multi-line string.
+  public var removingEmptyLines: String {
+    return
+      self
+      .split(whereSeparator: \.isNewline)
+      .filter { !$0.allSatisfy(\.isWhitespace) }
+      .joined(separator: "\n")
+  }
 }

--- a/CodeGeneration/Sources/Utils/Utils.swift
+++ b/CodeGeneration/Sources/Utils/Utils.swift
@@ -35,14 +35,3 @@ public func removedEmptyLines(string: String) -> String {
     .filter { !$0.allSatisfy(\.isWhitespace) }
     .joined(separator: "\n")
 }
-
-public extension Collection {
-  /// If the collection contains a single element, return it, otherwise `nil`.
-  var only: Element? {
-    if !isEmpty && index(after: startIndex) == endIndex {
-      return self.first!
-    } else {
-      return nil
-    }
-  }
-}

--- a/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
@@ -86,16 +86,14 @@ extension LayoutNode {
       return "  - \(child.varName): \(firstLine)"
     }
 
-    let formattedParams = removedEmptyLines(
-      string: """
-        - Parameters:
-          - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. \
-        If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-        \(children.compactMap(generateParamDocComment).joined(separator: "\n"))
-          - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. \
-        If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-        """
-    )
+    let formattedParams = """
+      - Parameters:
+        - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. \
+      If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+      \(children.compactMap(generateParamDocComment).joined(separator: "\n"))
+        - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. \
+      If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+      """.removingEmptyLines
 
     return docCommentTrivia(from: formattedParams)
   }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -17,11 +17,15 @@ import Utils
 
 let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   for node in SYNTAX_NODES.compactMap(\.collectionNode) {
+    let documentation = """
+      \(node.documentation)
+      \(node.documentation.isEmpty ? "" : "///")
+      \(node.grammar)
+      """.removingEmptyLines
+
     try! StructDeclSyntax(
       """
-      \(raw: node.documentation)
-      \(raw: node.documentation.isEmpty ? "" : "///")
-      \(raw: node.grammar)
+      \(raw: documentation)
       public struct \(node.kind.syntaxType): SyntaxCollection, SyntaxHashable
       """
     ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -20,7 +20,9 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     try! StructDeclSyntax(
       """
       \(raw: node.documentation)
-      public struct \(raw: node.kind.syntaxType): SyntaxCollection, SyntaxHashable
+      \(raw: node.documentation.isEmpty ? "" : "///")
+      \(raw: node.grammar)
+      public struct \(node.kind.syntaxType): SyntaxCollection, SyntaxHashable
       """
     ) {
       if let onlyElement = node.elementChoices.only {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -20,8 +20,7 @@ extension Child {
     guard let description = documentation else {
       return []
     }
-    let dedented = dedented(string: description)
-    let lines = dedented.split(separator: "\n", omittingEmptySubsequences: false)
+    let lines = description.split(separator: "\n", omittingEmptySubsequences: false)
     let pieces = lines.map { SwiftSyntax.TriviaPiece.docLineComment("/// \($0)") }
     return Trivia(pieces: pieces)
   }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -33,14 +33,18 @@ extension Child {
 func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
   SourceFileSyntax(leadingTrivia: copyrightHeader) {
     for node in SYNTAX_NODES.compactMap(\.layoutNode) where node.base == emitKind {
+      let documentation = """
+        \(node.documentation)
+        \(node.documentation.isEmpty ? "" : "///")
+        \(node.grammar)
+        """.removingEmptyLines
+
       // We are actually handling this node now
       try! StructDeclSyntax(
         """
         // MARK: - \(raw: node.kind.syntaxType)
 
-        \(raw: node.documentation)
-        \(raw: node.documentation.isEmpty ? "" : "///")
-        \(raw: node.grammar)
+        \(raw: documentation)
         public struct \(raw: node.kind.syntaxType): \(raw: node.baseType.syntaxBaseName)Protocol, SyntaxHashable
         """
       ) {

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-
 /// ### Children
 /// 
 /// ``AccessorDeclSyntax`` `*`
@@ -32,7 +30,6 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.accessorList
 }
 
-
 /// ### Children
 /// 
 /// ``ArrayElementSyntax`` `*`
@@ -50,7 +47,6 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.arrayElementList
 }
-
 
 /// ### Children
 /// 
@@ -112,7 +108,6 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.attributeList
 }
 
-
 /// ### Children
 /// 
 /// ``AvailabilityArgumentSyntax`` `*`
@@ -130,7 +125,6 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.availabilitySpecList
 }
-
 
 /// ### Children
 /// 
@@ -150,7 +144,6 @@ public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, Syntax
   public static let syntaxKind = SyntaxKind.availabilityVersionRestrictionList
 }
 
-
 /// ### Children
 /// 
 /// ``CaseItemSyntax`` `*`
@@ -168,7 +161,6 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.caseItemList
 }
-
 
 /// ### Children
 /// 
@@ -188,7 +180,6 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.catchClauseList
 }
 
-
 /// ### Children
 /// 
 /// ``CatchItemSyntax`` `*`
@@ -206,7 +197,6 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.catchItemList
 }
-
 
 /// ### Children
 /// 
@@ -226,7 +216,6 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.closureCaptureItemList
 }
 
-
 /// ### Children
 /// 
 /// ``ClosureParamSyntax`` `*`
@@ -244,7 +233,6 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.closureParamList
 }
-
 
 /// ### Children
 /// 
@@ -264,7 +252,6 @@ public struct ClosureParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.closureParameterList
 }
 
-
 /// ### Children
 /// 
 /// ``CodeBlockItemSyntax`` `*`
@@ -282,7 +269,6 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.codeBlockItemList
 }
-
 
 /// ### Children
 /// 
@@ -302,7 +288,6 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   public static let syntaxKind = SyntaxKind.compositionTypeElementList
 }
 
-
 /// ### Children
 /// 
 /// ``ConditionElementSyntax`` `*`
@@ -320,7 +305,6 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.conditionElementList
 }
-
 
 /// ### Children
 /// 
@@ -340,7 +324,6 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.declNameArgumentList
 }
 
-
 /// ### Children
 /// 
 /// ``DesignatedTypeElementSyntax`` `*`
@@ -359,7 +342,6 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.designatedTypeList
 }
 
-
 /// ### Children
 /// 
 /// ``DictionaryElementSyntax`` `*`
@@ -377,7 +359,6 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.dictionaryElementList
 }
-
 
 /// ### Children
 /// 
@@ -457,7 +438,6 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.enumCaseElementList
 }
 
-
 /// ### Children
 /// 
 /// ``EnumCaseParameterSyntax`` `*`
@@ -496,7 +476,6 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.exprList
 }
 
-
 /// ### Children
 /// 
 /// ``FunctionParameterSyntax`` `*`
@@ -514,7 +493,6 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.functionParameterList
 }
-
 
 /// ### Children
 /// 
@@ -534,7 +512,6 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.genericArgumentList
 }
 
-
 /// ### Children
 /// 
 /// ``GenericParameterSyntax`` `*`
@@ -552,7 +529,6 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.genericParameterList
 }
-
 
 /// ### Children
 /// 
@@ -572,7 +548,6 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.genericRequirementList
 }
 
-
 /// ### Children
 /// 
 /// ``IfConfigClauseSyntax`` `*`
@@ -590,7 +565,6 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.ifConfigClauseList
 }
-
 
 /// ### Children
 /// 
@@ -610,7 +584,6 @@ public struct ImportPathSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.importPath
 }
 
-
 /// ### Children
 /// 
 /// ``InheritedTypeSyntax`` `*`
@@ -628,7 +601,6 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.inheritedTypeList
 }
-
 
 /// ### Children
 /// 
@@ -648,7 +620,6 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.keyPathComponentList
 }
 
-
 /// ### Children
 /// 
 /// ``MemberDeclListItemSyntax`` `*`
@@ -666,7 +637,6 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.memberDeclList
 }
-
 
 /// ### Children
 /// 
@@ -686,7 +656,6 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.modifierList
 }
 
-
 /// ### Children
 /// 
 /// ``MultipleTrailingClosureElementSyntax`` `*`
@@ -704,7 +673,6 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   
   public static let syntaxKind = SyntaxKind.multipleTrailingClosureElementList
 }
-
 
 /// ### Children
 /// 
@@ -724,7 +692,6 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.objCSelector
 }
 
-
 /// ### Children
 /// 
 /// ``PatternBindingSyntax`` `*`
@@ -742,7 +709,6 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.patternBindingList
 }
-
 
 /// ### Children
 /// 
@@ -816,7 +782,6 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   public static let syntaxKind = SyntaxKind.precedenceGroupAttributeList
 }
 
-
 /// ### Children
 /// 
 /// ``PrecedenceGroupNameElementSyntax`` `*`
@@ -834,7 +799,6 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.precedenceGroupNameList
 }
-
 
 /// ### Children
 /// 
@@ -941,7 +905,6 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   public static let syntaxKind = SyntaxKind.specializeAttributeSpecList
 }
 
-
 /// ### Children
 /// 
 /// (``StringSegmentSyntax`` | ``ExpressionSegmentSyntax``) `*`
@@ -1001,7 +964,6 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.stringLiteralSegments
 }
-
 
 /// ### Children
 /// 
@@ -1063,7 +1025,6 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.switchCaseList
 }
 
-
 /// ### Children
 /// 
 /// ``TupleExprElementSyntax`` `*`
@@ -1082,7 +1043,6 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.tupleExprElementList
 }
 
-
 /// ### Children
 /// 
 /// ``TuplePatternElementSyntax`` `*`
@@ -1100,7 +1060,6 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.tuplePatternElementList
 }
-
 
 /// ### Children
 /// 
@@ -1140,7 +1099,6 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.unexpectedNodes
 }
 
-
 /// ### Children
 /// 
 /// ``VersionComponentSyntax`` `*`
@@ -1158,7 +1116,6 @@ public struct VersionComponentListSyntax: SyntaxCollection, SyntaxHashable {
   
   public static let syntaxKind = SyntaxKind.versionComponentList
 }
-
 
 /// ### Children
 /// 

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -13,6 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 
+
+/// ### Children
+/// 
+/// ``AccessorDeclSyntax`` `*`
 public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = AccessorDeclSyntax
   
@@ -28,6 +32,10 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.accessorList
 }
 
+
+/// ### Children
+/// 
+/// ``ArrayElementSyntax`` `*`
 public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = ArrayElementSyntax
   
@@ -43,6 +51,10 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.arrayElementList
 }
 
+
+/// ### Children
+/// 
+/// (``AttributeSyntax`` | ``IfConfigDeclSyntax``) `*`
 public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   public enum Element: SyntaxChildChoices {
     case `attribute`(AttributeSyntax)
@@ -100,6 +112,10 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.attributeList
 }
 
+
+/// ### Children
+/// 
+/// ``AvailabilityArgumentSyntax`` `*`
 public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = AvailabilityArgumentSyntax
   
@@ -115,6 +131,10 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.availabilitySpecList
 }
 
+
+/// ### Children
+/// 
+/// ``AvailabilityVersionRestrictionListEntrySyntax`` `*`
 public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = AvailabilityVersionRestrictionListEntrySyntax
   
@@ -130,6 +150,10 @@ public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, Syntax
   public static let syntaxKind = SyntaxKind.availabilityVersionRestrictionList
 }
 
+
+/// ### Children
+/// 
+/// ``CaseItemSyntax`` `*`
 public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = CaseItemSyntax
   
@@ -145,6 +169,10 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.caseItemList
 }
 
+
+/// ### Children
+/// 
+/// ``CatchClauseSyntax`` `*`
 public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = CatchClauseSyntax
   
@@ -160,6 +188,10 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.catchClauseList
 }
 
+
+/// ### Children
+/// 
+/// ``CatchItemSyntax`` `*`
 public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = CatchItemSyntax
   
@@ -175,6 +207,10 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.catchItemList
 }
 
+
+/// ### Children
+/// 
+/// ``ClosureCaptureItemSyntax`` `*`
 public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = ClosureCaptureItemSyntax
   
@@ -190,6 +226,10 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.closureCaptureItemList
 }
 
+
+/// ### Children
+/// 
+/// ``ClosureParamSyntax`` `*`
 public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = ClosureParamSyntax
   
@@ -205,6 +245,10 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.closureParamList
 }
 
+
+/// ### Children
+/// 
+/// ``ClosureParameterSyntax`` `*`
 public struct ClosureParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = ClosureParameterSyntax
   
@@ -220,6 +264,10 @@ public struct ClosureParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.closureParameterList
 }
 
+
+/// ### Children
+/// 
+/// ``CodeBlockItemSyntax`` `*`
 public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = CodeBlockItemSyntax
   
@@ -235,6 +283,10 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.codeBlockItemList
 }
 
+
+/// ### Children
+/// 
+/// ``CompositionTypeElementSyntax`` `*`
 public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = CompositionTypeElementSyntax
   
@@ -250,6 +302,10 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   public static let syntaxKind = SyntaxKind.compositionTypeElementList
 }
 
+
+/// ### Children
+/// 
+/// ``ConditionElementSyntax`` `*`
 public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = ConditionElementSyntax
   
@@ -265,6 +321,10 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.conditionElementList
 }
 
+
+/// ### Children
+/// 
+/// ``DeclNameArgumentSyntax`` `*`
 public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = DeclNameArgumentSyntax
   
@@ -280,6 +340,10 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.declNameArgumentList
 }
 
+
+/// ### Children
+/// 
+/// ``DesignatedTypeElementSyntax`` `*`
 public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = DesignatedTypeElementSyntax
   
@@ -295,6 +359,10 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.designatedTypeList
 }
 
+
+/// ### Children
+/// 
+/// ``DictionaryElementSyntax`` `*`
 public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = DictionaryElementSyntax
   
@@ -310,6 +378,10 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.dictionaryElementList
 }
 
+
+/// ### Children
+/// 
+/// ``DifferentiabilityParamSyntax`` `*`
 public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = DifferentiabilityParamSyntax
   
@@ -326,6 +398,10 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
 }
 
 /// The arguments of the '@_documentation' attribute
+///
+/// ### Children
+/// 
+/// ``DocumentationAttributeArgumentSyntax`` `*`
 public struct DocumentationAttributeArgumentsSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = DocumentationAttributeArgumentSyntax
   
@@ -342,6 +418,10 @@ public struct DocumentationAttributeArgumentsSyntax: SyntaxCollection, SyntaxHas
 }
 
 /// The arguments of the '@_effect' attribute. These will be parsed during the SIL stage.
+///
+/// ### Children
+/// 
+/// ``TokenSyntax`` `*`
 public struct EffectsArgumentsSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = TokenSyntax
   
@@ -358,6 +438,10 @@ public struct EffectsArgumentsSyntax: SyntaxCollection, SyntaxHashable {
 }
 
 /// A collection of 0 or more `EnumCaseElement`s.
+///
+/// ### Children
+/// 
+/// ``EnumCaseElementSyntax`` `*`
 public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = EnumCaseElementSyntax
   
@@ -373,6 +457,10 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.enumCaseElementList
 }
 
+
+/// ### Children
+/// 
+/// ``EnumCaseParameterSyntax`` `*`
 public struct EnumCaseParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = EnumCaseParameterSyntax
   
@@ -389,6 +477,10 @@ public struct EnumCaseParameterListSyntax: SyntaxCollection, SyntaxHashable {
 }
 
 /// A list of expressions connected by operators. This list is contained by a ``SequenceExprSyntax``.
+///
+/// ### Children
+/// 
+/// ``ExprSyntax`` `*`
 public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = ExprSyntax
   
@@ -404,6 +496,10 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.exprList
 }
 
+
+/// ### Children
+/// 
+/// ``FunctionParameterSyntax`` `*`
 public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = FunctionParameterSyntax
   
@@ -419,6 +515,10 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.functionParameterList
 }
 
+
+/// ### Children
+/// 
+/// ``GenericArgumentSyntax`` `*`
 public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = GenericArgumentSyntax
   
@@ -434,6 +534,10 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.genericArgumentList
 }
 
+
+/// ### Children
+/// 
+/// ``GenericParameterSyntax`` `*`
 public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = GenericParameterSyntax
   
@@ -449,6 +553,10 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.genericParameterList
 }
 
+
+/// ### Children
+/// 
+/// ``GenericRequirementSyntax`` `*`
 public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = GenericRequirementSyntax
   
@@ -464,6 +572,10 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.genericRequirementList
 }
 
+
+/// ### Children
+/// 
+/// ``IfConfigClauseSyntax`` `*`
 public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = IfConfigClauseSyntax
   
@@ -479,6 +591,10 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.ifConfigClauseList
 }
 
+
+/// ### Children
+/// 
+/// ``ImportPathComponentSyntax`` `*`
 public struct ImportPathSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = ImportPathComponentSyntax
   
@@ -494,6 +610,10 @@ public struct ImportPathSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.importPath
 }
 
+
+/// ### Children
+/// 
+/// ``InheritedTypeSyntax`` `*`
 public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = InheritedTypeSyntax
   
@@ -509,6 +629,10 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.inheritedTypeList
 }
 
+
+/// ### Children
+/// 
+/// ``KeyPathComponentSyntax`` `*`
 public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = KeyPathComponentSyntax
   
@@ -524,6 +648,10 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.keyPathComponentList
 }
 
+
+/// ### Children
+/// 
+/// ``MemberDeclListItemSyntax`` `*`
 public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = MemberDeclListItemSyntax
   
@@ -539,6 +667,10 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.memberDeclList
 }
 
+
+/// ### Children
+/// 
+/// ``DeclModifierSyntax`` `*`
 public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = DeclModifierSyntax
   
@@ -554,6 +686,10 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.modifierList
 }
 
+
+/// ### Children
+/// 
+/// ``MultipleTrailingClosureElementSyntax`` `*`
 public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = MultipleTrailingClosureElementSyntax
   
@@ -569,6 +705,10 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   public static let syntaxKind = SyntaxKind.multipleTrailingClosureElementList
 }
 
+
+/// ### Children
+/// 
+/// ``ObjCSelectorPieceSyntax`` `*`
 public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = ObjCSelectorPieceSyntax
   
@@ -584,6 +724,10 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.objCSelector
 }
 
+
+/// ### Children
+/// 
+/// ``PatternBindingSyntax`` `*`
 public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = PatternBindingSyntax
   
@@ -599,6 +743,10 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.patternBindingList
 }
 
+
+/// ### Children
+/// 
+/// (``PrecedenceGroupRelationSyntax`` | ``PrecedenceGroupAssignmentSyntax`` | ``PrecedenceGroupAssociativitySyntax``) `*`
 public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashable {
   public enum Element: SyntaxChildChoices {
     case `precedenceGroupRelation`(PrecedenceGroupRelationSyntax)
@@ -668,6 +816,10 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   public static let syntaxKind = SyntaxKind.precedenceGroupAttributeList
 }
 
+
+/// ### Children
+/// 
+/// ``PrecedenceGroupNameElementSyntax`` `*`
 public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = PrecedenceGroupNameElementSyntax
   
@@ -683,6 +835,10 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.precedenceGroupNameList
 }
 
+
+/// ### Children
+/// 
+/// ``PrimaryAssociatedTypeSyntax`` `*`
 public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = PrimaryAssociatedTypeSyntax
   
@@ -699,6 +855,10 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
 }
 
 /// A collection of arguments for the `@_specialize` attribute
+///
+/// ### Children
+/// 
+/// (``LabeledSpecializeEntrySyntax`` | ``AvailabilityEntrySyntax`` | ``TargetFunctionEntrySyntax`` | ``GenericWhereClauseSyntax``) `*`
 public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashable {
   public enum Element: SyntaxChildChoices {
     case `labeledSpecializeEntry`(LabeledSpecializeEntrySyntax)
@@ -781,6 +941,10 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   public static let syntaxKind = SyntaxKind.specializeAttributeSpecList
 }
 
+
+/// ### Children
+/// 
+/// (``StringSegmentSyntax`` | ``ExpressionSegmentSyntax``) `*`
 public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   public enum Element: SyntaxChildChoices {
     case `stringSegment`(StringSegmentSyntax)
@@ -838,6 +1002,10 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.stringLiteralSegments
 }
 
+
+/// ### Children
+/// 
+/// (``SwitchCaseSyntax`` | ``IfConfigDeclSyntax``) `*`
 public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   public enum Element: SyntaxChildChoices {
     case `switchCase`(SwitchCaseSyntax)
@@ -895,6 +1063,10 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.switchCaseList
 }
 
+
+/// ### Children
+/// 
+/// ``TupleExprElementSyntax`` `*`
 public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = TupleExprElementSyntax
   
@@ -910,6 +1082,10 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.tupleExprElementList
 }
 
+
+/// ### Children
+/// 
+/// ``TuplePatternElementSyntax`` `*`
 public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = TuplePatternElementSyntax
   
@@ -925,6 +1101,10 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.tuplePatternElementList
 }
 
+
+/// ### Children
+/// 
+/// ``TupleTypeElementSyntax`` `*`
 public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = TupleTypeElementSyntax
   
@@ -941,6 +1121,10 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
 }
 
 /// A collection of syntax nodes that occurred in the source code but could not be used to form a valid syntax tree.
+///
+/// ### Children
+/// 
+/// ``Syntax`` `*`
 public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = Syntax
   
@@ -956,6 +1140,10 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.unexpectedNodes
 }
 
+
+/// ### Children
+/// 
+/// ``VersionComponentSyntax`` `*`
 public struct VersionComponentListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = VersionComponentSyntax
   
@@ -971,6 +1159,10 @@ public struct VersionComponentListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.versionComponentList
 }
 
+
+/// ### Children
+/// 
+/// ``YieldExprListElementSyntax`` `*`
 public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   public typealias Element = YieldExprListElementSyntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -14,8 +14,6 @@
 
 // MARK: - AccessorDeclSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `attributes`: ``AttributeListSyntax``
@@ -296,8 +294,6 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ActorDeclSyntax
-
-
 
 /// ### Children
 /// 
@@ -2427,8 +2423,6 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ExtensionDeclSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `attributes`: ``AttributeListSyntax``
@@ -2735,8 +2729,6 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - FunctionDeclSyntax
-
-
 
 /// ### Children
 /// 
@@ -3073,8 +3065,6 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - IfConfigDeclSyntax
-
-
 
 /// ### Children
 /// 
@@ -3870,8 +3860,6 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - MacroDeclSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `attributes`: ``AttributeListSyntax``
@@ -4207,8 +4195,6 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - MacroExpansionDeclSyntax
-
-
 
 /// ### Children
 /// 
@@ -5032,8 +5018,6 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - PoundSourceLocationSyntax
-
-
 
 /// ### Children
 /// 
@@ -6310,8 +6294,6 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - SubscriptDeclSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `attributes`: ``AttributeListSyntax``
@@ -6690,8 +6672,6 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - TypealiasDeclSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `attributes`: ``AttributeListSyntax``
@@ -7000,8 +6980,6 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - VariableDeclSyntax
-
-
 
 /// ### Children
 /// 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -14,8 +14,6 @@
 
 // MARK: - ArrayExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftSquare`: `'['`
@@ -189,8 +187,6 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ArrowExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `effectSpecifiers`: ``TypeEffectSpecifiersSyntax``?
@@ -312,8 +308,6 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - AsExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -491,8 +485,6 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - AssignmentExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `equal`: `'='`
@@ -575,8 +567,6 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - AwaitExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -700,8 +690,6 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - BinaryOperatorExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `operator`: `<binaryOperator>`
@@ -785,8 +773,6 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - BooleanLiteralExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `literal`: (`'true'` | `'false'`)
@@ -869,8 +855,6 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - BorrowExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -993,8 +977,6 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - CanImportExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -1199,8 +1181,6 @@ public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - CanImportVersionInfoSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `comma`: `','`
@@ -1376,8 +1356,6 @@ public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ClosureExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -1579,8 +1557,6 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - CopyExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `copyKeyword`: `'copy'`
@@ -1702,8 +1678,6 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - DictionaryExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -1896,8 +1870,6 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - DiscardAssignmentExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `wildcard`: `'_'`
@@ -1980,8 +1952,6 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - EditorPlaceholderExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -2066,8 +2036,6 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - FloatLiteralExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `digits`: `<floatingLiteral>`
@@ -2150,8 +2118,6 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ForcedValueExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -2274,8 +2240,6 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - FunctionCallExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -2555,8 +2519,6 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - IdentifierExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `identifier`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<dollarIdentifier>` | `<binaryOperator>`)
@@ -2678,8 +2640,6 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - IfExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -2950,8 +2910,6 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - InOutExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `ampersand`: `'&'`
@@ -3073,8 +3031,6 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - InfixOperatorExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -3224,8 +3180,6 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - IntegerLiteralExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -3473,8 +3427,6 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - KeyPathExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `backslash`: `'\'`
@@ -3647,8 +3599,6 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - MacroExpansionExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -3984,8 +3934,6 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - MemberAccessExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `base`: ``ExprSyntax``?
@@ -4249,8 +4197,6 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - MoveExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `consumeKeyword`: (`'_move'` | `'consume'`)
@@ -4373,8 +4319,6 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - NilLiteralExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `nilKeyword`: `'nil'`
@@ -4457,8 +4401,6 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - OptionalChainingExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -4582,8 +4524,6 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - PackElementExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `eachKeyword`: `'each'`
@@ -4705,8 +4645,6 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - PackExpansionExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -4830,8 +4768,6 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - PostfixIfConfigExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `base`: ``ExprSyntax``?
@@ -4953,8 +4889,6 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - PostfixUnaryExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -5078,8 +5012,6 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - PrefixOperatorExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `operator`: `<prefixOperator>`?
@@ -5201,8 +5133,6 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - RegexLiteralExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -5407,8 +5337,6 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - SequenceExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `elements`: ``ExprListSyntax``
@@ -5515,8 +5443,6 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - SpecializeExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -5639,8 +5565,6 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - StringLiteralExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -5868,8 +5792,6 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - SubscriptExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -6149,8 +6071,6 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - SuperRefExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `superKeyword`: `'super'`
@@ -6233,8 +6153,6 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - SwitchExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -6463,8 +6381,6 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - TernaryExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `conditionExpression`: ``ExprSyntax``
@@ -6668,8 +6584,6 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - TryExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `tryKeyword`: `'try'`
@@ -6818,8 +6732,6 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - TupleExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -6994,8 +6906,6 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - TypeExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `type`: ``TypeSyntax``
@@ -7078,8 +6988,6 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - UnresolvedAsExprSyntax
-
-
 
 /// ### Children
 /// 
@@ -7203,8 +7111,6 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - UnresolvedIsExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `isKeyword`: `'is'`
@@ -7288,8 +7194,6 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - UnresolvedPatternExprSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `pattern`: ``PatternSyntax``
@@ -7372,8 +7276,6 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - UnresolvedTernaryExprSyntax
-
-
 
 /// ### Children
 /// 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -14,8 +14,6 @@
 
 // MARK: - AccessesEffectSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `accessesKeyword`: `'accesses'`
@@ -216,8 +214,6 @@ public struct AccessesEffectSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - AccessorBlockSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftBrace`: `'{'`
@@ -391,8 +387,6 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - AccessorEffectSpecifiersSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `asyncSpecifier`: `'async'`?
@@ -515,8 +509,6 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - AccessorInitEffectsSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `initializesEffect`: ``InitializesEffectSyntax``?
@@ -638,8 +630,6 @@ public struct AccessorInitEffectsSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - AccessorParameterSyntax
-
-
 
 /// ### Children
 /// 
@@ -789,8 +779,6 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ArrayElementSyntax
-
-
 
 /// ### Children
 /// 
@@ -1570,8 +1558,6 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - AvailabilityConditionSyntax
-
-
 
 /// ### Children
 /// 
@@ -2611,8 +2597,6 @@ public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashabl
 
 // MARK: - CaseItemSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `pattern`: ``PatternSyntax``
@@ -2761,8 +2745,6 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - CatchClauseSyntax
-
-
 
 /// ### Children
 /// 
@@ -2937,8 +2919,6 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - CatchItemSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `pattern`: ``PatternSyntax``?
@@ -3087,8 +3067,6 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ClosureCaptureItemSpecifierSyntax
-
-
 
 /// ### Children
 /// 
@@ -3265,8 +3243,6 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
 }
 
 // MARK: - ClosureCaptureItemSyntax
-
-
 
 /// ### Children
 /// 
@@ -3471,8 +3447,6 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - ClosureCaptureSignatureSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftSquare`: `'['`
@@ -3646,8 +3620,6 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - ClosureParamSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `name`: (`<identifier>` | `'_'`)
@@ -3769,8 +3741,6 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ClosureParameterClauseSyntax
-
-
 
 /// ### Children
 /// 
@@ -3950,8 +3920,6 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ClosureParameterSyntax
-
-
 
 /// ### Children
 /// 
@@ -4296,8 +4264,6 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ClosureSignatureSyntax
-
-
 
 /// ### Children
 /// 
@@ -4776,8 +4742,6 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - CodeBlockSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftBrace`: `'{'`
@@ -4951,8 +4915,6 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - CompositionTypeElementSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `type`: ``TypeSyntax``
@@ -5074,8 +5036,6 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ConditionElementSyntax
-
-
 
 /// ### Children
 /// 
@@ -5267,8 +5227,6 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ConformanceRequirementSyntax
-
-
 
 /// ### Children
 /// 
@@ -5777,8 +5735,6 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
 
 // MARK: - DeclModifierDetailSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftParen`: `'('`
@@ -5928,8 +5884,6 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - DeclModifierSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `name`: (`'__consuming'` | `'__setter_access'` | `'_const'` | `'_local'` | `'actor'` | `'async'` | `'borrowing'` | `'class'` | `'consuming'` | `'convenience'` | `'distributed'` | `'dynamic'` | `'fileprivate'` | `'final'` | `'indirect'` | `'infix'` | `'internal'` | `'isolated'` | `'lazy'` | `'mutating'` | `'nonisolated'` | `'nonmutating'` | `'open'` | `'optional'` | `'override'` | `'package'` | `'postfix'` | `'prefix'` | `'private'` | `'public'` | `'reasync'` | `'required'` | `'static'` | `'unowned'` | `'weak'`)
@@ -6052,8 +6006,6 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - DeclNameArgumentSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `name`: ``TokenSyntax``
@@ -6175,8 +6127,6 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - DeclNameArgumentsSyntax
-
-
 
 /// ### Children
 /// 
@@ -6351,8 +6301,6 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - DeclNameSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `baseName`: (`<identifier>` | `<binaryOperator>` | `'init'` | `'self'` | `'Self'`)
@@ -6478,8 +6426,6 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - DeinitEffectSpecifiersSyntax
-
-
 
 /// ### Children
 /// 
@@ -6833,8 +6779,6 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
 
 // MARK: - DesignatedTypeElementSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leadingComma`: `','`
@@ -6956,8 +6900,6 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - DictionaryElementSyntax
-
-
 
 /// ### Children
 /// 
@@ -7844,8 +7786,6 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
 
 // MARK: - DocumentationAttributeArgumentSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `label`: (`'visibility'` | `'metadata'`)
@@ -8403,8 +8343,6 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - EnumCaseParameterClauseSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftParen`: `'('`
@@ -8583,8 +8521,6 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - EnumCaseParameterSyntax
-
-
 
 /// ### Children
 /// 
@@ -9026,8 +8962,6 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - ExpressionSegmentSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `backslash`: `'\'`
@@ -9255,8 +9189,6 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - FunctionEffectSpecifiersSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `asyncSpecifier`: (`'async'` | `'reasync'`)?
@@ -9378,8 +9310,6 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - FunctionParameterSyntax
-
-
 
 /// ### Children
 /// 
@@ -9740,8 +9670,6 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - FunctionSignatureSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `parameterClause`: ``ParameterClauseSyntax``
@@ -9890,8 +9818,6 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - GenericArgumentClauseSyntax
-
-
 
 /// ### Children
 /// 
@@ -10065,8 +9991,6 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - GenericArgumentSyntax
-
-
 
 /// ### Children
 /// 
@@ -10400,8 +10324,6 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - GenericParameterSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `attributes`: ``AttributeListSyntax``
@@ -10655,8 +10577,6 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - GenericRequirementSyntax
-
-
 
 /// ### Children
 /// 
@@ -10984,8 +10904,6 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - IfConfigClauseSyntax
-
-
 
 /// ### Children
 /// 
@@ -11403,8 +11321,6 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 
 // MARK: - ImportPathComponentSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `name`: (`<identifier>` | `<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
@@ -11526,8 +11442,6 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - InheritedTypeSyntax
-
-
 
 /// ### Children
 /// 
@@ -11651,8 +11565,6 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - InitializerClauseSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `equal`: `'='`
@@ -11774,8 +11686,6 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - InitializesEffectSyntax
-
-
 
 /// ### Children
 /// 
@@ -11977,8 +11887,6 @@ public struct InitializesEffectSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - KeyPathComponentSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `period`: `'.'`?
@@ -12154,8 +12062,6 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - KeyPathOptionalComponentSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `questionOrExclamationMark`: (`'?'` | `'!'`)
@@ -12238,8 +12144,6 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - KeyPathPropertyComponentSyntax
-
-
 
 /// ### Children
 /// 
@@ -12389,8 +12293,6 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - KeyPathSubscriptComponentSyntax
-
-
 
 /// ### Children
 /// 
@@ -12751,8 +12653,6 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - LayoutRequirementSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `typeIdentifier`: ``TypeSyntax``
@@ -13037,8 +12937,6 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - MatchingPatternConditionSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `caseKeyword`: `'case'`
@@ -13214,8 +13112,6 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - MemberDeclBlockSyntax
-
-
 
 /// ### Children
 /// 
@@ -13604,8 +13500,6 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - MultipleTrailingClosureElementSyntax
-
-
 
 /// ### Children
 /// 
@@ -14214,8 +14108,6 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - OptionalBindingConditionSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `bindingSpecifier`: (`'let'` | `'var'` | `'inout'`)
@@ -14621,8 +14513,6 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 
 // MARK: - ParameterClauseSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftParen`: `'('`
@@ -14795,8 +14685,6 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - PatternBindingSyntax
-
-
 
 /// ### Children
 /// 
@@ -15042,8 +14930,6 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - PoundSourceLocationArgsSyntax
-
-
 
 /// ### Children
 /// 
@@ -15608,8 +15494,6 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 
 // MARK: - PrecedenceGroupNameElementSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `name`: `<identifier>`
@@ -15911,8 +15795,6 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - PrimaryAssociatedTypeClauseSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftAngle`: `'<'`
@@ -16085,8 +15967,6 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
 }
 
 // MARK: - PrimaryAssociatedTypeSyntax
-
-
 
 /// ### Children
 /// 
@@ -16394,8 +16274,6 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - ReturnClauseSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `arrow`: `'->'`
@@ -16517,8 +16395,6 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - SameTypeRequirementSyntax
-
-
 
 /// ### Children
 /// 
@@ -16669,8 +16545,6 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - SourceFileSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `statements`: ``CodeBlockItemListSyntax``
@@ -16817,8 +16691,6 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - StringSegmentSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `content`: `<stringSegment>`
@@ -16901,8 +16773,6 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - SwitchCaseLabelSyntax
-
-
 
 /// ### Children
 /// 
@@ -17076,8 +16946,6 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - SwitchCaseSyntax
-
-
 
 /// ### Children
 /// 
@@ -17293,8 +17161,6 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - SwitchDefaultLabelSyntax
-
-
 
 /// ### Children
 /// 
@@ -17604,8 +17470,6 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - TupleExprElementSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `label`: (`<identifier>` | `'_'`)?
@@ -17782,8 +17646,6 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - TuplePatternElementSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `label`: `<identifier>`?
@@ -17959,8 +17821,6 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - TupleTypeElementSyntax
-
-
 
 /// ### Children
 /// 
@@ -18246,8 +18106,6 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - TypeAnnotationSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `colon`: `':'`
@@ -18370,8 +18228,6 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - TypeEffectSpecifiersSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `asyncSpecifier`: `'async'`?
@@ -18493,8 +18349,6 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - TypeInheritanceClauseSyntax
-
-
 
 /// ### Children
 /// 
@@ -18641,8 +18495,6 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - TypeInitializerClauseSyntax
-
-
 
 /// ### Children
 /// 
@@ -19348,8 +19200,6 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - WhereClauseSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `whereKeyword`: `'where'`
@@ -19472,8 +19322,6 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - YieldExprListElementSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `expression`: ``ExprSyntax``
@@ -19595,8 +19443,6 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - YieldListSyntax
-
-
 
 /// ### Children
 /// 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -14,8 +14,6 @@
 
 // MARK: - ExpressionPatternSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `expression`: ``ExprSyntax``
@@ -99,8 +97,6 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
 // MARK: - IdentifierPatternSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `identifier`: (`<identifier>` | `'self'` | `'init'`)
@@ -183,8 +179,6 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - IsTypePatternSyntax
-
-
 
 /// ### Children
 /// 
@@ -395,8 +389,6 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
 // MARK: - TuplePatternSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftParen`: `'('`
@@ -570,8 +562,6 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ValueBindingPatternSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `bindingSpecifier`: (`'let'` | `'var'` | `'inout'`)
@@ -693,8 +683,6 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - WildcardPatternSyntax
-
-
 
 /// ### Children
 /// 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -14,8 +14,6 @@
 
 // MARK: - BreakStmtSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `breakKeyword`: `'break'`
@@ -137,8 +135,6 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ContinueStmtSyntax
-
-
 
 /// ### Children
 /// 
@@ -262,8 +258,6 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 // MARK: - DeferStmtSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `deferKeyword`: `'defer'`
@@ -386,8 +380,6 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 // MARK: - DiscardStmtSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `discardKeyword`: (`'_forget'` | `'discard'`)
@@ -509,8 +501,6 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - DoStmtSyntax
-
-
 
 /// ### Children
 /// 
@@ -685,8 +675,6 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ExpressionStmtSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `expression`: ``ExprSyntax``
@@ -770,8 +758,6 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 // MARK: - FallthroughStmtSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `fallthroughKeyword`: `'fallthrough'`
@@ -854,8 +840,6 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ForInStmtSyntax
-
-
 
 /// ### Children
 /// 
@@ -1195,8 +1179,6 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 // MARK: - GuardStmtSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `guardKeyword`: `'guard'`
@@ -1396,8 +1378,6 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - LabeledStmtSyntax
-
-
 
 /// ### Children
 /// 
@@ -1635,8 +1615,6 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 // MARK: - RepeatWhileStmtSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `repeatKeyword`: `'repeat'`
@@ -1813,8 +1791,6 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ReturnStmtSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `returnKeyword`: `'return'`
@@ -1937,8 +1913,6 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ThrowStmtSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `throwKeyword`: `'throw'`
@@ -2060,8 +2034,6 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - WhileStmtSyntax
-
-
 
 /// ### Children
 /// 
@@ -2235,8 +2207,6 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - YieldStmtSyntax
-
-
 
 /// ### Children
 /// 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -14,8 +14,6 @@
 
 // MARK: - ArrayTypeSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `leftSquare`: `'['`
@@ -164,8 +162,6 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - AttributedTypeSyntax
-
-
 
 /// ### Children
 /// 
@@ -340,8 +336,6 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ClassRestrictionTypeSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `classKeyword`: `'class'`
@@ -424,8 +418,6 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - CompositionTypeSyntax
-
-
 
 /// ### Children
 /// 
@@ -533,8 +525,6 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - ConstrainedSugarTypeSyntax
-
-
 
 /// ### Children
 /// 
@@ -657,8 +647,6 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - DictionaryTypeSyntax
-
-
 
 /// ### Children
 /// 
@@ -862,8 +850,6 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - FunctionTypeSyntax
-
-
 
 /// ### Children
 /// 
@@ -1092,8 +1078,6 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ImplicitlyUnwrappedOptionalTypeSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `wrappedType`: ``TypeSyntax``
@@ -1215,8 +1199,6 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 }
 
 // MARK: - MemberTypeIdentifierSyntax
-
-
 
 /// ### Children
 /// 
@@ -1393,8 +1375,6 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - MetatypeTypeSyntax
-
-
 
 /// ### Children
 /// 
@@ -1632,8 +1612,6 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
 // MARK: - NamedOpaqueReturnTypeSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `genericParameterClause`: ``GenericParameterClauseSyntax``
@@ -1758,8 +1736,6 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
 // MARK: - OptionalTypeSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `wrappedType`: ``TypeSyntax``
@@ -1881,8 +1857,6 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - PackExpansionTypeSyntax
-
-
 
 /// ### Children
 /// 
@@ -2006,8 +1980,6 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
 // MARK: - PackReferenceTypeSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `eachKeyword`: `'each'`
@@ -2129,8 +2101,6 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - SimpleTypeIdentifierSyntax
-
-
 
 /// ### Children
 /// 
@@ -2254,8 +2224,6 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
 // MARK: - SuppressedTypeSyntax
 
-
-
 /// ### Children
 /// 
 ///  - `withoutTilde`: `<prefixOperator>`
@@ -2377,8 +2345,6 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 }
 
 // MARK: - TupleTypeSyntax
-
-
 
 /// ### Children
 /// 


### PR DESCRIPTION
This simplifies the navigation of the syntax tree hierarchy in the generated documentation. 

Also remove a bunch of empty lines from the generated files.