### PR TITLE
Audit public API on `SyntaxProtocol`

### DIFF
--- a/Sources/SwiftIDEUtils/Syntax+Classifications.swift
+++ b/Sources/SwiftIDEUtils/Syntax+Classifications.swift
@@ -21,7 +21,7 @@ public extension SyntaxProtocol {
   /// consecutive tokens would have the same classification then a single classified
   /// range is provided for all of them.
   var classifications: SyntaxClassifications {
-    let fullRange = ByteSourceRange(offset: 0, length: byteSize)
+    let fullRange = ByteSourceRange(offset: 0, length: totalLength.utf8Length)
     return SyntaxClassifications(_syntaxNode, in: fullRange)
   }
 

--- a/Sources/SwiftParser/IncrementalParseTransition.swift
+++ b/Sources/SwiftParser/IncrementalParseTransition.swift
@@ -20,7 +20,7 @@ extension Parser {
 
     let currentOffset = self.lexemes.offsetToStart(self.currentToken)
     if let node = parseLookup!.lookUp(currentOffset, kind: kind) {
-      self.lexemes.advance(by: node.byteSize, currentToken: &self.currentToken)
+      self.lexemes.advance(by: node.totalLength.utf8Length, currentToken: &self.currentToken)
       return node
     }
 

--- a/Sources/SwiftParserDiagnostics/MissingTokenError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingTokenError.swift
@@ -136,7 +136,7 @@ extension ParseDiagnosticsGenerator {
     missingToken: TokenSyntax,
     invalidTokenContainer: UnexpectedNodesSyntax
   ) -> Bool {
-    let isTooMany = invalidToken.contentLength > missingToken.contentLength
+    let isTooMany = invalidToken.trimmedLength > missingToken.trimmedLength
     let message: DiagnosticMessage
     if missingToken.parent?.is(ExpressionSegmentSyntax.self) == true {
       message = .tooManyRawStringDelimitersToStartInterpolation
@@ -157,7 +157,7 @@ extension ParseDiagnosticsGenerator {
     )
     addDiagnostic(
       invalidToken,
-      position: invalidToken.positionAfterSkippingLeadingTrivia.advanced(by: missingToken.contentLength.utf8Length),
+      position: invalidToken.positionAfterSkippingLeadingTrivia.advanced(by: missingToken.trimmedLength.utf8Length),
       message,
       fixIts: [fixIt],
       handledNodes: [invalidTokenContainer.id]

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -508,7 +508,7 @@ extension RawSyntax {
   /// The length of this node’s content, without the first leading and the last
   /// trailing trivia. Intermediate trivia inside a layout node is included in
   /// this.
-  var contentByteLength: Int {
+  var trimmedByteLength: Int {
     let result = byteLength - leadingTriviaByteLength - trailingTriviaByteLength
     precondition(result >= 0)
     return result
@@ -523,8 +523,8 @@ extension RawSyntax {
   }
 
   /// The length of this node excluding its leading and trailing trivia.
-  var contentLength: SourceLength {
-    SourceLength(utf8Length: contentByteLength)
+  var trimmedLength: SourceLength {
+    SourceLength(utf8Length: trimmedByteLength)
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -229,7 +229,7 @@ public struct RawSyntaxTokenView {
   }
 
   @_spi(RawSyntax)
-  public var contentLength: SourceLength {
+  public var trimmedLength: SourceLength {
     SourceLength(utf8Length: textByteLength)
   }
 

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -192,7 +192,7 @@ public final class SourceLocationConverter {
     self.file = file
     self.source = tree.syntaxTextBytes
     (self.lines, endOfFile) = computeLines(tree: Syntax(tree))
-    precondition(tree.byteSize == endOfFile.utf8Offset)
+    precondition(tree.totalLength.utf8Length == endOfFile.utf8Offset)
 
     for directive in SourceLocationCollector.collectSourceLocations(in: tree) {
       let location = self.physicalLocation(for: directive.positionAfterSkippingLeadingTrivia)

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -400,7 +400,7 @@ public extension Syntax {
   ) -> SourceLocation {
     var pos = data.position
     pos += raw.leadingTriviaLength
-    pos += raw.contentLength
+    pos += raw.trimmedLength
     if afterTrailingTrivia {
       pos += raw.trailingTriviaLength
     }

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -477,14 +477,9 @@ public extension SyntaxProtocol {
     return data.endPosition
   }
 
-  /// The textual byte length of this node including leading and trailing trivia.
-  var byteSize: Int {
-    return totalLength.utf8Length
-  }
-
-  /// The byte source range of this node including leading and trailing trivia.
-  var byteRange: ByteSourceRange {
-    return ByteSourceRange(offset: position.utf8Offset, length: byteSize)
+  /// The length of this node including all of its trivia.
+  var totalLength: SourceLength {
+    return raw.totalLength
   }
 
   /// The length this node takes up spelled out in the source, excluding its
@@ -493,12 +488,32 @@ public extension SyntaxProtocol {
     return raw.contentLength
   }
 
-  /// The length of this node including all of its trivia.
-  var totalLength: SourceLength {
-    return raw.totalLength
+  /// The byte source range of this node including leading and trailing trivia.
+  var totalByteRange: ByteSourceRange {
+    return ByteSourceRange(offset: position.utf8Offset, length: totalLength.utf8Length)
+  }
+
+  /// The byte source range of this node excluding leading and trailing trivia.
+  var contentByteRange: ByteSourceRange {
+    return ByteSourceRange(
+      offset: positionAfterSkippingLeadingTrivia.utf8Offset,
+      length: contentLength.utf8Length
+    )
+  }
+
+  @available(*, deprecated, renamed: "totalByteRange")
+  var byteRange: ByteSourceRange {
+    return ByteSourceRange(offset: position.utf8Offset, length: totalLength.utf8Length)
+  }
+
+  /// The textual byte length of this node including leading and trailing trivia.
+  @available(*, deprecated, message: "Use totalLength.utf8Length")
+  var byteSize: Int {
+    return totalLength.utf8Length
   }
 
   /// The textual byte length of this node exluding leading and trailing trivia.
+  @available(*, deprecated, message: "Use contentLength.utf8Length")
   var byteSizeAfterTrimmingTrivia: Int {
     return contentLength.utf8Length
   }

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -624,6 +624,7 @@ public extension SyntaxProtocol {
 public extension SyntaxProtocol {
   /// When isImplicit is true, the syntax node doesn't include any
   /// underlying tokens, e.g. an empty CodeBlockItemList.
+  @available(*, deprecated, message: "Check children(viewMode: .all).isEmpty instead")
   var isImplicit: Bool {
     return raw.isEmpty
   }

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -178,6 +178,22 @@ public protocol SyntaxProtocol: CustomStringConvertible,
   static var structure: SyntaxNodeStructure { get }
 }
 
+// MARK: Access underlying data
+
+extension SyntaxProtocol {
+  var data: SyntaxData {
+    return _syntaxNode.data
+  }
+
+  /// Access the raw syntax assuming the node is a Syntax.
+  @_spi(RawSyntax)
+  public var raw: RawSyntax {
+    return _syntaxNode.data.raw
+  }
+}
+
+// MARK: Casting
+
 // Casting functions to specialized syntax nodes.
 public extension SyntaxProtocol {
   /// Converts the given specialized node to this type. Returns `nil` if the
@@ -202,6 +218,8 @@ public extension SyntaxProtocol {
   }
 }
 
+// MARK: Modifying
+
 public extension SyntaxProtocol {
   /// Returns a new syntax node that has the child at `keyPath` replaced by
   /// `value`.
@@ -210,29 +228,21 @@ public extension SyntaxProtocol {
     copy[keyPath: keyPath] = value
     return copy
   }
-}
-
-extension SyntaxProtocol {
-  var data: SyntaxData {
-    return _syntaxNode.data
-  }
-
-  /// Access the raw syntax assuming the node is a Syntax.
-  @_spi(RawSyntax)
-  public var raw: RawSyntax {
-    return _syntaxNode.data.raw
-  }
 
   /// Return this subtree with this node as the root, ie. detach this node
   /// from its parent.
-  public var detached: Self {
+  var detached: Self {
     // Make sure `self` (and thus the arena of `self.raw`) can’t get deallocated
     // before the detached node can be created.
     return withExtendedLifetime(self) {
       return Syntax(raw: self.raw, rawNodeArena: self.raw.arena).cast(Self.self)
     }
   }
+}
 
+// MARK: Type information
+
+extension SyntaxProtocol {
   /// The kind of the syntax node, e.g. if it is a `functionDecl`.
   ///
   /// If you want to check for a node's kind and cast the node to that type, see
@@ -241,15 +251,18 @@ extension SyntaxProtocol {
     return raw.kind
   }
 
-  /// The dynamic metatype of the concrete node. You almost always want to prefer this
-  /// over `type(of: self)` because if `self` is a ``DeclSyntax`` representing a
-  /// ``FunctionDeclSyntax``, `type(of: self)` will return ``DeclSyntax``, while
-  /// `syntaxNodeType` looks at the dynamic kind of this node and returns
-  /// ``FunctionDeclSyntax``.
+  /// The dynamic metatype of the concrete node.
+  ///
+  /// You almost always want to prefer this over `type(of: self)` because if
+  /// `self` is a ``DeclSyntax`` representing a ``FunctionDeclSyntax``,
+  /// `type(of: self)` will return ``DeclSyntax``, while `syntaxNodeType` looks
+  /// at the dynamic kind of this node and returns ``FunctionDeclSyntax``.
   public var syntaxNodeType: SyntaxProtocol.Type {
     return self.raw.kind.syntaxNodeType
   }
 }
+
+// MARK: Children / parent
 
 public extension SyntaxProtocol {
   /// A sequence over the `present` children of this node.
@@ -262,32 +275,18 @@ public extension SyntaxProtocol {
     return SyntaxChildrenIndex(self.data.absoluteInfo)
   }
 
-  /// Whether the tree contained by this layout has any
-  ///  - missing nodes or
-  ///  - unexpected nodes or
-  ///  - tokens with a ``TokenDiagnostic`` of severity ``TokenDiagnostic/Severity-swift.enum/error``.
-  var hasError: Bool {
-    return raw.hasError
-  }
-
-  /// Whether the tree contained by this layout has any tokens with a
-  /// ``TokenDiagnostic`` of severity `warning`.
-  var hasWarning: Bool {
-    return raw.recursiveFlags.contains(.hasWarning)
-  }
-
-  /// Whether this tree contains a missing token or unexpected node.
-  var hasSequenceExpr: Bool {
-    return raw.recursiveFlags.contains(.hasSequenceExpr)
-  }
-
-  var hasMaximumNestingLevelOverflow: Bool {
-    return raw.recursiveFlags.contains(.hasMaximumNestingLevelOverflow)
-  }
-
   /// The parent of this syntax node, or `nil` if this node is the root.
   var parent: Syntax? {
     return data.parent.map(Syntax.init(_:))
+  }
+
+  /// The root of the tree in which this node resides.
+  var root: Syntax {
+    var this = _syntaxNode
+    while let parent = this.parent {
+      this = parent
+    }
+    return this
   }
 
   /// Whether or not this node has a parent.
@@ -309,7 +308,11 @@ public extension SyntaxProtocol {
   var previousToken: TokenSyntax? {
     return self.previousToken(viewMode: .sourceAccurate)
   }
+}
 
+// MARK: Accessing tokens
+
+public extension SyntaxProtocol {
   /// Recursively walks through the tree to find the token semantically before
   /// this node.
   func previousToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
@@ -392,6 +395,11 @@ public extension SyntaxProtocol {
     return nil
   }
 
+  /// Sequence of tokens that are part of this Syntax node.
+  func tokens(viewMode: SyntaxTreeViewMode) -> TokenSequence {
+    return TokenSequence(_syntaxNode, viewMode: viewMode)
+  }
+
   /// Find the syntax token at the given absolute position within this
   /// syntax node or any of its children.
   func token(at position: AbsolutePosition) -> TokenSyntax? {
@@ -414,7 +422,38 @@ public extension SyntaxProtocol {
 
     fatalError("Children of syntax node do not cover all positions in it")
   }
+}
 
+// MARK: Recursive flags
+
+public extension SyntaxProtocol {
+  /// Whether the tree contained by this layout has any
+  ///  - missing nodes or
+  ///  - unexpected nodes or
+  ///  - tokens with a ``TokenDiagnostic`` of severity ``TokenDiagnostic/Severity-swift.enum/error``.
+  var hasError: Bool {
+    return raw.hasError
+  }
+
+  /// Whether the tree contained by this layout has any tokens with a
+  /// ``TokenDiagnostic`` of severity `warning`.
+  var hasWarning: Bool {
+    return raw.recursiveFlags.contains(.hasWarning)
+  }
+
+  /// Whether this tree contains a missing token or unexpected node.
+  var hasSequenceExpr: Bool {
+    return raw.recursiveFlags.contains(.hasSequenceExpr)
+  }
+
+  var hasMaximumNestingLevelOverflow: Bool {
+    return raw.recursiveFlags.contains(.hasMaximumNestingLevelOverflow)
+  }
+}
+
+// MARK: Position / length / range
+
+public extension SyntaxProtocol {
   /// The absolute position of the starting point of this node. If the first token
   /// is with leading trivia, the position points to the start of the leading
   /// trivia.
@@ -454,6 +493,20 @@ public extension SyntaxProtocol {
     return raw.contentLength
   }
 
+  /// The length of this node including all of its trivia.
+  var totalLength: SourceLength {
+    return raw.totalLength
+  }
+
+  /// The textual byte length of this node exluding leading and trailing trivia.
+  var byteSizeAfterTrimmingTrivia: Int {
+    return contentLength.utf8Length
+  }
+}
+
+// MARK: Trivia
+
+public extension SyntaxProtocol {
   /// The leading trivia of this syntax node. Leading trivia is attached to
   /// the first token syntax contained by this node. Without such token, this
   /// property will return nil.
@@ -499,42 +552,9 @@ public extension SyntaxProtocol {
   var trailingTriviaLength: SourceLength {
     return raw.trailingTriviaLength
   }
-
-  /// The length of this node including all of its trivia.
-  var totalLength: SourceLength {
-    return raw.totalLength
-  }
-
-  /// When isImplicit is true, the syntax node doesn't include any
-  /// underlying tokens, e.g. an empty CodeBlockItemList.
-  var isImplicit: Bool {
-    return raw.isEmpty
-  }
-
-  /// The textual byte length of this node exluding leading and trailing trivia.
-  var byteSizeAfterTrimmingTrivia: Int {
-    return contentLength.utf8Length
-  }
-
-  /// The root of the tree in which this node resides.
-  var root: Syntax {
-    var this = _syntaxNode
-    while let parent = this.parent {
-      this = parent
-    }
-    return this
-  }
-
-  /// Sequence of tokens that are part of this Syntax node.
-  func tokens(viewMode: SyntaxTreeViewMode) -> TokenSequence {
-    return TokenSequence(_syntaxNode, viewMode: viewMode)
-  }
-
-  /// Returns a value representing the unique identity of the node.
-  var id: SyntaxIdentifier {
-    return data.nodeId
-  }
 }
+
+// MARK: Content
 
 /// Provides the source-accurate text for a node
 public extension SyntaxProtocol {
@@ -598,6 +618,23 @@ public extension SyntaxProtocol {
     return self.trimmed(matching: filter).description
   }
 }
+
+// MARK: Miscellaneous
+
+public extension SyntaxProtocol {
+  /// When isImplicit is true, the syntax node doesn't include any
+  /// underlying tokens, e.g. an empty CodeBlockItemList.
+  var isImplicit: Bool {
+    return raw.isEmpty
+  }
+
+  /// Returns a value representing the unique identity of the node.
+  var id: SyntaxIdentifier {
+    return data.nodeId
+  }
+}
+
+// MARK: Debug description
 
 /// Provides debug descriptions for a node
 public extension SyntaxProtocol {

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -484,8 +484,11 @@ public extension SyntaxProtocol {
 
   /// The length this node takes up spelled out in the source, excluding its
   /// leading or trailing trivia.
-  var contentLength: SourceLength {
-    return raw.contentLength
+  ///
+  /// - Note: If this node consists of multiple tokens, only the first token’s
+  ///   leading and the last token’s trailing trivia will be trimmed.
+  var trimmedLength: SourceLength {
+    return raw.trimmedLength
   }
 
   /// The byte source range of this node including leading and trailing trivia.
@@ -494,11 +497,19 @@ public extension SyntaxProtocol {
   }
 
   /// The byte source range of this node excluding leading and trailing trivia.
-  var contentByteRange: ByteSourceRange {
+  ///
+  /// - Note: If this node consists of multiple tokens, only the first token’s
+  ///   leading and the last token’s trailing trivia will be trimmed.
+  var trimmedByteRange: ByteSourceRange {
     return ByteSourceRange(
       offset: positionAfterSkippingLeadingTrivia.utf8Offset,
-      length: contentLength.utf8Length
+      length: trimmedLength.utf8Length
     )
+  }
+
+  @available(*, deprecated, renamed: "trimmedLength")
+  var contentLength: SourceLength {
+    return trimmedLength
   }
 
   @available(*, deprecated, renamed: "totalByteRange")
@@ -513,9 +524,9 @@ public extension SyntaxProtocol {
   }
 
   /// The textual byte length of this node exluding leading and trailing trivia.
-  @available(*, deprecated, message: "Use contentLength.utf8Length")
+  @available(*, deprecated, message: "Use trimmedLength.utf8Length")
   var byteSizeAfterTrimmingTrivia: Int {
-    return contentLength.utf8Length
+    return trimmedLength.utf8Length
   }
 }
 

--- a/Sources/SwiftSyntax/TokenSyntax.swift
+++ b/Sources/SwiftSyntax/TokenSyntax.swift
@@ -121,8 +121,8 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
 
   /// The length this node takes up spelled out in the source, excluding its
   /// leading or trailing trivia.
-  public var contentLength: SourceLength {
-    return tokenView.contentLength
+  public var trimmedLength: SourceLength {
+    return tokenView.trimmedLength
   }
 
   /// The length this node's leading trivia takes up spelled out in source.

--- a/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
+++ b/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
@@ -84,11 +84,11 @@ public func assertIncrementalParse(
       continue
     }
 
-    guard let reusedNode = reusedNodes.first(where: { $0.byteRangeAfterTrimmingTrivia == range }) else {
+    guard let reusedNode = reusedNodes.first(where: { $0.contentByteRange == range }) else {
       XCTFail(
         """
         Fail to match the range of \(expectedReusedNode.source) in:
-        \(reusedNodes.map({"\($0.byteRangeAfterTrimmingTrivia): \($0.description)"}).joined(separator: "\n"))
+        \(reusedNodes.map({"\($0.contentByteRange): \($0.description)"}).joined(separator: "\n"))
         """,
         file: expectedReusedNode.file,
         line: expectedReusedNode.line
@@ -219,11 +219,4 @@ public func applyEdits(
     bytes.insert(contentsOf: [UInt8](repeating: replacementAscii, count: edit.replacementLength), at: edit.offset)
   }
   return String(bytes: bytes, encoding: .utf8)!
-}
-
-fileprivate extension Syntax {
-  /// The  byte source range of this node exluding leading and trailing trivia.
-  var byteRangeAfterTrimmingTrivia: ByteSourceRange {
-    return ByteSourceRange(offset: positionAfterSkippingLeadingTrivia.utf8Offset, length: byteSizeAfterTrimmingTrivia)
-  }
 }

--- a/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
+++ b/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
@@ -84,11 +84,11 @@ public func assertIncrementalParse(
       continue
     }
 
-    guard let reusedNode = reusedNodes.first(where: { $0.contentByteRange == range }) else {
+    guard let reusedNode = reusedNodes.first(where: { $0.trimmedByteRange == range }) else {
       XCTFail(
         """
         Fail to match the range of \(expectedReusedNode.source) in:
-        \(reusedNodes.map({"\($0.contentByteRange): \($0.description)"}).joined(separator: "\n"))
+        \(reusedNodes.map({"\($0.trimmedByteRange): \($0.description)"}).joined(separator: "\n"))
         """,
         file: expectedReusedNode.file,
         line: expectedReusedNode.line

--- a/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
@@ -83,7 +83,7 @@ public class AbsolutePositionTests: XCTestCase {
       state.totalLength.utf8Length,
       state.leadingTrivia.sourceLength.utf8Length
         + state.trailingTrivia.sourceLength.utf8Length
-        + state.contentLength.utf8Length
+        + state.trimmedLength.utf8Length
     )
 
     // Test Node trivia setters and getters

--- a/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
@@ -85,7 +85,6 @@ public class AbsolutePositionTests: XCTestCase {
         + state.trailingTrivia.sourceLength.utf8Length
         + state.byteSizeAfterTrimmingTrivia
     )
-    XCTAssertFalse(root.statements.isImplicit)
 
     // Test Node trivia setters and getters
 
@@ -120,11 +119,6 @@ public class AbsolutePositionTests: XCTestCase {
     XCTAssertEqual(AbsolutePositionTests.trailingTrivia, root.statements.trailingTrivia)
     modifiedStatements2.trailingTrivia = [.verticalTabs(4)]
     XCTAssertEqual([.verticalTabs(4)], modifiedStatements2.trailingTrivia)
-  }
-
-  public func testImplicit() {
-    let root = self.createSourceFile(0)
-    XCTAssertTrue(root.statements.isImplicit)
   }
 
   public func testWithoutSourceFileRoot() {

--- a/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
@@ -34,7 +34,7 @@ public class AbsolutePositionTests: XCTestCase {
       endOfFileToken: .endOfFileToken()
     )
     _ = root.statements[idx].position
-    _ = root.statements[idx].byteSize
+    _ = root.statements[idx].totalLength.utf8Length
     _ = root.statements[idx].positionAfterSkippingLeadingTrivia
   }
 
@@ -80,10 +80,10 @@ public class AbsolutePositionTests: XCTestCase {
     XCTAssertEqual(3, state.leadingTrivia.count)
     XCTAssertEqual(2, state.trailingTrivia.count)
     XCTAssertEqual(
-      state.byteSize,
+      state.totalLength.utf8Length,
       state.leadingTrivia.sourceLength.utf8Length
         + state.trailingTrivia.sourceLength.utf8Length
-        + state.byteSizeAfterTrimmingTrivia
+        + state.contentLength.utf8Length
     )
 
     // Test Node trivia setters and getters

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -123,6 +123,6 @@ public class SyntaxTests: XCTestCase {
     XCTAssertEqual(funcKW.positionAfterSkippingLeadingTrivia, AbsolutePosition(utf8Offset: 2))
     XCTAssertEqual(funcKW.endPositionBeforeTrailingTrivia, AbsolutePosition(utf8Offset: 6))
     XCTAssertEqual(funcKW.endPosition, AbsolutePosition(utf8Offset: 7))
-    XCTAssertEqual(funcKW.contentLength, SourceLength(utf8Length: 4))
+    XCTAssertEqual(funcKW.trimmedLength, SourceLength(utf8Length: 4))
   }
 }


### PR DESCRIPTION
First, re-arrange the properties in `SyntaxProtocol` to group them logically.

Then, I found two areas of improvement:
- Deprecated `isImplicit`
  - This property seems to be pretty useless and probably dates back to a completely different design of the syntax tree where implicit nodes were a thing.
- Clean up position/range API on `SyntaxProtocol`
  - The position and range API on `SyntaxProtocol` was a little inconsistent and misleading. Clean it up so that we have `totalLength` (including trivia), `contentLength` (excluding trivia) and a matching pair for `byteRange`.