### PR TITLE
Use rewrite func instead of visit for SyntaxRewriter

### DIFF
--- a/Tests/PerformanceTest/VisitorPerformanceTests.swift
+++ b/Tests/PerformanceTest/VisitorPerformanceTests.swift
@@ -45,7 +45,7 @@ public class VisitorPerformanceTests: XCTestCase {
     let emptyRewriter = EmptyRewriter(viewMode: .sourceAccurate)
 
     try measureInstructions {
-      _ = emptyRewriter.visit(parsed)
+      _ = emptyRewriter.rewrite(parsed)
     }
   }
 

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -86,7 +86,7 @@ extension OperatorTable {
 
     // Parse and "fold" the parenthesized version.
     let parenthesizedParsed = Parser.parse(source: fullyParenthesizedSource)
-    let parenthesizedSyntax = ExplicitParenFolder(viewMode: .sourceAccurate).visit(parenthesizedParsed)
+    let parenthesizedSyntax = ExplicitParenFolder(viewMode: .sourceAccurate).rewrite(parenthesizedParsed)
     XCTAssertFalse(parenthesizedSyntax.containsExprSequence)
 
     // Make sure the two have the same structure.

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -235,7 +235,7 @@ final class StringInterpolationTests: XCTestCase {
         return DeclSyntax(newFunc)
       }
     }
-    let rewrittenSourceFile = Rewriter(viewMode: .sourceAccurate).visit(sourceFile)
+    let rewrittenSourceFile = Rewriter(viewMode: .sourceAccurate).rewrite(sourceFile)
     XCTAssertEqual(
       rewrittenSourceFile.description,
       """

--- a/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
@@ -159,7 +159,7 @@ public class SyntaxVisitorTests: XCTestCase {
       statements: CodeBlockItemListSyntax([])
     )
     let rewriter = ClosureRewriter(viewMode: .sourceAccurate)
-    let rewritten = rewriter.visit(closure)
+    let rewritten = rewriter.rewrite(closure)
     XCTAssertEqual(closure.description, rewritten.description)
   }
 
@@ -236,8 +236,8 @@ public class SyntaxVisitorTests: XCTestCase {
       ])
     )
     XCTAssertEqual(source.description, "let a = 5")
-    let visitor = TriviaRemover(viewMode: .sourceAccurate)
-    let rewritten = visitor.visit(source)
+    let rewriter = TriviaRemover(viewMode: .sourceAccurate)
+    let rewritten = rewriter.rewrite(source)
     XCTAssertEqual(rewritten.description, "leta=5")
   }
 }


### PR DESCRIPTION
In my opinion, using `rewrite` func is a bit easier to understand for `SyntaxRewriter`. `visit` func can literally be used to visit for `SyntaxVisitor` instead.