### PR TITLE
Update code-gen tool for lowercase child name consistency

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -114,16 +114,18 @@ public class Node {
       // any two defined children
       childrenWithUnexpected =
         children.enumerated().flatMap { (i, child) -> [Child] in
+          let childName = child.name.withFirstCharacterUppercased
+
           let unexpectedName: String
           let unexpectedDeprecatedName: String?
 
           if i == 0 {
-            unexpectedName = "UnexpectedBefore\(child.name)"
+            unexpectedName = "UnexpectedBefore\(childName)"
             unexpectedDeprecatedName = child.deprecatedName.map { "UnexpectedBefore\($0)" }
           } else {
-            unexpectedName = "UnexpectedBetween\(children[i - 1].name)And\(child.name)"
+            unexpectedName = "UnexpectedBetween\(children[i - 1].name.withFirstCharacterUppercased)And\(childName)"
             if let deprecatedName = children[i - 1].deprecatedName {
-              unexpectedDeprecatedName = "UnexpectedBetween\(deprecatedName)And\(child.deprecatedName ?? child.name)"
+              unexpectedDeprecatedName = "UnexpectedBetween\(deprecatedName)And\(child.deprecatedName ?? childName)"
             } else if let deprecatedName = child.deprecatedName {
               unexpectedDeprecatedName = "UnexpectedBetween\(children[i - 1].name)And\(deprecatedName)"
             } else {
@@ -139,9 +141,9 @@ public class Node {
           return [unexpectedBefore, child]
         } + [
           Child(
-            name: "UnexpectedAfter\(children.last!.name)",
+            name: "UnexpectedAfter\(children.last!.name.withFirstCharacterUppercased)",
             deprecatedName: children.last!.deprecatedName.map { "UnexpectedAfter\($0)" },
-            kind: .collection(kind: .unexpectedNodes, collectionElementName: "UnexpectedAfter\(children.last!.name)"),
+            kind: .collection(kind: .unexpectedNodes, collectionElementName: "UnexpectedAfter\(children.last!.name.withFirstCharacterUppercased)"),
             isOptional: true
           )
         ]

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -47,7 +47,7 @@ public extension Child {
   var parameterBaseType: String {
     switch kind {
     case .nodeChoices:
-      return self.name
+      return self.name.withFirstCharacterUppercased
     default:
       return type.parameterBaseType
     }

--- a/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
@@ -24,7 +24,7 @@ extension LayoutNode {
     func createFunctionParameterSyntax(for child: Child) -> FunctionParameterSyntax {
       var paramType: TypeSyntax
       if !child.kind.isNodeChoicesEmpty {
-        paramType = "\(raw: child.name)"
+        paramType = "\(raw: child.name.withFirstCharacterUppercased)"
       } else if child.hasBaseType {
         paramType = "some \(raw: child.syntaxNodeKind.protocolType)"
       } else {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserTokenSpecSetFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserTokenSpecSetFile.swift
@@ -22,7 +22,7 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     for child in layoutNode.children {
       if case let .token(choices, _, _) = child.kind, choices.count > 1 {
         try! ExtensionDeclSyntax("extension \(raw: layoutNode.kind.syntaxType)") {
-          try EnumDeclSyntax("enum \(raw: child.name)Options: TokenSpecSet") {
+          try EnumDeclSyntax("enum \(raw: child.name.withFirstCharacterUppercased)Options: TokenSpecSet") {
             for choice in choices {
               switch choice {
               case .keyword(let keywordText):

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -22,7 +22,7 @@ fileprivate extension Node {
       return node.children.compactMap { child -> (name: TokenSyntax, choices: [(caseName: TokenSyntax, kind: SyntaxNodeKind)])? in
         switch child.kind {
         case .nodeChoices(let choices):
-          return (.identifier(child.name), choices.map { (.identifier($0.varName), $0.syntaxNodeKind) })
+          return (.identifier(child.name.withFirstCharacterUppercased), choices.map { (.identifier($0.varName), $0.syntaxNodeKind) })
         default:
           return nil
         }
@@ -257,7 +257,7 @@ fileprivate extension Child {
   var rawParameterType: TypeSyntax {
     let paramType: TypeSyntax
     if case ChildKind.nodeChoices = kind {
-      paramType = "\(raw: name)"
+      paramType = "\(raw: name.withFirstCharacterUppercased)"
     } else {
       paramType = syntaxNodeKind.rawType
     }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RenamedChildrenCompatibilityFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RenamedChildrenCompatibilityFile.swift
@@ -20,7 +20,7 @@ let renamedChildrenCompatibilityFile = try! SourceFileSyntax(leadingTrivia: copy
     try ExtensionDeclSyntax("extension \(raw: layoutNode.type.syntaxBaseName)") {
       for child in layoutNode.children {
         if let deprecatedVarName = child.deprecatedVarName {
-          let childType: TypeSyntax = child.kind.isNodeChoicesEmpty ? child.syntaxNodeKind.syntaxType : "\(raw: child.name)"
+          let childType: TypeSyntax = child.kind.isNodeChoicesEmpty ? child.syntaxNodeKind.syntaxType : "\(raw: child.name.withFirstCharacterUppercased)"
           let type = child.isOptional ? TypeSyntax("\(raw: childType)?") : TypeSyntax("\(raw: childType)")
 
           DeclSyntax(

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -160,7 +160,7 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
           // Children properties
           // ===================
 
-          let childType: TypeSyntax = child.kind.isNodeChoicesEmpty ? child.syntaxNodeKind.syntaxType : "\(raw: child.name)"
+          let childType: TypeSyntax = child.kind.isNodeChoicesEmpty ? child.syntaxNodeKind.syntaxType : "\(raw: child.name.withFirstCharacterUppercased)"
           let type = child.isOptional ? TypeSyntax("\(raw: childType)?") : TypeSyntax("\(raw: childType)")
 
           try! VariableDeclSyntax(
@@ -243,7 +243,7 @@ private func generateSyntaxChildChoices(for child: Child) throws -> EnumDeclSynt
     return nil
   }
 
-  return try! EnumDeclSyntax("public enum \(raw: child.name): SyntaxChildChoices") {
+  return try! EnumDeclSyntax("public enum \(raw: child.name.withFirstCharacterUppercased): SyntaxChildChoices") {
     for choice in choices {
       DeclSyntax("case `\(raw: choice.varName)`(\(raw: choice.syntaxNodeKind.syntaxType))")
     }


### PR DESCRIPTION
This PR introduces changes to the code-gen tool to ensure consistency with already generated code. This is a preparatory step before we start changing the names of all child elements to be lowercase - #1901.

In the #1901 issue description @ahoppen mention that 

> It's a little counter-intuitive that the `name` property of `Child` needs to be uppercase because AFAICT we are always using it as lowercase

After research, I've learned that we're using the `name` property of `Child` as uppercased in the following contexts:
* as enum names e.g.: `enum accessorSpecifierOptions: TokenSpecSet` and them as types e.g.: `ElseBody` for `IfExprSyntax`,
* to build names of "unexpected" nodes.

I guess now with this knowledge the question is: should we still lowercased values of the `name` property of each `Child`? 