### PR TITLE
Simplify checking if a token can be an argument label 

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -2084,7 +2084,7 @@ extension Parser {
       let unexpectedBeforeLabel: RawUnexpectedNodesSyntax?
       let label: RawTokenSyntax?
       let colon: RawTokenSyntax?
-      if currentToken.canBeArgumentLabel(allowDollarIdentifier: true) && self.peek().rawTokenKind == .colon {
+      if self.atArgumentLabel(allowDollarIdentifier: true) && self.peek().rawTokenKind == .colon {
         (unexpectedBeforeLabel, label) = parseArgumentLabel()
         colon = consumeAnyToken()
       } else {
@@ -2169,7 +2169,7 @@ extension Parser.Lookahead {
     // Fast path: the next two tokens must be a label and a colon.
     // But 'default:' is ambiguous with switch cases and we disallow it
     // (unless escaped) even outside of switches.
-    if !self.currentToken.canBeArgumentLabel()
+    if !self.atArgumentLabel()
       || self.at(.keyword(.default))
       || self.peek().rawTokenKind != .colon
     {

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -589,21 +589,18 @@ extension Parser {
     // First check to see if we have the start of a regex literal `/.../`.
     //    tryLexRegexLiteral(/*forUnappliedOperator*/ false)
 
-    switch self.currentToken {
     // Try parse an 'if' or 'switch' as an expression. Note we do this here in
     // parseUnaryExpression as we don't allow postfix syntax to hang off such
     // expressions to avoid ambiguities such as postfix '.member', which can
     // currently be parsed as a static dot member for a result builder.
-    case TokenSpec(.switch):
+    if self.at(.keyword(.switch)) {
       return RawExprSyntax(
         parseSwitchExpression(switchHandle: .constant(.keyword(.switch)))
       )
-    case TokenSpec(.if):
+    } else if self.at(.keyword(.if)) {
       return RawExprSyntax(
         parseIfExpression(ifHandle: .constant(.keyword(.if)))
       )
-    default:
-      break
     }
 
     switch self.at(anyIn: ExpressionPrefixOperator.self) {
@@ -951,7 +948,7 @@ extension Parser {
         // Check if the first '#if' body starts with '.' <identifier>, and parse
         // it as a "postfix ifconfig expression".
         do {
-          var backtrack = self.lookahead()
+          var lookahead = self.lookahead()
           // Skip to the first body. We may need to skip multiple '#if' directives
           // since we support nested '#if's. e.g.
           //   baseExpr
@@ -960,13 +957,13 @@ extension Parser {
           //       .someMember
           var loopProgress = LoopProgressCondition()
           repeat {
-            backtrack.eat(.poundIf)
-            while !backtrack.at(.endOfFile) && !backtrack.currentToken.isAtStartOfLine {
-              backtrack.skipSingle()
+            lookahead.eat(.poundIf)
+            while !lookahead.at(.endOfFile) && !lookahead.currentToken.isAtStartOfLine {
+              lookahead.skipSingle()
             }
-          } while backtrack.at(.poundIf) && backtrack.hasProgressed(&loopProgress)
+          } while lookahead.at(.poundIf) && lookahead.hasProgressed(&loopProgress)
 
-          guard backtrack.isAtStartOfPostfixExprSuffix() else {
+          guard lookahead.isAtStartOfPostfixExprSuffix() else {
             break
           }
         }

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -223,9 +223,9 @@ extension Parser {
         inheritanceClause: nil,
         genericWhereClause: nil,
         memberBlock: RawMemberDeclBlockSyntax(
-          leftBrace: RawTokenSyntax(missing: .leftBrace, arena: self.arena),
+          leftBrace: missingToken(.leftBrace),
           members: RawMemberDeclListSyntax(elements: [], arena: self.arena),
-          rightBrace: RawTokenSyntax(missing: .rightBrace, arena: self.arena),
+          rightBrace: missingToken(.rightBrace),
           arena: self.arena
         ),
         arena: self.arena

--- a/Sources/SwiftParser/Parameters.swift
+++ b/Sources/SwiftParser/Parameters.swift
@@ -64,7 +64,7 @@ extension Parser {
   fileprivate mutating func parseParameterNames() -> ParameterNames {
     let unexpectedBeforeFirstName: RawUnexpectedNodesSyntax?
     let firstName: RawTokenSyntax?
-    if self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true) {
+    if self.atArgumentLabel(allowDollarIdentifier: true) {
       (unexpectedBeforeFirstName, firstName) = self.parseArgumentLabel()
     } else {
       (unexpectedBeforeFirstName, firstName) = (nil, nil)
@@ -72,7 +72,7 @@ extension Parser {
 
     let unexpectedBeforeSecondName: RawUnexpectedNodesSyntax?
     let secondName: RawTokenSyntax?
-    if self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true) {
+    if self.atArgumentLabel(allowDollarIdentifier: true) {
       (unexpectedBeforeSecondName, secondName) = self.parseArgumentLabel()
     } else {
       (unexpectedBeforeSecondName, secondName) = (nil, nil)
@@ -280,7 +280,7 @@ extension Parser {
     // to be an argument label, don't parse any parameters.
     let shouldSkipParameterParsing =
       lparen.isMissing
-      && (!currentToken.canBeArgumentLabel(allowDollarIdentifier: true) || currentToken.isLexerClassifiedKeyword)
+      && (!self.atArgumentLabel(allowDollarIdentifier: true) || currentToken.isLexerClassifiedKeyword)
     if !shouldSkipParameterParsing {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -90,7 +90,12 @@ public struct Parser {
   var arena: ParsingSyntaxArena
   /// A view of the sequence of lexemes in the input.
   var lexemes: Lexer.LexemeSequence
-  /// The current token. If there was no input, this token will have a kind of `.endOfFile`.
+  /// The current token that should be consumed next.
+  ///
+  /// If the end of the source file is reached, this is `.endOfFile`.
+  ///
+  /// - Important: You should almost never need to access this token directly
+  ///   in the parser. Instead, prefer using the `at` methods.
   var currentToken: Lexer.Lexeme
 
   /// The current nesting level, i.e. the number of tokens that

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -386,7 +386,7 @@ extension Parser.Lookahead {
     }
 
     // To have a parameter name here, we need a name.
-    guard self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true) else {
+    guard self.atArgumentLabel(allowDollarIdentifier: true) else {
       return false
     }
 
@@ -397,7 +397,7 @@ extension Parser.Lookahead {
     }
 
     // If the next token can be an argument label, we might have a name.
-    if nextTok.canBeArgumentLabel(allowDollarIdentifier: true) {
+    if nextTok.isArgumentLabel(allowDollarIdentifier: true) {
       // If the first name wasn't a contextual keyword, we're done.
       if !self.at(.keyword(.isolated))
         && !self.at(.keyword(.some))
@@ -420,7 +420,7 @@ extension Parser.Lookahead {
           return true  // isolated :
         }
         self.consumeAnyToken()
-        return self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true) && self.peek().rawTokenKind == .colon
+        return self.atArgumentLabel(allowDollarIdentifier: true) && self.peek().rawTokenKind == .colon
       }
     }
 

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -921,7 +921,7 @@ extension Parser {
 
   // label-name → identifier
   mutating func parseOptionalControlTransferTarget() -> RawTokenSyntax? {
-    guard !self.currentToken.isAtStartOfLine else {
+    guard !self.atStartOfLine else {
       return nil
     }
 

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -128,7 +128,7 @@ extension TokenConsumer {
   /// If this is the case, return the `Subset` case that the parser is positioned in
   /// as well as a handle to consume that token.
   @inline(__always)
-  mutating func at<SpecSet: TokenSpecSet>(anyIn specSet: SpecSet.Type) -> (SpecSet, TokenConsumptionHandle)? {
+  mutating func at<SpecSet: TokenSpecSet>(anyIn specSet: SpecSet.Type) -> (spec: SpecSet, handle: TokenConsumptionHandle)? {
     #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
     if shouldRecordAlternativeTokenChoices {
       recordAlternativeTokenChoice(for: self.currentToken, choices: specSet.allCases.map(\.spec))

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -308,4 +308,9 @@ extension TokenConsumer {
       return false
     }
   }
+
+  /// Whether the current token can be a function argument label.
+  func atArgumentLabel(allowDollarIdentifier: Bool = false) -> Bool {
+    return self.currentToken.isArgumentLabel(allowDollarIdentifier: allowDollarIdentifier)
+  }
 }

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -26,7 +26,7 @@ extension Parser {
   /// as unexpected nodes that have the `isMaximumNestingLevelOverflow` bit set.
   /// Check this in places that are likely to cause deep recursion and if this returns non-nil, abort parsing.
   mutating func remainingTokensIfMaximumNestingLevelReached() -> RawUnexpectedNodesSyntax? {
-    if nestingLevel > self.maximumNestingLevel && self.currentToken.rawTokenKind != .endOfFile {
+    if nestingLevel > self.maximumNestingLevel && !self.at(.endOfFile) {
       let remainingTokens = self.consumeRemainingTokens()
       return RawUnexpectedNodesSyntax(elements: remainingTokens, isMaximumNestingLevelOverflow: true, arena: self.arena)
     } else {

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -235,19 +235,49 @@ extension Parser {
   mutating func parseSimpleType(
     stopAtFirstPeriod: Bool = false
   ) -> RawTypeSyntax {
+    enum TypeBaseStart: TokenSpecSet {
+      case `Self`
+      case `Any`
+      case identifier
+      case leftParen
+      case leftSquare
+      case wildcard
+
+      init?(lexeme: Lexer.Lexeme) {
+        switch PrepareForKeywordMatch(lexeme) {
+        case .keyword(.Self): self = .Self
+        case .keyword(.Any): self = .Any
+        case .identifier: self = .identifier
+        case .leftParen: self = .leftParen
+        case .leftSquare: self = .leftSquare
+        case .wildcard: self = .wildcard
+        default: return nil
+        }
+      }
+
+      var spec: TokenSpec {
+        switch self {
+        case .Self: return .keyword(.Self)
+        case .Any: return .keyword(.Any)
+        case .identifier: return .identifier
+        case .leftParen: return .leftParen
+        case .leftSquare: return .leftSquare
+        case .wildcard: return .wildcard
+        }
+      }
+    }
+
     var base: RawTypeSyntax
-    switch self.currentToken {
-    case TokenSpec(.Self),
-      TokenSpec(.Any),
-      TokenSpec(.identifier):
+    switch self.at(anyIn: TypeBaseStart.self)?.spec {
+    case .Self, .Any, .identifier:
       base = self.parseTypeIdentifier()
-    case TokenSpec(.leftParen):
+    case .leftParen:
       base = RawTypeSyntax(self.parseTupleTypeBody())
-    case TokenSpec(.leftSquare):
+    case .leftSquare:
       base = RawTypeSyntax(self.parseCollectionType())
-    case TokenSpec(.wildcard):
+    case .wildcard:
       base = RawTypeSyntax(self.parsePlaceholderType())
-    default:
+    case nil:
       return RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena))
     }
 

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -508,7 +508,7 @@ extension Parser {
             second = nil
             unexpectedBeforeColon = nil
             colon = parsedColon
-          } else if self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true) && self.peek().rawTokenKind == .colon {
+          } else if self.atArgumentLabel(allowDollarIdentifier: true) && self.peek().rawTokenKind == .colon {
             (unexpectedBeforeSecond, second) = self.parseArgumentLabel()
             (unexpectedBeforeColon, colon) = self.expect(.colon)
           } else {
@@ -802,7 +802,7 @@ extension Parser.Lookahead {
       // by a type annotation.
       if self.startsParameterName(isClosure: false, allowMisplacedSpecifierRecovery: false) {
         self.consumeAnyToken()
-        if self.currentToken.canBeArgumentLabel() {
+        if self.atArgumentLabel() {
           self.consumeAnyToken()
           guard self.at(.colon) else {
             return false
@@ -1061,12 +1061,6 @@ extension Parser {
 }
 
 extension Lexer.Lexeme {
-  var isAnyOperator: Bool {
-    return self.rawTokenKind == .binaryOperator
-      || self.rawTokenKind == .postfixOperator
-      || self.rawTokenKind == .prefixOperator
-  }
-
   var isGenericTypeDisambiguatingToken: Bool {
     switch self.rawTokenKind {
     case .rightParen,


### PR DESCRIPTION
Mostly, change `self.currentToken.canBeArgumentLabel` to `self.atArgumentLabel`.

Also some other miscellaneous smaller improvements in the parser.