### PR TITLE
Simplify consumption of prefixes in a token

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -435,12 +435,7 @@ extension Parser {
       )
     }
 
-    let langle: RawTokenSyntax
-    if self.currentToken.starts(with: "<") {
-      langle = self.consumePrefix("<", as: .leftAngle)
-    } else {
-      langle = missingToken(.leftAngle)
-    }
+    let langle = self.expectWithoutRecovery(prefix: "<", as: .leftAngle)
     var elements = [RawGenericParameterSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil
@@ -452,8 +447,7 @@ extension Parser {
         var each = self.consume(if: .keyword(.each))
 
         let (unexpectedBetweenEachAndName, name) = self.expectIdentifier(allowSelfOrCapitalSelfAsIdentifier: true)
-        if attributes == nil && each == nil && unexpectedBetweenEachAndName == nil && name.isMissing && elements.isEmpty && !self.currentToken.starts(with: ">")
-        {
+        if attributes == nil && each == nil && unexpectedBetweenEachAndName == nil && name.isMissing && elements.isEmpty && !self.at(prefix: ">") {
           break
         }
 
@@ -518,12 +512,7 @@ extension Parser {
       whereClause = nil
     }
 
-    let rangle: RawTokenSyntax
-    if self.currentToken.starts(with: ">") {
-      rangle = self.consumePrefix(">", as: .rightAngle)
-    } else {
-      rangle = RawTokenSyntax(missing: .rightAngle, arena: self.arena)
-    }
+    let rangle = expectWithoutRecovery(prefix: ">", as: .rightAngle)
 
     let parameters: RawGenericParameterListSyntax
     if elements.isEmpty && rangle.isMissing {
@@ -1011,7 +1000,7 @@ extension Parser {
     }
 
     let generics: RawGenericParameterClauseSyntax?
-    if self.currentToken.starts(with: "<") {
+    if self.at(prefix: "<") {
       generics = self.parseGenericParameters()
     } else {
       generics = nil
@@ -1145,7 +1134,7 @@ extension Parser {
     }
 
     let genericParams: RawGenericParameterClauseSyntax?
-    if self.currentToken.starts(with: "<") {
+    if self.at(prefix: "<") {
       genericParams = self.parseGenericParameters()
     } else {
       genericParams = nil
@@ -1229,14 +1218,14 @@ extension Parser {
     let (unexpectedBeforeSubscriptKeyword, subscriptKeyword) = self.eat(handle)
 
     let unexpectedName: RawTokenSyntax?
-    if self.at(.identifier) && self.peek().starts(with: "<") || self.peek().rawTokenKind == .leftParen {
+    if self.at(.identifier) && self.peek().tokenText.hasPrefix("<") || self.peek().rawTokenKind == .leftParen {
       unexpectedName = self.consumeAnyToken()
     } else {
       unexpectedName = nil
     }
 
     let genericParameterClause: RawGenericParameterClauseSyntax?
-    if self.currentToken.starts(with: "<") {
+    if self.at(prefix: "<") {
       genericParameterClause = self.parseGenericParameters()
     } else {
       genericParameterClause = nil
@@ -1617,7 +1606,7 @@ extension Parser {
 
     // Parse a generic parameter list if it is present.
     let generics: RawGenericParameterClauseSyntax?
-    if self.currentToken.starts(with: "<") {
+    if self.at(prefix: "<") {
       generics = self.parseGenericParameters()
     } else {
       generics = nil
@@ -2012,7 +2001,7 @@ extension Parser {
 
     // Optional generic parameters.
     let genericParams: RawGenericParameterClauseSyntax?
-    if self.currentToken.starts(with: "<") {
+    if self.at(prefix: "<") {
       genericParams = self.parseGenericParameters()
     } else {
       genericParams = nil

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1023,21 +1023,12 @@ extension Parser {
 
     for _ in 0..<numComponents {
       // Consume a period, if there is one.
-      let period: RawTokenSyntax?
-      if self.currentToken.starts(with: ".") {
-        period = self.consumePrefix(".", as: .period)
-      } else {
-        period = nil
-      }
+      let period = self.consume(ifPrefix: ".", as: .period)
 
       // Consume the '!' or '?'.
-      let questionOrExclaim: RawTokenSyntax
-      if self.currentToken.starts(with: "!") {
-        questionOrExclaim = self.consumePrefix("!", as: .exclamationMark)
-      } else {
-        precondition(self.currentToken.starts(with: "?"))
-        questionOrExclaim = self.consumePrefix("?", as: .postfixQuestionMark)
-      }
+      let questionOrExclaim =
+        self.consume(ifPrefix: "!", as: .exclamationMark)
+        ?? self.expectWithoutRecovery(prefix: "?", as: .postfixQuestionMark)
 
       components.append(
         RawKeyPathComponentSyntax(
@@ -1078,7 +1069,7 @@ extension Parser {
     // operator token. Since keypath allows '.!' '.?' and '.[', consume '.'
     // the token is an operator starts with '.', or the following token is '['.
     let rootType: RawTypeSyntax?
-    if !self.currentToken.starts(with: ".") {
+    if !self.at(prefix: ".") {
       rootType = self.parseSimpleType(stopAtFirstPeriod: true)
     } else {
       rootType = nil

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -117,6 +117,10 @@ extension Parser.Lookahead {
   ///
   ///     <TOKEN> ... -> consumePrefix(<TOK>) -> [ <TOK> ] <EN> ...
   mutating func consumePrefix(_ prefix: SyntaxText, as tokenKind: RawTokenKind) {
+    precondition(
+      tokenKind.defaultText == nil || prefix == tokenKind.defaultText!,
+      "If tokenKind has a defaultText, the prefix needs to match it"
+    )
     let tokenText = self.currentToken.tokenText
 
     if tokenText == prefix {

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -228,7 +228,7 @@ extension Parser.Lookahead {
     guard lookahead.canParseTypeIdentifier() else {
       return false
     }
-    return lookahead.currentToken.starts(with: ".")
+    return lookahead.at(prefix: ".")
   }
 }
 
@@ -288,13 +288,5 @@ extension Lexer.Lexeme {
     // Contextual keywords will only be made keywords when a ``RawTokenSyntax`` is
     // constructed from them.
     return self.rawTokenKind == .keyword
-  }
-
-  func starts(with symbol: SyntaxText) -> Bool {
-    guard Operator(lexeme: self) != nil || self.rawTokenKind.isPunctuation else {
-      return false
-    }
-
-    return self.tokenText.hasPrefix(symbol)
   }
 }

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -233,7 +233,7 @@ extension Parser {
     }
 
     let primaryOrGenerics: T.PrimaryOrGenerics?
-    if self.currentToken.starts(with: "<") {
+    if self.at(prefix: "<") {
       primaryOrGenerics = T.parsePrimaryOrGenerics(&self)
     } else {
       primaryOrGenerics = nil
@@ -352,18 +352,10 @@ extension Parser {
         )
       } while keepGoing != nil && loopProgress.evaluate(currentToken)
     }
-    let unexpectedBeforeRangle: RawUnexpectedNodesSyntax?
-    let rangle: RawTokenSyntax
-    if self.currentToken.starts(with: ">") {
-      unexpectedBeforeRangle = nil
-      rangle = self.consumePrefix(">", as: .rightAngle)
-    } else {
-      (unexpectedBeforeRangle, rangle) = self.expect(.rightAngle)
-    }
+    let rangle = self.expectWithoutRecovery(prefix: ">", as: .rightAngle)
     return RawPrimaryAssociatedTypeClauseSyntax(
       leftAngle: langle,
       primaryAssociatedTypeList: RawPrimaryAssociatedTypeListSyntax(elements: associatedTypes, arena: self.arena),
-      unexpectedBeforeRangle,
       rightAngle: rangle,
       arena: self.arena
     )

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -471,6 +471,17 @@ extension Parser {
     )
   }
 
+  /// If the current token starts with the given prefix, consume the prefis as the given token kind.
+  ///
+  /// Otherwise, synthesize a missing token of the given kind.
+  mutating func expectWithoutRecovery(prefix: SyntaxText, as tokenKind: RawTokenKind) -> Token {
+    if self.at(prefix: prefix) {
+      return consumePrefix(prefix, as: tokenKind)
+    } else {
+      return missingToken(tokenKind)
+    }
+  }
+
   /// - Parameters:
   ///   - keywordRecovery: If set to `true` and the parser is currently
   ///     positioned at a keyword instead of an identifier, this method recovers

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -605,6 +605,10 @@ extension Parser {
     _ prefix: SyntaxText,
     as tokenKind: RawTokenKind
   ) -> RawTokenSyntax {
+    precondition(
+      tokenKind.defaultText == nil || prefix == tokenKind.defaultText!,
+      "If tokenKind has a defaultText, the prefix needs to match it"
+    )
     let current = self.currentToken
     // Current token can be either one-character token we want to consume...
     let tokenText = current.tokenText

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -650,7 +650,7 @@ extension Parser.Lookahead {
       return false
     }
 
-    if self.currentToken.isEllipsis {
+    if self.atContextualPunctuator("...") {
       self.consumeAnyToken()
     }
 
@@ -1065,10 +1065,6 @@ extension Lexer.Lexeme {
     return self.rawTokenKind == .binaryOperator
       || self.rawTokenKind == .postfixOperator
       || self.rawTokenKind == .prefixOperator
-  }
-
-  var isEllipsis: Bool {
-    return self.isAnyOperator && self.tokenText == "..."
   }
 
   var isGenericTypeDisambiguatingToken: Bool {

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -422,8 +422,7 @@ extension Parser {
   ///     generic-argument-list → generic-argument | generic-argument ',' generic-argument-list
   ///     generic-argument → type
   mutating func parseGenericArguments() -> RawGenericArgumentClauseSyntax {
-    precondition(self.currentToken.starts(with: "<"))
-    let langle = self.consumePrefix("<", as: .leftAngle)
+    let langle = self.expectWithoutRecovery(prefix: "<", as: .leftAngle)
     var arguments = [RawGenericArgumentSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil
@@ -444,12 +443,7 @@ extension Parser {
       } while keepGoing != nil && loopProgress.evaluate(currentToken)
     }
 
-    let rangle: RawTokenSyntax
-    if self.currentToken.starts(with: ">") {
-      rangle = self.consumePrefix(">", as: .rightAngle)
-    } else {
-      rangle = RawTokenSyntax(missing: .rightAngle, arena: self.arena)
-    }
+    let rangle = self.expectWithoutRecovery(prefix: ">", as: .rightAngle)
 
     let args: RawGenericArgumentListSyntax
     if arguments.isEmpty && rangle.isMissing {
@@ -884,7 +878,7 @@ extension Parser.Lookahead {
     self.consumeAnyToken()
 
     // Parse an optional generic argument list.
-    if self.currentToken.starts(with: "<") && !self.consumeGenericArguments() {
+    if self.at(prefix: "<") && !self.consumeGenericArguments() {
       return false
     }
 
@@ -905,13 +899,11 @@ extension Parser.Lookahead {
 
   mutating func consumeGenericArguments() -> Bool {
     // Parse the opening '<'.
-    guard self.currentToken.starts(with: "<") else {
+    guard self.consume(ifPrefix: "<", as: .leftAngle) != nil else {
       return false
     }
 
-    self.consumePrefix("<", as: .leftAngle)
-
-    if !self.currentToken.starts(with: ">") {
+    if !self.at(prefix: ">") {
       var loopProgress = LoopProgressCondition()
       repeat {
         guard self.canParseType() else {
@@ -921,11 +913,10 @@ extension Parser.Lookahead {
       } while self.consume(if: .comma) != nil && loopProgress.evaluate(currentToken)
     }
 
-    guard self.currentToken.starts(with: ">") else {
+    guard self.consume(ifPrefix: ">", as: .rightAngle) != nil else {
       return false
     }
 
-    self.consumePrefix(">", as: .rightAngle)
     return true
   }
 }
@@ -1001,7 +992,7 @@ extension Parser {
 
 extension Parser {
   mutating func parseResultType() -> RawTypeSyntax {
-    if self.currentToken.starts(with: "<") {
+    if self.at(prefix: "<") {
       let generics = self.parseGenericParameters()
       let baseType = self.parseType()
       return RawTypeSyntax(


### PR DESCRIPTION
In essence, introduce `at(prefix:)` and `consume(ifPrefix:)` and use them in the codebase.

I measured performance and there’s no performance regression associated with this change (based on parsing MovieSwiftUI).