### PR TITLE
[5.9] Support parsing of `borrowing get`

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1458,7 +1458,7 @@ extension Parser {
     // Check there is an identifier before consuming
     var look = self.lookahead()
     let _ = look.consumeAttributeList()
-    let hasModifier = look.consume(if: .keyword(.mutating), .keyword(.nonmutating), .keyword(.__consuming)) != nil
+    let hasModifier = look.consume(ifAnyIn: AccessorModifier.self) != nil
     guard let (kind, _) = look.at(anyIn: AccessorKind.self) ?? forcedKind else {
       return nil
     }
@@ -1469,7 +1469,7 @@ extension Parser {
     // get and set.
     let modifier: RawDeclModifierSyntax?
     if hasModifier {
-      let (unexpectedBeforeName, name) = self.expect(.keyword(.mutating), .keyword(.nonmutating), .keyword(.__consuming), default: .keyword(.mutating))
+      let (unexpectedBeforeName, name) = self.expect(anyIn: AccessorModifier.self, default: .mutating)
       modifier = RawDeclModifierSyntax(
         unexpectedBeforeName,
         name: name,

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -76,6 +76,35 @@ enum AccessorKind: TokenSpecSet {
   }
 }
 
+enum AccessorModifier: TokenSpecSet {
+  case __consuming
+  case consuming
+  case borrowing
+  case mutating
+  case nonmutating
+
+  init?(lexeme: Lexer.Lexeme) {
+    switch PrepareForKeywordMatch(lexeme) {
+    case TokenSpec(.__consuming): self = .__consuming
+    case TokenSpec(.consuming): self = .consuming
+    case TokenSpec(.borrowing): self = .borrowing
+    case TokenSpec(.mutating): self = .mutating
+    case TokenSpec(.nonmutating): self = .nonmutating
+    default: return nil
+    }
+  }
+
+  var spec: TokenSpec {
+    switch self {
+    case .__consuming: return .keyword(.__consuming)
+    case .consuming: return .keyword(.consuming)
+    case .borrowing: return .keyword(.borrowing)
+    case .mutating: return .keyword(.mutating)
+    case .nonmutating: return .keyword(.nonmutating)
+    }
+  }
+}
+
 enum CanBeStatementStart: TokenSpecSet {
   case _forget  // NOTE: support for deprecated _forget
   case `break`

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -2031,4 +2031,16 @@ final class DeclarationTests: XCTestCase {
         """
     )
   }
+
+  func testBorrowingGetAccessor() {
+    assertParse(
+      """
+      struct Foo {
+        var x: Int {
+          borrowing get {}
+        }
+      }
+      """
+    )
+  }
 }


### PR DESCRIPTION
* **Explanation**: The new parser didn’t accept `borrowing get` while the C++ parser did
* **Scope**: Parsing of modifiers in front of accessors
* **Risk**: Low, very targeted change
* **Testing**: Added new test case
* **Issue**: rdar://112168704
* **Reviewer**:  @bnbarham and @rintaro on https://github.com/apple/swift-syntax/pull/1904

