### PR TITLE
Display actual expanded source, not expected source

### DIFF
--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -297,7 +297,7 @@ public func assertMacroExpansion(
     expandedSource.trimmingCharacters(in: .newlines),
     additionalInfo: """
       Actual expanded source:
-      \(expandedSource)
+      \(formattedSourceFile)
       """,
     file: file,
     line: line

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -248,8 +248,8 @@ func assertDiagnostic(
 /// - Parameters:
 ///   - originalSource: The original source code, which is expected to contain
 ///     macros in various places (e.g., `#stringify(x + y)`).
-///   - expandedSource: The source code that we expect to see after performing
-///     macro expansion on the original source.
+///   - expectedExpandedSource: The source code that we expect to see after
+///     performing macro expansion on the original source.
 ///   - diagnostics: The diagnostics when expanding any macro
 ///   - macros: The macros that should be expanded, provided as a dictionary
 ///     mapping macro names (e.g., `"stringify"`) to implementation types
@@ -258,7 +258,7 @@ func assertDiagnostic(
 ///   - testFileName: The name of the test file name to use.
 public func assertMacroExpansion(
   _ originalSource: String,
-  expandedSource: String,
+  expandedSource expectedExpandedSource: String,
   diagnostics: [DiagnosticSpec] = [],
   macros: [String: Macro.Type],
   testModuleName: String = "TestModule",
@@ -294,7 +294,7 @@ public func assertMacroExpansion(
   let formattedSourceFile = expandedSourceFile.formatted(using: BasicFormat(indentationWidth: indentationWidth))
   assertStringsEqualWithDiff(
     formattedSourceFile.description.trimmingCharacters(in: .newlines),
-    expandedSource.trimmingCharacters(in: .newlines),
+    expectedExpandedSource.trimmingCharacters(in: .newlines),
     additionalInfo: """
       Actual expanded source:
       \(formattedSourceFile)


### PR DESCRIPTION
While using this function I was confused by the error message. I think it should include the actual expansion, not what's expected?

I also renamed the variable to try and make it a little clearer and (assuming this is correct) prevent a mistake like this again. This was done in 3c46da3712dec11e5d485c96b6b7d9d40b7c8f25 so can be easily reverted.