### PR TITLE
[5.9] Display actual expanded source, not expected source

### DIFF
--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -304,7 +304,7 @@ public func assertMacroExpansion(
     expandedSource.trimmingCharacters(in: .newlines),
     additionalInfo: """
       Actual expanded source:
-      \(expandedSource)
+      \(formattedSourceFile)
       """,
     file: file,
     line: line

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -255,8 +255,8 @@ func assertDiagnostic<T: SyntaxProtocol>(
 /// - Parameters:
 ///   - originalSource: The original source code, which is expected to contain
 ///     macros in various places (e.g., `#stringify(x + y)`).
-///   - expandedSource: The source code that we expect to see after performing
-///     macro expansion on the original source.
+///   - expectedExpandedSource: The source code that we expect to see after
+///     performing macro expansion on the original source.
 ///   - diagnostics:
 ///   - macros: The macros that should be expanded, provided as a dictionary
 ///     mapping macro names (e.g., `"stringify"`) to implementation types
@@ -265,7 +265,7 @@ func assertDiagnostic<T: SyntaxProtocol>(
 ///   - testFileName: The name of the test file name to use.
 public func assertMacroExpansion(
   _ originalSource: String,
-  expandedSource: String,
+  expandedSource expectedExpandedSource: String,
   diagnostics: [DiagnosticSpec] = [],
   macros: [String: Macro.Type],
   testModuleName: String = "TestModule",
@@ -301,7 +301,7 @@ public func assertMacroExpansion(
   let formattedSourceFile = expandedSourceFile.formatted(using: BasicFormat(indentationWidth: indentationWidth))
   assertStringsEqualWithDiff(
     formattedSourceFile.description.trimmingCharacters(in: .newlines),
-    expandedSource.trimmingCharacters(in: .newlines),
+    expectedExpandedSource.trimmingCharacters(in: .newlines),
     additionalInfo: """
       Actual expanded source:
       \(formattedSourceFile)


### PR DESCRIPTION
* **Explanation**: When `assertMacroExpansion` fails, it incorrectly displayed the expected source as the expanded source.
* **Scope**: The `assertMacroExpansion` test function
* **Risk**: Very low, only changes the description in case of an `XCTFail`
* **Testing**: Tested manually
* **Issue**: n/a
* **Reviewer**:  @ahoppen on #1917