### PR TITLE
Don’t add two spaces in front of `{` if a property already has an accessor

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -346,9 +346,9 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
             \.accessor,
             .accessors(
               .init(
-                leftBrace: .leftBraceToken(leadingTrivia: .space),
+                leftBrace: .leftBraceToken(),
                 accessors: .init(accessors),
-                rightBrace: .rightBraceToken(leadingTrivia: .newline)
+                rightBrace: .rightBraceToken()
               )
             )
           )


### PR DESCRIPTION
If a property already had an accessor, the type annotation contained a trailing whitespace. We were explicitly adding a leading whitespace to the `{` for the accessors, resulting in two whitespace.

To fix it, don’t explicitly add the leading whitespace to the opening `{` and rely on `BasicFormat` to add it, if needed.

rdar://111215192