### PR TITLE
Remove `SyntaxProtocol.index` in favor of `index(of:)` methods in `SyntaxCollection` and `SyntaxChildren`

### DIFF
--- a/Sources/SwiftParser/IncrementalParseTransition.swift
+++ b/Sources/SwiftParser/IncrementalParseTransition.swift
@@ -213,8 +213,10 @@ fileprivate struct SyntaxCursor {
     var node = self.node
     while let parent = node.parent {
       let children = parent.children(viewMode: viewMode)
-      if children.index(after: node.index) != children.endIndex {
-        return children[children.index(after: node.index)]
+      if let nodeIndex = children.index(of: node),
+        children.index(after: nodeIndex) != children.endIndex
+      {
+        return children[children.index(after: nodeIndex)]
       }
       node = parent
     }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -1818,7 +1818,8 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     }
     if node.colon.isMissing {
       if let siblings = node.parent?.children(viewMode: .all),
-        let nextSibling = siblings[siblings.index(after: node.index)...].first,
+        let nodeIndex = siblings.index(of: node),
+        let nextSibling = siblings[siblings.index(after: nodeIndex)...].first,
         nextSibling.is(MissingExprSyntax.self)
       {
         addDiagnostic(

--- a/Sources/SwiftSyntax/CommonAncestor.swift
+++ b/Sources/SwiftSyntax/CommonAncestor.swift
@@ -18,7 +18,7 @@ public func findCommonAncestorOrSelf(_ lhs: Syntax, _ rhs: Syntax) -> Syntax? {
     if lhs == rhs {
       return lhs
     }
-    if let lhsIndex = lhs?.index.data?.indexInTree, let rhsIndex = rhs?.index.data?.indexInTree {
+    if let lhsIndex = lhs?.indexInParent.data?.indexInTree, let rhsIndex = rhs?.indexInParent.data?.indexInTree {
       if lhsIndex < rhsIndex {
         rhs = rhs?.parent
       } else {

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -258,7 +258,13 @@ public extension SyntaxProtocol {
   }
 
   /// The index of this node in a ``SyntaxChildren`` collection.
+  @available(*, deprecated, message: "Use index(of:) on the collection that contains this node")
   var index: SyntaxChildrenIndex {
+    return indexInParent
+  }
+
+  /// The index of this node in a ``SyntaxChildren`` collection.
+  internal var indexInParent: SyntaxChildrenIndex {
     return SyntaxChildrenIndex(self.data.absoluteInfo)
   }
 
@@ -319,8 +325,8 @@ public extension SyntaxProtocol {
     let siblings = NonNilRawSyntaxChildren(parent, viewMode: viewMode)
     // `self` could be a missing node at index 0 and `viewMode` be `.sourceAccurate`.
     // In that case `siblings` skips over the missing `self` node and has a `startIndex > 0`.
-    if self.index >= siblings.startIndex {
-      for absoluteRaw in siblings[..<self.index].reversed() {
+    if self.indexInParent >= siblings.startIndex {
+      for absoluteRaw in siblings[..<self.indexInParent].reversed() {
         let child = Syntax(SyntaxData(absoluteRaw, parent: parent))
         if let token = child.lastToken(viewMode: viewMode) {
           return token
@@ -342,7 +348,7 @@ public extension SyntaxProtocol {
       return nil
     }
     let siblings = NonNilRawSyntaxChildren(parent, viewMode: viewMode)
-    let nextSiblingIndex = siblings.index(after: self.index)
+    let nextSiblingIndex = siblings.index(after: self.indexInParent)
     for absoluteRaw in siblings[nextSiblingIndex...] {
       let child = Syntax(SyntaxData(absoluteRaw, parent: parent))
       if let token = child.firstToken(viewMode: viewMode) {

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -455,4 +455,25 @@ public struct SyntaxChildren: BidirectionalCollection {
     self.rawChildren = NonNilRawSyntaxChildren(node, viewMode: viewMode)
     self.parent = node
   }
+
+  /// Return the index of `node` within this collection.
+  ///
+  /// If `node` is not part of this collection, returns `nil`.
+  public func index(of node: some SyntaxProtocol) -> SyntaxChildrenIndex? {
+    return index(of: Syntax(node))
+  }
+
+  /// Return the index of `node` within this collection.
+  ///
+  /// If `node` is not part of this collection, returns `nil`.
+  ///
+  /// - Note: This method is functionally equivalent to the one that takes
+  ///   ``SyntaxProtocol``. It is provided because otherwise `Collection.index(of:)`
+  ///   is chosen, which is marked as deprecated and renamed to `firstIndex(of:)`.
+  public func index(of node: Syntax) -> SyntaxChildrenIndex? {
+    guard node.parent == parent else {
+      return nil
+    }
+    return node.indexInParent
+  }
 }

--- a/Sources/SwiftSyntax/SyntaxCollection.swift
+++ b/Sources/SwiftSyntax/SyntaxCollection.swift
@@ -65,6 +65,30 @@ extension SyntaxCollection {
     return Syntax(newData).cast(Self.self)
   }
 
+  /// Return the index of `node` within this collection.
+  ///
+  /// If `node` is not part of this collection, returns `nil`.
+  public func index(of node: some SyntaxProtocol) -> SyntaxChildrenIndex? {
+    guard let node = node as? Element else {
+      return nil
+    }
+    return index(of: node)
+  }
+
+  /// Return the index of `node` within this collection.
+  ///
+  /// If `node` is not part of this collection, returns `nil`.
+  ///
+  /// - Note: This method is functionally equivalent to the one that takes
+  ///   ``SyntaxProtocol``. It is provided because otherwise `Collection.index(of:)`
+  ///   is chosen, which is marked as deprecated and renamed to `firstIndex(of:)`.
+  public func index(of node: Element) -> SyntaxChildrenIndex? {
+    guard node.parent == Syntax(self) else {
+      return nil
+    }
+    return node.indexInParent
+  }
+
   /// Creates a new collection by appending the provided syntax element
   /// to the children.
   ///
@@ -232,7 +256,7 @@ extension SyntaxCollection {
       /// Make sure the index is a valid index for replacing
       precondition(
         (newLayout.startIndex..<newLayout.endIndex).contains(indexToReplace),
-        "replacing node at invalid index \(index)"
+        "replacing node at invalid index \(indexInParent)"
       )
       newLayout[indexToReplace] = newValue.raw
       self = replacingLayout(newLayout)


### PR DESCRIPTION
Make `SyntaxProtocol.index` internal and `index(of:)` call the internal `index` method + validate that the node is actually in the collection (otherwise return `nil`).

rdar://111944622