### PR TITLE
Reduce usage of `currentToken`

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -1023,7 +1023,7 @@ extension Parser {
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     let base: RawTokenSyntax
     let args: RawDeclNameArgumentsSyntax?
-    if label.isMissing && colon.isMissing && self.currentToken.isAtStartOfLine {
+    if label.isMissing && colon.isMissing && self.atStartOfLine {
       base = RawTokenSyntax(missing: .identifier, arena: self.arena)
       args = nil
     } else {

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -23,7 +23,7 @@ extension Parser {
     repeat {
       let attribute = self.parseAttribute()
       elements.append(attribute)
-    } while self.at(.atSign, .poundIf) && loopProgress.evaluate(currentToken)
+    } while self.at(.atSign, .poundIf) && loopProgress.evaluate(self)
     return RawAttributeListSyntax(elements: elements, arena: self.arena)
   }
 }
@@ -453,7 +453,7 @@ extension Parser {
 
     var elements = [RawDifferentiabilityParamSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !self.at(.endOfFile, .rightParen) && loopProgress.evaluate(currentToken) {
+    while !self.at(.endOfFile, .rightParen) && loopProgress.evaluate(self) {
       guard let param = self.parseDifferentiabilityParameter() else {
         break
       }
@@ -594,7 +594,7 @@ extension Parser {
   mutating func parseObjectiveCSelector() -> RawObjCSelectorSyntax {
     var elements = [RawObjCSelectorPieceSyntax]()
     var loopProgress = LoopProgressCondition()
-    while loopProgress.evaluate(currentToken) {
+    while loopProgress.evaluate(self) {
       // Empty selector piece.
       if let colon = self.consume(if: .colon) {
         elements.append(
@@ -676,7 +676,7 @@ extension Parser {
     var elements = [RawSpecializeAttributeSpecListSyntax.Element]()
     // Parse optional "exported" and "kind" labeled parameters.
     var loopProgress = LoopProgressCondition()
-    while !self.at(.endOfFile, .rightParen, .keyword(.where)) && loopProgress.evaluate(currentToken) {
+    while !self.at(.endOfFile, .rightParen, .keyword(.where)) && loopProgress.evaluate(self) {
       switch self.at(anyIn: SpecializeParameter.self) {
       case (.target, let handle)?:
         let ident = self.eat(handle)

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -23,7 +23,7 @@ extension Parser {
     repeat {
       let attribute = self.parseAttribute()
       elements.append(attribute)
-    } while self.at(.atSign, .poundIf) && loopProgress.evaluate(self)
+    } while self.at(.atSign, .poundIf) && self.hasProgressed(&loopProgress)
     return RawAttributeListSyntax(elements: elements, arena: self.arena)
   }
 }
@@ -453,7 +453,7 @@ extension Parser {
 
     var elements = [RawDifferentiabilityParamSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !self.at(.endOfFile, .rightParen) && loopProgress.evaluate(self) {
+    while !self.at(.endOfFile, .rightParen) && self.hasProgressed(&loopProgress) {
       guard let param = self.parseDifferentiabilityParameter() else {
         break
       }
@@ -594,7 +594,7 @@ extension Parser {
   mutating func parseObjectiveCSelector() -> RawObjCSelectorSyntax {
     var elements = [RawObjCSelectorPieceSyntax]()
     var loopProgress = LoopProgressCondition()
-    while loopProgress.evaluate(self) {
+    while self.hasProgressed(&loopProgress) {
       // Empty selector piece.
       if let colon = self.consume(if: .colon) {
         elements.append(
@@ -676,7 +676,7 @@ extension Parser {
     var elements = [RawSpecializeAttributeSpecListSyntax.Element]()
     // Parse optional "exported" and "kind" labeled parameters.
     var loopProgress = LoopProgressCondition()
-    while !self.at(.endOfFile, .rightParen, .keyword(.where)) && loopProgress.evaluate(self) {
+    while !self.at(.endOfFile, .rightParen, .keyword(.where)) && self.hasProgressed(&loopProgress) {
       switch self.at(anyIn: SpecializeParameter.self) {
       case (.target, let handle)?:
         let ident = self.eat(handle)

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -48,7 +48,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && availabilityArgumentProgress.evaluate(currentToken)
+      } while keepGoing != nil && availabilityArgumentProgress.evaluate(self)
     }
 
     return RawAvailabilitySpecListSyntax(elements: elements, arena: self.arena)
@@ -176,7 +176,7 @@ extension Parser {
           arena: self.arena
         )
       )
-    } while keepGoing != nil && loopProgressCondition.evaluate(currentToken)
+    } while keepGoing != nil && loopProgressCondition.evaluate(self)
     return RawAvailabilitySpecListSyntax(elements: elements, arena: self.arena)
   }
 
@@ -266,7 +266,7 @@ extension Parser {
         unexpectedTokens.append(unexpectedVersion)
       }
       keepGoing = self.consume(if: .period)
-    } while keepGoing != nil && loopProgress.evaluate(currentToken)
+    } while keepGoing != nil && loopProgress.evaluate(self)
     return RawUnexpectedNodesSyntax(unexpectedTokens, arena: self.arena)
   }
 

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -48,7 +48,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && availabilityArgumentProgress.evaluate(self)
+      } while keepGoing != nil && self.hasProgressed(&availabilityArgumentProgress)
     }
 
     return RawAvailabilitySpecListSyntax(elements: elements, arena: self.arena)
@@ -99,7 +99,7 @@ extension Parser {
     var elements = [RawAvailabilityArgumentSyntax]()
     var keepGoing: RawTokenSyntax? = nil
 
-    var loopProgressCondition = LoopProgressCondition()
+    var loopProgress = LoopProgressCondition()
     LOOP: repeat {
       let entry: RawAvailabilityArgumentSyntax.Entry
       switch self.at(anyIn: AvailabilityArgumentKind.self) {
@@ -176,7 +176,7 @@ extension Parser {
           arena: self.arena
         )
       )
-    } while keepGoing != nil && loopProgressCondition.evaluate(self)
+    } while keepGoing != nil && self.hasProgressed(&loopProgress)
     return RawAvailabilitySpecListSyntax(elements: elements, arena: self.arena)
   }
 
@@ -266,7 +266,7 @@ extension Parser {
         unexpectedTokens.append(unexpectedVersion)
       }
       keepGoing = self.consume(if: .period)
-    } while keepGoing != nil && loopProgress.evaluate(self)
+    } while keepGoing != nil && self.hasProgressed(&loopProgress)
     return RawUnexpectedNodesSyntax(unexpectedTokens, arena: self.arena)
   }
 

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -61,7 +61,7 @@ extension TokenConsumer {
 
     var hasAttribute = false
     var attributeProgress = LoopProgressCondition()
-    while attributeProgress.evaluate(subparser.currentToken) && subparser.at(.atSign) {
+    while attributeProgress.evaluate(subparser) && subparser.at(.atSign) {
       hasAttribute = true
       _ = subparser.consumeAttributeList()
     }
@@ -71,7 +71,7 @@ extension TokenConsumer {
       var modifierProgress = LoopProgressCondition()
       while let (modifierKind, handle) = subparser.at(anyIn: DeclarationModifier.self),
         modifierKind != .class,
-        modifierProgress.evaluate(subparser.currentToken)
+        modifierProgress.evaluate(subparser)
       {
         hasModifier = true
         subparser.eat(handle)
@@ -356,7 +356,7 @@ extension Parser {
           arena: self.arena
         )
       )
-    } while keepGoing != nil && loopProgress.evaluate(currentToken)
+    } while keepGoing != nil && loopProgress.evaluate(self)
     return RawImportPathSyntax(elements: elements, arena: self.arena)
   }
 }
@@ -486,7 +486,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(currentToken)
+      } while keepGoing != nil && loopProgress.evaluate(self)
     }
 
     let whereClause: RawGenericWhereClauseSyntax?
@@ -692,7 +692,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(currentToken)
+      } while keepGoing != nil && loopProgress.evaluate(self)
     }
 
     return RawGenericWhereClauseSyntax(
@@ -758,7 +758,7 @@ extension Parser {
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.endOfFile, .rightBrace) && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightBrace) && loopProgress.evaluate(self) {
         let newItemAtStartOfLine = self.currentToken.isAtStartOfLine
         guard let newElement = self.parseMemberDeclListItem() else {
           break
@@ -858,7 +858,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(currentToken)
+      } while keepGoing != nil && loopProgress.evaluate(self)
     }
 
     return RawEnumCaseDeclSyntax(
@@ -1376,7 +1376,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(currentToken)
+      } while keepGoing != nil && loopProgress.evaluate(self)
     }
 
     return RawVariableDeclSyntax(
@@ -1521,7 +1521,7 @@ extension Parser {
     var elements = [RawAccessorDeclSyntax]()
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.endOfFile, .rightBrace) && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightBrace) && loopProgress.evaluate(self) {
         guard let introducer = self.parseAccessorIntroducer() else {
           // There can only be an implicit getter if no other accessors were
           // seen before this one.
@@ -1741,7 +1741,7 @@ extension Parser {
     while (identifiersAfterOperatorName.last ?? name).trailingTriviaByteLength == 0,
       self.currentToken.leadingTriviaByteLength == 0,
       !self.at(.colon, .leftBrace, .endOfFile),
-      loopProgress.evaluate(self.currentToken)
+      loopProgress.evaluate(self)
     {
       identifiersAfterOperatorName.append(consumeAnyToken())
     }
@@ -1888,7 +1888,7 @@ extension Parser {
     var elements = [RawPrecedenceGroupAttributeListSyntax.Element]()
     do {
       var attributesProgress = LoopProgressCondition()
-      LOOP: while !self.at(.endOfFile, .rightBrace) && attributesProgress.evaluate(currentToken) {
+      LOOP: while !self.at(.endOfFile, .rightBrace) && attributesProgress.evaluate(self) {
         switch self.at(anyIn: LabelText.self) {
         case (.associativity, let handle)?:
           let associativity = self.eat(handle)
@@ -1952,7 +1952,7 @@ extension Parser {
                   arena: self.arena
                 )
               )
-            } while keepGoing != nil && namesProgress.evaluate(currentToken)
+            } while keepGoing != nil && namesProgress.evaluate(self)
           }
           elements.append(
             .precedenceGroupRelation(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -759,7 +759,7 @@ extension Parser {
     do {
       var loopProgress = LoopProgressCondition()
       while !self.at(.endOfFile, .rightBrace) && loopProgress.evaluate(self) {
-        let newItemAtStartOfLine = self.currentToken.isAtStartOfLine
+        let newItemAtStartOfLine = self.atStartOfLine
         guard let newElement = self.parseMemberDeclListItem() else {
           break
         }
@@ -1341,7 +1341,7 @@ extension Parser {
             value: initExpr,
             arena: self.arena
           )
-        } else if self.atStartOfExpression(), !self.at(.leftBrace), !self.currentToken.flags.contains(.isAtStartOfLine) {
+        } else if self.atStartOfExpression(), !self.at(.leftBrace), !self.atStartOfLine {
           let missingEqual = RawTokenSyntax(missing: .equal, arena: self.arena)
           let expr = self.parseExpression()
           initializer = RawInitializerClauseSyntax(
@@ -2050,7 +2050,7 @@ extension Parser {
     }
     var unexpectedBeforeMacro: RawUnexpectedNodesSyntax?
     var macro: RawTokenSyntax
-    if !self.currentToken.isAtStartOfLine {
+    if !self.atStartOfLine {
       (unexpectedBeforeMacro, macro) = self.expectIdentifier(allowKeywordsAsIdentifier: true)
       if macro.leadingTriviaByteLength != 0 {
         unexpectedBeforeMacro = RawUnexpectedNodesSyntax(combining: unexpectedBeforeMacro, macro, arena: self.arena)

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -61,7 +61,7 @@ extension TokenConsumer {
 
     var hasAttribute = false
     var attributeProgress = LoopProgressCondition()
-    while attributeProgress.evaluate(subparser) && subparser.at(.atSign) {
+    while subparser.hasProgressed(&attributeProgress) && subparser.at(.atSign) {
       hasAttribute = true
       _ = subparser.consumeAttributeList()
     }
@@ -71,7 +71,7 @@ extension TokenConsumer {
       var modifierProgress = LoopProgressCondition()
       while let (modifierKind, handle) = subparser.at(anyIn: DeclarationModifier.self),
         modifierKind != .class,
-        modifierProgress.evaluate(subparser)
+        subparser.hasProgressed(&modifierProgress)
       {
         hasModifier = true
         subparser.eat(handle)
@@ -356,7 +356,7 @@ extension Parser {
           arena: self.arena
         )
       )
-    } while keepGoing != nil && loopProgress.evaluate(self)
+    } while keepGoing != nil && self.hasProgressed(&loopProgress)
     return RawImportPathSyntax(elements: elements, arena: self.arena)
   }
 }
@@ -486,7 +486,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(self)
+      } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
 
     let whereClause: RawGenericWhereClauseSyntax?
@@ -692,7 +692,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(self)
+      } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
 
     return RawGenericWhereClauseSyntax(
@@ -758,7 +758,7 @@ extension Parser {
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.endOfFile, .rightBrace) && loopProgress.evaluate(self) {
+      while !self.at(.endOfFile, .rightBrace) && self.hasProgressed(&loopProgress) {
         let newItemAtStartOfLine = self.atStartOfLine
         guard let newElement = self.parseMemberDeclListItem() else {
           break
@@ -858,7 +858,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(self)
+      } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
 
     return RawEnumCaseDeclSyntax(
@@ -1376,7 +1376,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(self)
+      } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
 
     return RawVariableDeclSyntax(
@@ -1521,7 +1521,7 @@ extension Parser {
     var elements = [RawAccessorDeclSyntax]()
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.endOfFile, .rightBrace) && loopProgress.evaluate(self) {
+      while !self.at(.endOfFile, .rightBrace) && self.hasProgressed(&loopProgress) {
         guard let introducer = self.parseAccessorIntroducer() else {
           // There can only be an implicit getter if no other accessors were
           // seen before this one.
@@ -1741,7 +1741,7 @@ extension Parser {
     while (identifiersAfterOperatorName.last ?? name).trailingTriviaByteLength == 0,
       self.currentToken.leadingTriviaByteLength == 0,
       !self.at(.colon, .leftBrace, .endOfFile),
-      loopProgress.evaluate(self)
+      self.hasProgressed(&loopProgress)
     {
       identifiersAfterOperatorName.append(consumeAnyToken())
     }
@@ -1888,7 +1888,7 @@ extension Parser {
     var elements = [RawPrecedenceGroupAttributeListSyntax.Element]()
     do {
       var attributesProgress = LoopProgressCondition()
-      LOOP: while !self.at(.endOfFile, .rightBrace) && attributesProgress.evaluate(self) {
+      LOOP: while !self.at(.endOfFile, .rightBrace) && self.hasProgressed(&attributesProgress) {
         switch self.at(anyIn: LabelText.self) {
         case (.associativity, let handle)?:
           let associativity = self.eat(handle)
@@ -1952,7 +1952,7 @@ extension Parser {
                   arena: self.arena
                 )
               )
-            } while keepGoing != nil && namesProgress.evaluate(self)
+            } while keepGoing != nil && self.hasProgressed(&namesProgress)
           }
           elements.append(
             .precedenceGroupRelation(

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -121,7 +121,7 @@ extension Parser {
 
     // Proceed to parse #if continuation clauses (#elseif, #else, check #elif typo, #endif)
     var loopProgress = LoopProgressCondition()
-    LOOP: while let (match, handle) = self.canRecoverTo(anyIn: IfConfigContinuationClauseStartKeyword.self), loopProgress.evaluate(self) {
+    LOOP: while let (match, handle) = self.canRecoverTo(anyIn: IfConfigContinuationClauseStartKeyword.self), self.hasProgressed(&loopProgress) {
       var unexpectedBeforePound: RawUnexpectedNodesSyntax?
       var pound: RawTokenSyntax
       let condition: RawExprSyntax?
@@ -207,7 +207,7 @@ extension Parser {
     while !self.at(.endOfFile)
       && !self.at(.poundElse, .poundElseif, .poundEndif)
       && !self.atElifTypo()
-      && elementsProgress.evaluate(self)
+      && self.hasProgressed(&elementsProgress)
     {
       let newItemAtStartOfLine = self.atStartOfLine
       guard let element = parseElement(&self, elements.isEmpty), !element.isEmpty else {

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -121,7 +121,7 @@ extension Parser {
 
     // Proceed to parse #if continuation clauses (#elseif, #else, check #elif typo, #endif)
     var loopProgress = LoopProgressCondition()
-    LOOP: while let (match, handle) = self.canRecoverTo(anyIn: IfConfigContinuationClauseStartKeyword.self), loopProgress.evaluate(self.currentToken) {
+    LOOP: while let (match, handle) = self.canRecoverTo(anyIn: IfConfigContinuationClauseStartKeyword.self), loopProgress.evaluate(self) {
       var unexpectedBeforePound: RawUnexpectedNodesSyntax?
       var pound: RawTokenSyntax
       let condition: RawExprSyntax?
@@ -207,7 +207,7 @@ extension Parser {
     while !self.at(.endOfFile)
       && !self.at(.poundElse, .poundElseif, .poundEndif)
       && !self.atElifTypo()
-      && elementsProgress.evaluate(currentToken)
+      && elementsProgress.evaluate(self)
     {
       let newItemAtStartOfLine = self.currentToken.isAtStartOfLine
       guard let element = parseElement(&self, elements.isEmpty), !element.isEmpty else {

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -209,7 +209,7 @@ extension Parser {
       && !self.atElifTypo()
       && elementsProgress.evaluate(self)
     {
-      let newItemAtStartOfLine = self.currentToken.isAtStartOfLine
+      let newItemAtStartOfLine = self.atStartOfLine
       guard let element = parseElement(&self, elements.isEmpty), !element.isEmpty else {
         break
       }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -151,8 +151,8 @@ extension Parser {
       pattern: pattern
     )
 
-    var loopCondition = LoopProgressCondition()
-    while loopCondition.evaluate(self) {
+    var loopProgress = LoopProgressCondition()
+    while self.hasProgressed(&loopProgress) {
       guard
         !lastElement.is(RawMissingExprSyntax.self),
         !(forDirective && self.atStartOfLine)
@@ -806,8 +806,8 @@ extension Parser {
   ) -> RawExprSyntax {
     // Handle suffix expressions.
     var leadingExpr = start
-    var loopCondition = LoopProgressCondition()
-    while loopCondition.evaluate(self) {
+    var loopProgress = LoopProgressCondition()
+    while self.hasProgressed(&loopProgress) {
       if forDirective && self.atStartOfLine {
         return leadingExpr
       }
@@ -964,7 +964,7 @@ extension Parser {
             while !backtrack.at(.endOfFile) && !backtrack.currentToken.isAtStartOfLine {
               backtrack.skipSingle()
             }
-          } while backtrack.at(.poundIf) && loopProgress.evaluate(backtrack)
+          } while backtrack.at(.poundIf) && backtrack.hasProgressed(&loopProgress)
 
           guard backtrack.isAtStartOfPostfixExprSuffix() else {
             break
@@ -1077,8 +1077,8 @@ extension Parser {
     }
 
     var components: [RawKeyPathComponentSyntax] = []
-    var loopCondition = LoopProgressCondition()
-    while loopCondition.evaluate(self) {
+    var loopProgress = LoopProgressCondition()
+    while self.hasProgressed(&loopProgress) {
       // Check for a [] or .[] suffix. The latter is only permitted when there
       // are no components.
       if self.at(TokenSpec(.leftSquare, allowAtStartOfLine: false))
@@ -1683,8 +1683,8 @@ extension Parser {
     var elementKind: CollectionKind? = nil
     var elements = [RawSyntax]()
     do {
-      var collectionLoopCondition = LoopProgressCondition()
-      COLLECTION_LOOP: while collectionLoopCondition.evaluate(self) {
+      var collectionProgress = LoopProgressCondition()
+      COLLECTION_LOOP: while self.hasProgressed(&collectionProgress) {
         elementKind = self.parseCollectionElement(elementKind)
 
         // Parse the ',' if exists.
@@ -1928,7 +1928,7 @@ extension Parser {
               arena: self.arena
             )
           )
-        } while keepGoing != nil && loopProgress.evaluate(self)
+        } while keepGoing != nil && self.hasProgressed(&loopProgress)
       }
       // We were promised a right square bracket, so we're going to get it.
       var unexpectedNodes = [RawSyntax]()
@@ -1983,7 +1983,7 @@ extension Parser {
                 arena: self.arena
               )
             )
-          } while keepGoing != nil && loopProgress.evaluate(self)
+          } while keepGoing != nil && self.hasProgressed(&loopProgress)
         }
 
         parameterClause = .simpleInput(RawClosureParamListSyntax(elements: params, arena: self.arena))
@@ -2122,7 +2122,7 @@ extension Parser {
           arena: self.arena
         )
       )
-    } while keepGoing != nil && loopProgress.evaluate(self)
+    } while keepGoing != nil && self.hasProgressed(&loopProgress)
     return result
   }
 }
@@ -2143,7 +2143,7 @@ extension Parser {
     // Parse labeled trailing closures.
     var elements = [RawMultipleTrailingClosureElementSyntax]()
     var loopProgress = LoopProgressCondition()
-    while self.withLookahead({ $0.isStartOfLabelledTrailingClosure() }) && loopProgress.evaluate(self) {
+    while self.withLookahead({ $0.isStartOfLabelledTrailingClosure() }) && self.hasProgressed(&loopProgress) {
       let (unexpectedBeforeLabel, label) = self.parseArgumentLabel()
       let (unexpectedBeforeColon, colon) = self.expect(.colon)
       let closure = self.parseClosureExpression()
@@ -2240,7 +2240,7 @@ extension Parser.Lookahead {
     var loopProgress = LoopProgressCondition()
     while !backtrack.at(.endOfFile, .rightBrace)
       && !backtrack.at(.poundEndif, .poundElse, .poundElseif)
-      && loopProgress.evaluate(backtrack)
+      && backtrack.hasProgressed(&loopProgress)
     {
       backtrack.skipSingle()
     }
@@ -2392,7 +2392,7 @@ extension Parser {
     var elements = [RawSwitchCaseListSyntax.Element]()
     var elementsProgress = LoopProgressCondition()
     while !self.at(.endOfFile, .rightBrace) && !self.at(.poundEndif, .poundElseif, .poundElse)
-      && elementsProgress.evaluate(self)
+      && self.hasProgressed(&elementsProgress)
     {
       if self.withLookahead({ $0.isAtStartOfSwitchCase(allowRecovery: false) }) {
         elements.append(.switchCase(self.parseSwitchCase()))
@@ -2556,7 +2556,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(self)
+      } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     return RawSwitchCaseLabelSyntax(
@@ -2669,7 +2669,7 @@ extension Parser.Lookahead {
   mutating func consumeEffectsSpecifiers() {
     var loopProgress = LoopProgressCondition()
     while let (_, handle) = self.at(anyIn: EffectSpecifier.self),
-      loopProgress.evaluate(self)
+      self.hasProgressed(&loopProgress)
     {
       self.eat(handle)
     }
@@ -2679,7 +2679,7 @@ extension Parser.Lookahead {
     // Consume attributes.
     var lookahead = self.lookahead()
     var attributesProgress = LoopProgressCondition()
-    while let _ = lookahead.consume(if: .atSign), attributesProgress.evaluate(lookahead) {
+    while let _ = lookahead.consume(if: .atSign), lookahead.hasProgressed(&attributesProgress) {
       guard lookahead.at(.identifier) else {
         break
       }
@@ -2699,7 +2699,7 @@ extension Parser.Lookahead {
 
       // While we don't have '->' or ')', eat balanced tokens.
       var skipProgress = LoopProgressCondition()
-      while !lookahead.at(.endOfFile, .rightParen) && skipProgress.evaluate(lookahead) {
+      while !lookahead.at(.endOfFile, .rightParen) && lookahead.hasProgressed(&skipProgress) {
         lookahead.skipSingle()
       }
 
@@ -2722,7 +2722,7 @@ extension Parser.Lookahead {
       lookahead.consumeAnyToken()
 
       var parametersProgress = LoopProgressCondition()
-      while lookahead.consume(if: .comma) != nil && parametersProgress.evaluate(lookahead) {
+      while lookahead.consume(if: .comma) != nil && lookahead.hasProgressed(&parametersProgress) {
         if lookahead.at(.identifier) || lookahead.at(.wildcard) {
           lookahead.consumeAnyToken()
           continue

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -226,7 +226,7 @@ extension Parser.Lookahead {
       self.skipUntilEndOfLine()
 
       var attributesLoopProgress = LoopProgressCondition()
-      ATTRIBUTE_LOOP: while attributesLoopProgress.evaluate(self) {
+      ATTRIBUTE_LOOP: while self.hasProgressed(&attributesLoopProgress) {
         switch self.currentToken.rawTokenKind {
         case .atSign:
           didSeeAnyAttributes = true
@@ -237,7 +237,7 @@ extension Parser.Lookahead {
           break ATTRIBUTE_LOOP
         }
       }
-    } while self.at(.poundElseif, .poundElse) && poundIfLoopProgress.evaluate(self)
+    } while self.at(.poundElseif, .poundElse) && self.hasProgressed(&poundIfLoopProgress)
 
     return didSeeAnyAttributes && self.atStartOfLine && self.consume(if: .poundEndif) != nil
   }

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -239,7 +239,7 @@ extension Parser.Lookahead {
       }
     } while self.at(.poundElseif, .poundElse) && poundIfLoopProgress.evaluate(self)
 
-    return didSeeAnyAttributes && self.currentToken.isAtStartOfLine && self.consume(if: .poundEndif) != nil
+    return didSeeAnyAttributes && self.atStartOfLine && self.consume(if: .poundEndif) != nil
   }
 }
 
@@ -295,7 +295,7 @@ extension Parser.Lookahead {
   }
 
   mutating func skipUntilEndOfLine() {
-    while !self.at(.endOfFile) && !self.currentToken.isAtStartOfLine {
+    while !self.at(.endOfFile) && !self.atStartOfLine {
       self.skipSingle()
     }
   }

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -226,7 +226,7 @@ extension Parser.Lookahead {
       self.skipUntilEndOfLine()
 
       var attributesLoopProgress = LoopProgressCondition()
-      ATTRIBUTE_LOOP: while attributesLoopProgress.evaluate(self.currentToken) {
+      ATTRIBUTE_LOOP: while attributesLoopProgress.evaluate(self) {
         switch self.currentToken.rawTokenKind {
         case .atSign:
           didSeeAnyAttributes = true
@@ -237,7 +237,7 @@ extension Parser.Lookahead {
           break ATTRIBUTE_LOOP
         }
       }
-    } while self.at(.poundElseif, .poundElse) && poundIfLoopProgress.evaluate(self.currentToken)
+    } while self.at(.poundElseif, .poundElse) && poundIfLoopProgress.evaluate(self)
 
     return didSeeAnyAttributes && self.currentToken.isAtStartOfLine && self.consume(if: .poundEndif) != nil
   }

--- a/Sources/SwiftParser/LoopProgressCondition.swift
+++ b/Sources/SwiftParser/LoopProgressCondition.swift
@@ -12,38 +12,30 @@
 
 @_spi(RawSyntax) import SwiftSyntax
 
-/// A type that can be used in place of a `while true` loop.
-/// See `evaluate` for more detail.
+/// A type that can be used to make sure that a loop in the parser makes process.
+///
+/// See `TokenConsumer.hasProgressed` for details.
 struct LoopProgressCondition {
   var currentToken: Lexer.Lexeme?
 
   init() {}
+}
 
-  /// Check that the loop has made progress since `evaluate` was called the last time.
-  /// In assert builds, this traps if the loop has not made any parser progress in between two iterations,
-  /// ie. it checks if the parser's `currentToken` has changed in between two calls to `evaluate`.
-  /// In non-assert builds, `evaluate()` returns `false` if the loop has not made progress, thus aborting the loop.
-  @inline(__always)
-  mutating func evaluate(_ parser: Parser) -> Bool {
-    return evaluate(parser.currentToken)
-  }
-
-  /// Check that the loop has made progress since `evaluate` was called the last time.
-  /// In assert builds, this traps if the loop has not made any parser progress in between two iterations,
-  /// ie. it checks if the parser's `currentToken` has changed in between two calls to `evaluate`.
-  /// In non-assert builds, `evaluate()` returns `false` if the loop has not made progress, thus aborting the loop.
-  @inline(__always)
-  mutating func evaluate(_ parser: Parser.Lookahead) -> Bool {
-    return evaluate(parser.currentToken)
-  }
-
-  /// Implementation of the above `evaluate` methods.
-  private mutating func evaluate(_ currentToken: Lexer.Lexeme) -> Bool {
+extension TokenConsumer {
+  /// Check that the token consumer has made progress since `hasProgress` was
+  /// called the last time with this `loopProgress`.
+  ///
+  /// In assert builds, this traps if the loop has not made any parser progress
+  /// in between two iterations, ie. it checks if the parser's `currentToken`
+  /// has changed in between two calls to `evaluate`.
+  /// In non-assert builds, `evaluate()` returns `false` if the loop has not made
+  /// progress, thus aborting the loop.
+  func hasProgressed(_ loopProgress: inout LoopProgressCondition) -> Bool {
     defer {
-      self.currentToken = currentToken
+      loopProgress.currentToken = currentToken
     }
 
-    guard let previousToken = self.currentToken else {
+    guard let previousToken = loopProgress.currentToken else {
       return true
     }
     // The loop has made progress if either

--- a/Sources/SwiftParser/LoopProgressCondition.swift
+++ b/Sources/SwiftParser/LoopProgressCondition.swift
@@ -20,11 +20,25 @@ struct LoopProgressCondition {
   init() {}
 
   /// Check that the loop has made progress since `evaluate` was called the last time.
-  /// `currentToken` is the current token of the parser.
   /// In assert builds, this traps if the loop has not made any parser progress in between two iterations,
   /// ie. it checks if the parser's `currentToken` has changed in between two calls to `evaluate`.
   /// In non-assert builds, `evaluate()` returns `false` if the loop has not made progress, thus aborting the loop.
-  mutating func evaluate(_ currentToken: Lexer.Lexeme) -> Bool {
+  @inline(__always)
+  mutating func evaluate(_ parser: Parser) -> Bool {
+    return evaluate(parser.currentToken)
+  }
+
+  /// Check that the loop has made progress since `evaluate` was called the last time.
+  /// In assert builds, this traps if the loop has not made any parser progress in between two iterations,
+  /// ie. it checks if the parser's `currentToken` has changed in between two calls to `evaluate`.
+  /// In non-assert builds, `evaluate()` returns `false` if the loop has not made progress, thus aborting the loop.
+  @inline(__always)
+  mutating func evaluate(_ parser: Parser.Lookahead) -> Bool {
+    return evaluate(parser.currentToken)
+  }
+
+  /// Implementation of the above `evaluate` methods.
+  private mutating func evaluate(_ currentToken: Lexer.Lexeme) -> Bool {
     defer {
       self.currentToken = currentToken
     }

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -15,8 +15,8 @@
 extension Parser {
   mutating func parseModifierList() -> RawModifierListSyntax? {
     var elements = [RawDeclModifierSyntax]()
-    var modifierLoopCondition = LoopProgressCondition()
-    MODIFIER_LOOP: while modifierLoopCondition.evaluate(self) {
+    var modifierLoopProgress = LoopProgressCondition()
+    MODIFIER_LOOP: while self.hasProgressed(&modifierLoopProgress) {
       switch self.canRecoverTo(anyIn: DeclarationStart.self) {
       case (.declarationModifier(.private), _)?,
         (.declarationModifier(.fileprivate), _)?,

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -16,7 +16,7 @@ extension Parser {
   mutating func parseModifierList() -> RawModifierListSyntax? {
     var elements = [RawDeclModifierSyntax]()
     var modifierLoopCondition = LoopProgressCondition()
-    MODIFIER_LOOP: while modifierLoopCondition.evaluate(currentToken) {
+    MODIFIER_LOOP: while modifierLoopCondition.evaluate(self) {
       switch self.canRecoverTo(anyIn: DeclarationStart.self) {
       case (.declarationModifier(.private), _)?,
         (.declarationModifier(.fileprivate), _)?,

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -115,7 +115,7 @@ extension Parser {
     var elements = [RawDeclNameArgumentSyntax]()
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.endOfFile, .rightParen) && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightParen) && loopProgress.evaluate(self) {
         // Check to see if there is an argument label.
         precondition(self.currentToken.canBeArgumentLabel() && self.peek().rawTokenKind == .colon)
         let name = self.consumeAnyToken()
@@ -216,7 +216,7 @@ extension Parser {
       }
 
       keepGoing = self.consume(if: .period)
-    } while keepGoing != nil && loopProgress.evaluate(currentToken)
+    } while keepGoing != nil && loopProgress.evaluate(self)
 
     return result!
   }
@@ -240,7 +240,7 @@ extension Parser.Lookahead {
     }
 
     var loopProgress = LoopProgressCondition()
-    while !lookahead.at(.endOfFile, .rightParen) && loopProgress.evaluate(lookahead.currentToken) {
+    while !lookahead.at(.endOfFile, .rightParen) && loopProgress.evaluate(lookahead) {
       // Check to see if there is an argument label.
       guard lookahead.currentToken.canBeArgumentLabel() && lookahead.peek().rawTokenKind == .colon else {
         return false

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -115,7 +115,7 @@ extension Parser {
     var elements = [RawDeclNameArgumentSyntax]()
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.endOfFile, .rightParen) && loopProgress.evaluate(self) {
+      while !self.at(.endOfFile, .rightParen) && self.hasProgressed(&loopProgress) {
         // Check to see if there is an argument label.
         precondition(self.currentToken.canBeArgumentLabel() && self.peek().rawTokenKind == .colon)
         let name = self.consumeAnyToken()
@@ -216,7 +216,7 @@ extension Parser {
       }
 
       keepGoing = self.consume(if: .period)
-    } while keepGoing != nil && loopProgress.evaluate(self)
+    } while keepGoing != nil && self.hasProgressed(&loopProgress)
 
     return result!
   }
@@ -240,7 +240,7 @@ extension Parser.Lookahead {
     }
 
     var loopProgress = LoopProgressCondition()
-    while !lookahead.at(.endOfFile, .rightParen) && loopProgress.evaluate(lookahead) {
+    while !lookahead.at(.endOfFile, .rightParen) && lookahead.hasProgressed(&loopProgress) {
       // Check to see if there is an argument label.
       guard lookahead.currentToken.canBeArgumentLabel() && lookahead.peek().rawTokenKind == .colon else {
         return false

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -211,7 +211,7 @@ extension Parser {
   ) -> T where T: NominalTypeDeclarationTrait {
     let (unexpectedBeforeIntroducerKeyword, introducerKeyword) = self.eat(introucerHandle)
     let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
-    if unexpectedBeforeName == nil && name.isMissing && self.currentToken.isAtStartOfLine {
+    if unexpectedBeforeName == nil && name.isMissing && self.atStartOfLine {
       return T.init(
         attributes: attrs.attributes,
         modifiers: attrs.modifiers,

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -311,7 +311,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(currentToken)
+      } while keepGoing != nil && loopProgress.evaluate(self)
     }
 
     let unexpectedAfterInheritedTypeCollection: RawUnexpectedNodesSyntax?
@@ -350,7 +350,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(currentToken)
+      } while keepGoing != nil && loopProgress.evaluate(self)
     }
     let rangle = self.expectWithoutRecovery(prefix: ">", as: .rightAngle)
     return RawPrimaryAssociatedTypeClauseSyntax(

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -311,7 +311,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(self)
+      } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
 
     let unexpectedAfterInheritedTypeCollection: RawUnexpectedNodesSyntax?
@@ -350,7 +350,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(self)
+      } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
     let rangle = self.expectWithoutRecovery(prefix: ">", as: .rightAngle)
     return RawPrimaryAssociatedTypeClauseSyntax(

--- a/Sources/SwiftParser/Parameters.swift
+++ b/Sources/SwiftParser/Parameters.swift
@@ -236,8 +236,8 @@ extension Parser {
 extension Parser {
   mutating func parseParameterModifiers(isClosure: Bool) -> RawModifierListSyntax? {
     var elements = [RawDeclModifierSyntax]()
-    var loopCondition = LoopProgressCondition()
-    MODIFIER_LOOP: while loopCondition.evaluate(self) {
+    var loopProgress = LoopProgressCondition()
+    MODIFIER_LOOP: while self.hasProgressed(&loopProgress) {
       switch self.at(anyIn: ParameterModifier.self) {
       case (._const, let handle)?:
         elements.append(RawDeclModifierSyntax(name: self.eat(handle), detail: nil, arena: self.arena))
@@ -286,7 +286,7 @@ extension Parser {
       var loopProgress = LoopProgressCondition()
       while !self.at(.endOfFile, .rightParen)
         && keepGoing
-        && loopProgress.evaluate(self)
+        && self.hasProgressed(&loopProgress)
       {
         let parameter = parseParameter(&self)
         if parameter.isEmpty {

--- a/Sources/SwiftParser/Parameters.swift
+++ b/Sources/SwiftParser/Parameters.swift
@@ -237,7 +237,7 @@ extension Parser {
   mutating func parseParameterModifiers(isClosure: Bool) -> RawModifierListSyntax? {
     var elements = [RawDeclModifierSyntax]()
     var loopCondition = LoopProgressCondition()
-    MODIFIER_LOOP: while loopCondition.evaluate(currentToken) {
+    MODIFIER_LOOP: while loopCondition.evaluate(self) {
       switch self.at(anyIn: ParameterModifier.self) {
       case (._const, let handle)?:
         elements.append(RawDeclModifierSyntax(name: self.eat(handle), detail: nil, arena: self.arena))
@@ -286,7 +286,7 @@ extension Parser {
       var loopProgress = LoopProgressCondition()
       while !self.at(.endOfFile, .rightParen)
         && keepGoing
-        && loopProgress.evaluate(currentToken)
+        && loopProgress.evaluate(self)
       {
         let parameter = parseParameter(&self)
         if parameter.isEmpty {

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -290,7 +290,7 @@ extension Parser {
 
     var unexpectedTokens = [RawTokenSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !self.at(.endOfFile), !currentToken.isAtStartOfLine, loopProgress.evaluate(self.currentToken) {
+    while !self.at(.endOfFile), !currentToken.isAtStartOfLine, loopProgress.evaluate(self) {
       unexpectedTokens += [self.consumeAnyToken()]
     }
 

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -290,7 +290,7 @@ extension Parser {
 
     var unexpectedTokens = [RawTokenSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !self.at(.endOfFile), !atStartOfLine, loopProgress.evaluate(self) {
+    while !self.at(.endOfFile), !atStartOfLine, self.hasProgressed(&loopProgress) {
       unexpectedTokens += [self.consumeAnyToken()]
     }
 

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -284,13 +284,13 @@ extension Parser {
   /// Consumes remaining token on the line and returns a ``RawUnexpectedNodesSyntax``
   /// if there is any tokens consumed.
   mutating func consumeRemainingTokenOnLine() -> RawUnexpectedNodesSyntax? {
-    guard !self.currentToken.isAtStartOfLine else {
+    guard !self.atStartOfLine else {
       return nil
     }
 
     var unexpectedTokens = [RawTokenSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !self.at(.endOfFile), !currentToken.isAtStartOfLine, loopProgress.evaluate(self) {
+    while !self.at(.endOfFile), !atStartOfLine, loopProgress.evaluate(self) {
       unexpectedTokens += [self.consumeAnyToken()]
     }
 
@@ -525,8 +525,8 @@ extension Parser {
         self.missingToken(.identifier)
       )
     } else if keywordRecovery,
-      (self.currentToken.isLexerClassifiedKeyword || self.currentToken.rawTokenKind == .wildcard),
-      !self.currentToken.isAtStartOfLine
+      (self.currentToken.isLexerClassifiedKeyword || self.at(.wildcard)),
+      !self.atStartOfLine
     {
       let keyword = self.consumeAnyToken()
       return (

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -215,7 +215,7 @@ extension Parser {
     do {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()
-      while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(self) {
+      while !self.at(.endOfFile, .rightParen) && keepGoing && self.hasProgressed(&loopProgress) {
         // If the tuple element has a label, parse it.
         let labelAndColon = self.consume(if: .identifier, followedBy: .colon)
         var (label, colon) = (labelAndColon?.0, labelAndColon?.1)
@@ -368,7 +368,7 @@ extension Parser.Lookahead {
         guard self.canParsePattern() else {
           return false
         }
-      } while self.consume(if: .comma) != nil && loopProgress.evaluate(self)
+      } while self.consume(if: .comma) != nil && self.hasProgressed(&loopProgress)
     }
 
     return self.consume(if: .rightParen) != nil

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -215,7 +215,7 @@ extension Parser {
     do {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()
-      while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(self) {
         // If the tuple element has a label, parse it.
         let labelAndColon = self.consume(if: .identifier, followedBy: .colon)
         var (label, colon) = (labelAndColon?.0, labelAndColon?.1)
@@ -368,7 +368,7 @@ extension Parser.Lookahead {
         guard self.canParsePattern() else {
           return false
         }
-      } while self.consume(if: .comma) != nil && loopProgress.evaluate(currentToken)
+      } while self.consume(if: .comma) != nil && loopProgress.evaluate(self)
     }
 
     return self.consume(if: .rightParen) != nil

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -134,7 +134,7 @@ extension Parser {
         )
       )
     case nil:
-      if self.currentToken.isLexerClassifiedKeyword, !self.currentToken.isAtStartOfLine {
+      if self.currentToken.isLexerClassifiedKeyword, !self.atStartOfLine {
         // Recover if a keyword was used instead of an identifier
         let keyword = self.consumeAnyToken()
         return RawPatternSyntax(
@@ -171,7 +171,7 @@ extension Parser {
         arena: self.arena
       )
     } else if allowRecoveryFromMissingColon
-      && !self.currentToken.isAtStartOfLine
+      && !self.atStartOfLine
       && lookahead.canParseType()
     {
       let (unexpectedBeforeColon, colon) = self.expect(.colon)

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -139,7 +139,7 @@ extension Parser.Lookahead {
         return $0.spec.recoveryPrecedence
       }).min()!
     var loopProgress = LoopProgressCondition()
-    while !self.at(.endOfFile) && loopProgress.evaluate(self.currentToken) {
+    while !self.at(.endOfFile) && loopProgress.evaluate(self) {
       if !recoveryPrecedence.shouldSkipOverNewlines,
         self.currentToken.isAtStartOfLine
       {

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -77,7 +77,7 @@ extension Parser.Lookahead {
     let shouldSkipOverNewlines = recoveryPrecedence.shouldSkipOverNewlines && spec1.allowAtStartOfLine && spec2.allowAtStartOfLine && spec3.allowAtStartOfLine
 
     while !self.at(.endOfFile) {
-      if !shouldSkipOverNewlines, self.currentToken.isAtStartOfLine {
+      if !shouldSkipOverNewlines, self.atStartOfLine {
         break
       }
       let matchedSpec: TokenSpec?
@@ -140,9 +140,7 @@ extension Parser.Lookahead {
       }).min()!
     var loopProgress = LoopProgressCondition()
     while !self.at(.endOfFile) && loopProgress.evaluate(self) {
-      if !recoveryPrecedence.shouldSkipOverNewlines,
-        self.currentToken.isAtStartOfLine
-      {
+      if !recoveryPrecedence.shouldSkipOverNewlines, self.atStartOfLine {
         break
       }
       if let (kind, handle) = self.at(anyIn: specSet) {

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -139,7 +139,7 @@ extension Parser.Lookahead {
         return $0.spec.recoveryPrecedence
       }).min()!
     var loopProgress = LoopProgressCondition()
-    while !self.at(.endOfFile) && loopProgress.evaluate(self) {
+    while !self.at(.endOfFile) && self.hasProgressed(&loopProgress) {
       if !recoveryPrecedence.shouldSkipOverNewlines, self.atStartOfLine {
         break
       }

--- a/Sources/SwiftParser/Specifiers.swift
+++ b/Sources/SwiftParser/Specifiers.swift
@@ -598,7 +598,7 @@ extension Parser {
     }
 
     var unexpectedBeforeThrowsLoopProgress = LoopProgressCondition()
-    while unexpectedBeforeThrowsLoopProgress.evaluate(self.currentToken) {
+    while unexpectedBeforeThrowsLoopProgress.evaluate(self) {
       if let misspelledAsync = self.consume(ifAnyIn: S.MisspelledAsyncTokenKinds.self) {
         unexpectedBeforeThrows.append(RawSyntax(misspelledAsync))
       } else if let misspelledThrows = self.consume(ifAnyIn: S.MisspelledThrowsTokenKinds.self) {
@@ -620,7 +620,7 @@ extension Parser {
     }
 
     var unexpectedAfterThrowsLoopProgress = LoopProgressCondition()
-    while unexpectedAfterThrowsLoopProgress.evaluate(self.currentToken) {
+    while unexpectedAfterThrowsLoopProgress.evaluate(self) {
       if let (_, handle, _) = self.at(anyIn: S.MisspelledAsyncTokenKinds.self, or: S.CorrectAsyncTokenKinds.self) {
         let misspelledAsync = self.eat(handle)
         unexpectedAfterThrows.append(RawSyntax(misspelledAsync))
@@ -717,7 +717,7 @@ extension Parser {
     var synthesizedThrows: RawTokenSyntax? = nil
     var unexpected: [RawTokenSyntax] = []
     var loopProgress = LoopProgressCondition()
-    while loopProgress.evaluate(self.currentToken) {
+    while loopProgress.evaluate(self) {
       if let (spec, handle, matchedSubset) = self.at(anyIn: S.MisspelledAsyncTokenKinds.self, or: S.CorrectAsyncTokenKinds.self) {
         let misspelledAsync = self.eat(handle)
         unexpected.append(misspelledAsync)

--- a/Sources/SwiftParser/Specifiers.swift
+++ b/Sources/SwiftParser/Specifiers.swift
@@ -598,7 +598,7 @@ extension Parser {
     }
 
     var unexpectedBeforeThrowsLoopProgress = LoopProgressCondition()
-    while unexpectedBeforeThrowsLoopProgress.evaluate(self) {
+    while self.hasProgressed(&unexpectedBeforeThrowsLoopProgress) {
       if let misspelledAsync = self.consume(ifAnyIn: S.MisspelledAsyncTokenKinds.self) {
         unexpectedBeforeThrows.append(RawSyntax(misspelledAsync))
       } else if let misspelledThrows = self.consume(ifAnyIn: S.MisspelledThrowsTokenKinds.self) {
@@ -620,7 +620,7 @@ extension Parser {
     }
 
     var unexpectedAfterThrowsLoopProgress = LoopProgressCondition()
-    while unexpectedAfterThrowsLoopProgress.evaluate(self) {
+    while self.hasProgressed(&unexpectedAfterThrowsLoopProgress) {
       if let (_, handle, _) = self.at(anyIn: S.MisspelledAsyncTokenKinds.self, or: S.CorrectAsyncTokenKinds.self) {
         let misspelledAsync = self.eat(handle)
         unexpectedAfterThrows.append(RawSyntax(misspelledAsync))
@@ -717,7 +717,7 @@ extension Parser {
     var synthesizedThrows: RawTokenSyntax? = nil
     var unexpected: [RawTokenSyntax] = []
     var loopProgress = LoopProgressCondition()
-    while loopProgress.evaluate(self) {
+    while self.hasProgressed(&loopProgress) {
       if let (spec, handle, matchedSubset) = self.at(anyIn: S.MisspelledAsyncTokenKinds.self, or: S.CorrectAsyncTokenKinds.self) {
         let misspelledAsync = self.eat(handle)
         unexpected.append(misspelledAsync)

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -198,7 +198,7 @@ extension Parser {
           arena: self.arena
         )
       )
-    } while keepGoing != nil && loopProgress.evaluate(currentToken)
+    } while keepGoing != nil && loopProgress.evaluate(self)
 
     return RawConditionElementListSyntax(elements: elements, arena: self.arena)
   }
@@ -451,7 +451,7 @@ extension Parser {
     // If the next token is 'catch', this is a 'do'/'catch' statement.
     var elements = [RawCatchClauseSyntax]()
     var loopProgress = LoopProgressCondition()
-    while self.at(.keyword(.catch)) && loopProgress.evaluate(self.currentToken) {
+    while self.at(.keyword(.catch)) && loopProgress.evaluate(self) {
       // Parse 'catch' clauses
       elements.append(self.parseCatchClause())
     }
@@ -493,7 +493,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(currentToken)
+      } while keepGoing != nil && loopProgress.evaluate(self)
     }
     let body = self.parseCodeBlock(introducer: catchKeyword)
     return RawCatchClauseSyntax(
@@ -798,7 +798,7 @@ extension Parser {
         var keepGoing = true
         var elementList = [RawYieldExprListElementSyntax]()
         var loopProgress = LoopProgressCondition()
-        while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
+        while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(self) {
           let expr = self.parseExpression()
           let comma = self.consume(if: .comma)
           elementList.append(
@@ -1025,7 +1025,7 @@ extension Parser.Lookahead {
     var lookahead = self.lookahead()
     var loopProgress = LoopProgressCondition()
     var hasAttribute = false
-    while lookahead.at(.atSign) && loopProgress.evaluate(lookahead.currentToken) {
+    while lookahead.at(.atSign) && loopProgress.evaluate(lookahead) {
       guard lookahead.peek().rawTokenKind == .identifier else {
         return false
       }
@@ -1062,7 +1062,7 @@ extension Parser.Lookahead {
       lookahead.consumeAnyToken()
       // just find the end of the line
       lookahead.skipUntilEndOfLine()
-    } while lookahead.at(.poundIf, .poundElseif, .poundElse) && loopProgress.evaluate(lookahead.currentToken)
+    } while lookahead.at(.poundIf, .poundElseif, .poundElse) && loopProgress.evaluate(lookahead)
     return lookahead.isAtStartOfSwitchCase()
   }
 }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -198,7 +198,7 @@ extension Parser {
           arena: self.arena
         )
       )
-    } while keepGoing != nil && loopProgress.evaluate(self)
+    } while keepGoing != nil && self.hasProgressed(&loopProgress)
 
     return RawConditionElementListSyntax(elements: elements, arena: self.arena)
   }
@@ -451,7 +451,7 @@ extension Parser {
     // If the next token is 'catch', this is a 'do'/'catch' statement.
     var elements = [RawCatchClauseSyntax]()
     var loopProgress = LoopProgressCondition()
-    while self.at(.keyword(.catch)) && loopProgress.evaluate(self) {
+    while self.at(.keyword(.catch)) && self.hasProgressed(&loopProgress) {
       // Parse 'catch' clauses
       elements.append(self.parseCatchClause())
     }
@@ -493,7 +493,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(self)
+      } while keepGoing != nil && self.hasProgressed(&loopProgress)
     }
     let body = self.parseCodeBlock(introducer: catchKeyword)
     return RawCatchClauseSyntax(
@@ -798,7 +798,7 @@ extension Parser {
         var keepGoing = true
         var elementList = [RawYieldExprListElementSyntax]()
         var loopProgress = LoopProgressCondition()
-        while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(self) {
+        while !self.at(.endOfFile, .rightParen) && keepGoing && self.hasProgressed(&loopProgress) {
           let expr = self.parseExpression()
           let comma = self.consume(if: .comma)
           elementList.append(
@@ -1025,7 +1025,7 @@ extension Parser.Lookahead {
     var lookahead = self.lookahead()
     var loopProgress = LoopProgressCondition()
     var hasAttribute = false
-    while lookahead.at(.atSign) && loopProgress.evaluate(lookahead) {
+    while lookahead.at(.atSign) && lookahead.hasProgressed(&loopProgress) {
       guard lookahead.peek().rawTokenKind == .identifier else {
         return false
       }
@@ -1062,7 +1062,7 @@ extension Parser.Lookahead {
       lookahead.consumeAnyToken()
       // just find the end of the line
       lookahead.skipUntilEndOfLine()
-    } while lookahead.at(.poundIf, .poundElseif, .poundElse) && loopProgress.evaluate(lookahead)
+    } while lookahead.at(.poundIf, .poundElseif, .poundElse) && lookahead.hasProgressed(&loopProgress)
     return lookahead.isAtStartOfSwitchCase()
   }
 }

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -512,7 +512,7 @@ extension Parser {
         // line if this is a single-line literal. Leading trivia is fine as
         // we allow e.g "\(foo )".
         let rightParen: Token
-        if self.at(.rightParen) && self.currentToken.isAtStartOfLine && openQuote.tokenKind != .multilineStringQuote {
+        if self.at(.rightParen) && self.atStartOfLine && openQuote.tokenKind != .multilineStringQuote {
           rightParen = missingToken(.rightParen)
         } else {
           rightParen = self.expectWithoutRecovery(.rightParen)

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -487,7 +487,7 @@ extension Parser {
     /// Parse segments.
     var segments: [RawStringLiteralSegmentsSyntax.Element] = []
     var loopProgress = LoopProgressCondition()
-    while loopProgress.evaluate(self) {
+    while self.hasProgressed(&loopProgress) {
       // If we encounter a token with leading trivia, we're no longer in the
       // string literal.
       guard currentToken.leadingTriviaText.isEmpty else { break }
@@ -504,7 +504,7 @@ extension Parser {
         var unexpectedBeforeRightParen: [RawTokenSyntax] = []
         var unexpectedProgress = LoopProgressCondition()
         while !self.at(.rightParen, .stringSegment, .backslash) && !self.at(TokenSpec(openQuoteKind), .endOfFile)
-          && unexpectedProgress.evaluate(self)
+          && self.hasProgressed(&unexpectedProgress)
         {
           unexpectedBeforeRightParen.append(self.consumeAnyToken())
         }

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -487,7 +487,7 @@ extension Parser {
     /// Parse segments.
     var segments: [RawStringLiteralSegmentsSyntax.Element] = []
     var loopProgress = LoopProgressCondition()
-    while loopProgress.evaluate(self.currentToken) {
+    while loopProgress.evaluate(self) {
       // If we encounter a token with leading trivia, we're no longer in the
       // string literal.
       guard currentToken.leadingTriviaText.isEmpty else { break }
@@ -504,7 +504,7 @@ extension Parser {
         var unexpectedBeforeRightParen: [RawTokenSyntax] = []
         var unexpectedProgress = LoopProgressCondition()
         while !self.at(.rightParen, .stringSegment, .backslash) && !self.at(TokenSpec(openQuoteKind), .endOfFile)
-          && unexpectedProgress.evaluate(self.currentToken)
+          && unexpectedProgress.evaluate(self)
         {
           unexpectedBeforeRightParen.append(self.consumeAnyToken())
         }

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -150,6 +150,12 @@ extension TokenConsumer {
     return self.currentToken.tokenText.hasPrefix(prefix)
   }
 
+  /// Whether the current token is at the start of a line.
+  @inline(__always)
+  var atStartOfLine: Bool {
+    return self.currentToken.isAtStartOfLine
+  }
+
   /// Eat a token that we know we are currently positioned at, based on `at(anyIn:)`.
   @inline(__always)
   mutating func eat(_ handle: TokenConsumptionHandle) -> Token {

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -65,7 +65,7 @@ extension Parser {
   ) -> RawCodeBlockItemListSyntax {
     var elements = [RawCodeBlockItemSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !stopCondition(&self), loopProgress.evaluate(currentToken) {
+    while !stopCondition(&self), loopProgress.evaluate(self) {
       let newItemAtStartOfLine = self.currentToken.isAtStartOfLine
       guard let newElement = self.parseCodeBlockItem(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl) else {
         break

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -65,7 +65,7 @@ extension Parser {
   ) -> RawCodeBlockItemListSyntax {
     var elements = [RawCodeBlockItemSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !stopCondition(&self), loopProgress.evaluate(self) {
+    while !stopCondition(&self), self.hasProgressed(&loopProgress) {
       let newItemAtStartOfLine = self.atStartOfLine
       guard let newElement = self.parseCodeBlockItem(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl) else {
         break

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -66,7 +66,7 @@ extension Parser {
     var elements = [RawCodeBlockItemSyntax]()
     var loopProgress = LoopProgressCondition()
     while !stopCondition(&self), loopProgress.evaluate(self) {
-      let newItemAtStartOfLine = self.currentToken.isAtStartOfLine
+      let newItemAtStartOfLine = self.atStartOfLine
       guard let newElement = self.parseCodeBlockItem(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl) else {
         break
       }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -189,7 +189,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(currentToken)
+      } while keepGoing != nil && loopProgress.evaluate(self)
 
       base = RawTypeSyntax(
         RawCompositionTypeSyntax(
@@ -252,7 +252,7 @@ extension Parser {
     }
 
     var loopCondition = LoopProgressCondition()
-    while loopCondition.evaluate(currentToken) {
+    while loopCondition.evaluate(self) {
       if !stopAtFirstPeriod, self.at(.period) {
         let (unexpectedPeriod, period, skipMemberName) = self.consumeMemberPeriod(previousNode: base)
         if skipMemberName {
@@ -440,7 +440,7 @@ extension Parser {
             arena: self.arena
           )
         )
-      } while keepGoing != nil && loopProgress.evaluate(currentToken)
+      } while keepGoing != nil && loopProgress.evaluate(self)
     }
 
     let rangle = self.expectWithoutRecovery(prefix: ">", as: .rightAngle)
@@ -488,7 +488,7 @@ extension Parser {
     do {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()
-      while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
+      while !self.at(.endOfFile, .rightParen) && keepGoing && loopProgress.evaluate(self) {
         let unexpectedBeforeFirst: RawUnexpectedNodesSyntax?
         let first: RawTokenSyntax?
         let unexpectedBeforeSecond: RawUnexpectedNodesSyntax?
@@ -662,13 +662,13 @@ extension Parser.Lookahead {
     // TODO: Can we model isolated/_const so that they're specified in both canParse* and parse*?
     while canHaveParameterSpecifier,
       self.at(anyIn: TypeSpecifier.self) != nil || self.at(.keyword(.isolated)) || self.at(.keyword(._const)),
-      specifierProgress.evaluate(currentToken)
+      specifierProgress.evaluate(self)
     {
       self.consumeAnyToken()
     }
 
     var attributeProgress = LoopProgressCondition()
-    while self.at(.atSign), attributeProgress.evaluate(currentToken) {
+    while self.at(.atSign), attributeProgress.evaluate(self) {
       self.consumeAnyToken()
       self.skipTypeAttribute()
     }
@@ -688,7 +688,7 @@ extension Parser.Lookahead {
       // Handle type-function if we have an '->' with optional
       // 'async' and/or 'throws'.
       var loopProgress = LoopProgressCondition()
-      while let (_, handle) = self.at(anyIn: EffectSpecifier.self), loopProgress.evaluate(currentToken) {
+      while let (_, handle) = self.at(anyIn: EffectSpecifier.self), loopProgress.evaluate(self) {
         self.eat(handle)
       }
 
@@ -712,7 +712,7 @@ extension Parser.Lookahead {
     }
 
     var loopCondition = LoopProgressCondition()
-    while self.atContextualPunctuator("&") && loopCondition.evaluate(self.currentToken) {
+    while self.atContextualPunctuator("&") && loopCondition.evaluate(self) {
       self.consumeAnyToken()
       guard self.canParseSimpleType() else {
         return false
@@ -757,7 +757,7 @@ extension Parser.Lookahead {
     }
 
     var loopCondition = LoopProgressCondition()
-    while loopCondition.evaluate(currentToken) {
+    while loopCondition.evaluate(self) {
       if self.at(.period) {
         self.consumeAnyToken()
         if self.at(.keyword(.Type)) || self.at(.keyword(.Protocol)) {
@@ -823,7 +823,7 @@ extension Parser.Lookahead {
             && !self.at(.rightParen, .rightBrace, .comma)
             && !self.atContextualPunctuator("...")
             && !self.atStartOfDeclaration()
-            && skipProgress.evaluate(currentToken)
+            && skipProgress.evaluate(self)
           {
             self.skipSingle()
           }
@@ -838,7 +838,7 @@ extension Parser.Lookahead {
       }
 
       self.consumeIfContextualPunctuator("...")
-    } while self.consume(if: .comma) != nil && loopProgress.evaluate(currentToken)
+    } while self.consume(if: .comma) != nil && loopProgress.evaluate(self)
     return self.consume(if: .rightParen) != nil
   }
 
@@ -910,7 +910,7 @@ extension Parser.Lookahead {
           return false
         }
         // Parse the comma, if the list continues.
-      } while self.consume(if: .comma) != nil && loopProgress.evaluate(currentToken)
+      } while self.consume(if: .comma) != nil && loopProgress.evaluate(self)
     }
 
     guard self.consume(ifPrefix: ">", as: .rightAngle) != nil else {
@@ -956,7 +956,7 @@ extension Parser {
   mutating func parseTypeAttributeListPresent() -> RawAttributeListSyntax {
     var elements = [RawAttributeListSyntax.Element]()
     var attributeProgress = LoopProgressCondition()
-    while self.at(.atSign) && attributeProgress.evaluate(currentToken) {
+    while self.at(.atSign) && attributeProgress.evaluate(self) {
       elements.append(self.parseTypeAttribute())
     }
     return RawAttributeListSyntax(elements: elements, arena: self.arena)
@@ -1045,7 +1045,7 @@ extension Parser {
       }
 
       var loopProgress = LoopProgressCondition()
-      while loopProgress.evaluate(currentToken) {
+      while loopProgress.evaluate(self) {
         if self.at(TokenSpec(.postfixQuestionMark, allowAtStartOfLine: false)) {
           result = RawTypeSyntax(self.parseOptionalType(result))
         } else if self.at(TokenSpec(.exclamationMark, allowAtStartOfLine: false)) {

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -529,7 +529,7 @@ public extension SyntaxProtocol {
     return totalLength.utf8Length
   }
 
-  /// The textual byte length of this node exluding leading and trailing trivia.
+  /// The textual byte length of this node excluding leading and trailing trivia.
   @available(*, deprecated, message: "Use trimmedLength.utf8Length")
   var byteSizeAfterTrimmingTrivia: Int {
     return trimmedLength.utf8Length


### PR DESCRIPTION
The motivation for these changes is to reduce the usage of `Parser.currentToken` because in general the `at` primitives should be preferred to checking the `currentToken` itself. But independent of these motivations, I think the changes simplify the codebase on their own.

- Change `LoopProgress.evaluate` to take a `TokenConsumer` (i.e. `Parser` or `Lookahead`) instead of `currentToken`. This shortens the call sides slightly
- Add `atStartOfLine` to `Parser` to shorten `self.currentToken.isAtStartOfLine` to `self.atStartOfLine`

I measured performance and there’s no significant performance regression associated with this change (based on parsing MovieSwiftUI).