### PR TITLE
Add syntax trait covering `genericParameterClause` and `genericWhereClause`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -510,6 +510,7 @@ public let ATTRIBUTE_NODES: [Node] = [
         name: "GenericWhereClause",
         deprecatedName: "WhereClause",
         kind: .node(kind: .genericWhereClause),
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where T: Differentiable`.",
         isOptional: true
       ),
     ]

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -271,6 +271,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericParameterClause",
         kind: .node(kind: .genericParameterClause),
         nameForDiagnostics: "generic parameter clause",
+        documentation: "The parameter clause that defines the generic parameters.",
         isOptional: true
       ),
       Child(
@@ -283,6 +284,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericWhereClause",
         kind: .node(kind: .genericWhereClause),
         nameForDiagnostics: "generic where clause",
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
         isOptional: true
       ),
       Child(
@@ -944,6 +946,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericWhereClause",
         kind: .node(kind: .genericWhereClause),
         nameForDiagnostics: "generic where clause",
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
         isOptional: true
       ),
       Child(
@@ -993,6 +996,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericParameterClause",
         kind: .node(kind: .genericParameterClause),
         nameForDiagnostics: "generic parameter clause",
+        documentation: "The parameter clause that defines the generic parameters.",
         isOptional: true
       ),
       Child(
@@ -1004,6 +1008,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericWhereClause",
         kind: .node(kind: .genericWhereClause),
         nameForDiagnostics: "generic where clause",
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
         isOptional: true
       ),
       Child(
@@ -1401,6 +1406,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericParameterClause",
         kind: .node(kind: .genericParameterClause),
         nameForDiagnostics: "generic parameter clause",
+        documentation: "The parameter clause that defines the generic parameters.",
         isOptional: true
       ),
       Child(
@@ -1418,6 +1424,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericWhereClause",
         kind: .node(kind: .genericWhereClause),
         nameForDiagnostics: "generic where clause",
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
         isOptional: true
       ),
     ]
@@ -2222,6 +2229,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericParameterClause",
         kind: .node(kind: .genericParameterClause),
         nameForDiagnostics: "generic parameter clause",
+        documentation: "The parameter clause that defines the generic parameters.",
         isOptional: true
       ),
       Child(
@@ -2238,6 +2246,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericWhereClause",
         kind: .node(kind: .genericWhereClause),
         nameForDiagnostics: "generic where clause",
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
         isOptional: true
       ),
       Child(
@@ -2331,6 +2340,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericParameterClause",
         kind: .node(kind: .genericParameterClause),
         nameForDiagnostics: "generic parameter clause",
+        documentation: "The parameter clause that defines the generic parameters.",
         isOptional: true
       ),
       Child(
@@ -2341,6 +2351,7 @@ public let DECL_NODES: [Node] = [
         name: "GenericWhereClause",
         kind: .node(kind: .genericWhereClause),
         nameForDiagnostics: "generic where clause",
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
         isOptional: true
       ),
     ]

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -243,6 +243,7 @@ public let DECL_NODES: [Node] = [
       "DeclGroup",
       "IdentifiedDecl",
       "WithAttributes",
+      "WithGenericParameters",
       "WithModifiers",
     ],
     children: [
@@ -416,6 +417,7 @@ public let DECL_NODES: [Node] = [
       "DeclGroup",
       "IdentifiedDecl",
       "WithAttributes",
+      "WithGenericParameters",
       "WithModifiers",
     ],
     children: [
@@ -837,6 +839,7 @@ public let DECL_NODES: [Node] = [
       "DeclGroup",
       "IdentifiedDecl",
       "WithAttributes",
+      "WithGenericParameters",
       "WithModifiers",
     ],
     children: [
@@ -957,6 +960,7 @@ public let DECL_NODES: [Node] = [
     traits: [
       "IdentifiedDecl",
       "WithAttributes",
+      "WithGenericParameters",
       "WithModifiers",
     ],
     children: [
@@ -1300,6 +1304,7 @@ public let DECL_NODES: [Node] = [
       """,
     traits: [
       "WithAttributes",
+      "WithGenericParameters",
       "WithModifiers",
     ],
     children: [
@@ -1368,6 +1373,7 @@ public let DECL_NODES: [Node] = [
     traits: [
       "IdentifiedDecl",
       "WithAttributes",
+      "WithGenericParameters",
       "WithModifiers",
     ],
     children: [
@@ -2128,6 +2134,7 @@ public let DECL_NODES: [Node] = [
       "DeclGroup",
       "IdentifiedDecl",
       "WithAttributes",
+      "WithGenericParameters",
       "WithModifiers",
     ],
     children: [
@@ -2191,6 +2198,7 @@ public let DECL_NODES: [Node] = [
     nameForDiagnostics: "subscript",
     traits: [
       "WithAttributes",
+      "WithGenericParameters",
       "WithModifiers",
     ],
     children: [
@@ -2295,6 +2303,7 @@ public let DECL_NODES: [Node] = [
     traits: [
       "IdentifiedDecl",
       "WithAttributes",
+      "WithGenericParameters",
       "WithModifiers",
     ],
     children: [

--- a/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
@@ -37,27 +37,32 @@ public let GENERIC_NODES: [Node] = [
     kind: .genericParameterClause,
     base: .syntax,
     nameForDiagnostics: "generic parameter clause",
+    documentation: "The parameter clause that defines the generic parameters.",
     parserFunction: "parseGenericParameters",
     children: [
       Child(
         name: "LeftAngle",
         deprecatedName: "LeftAngleBracket",
-        kind: .token(choices: [.token(tokenKind: "LeftAngleToken")])
+        kind: .token(choices: [.token(tokenKind: "LeftAngleToken")]),
+        documentation: "The opening angle bracket (`<`) of the generic parameter clause."
       ),
       Child(
         name: "Parameters",
         deprecatedName: "GenericParameterList",
-        kind: .collection(kind: .genericParameterList, collectionElementName: "Parameter", deprecatedCollectionElementName: "GenericParameter")
+        kind: .collection(kind: .genericParameterList, collectionElementName: "Parameter", deprecatedCollectionElementName: "GenericParameter"),
+        documentation: "The list of generic parameters in the clause."
       ),
       Child(
         name: "GenericWhereClause",
         kind: .node(kind: .genericWhereClause),
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
         isOptional: true
       ),
       Child(
         name: "RightAngle",
         deprecatedName: "RightAngleBracket",
-        kind: .token(choices: [.token(tokenKind: "RightAngleToken")])
+        kind: .token(choices: [.token(tokenKind: "RightAngleToken")]),
+        documentation: "The closing angle bracket (`>`) of the generic parameter clause."
       ),
     ]
   ),
@@ -164,14 +169,17 @@ public let GENERIC_NODES: [Node] = [
     kind: .genericWhereClause,
     base: .syntax,
     nameForDiagnostics: "'where' clause",
+    documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
     children: [
       Child(
         name: "WhereKeyword",
-        kind: .token(choices: [.keyword(text: "where")])
+        kind: .token(choices: [.keyword(text: "where")]),
+        documentation: "The `where` keyword in the clause."
       ),
       Child(
         name: "RequirementList",
-        kind: .collection(kind: .genericRequirementList, collectionElementName: "Requirement")
+        kind: .collection(kind: .genericRequirementList, collectionElementName: "Requirement"),
+        documentation: "The list of requirements in the clause."
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -74,6 +74,23 @@ public let TRAITS: [Trait] = [
     ]
   ),
   Trait(
+    traitName: "MissingNode",
+    documentation: """
+      Represents a layout node that is missing in the source file.
+
+      See the types conforming to this protocol for examples of where missing nodes can occur.
+      """,
+    children: [
+      Child(
+        name: "Placeholder",
+        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        documentation: """
+          A placeholder, i.e. `<#placeholder#>`, that can be inserted into the source code to represent the missing node.
+          """
+      )
+    ]
+  ),
+  Trait(
     traitName: "Parenthesized",
     children: [
       Child(name: "LeftParen", kind: .token(choices: [.token(tokenKind: "LeftParenToken")])),
@@ -90,6 +107,29 @@ public let TRAITS: [Trait] = [
     traitName: "WithCodeBlock",
     children: [
       Child(name: "Body", kind: .node(kind: .codeBlock))
+    ]
+  ),
+  Trait(
+    traitName: "WithGenericParameters",
+    documentation: """
+      Syntax nodes that have generic parameters.
+
+      For example, functions or nominal types like `class` or `struct` can have generic parameters \
+      and have a generic where clause that restricts these generic parameters.
+      """,
+    children: [
+      Child(
+        name: "GenericParameterClause",
+        kind: .node(kind: .genericParameterClause),
+        documentation: "The parameter clause that defines the generic parameters.",
+        isOptional: true
+      ),
+      Child(
+        name: "GenericWhereClause",
+        kind: .node(kind: .genericWhereClause),
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
+        isOptional: true
+      ),
     ]
   ),
   Trait(
@@ -110,21 +150,9 @@ public let TRAITS: [Trait] = [
       Child(name: "TrailingComma", kind: .token(choices: [.token(tokenKind: "CommaToken")]), isOptional: true)
     ]
   ),
-  Trait(
-    traitName: "MissingNode",
-    documentation: """
-      Represents a layout node that is missing in the source file.
-
-      See the types conforming to this protocol for examples of where missing nodes can occur.
-      """,
-    children: [
-      Child(
-        name: "Placeholder",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
-        documentation: """
-          A placeholder, i.e. `<#placeholder#>`, that can be inserted into the source code to represent the missing node.
-          """
-      )
-    ]
-  ),
 ]
+
+//==========================================================================//
+// IMPORTANT: If you are tempted to add a trait here please insert in in    //
+// alphabetical order above                                                 //
+//==========================================================================//

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -40,7 +40,12 @@ public let TRAITS: [Trait] = [
       Child(name: "Attributes", kind: .node(kind: .attributeList), isOptional: true),
       Child(name: "Modifiers", kind: .node(kind: .modifierList), isOptional: true),
       Child(name: "InheritanceClause", kind: .node(kind: .typeInheritanceClause), isOptional: true),
-      Child(name: "GenericWhereClause", kind: .node(kind: .genericWhereClause), isOptional: true),
+      Child(
+        name: "GenericWhereClause",
+        kind: .node(kind: .genericWhereClause),
+        documentation: "A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.",
+        isOptional: true
+      ),
       Child(name: "MemberBlock", kind: .node(kind: .memberDeclBlock)),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -341,7 +341,8 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "GenericParameterClause",
         deprecatedName: "GenericParameters",
-        kind: .node(kind: .genericParameterClause)
+        kind: .node(kind: .genericParameterClause),
+        documentation: "The parameter clause that defines the generic parameters."
       ),
       Child(
         name: "BaseType",

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -377,13 +377,14 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/EffectSpecifiersSyntax>
 - <doc:SwiftSyntax/FreestandingMacroExpansionSyntax>
 - <doc:SwiftSyntax/IdentifiedDeclSyntax>
+- <doc:SwiftSyntax/MissingNodeSyntax>
 - <doc:SwiftSyntax/ParenthesizedSyntax>
 - <doc:SwiftSyntax/WithAttributesSyntax>
 - <doc:SwiftSyntax/WithCodeBlockSyntax>
+- <doc:SwiftSyntax/WithGenericParametersSyntax>
 - <doc:SwiftSyntax/WithModifiersSyntax>
 - <doc:SwiftSyntax/WithStatementsSyntax>
 - <doc:SwiftSyntax/WithTrailingCommaSyntax>
-- <doc:SwiftSyntax/MissingNodeSyntax>
 
 
 

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -73,6 +73,7 @@ public protocol DeclGroupSyntax: SyntaxProtocol {
     set
   }
   
+  /// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   var genericWhereClause: GenericWhereClauseSyntax? {
     get
     set

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -277,6 +277,46 @@ public extension SyntaxProtocol {
   }
 }
 
+// MARK: - MissingNodeSyntax
+
+/// Represents a layout node that is missing in the source file.
+/// 
+/// See the types conforming to this protocol for examples of where missing nodes can occur.
+public protocol MissingNodeSyntax: SyntaxProtocol {
+  /// A placeholder, i.e. `<#placeholder#>`, that can be inserted into the source code to represent the missing node.
+  var placeholder: TokenSyntax {
+    get
+    set
+  }
+}
+
+public extension MissingNodeSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<MissingNodeSyntax, T>, _ newChild: T) -> MissingNodeSyntax {
+    var copy: MissingNodeSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
+}
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to
+  /// `MissingNodeSyntax`.
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: MissingNodeSyntax.Protocol) -> Bool {
+    return self.asProtocol(MissingNodeSyntax.self) != nil
+  }
+  
+  /// Return the non-type erased version of this syntax node if it conforms to
+  /// `MissingNodeSyntax`. Otherwise return `nil`.
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: MissingNodeSyntax.Protocol) -> MissingNodeSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? MissingNodeSyntax
+  }
+}
+
 // MARK: - ParenthesizedSyntax
 
 
@@ -393,6 +433,52 @@ public extension SyntaxProtocol {
   }
 }
 
+// MARK: - WithGenericParametersSyntax
+
+/// Syntax nodes that have generic parameters.
+/// 
+/// For example, functions or nominal types like `class` or `struct` can have generic parameters and have a generic where clause that restricts these generic parameters.
+public protocol WithGenericParametersSyntax: SyntaxProtocol {
+  /// The parameter clause that defines the generic parameters.
+  var genericParameterClause: GenericParameterClauseSyntax? {
+    get
+    set
+  }
+  
+  /// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
+  var genericWhereClause: GenericWhereClauseSyntax? {
+    get
+    set
+  }
+}
+
+public extension WithGenericParametersSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<WithGenericParametersSyntax, T>, _ newChild: T) -> WithGenericParametersSyntax {
+    var copy: WithGenericParametersSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
+}
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to
+  /// `WithGenericParametersSyntax`.
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: WithGenericParametersSyntax.Protocol) -> Bool {
+    return self.asProtocol(WithGenericParametersSyntax.self) != nil
+  }
+  
+  /// Return the non-type erased version of this syntax node if it conforms to
+  /// `WithGenericParametersSyntax`. Otherwise return `nil`.
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: WithGenericParametersSyntax.Protocol) -> WithGenericParametersSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithGenericParametersSyntax
+  }
+}
+
 // MARK: - WithModifiersSyntax
 
 
@@ -504,46 +590,6 @@ public extension SyntaxProtocol {
   }
 }
 
-// MARK: - MissingNodeSyntax
-
-/// Represents a layout node that is missing in the source file.
-/// 
-/// See the types conforming to this protocol for examples of where missing nodes can occur.
-public protocol MissingNodeSyntax: SyntaxProtocol {
-  /// A placeholder, i.e. `<#placeholder#>`, that can be inserted into the source code to represent the missing node.
-  var placeholder: TokenSyntax {
-    get
-    set
-  }
-}
-
-public extension MissingNodeSyntax {
-  /// Without this function, the `with` function defined on `SyntaxProtocol`
-  /// does not work on existentials of this protocol type.
-  @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<MissingNodeSyntax, T>, _ newChild: T) -> MissingNodeSyntax {
-    var copy: MissingNodeSyntax = self
-    copy[keyPath: keyPath] = newChild
-    return copy
-  }
-}
-
-public extension SyntaxProtocol {
-  /// Check whether the non-type erased version of this syntax node conforms to
-  /// `MissingNodeSyntax`.
-  /// Note that this will incur an existential conversion.
-  func isProtocol(_: MissingNodeSyntax.Protocol) -> Bool {
-    return self.asProtocol(MissingNodeSyntax.self) != nil
-  }
-  
-  /// Return the non-type erased version of this syntax node if it conforms to
-  /// `MissingNodeSyntax`. Otherwise return `nil`.
-  /// Note that this will incur an existential conversion.
-  func asProtocol(_: MissingNodeSyntax.Protocol) -> MissingNodeSyntax? {
-    return Syntax(self).asProtocol(SyntaxProtocol.self) as? MissingNodeSyntax
-  }
-}
-
 extension AccessorBlockSyntax: BracedSyntax {}
 
 extension AccessorDeclSyntax: WithAttributesSyntax {}
@@ -552,7 +598,7 @@ extension AccessorEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
 extension AccessorParameterSyntax: ParenthesizedSyntax {}
 
-extension ActorDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
+extension ActorDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
 
 extension ArrayElementSyntax: WithTrailingCommaSyntax {}
 
@@ -570,7 +616,7 @@ extension CatchClauseSyntax: WithCodeBlockSyntax {}
 
 extension CatchItemSyntax: WithTrailingCommaSyntax {}
 
-extension ClassDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
+extension ClassDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
 
 extension ClosureCaptureItemSyntax: WithTrailingCommaSyntax {}
 
@@ -614,7 +660,7 @@ extension EnumCaseParameterClauseSyntax: ParenthesizedSyntax {}
 
 extension EnumCaseParameterSyntax: WithTrailingCommaSyntax, WithModifiersSyntax {}
 
-extension EnumDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
+extension EnumDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
 
 extension ExpressionSegmentSyntax: ParenthesizedSyntax {}
 
@@ -622,7 +668,7 @@ extension ExtensionDeclSyntax: DeclGroupSyntax, WithAttributesSyntax, WithModifi
 
 extension ForInStmtSyntax: WithCodeBlockSyntax {}
 
-extension FunctionDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
+extension FunctionDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
 
 extension FunctionEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
@@ -644,11 +690,11 @@ extension ImportDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 
 extension InheritedTypeSyntax: WithTrailingCommaSyntax {}
 
-extension InitializerDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
+extension InitializerDeclSyntax: WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
 
 extension LabeledSpecializeEntrySyntax: WithTrailingCommaSyntax {}
 
-extension MacroDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
+extension MacroDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
 
 extension MacroExpansionDeclSyntax: FreestandingMacroExpansionSyntax, WithAttributesSyntax, WithModifiersSyntax {}
 
@@ -688,9 +734,9 @@ extension RepeatWhileStmtSyntax: WithCodeBlockSyntax {}
 
 extension SourceFileSyntax: WithStatementsSyntax {}
 
-extension StructDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
+extension StructDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
 
-extension SubscriptDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
+extension SubscriptDeclSyntax: WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
 
 extension SwitchCaseSyntax: WithStatementsSyntax {}
 
@@ -712,7 +758,7 @@ extension TupleTypeSyntax: ParenthesizedSyntax {}
 
 extension TypeEffectSpecifiersSyntax: EffectSpecifiersSyntax {}
 
-extension TypealiasDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithModifiersSyntax {}
+extension TypealiasDeclSyntax: IdentifiedDeclSyntax, WithAttributesSyntax, WithGenericParametersSyntax, WithModifiersSyntax {}
 
 extension VariableDeclSyntax: WithAttributesSyntax, WithModifiersSyntax {}
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -329,6 +329,8 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - genericParameterClause: The parameter clause that defines the generic parameters.
+  ///   - genericWhereClause: A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -534,6 +536,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The parameter clause that defines the generic parameters.
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
       return data.child(at: 9, parent: Syntax(self)).map(GenericParameterClauseSyntax.init)
@@ -570,6 +573,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 13, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -2454,6 +2458,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - genericWhereClause: A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -2671,6 +2676,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 11, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -2762,6 +2768,8 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - genericParameterClause: The parameter clause that defines the generic parameters.
+  ///   - genericWhereClause: A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -2967,6 +2975,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The parameter clause that defines the generic parameters.
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
       return data.child(at: 9, parent: Syntax(self)).map(GenericParameterClauseSyntax.init)
@@ -3003,6 +3012,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 13, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -3892,6 +3902,8 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - genericParameterClause: The parameter clause that defines the generic parameters.
+  ///   - genericWhereClause: A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -4097,6 +4109,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The parameter clause that defines the generic parameters.
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
       return data.child(at: 9, parent: Syntax(self)).map(GenericParameterClauseSyntax.init)
@@ -4151,6 +4164,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 15, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -6370,6 +6384,8 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - genericParameterClause: The parameter clause that defines the generic parameters.
+  ///   - genericWhereClause: A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -6557,6 +6573,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The parameter clause that defines the generic parameters.
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
       return data.child(at: 7, parent: Syntax(self)).map(GenericParameterClauseSyntax.init)
@@ -6611,6 +6628,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 13, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -6703,6 +6721,8 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - genericParameterClause: The parameter clause that defines the generic parameters.
+  ///   - genericWhereClause: A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -6902,6 +6922,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The parameter clause that defines the generic parameters.
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
       return data.child(at: 9, parent: Syntax(self)).map(GenericParameterClauseSyntax.init)
@@ -6938,6 +6959,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 13, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -7664,6 +7664,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - kindSpecifierComma: The comma following the differentiability kind, if it exists.
   ///   - parametersComma: The comma following the differentiability parameters clause, if it exists.
+  ///   - genericWhereClause: A `where` clause that places additional constraints on generic parameters like `where T: Differentiable`.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -7805,6 +7806,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
     }
   }
   
+  /// A `where` clause that places additional constraints on generic parameters like `where T: Differentiable`.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 9, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -10188,8 +10190,8 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - GenericParameterClauseSyntax
 
-
-
+/// The parameter clause that defines the generic parameters.
+///
 /// ### Children
 /// 
 ///  - `leftAngle`: `'<'`
@@ -10216,6 +10218,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - leftAngle: The opening angle bracket (`<`) of the generic parameter clause.
+  ///   - parameters: The list of generic parameters in the clause.
+  ///   - genericWhereClause: A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
+  ///   - rightAngle: The closing angle bracket (`>`) of the generic parameter clause.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -10277,6 +10283,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The opening angle bracket (`<`) of the generic parameter clause.
   public var leftAngle: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
@@ -10295,6 +10302,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The list of generic parameters in the clause.
   public var parameters: GenericParameterListSyntax {
     get {
       return GenericParameterListSyntax(data.child(at: 3, parent: Syntax(self))!)
@@ -10337,6 +10345,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 5, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -10355,6 +10364,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The closing angle bracket (`>`) of the generic parameter clause.
   public var rightAngle: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 7, parent: Syntax(self))!)
@@ -10823,8 +10833,8 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 
 // MARK: - GenericWhereClauseSyntax
 
-
-
+/// A `where` clause that places additional constraints on generic parameters like `where Element: Hashable`.
+///
 /// ### Children
 /// 
 ///  - `whereKeyword`: `'where'`
@@ -10849,6 +10859,8 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - whereKeyword: The `where` keyword in the clause.
+  ///   - requirementList: The list of requirements in the clause.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -10898,6 +10910,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The `where` keyword in the clause.
   public var whereKeyword: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
@@ -10916,6 +10929,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The list of requirements in the clause.
   public var requirementList: GenericRequirementListSyntax {
     get {
       return GenericRequirementListSyntax(data.child(at: 3, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -1658,6 +1658,7 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - genericParameterClause: The parameter clause that defines the generic parameters.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -1707,6 +1708,7 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The parameter clause that defines the generic parameters.
   public var genericParameterClause: GenericParameterClauseSyntax {
     get {
       return GenericParameterClauseSyntax(data.child(at: 1, parent: Syntax(self))!)


### PR DESCRIPTION
Resolves #1810 

* Added the `WithGenericParameters` trait.
* Sorted the `TRAITS` collection declarations alphabetically.
* Included missing documentation for `GenericParameterClause` and `GenericWhereClause` types, as well as for all child nodes of the kind `genericParameterClause` and `genericWhereClause`.