### PR TITLE
Change `#if os(Darwin)` to `#if os(macOS)` in performanc test

### DIFF
--- a/Tests/PerformanceTest/InstructionsCountAssertion.swift
+++ b/Tests/PerformanceTest/InstructionsCountAssertion.swift
@@ -30,7 +30,9 @@ func measureInstructions(_ baselineName: StaticString = #function, block: () -> 
   let numberOfInstructions = endInstructions - startInstructions
   let strippedBaselineName = "\(baselineName)".replacingOccurrences(of: "()", with: "")
 
-  #if os(Darwin)
+  // Performance testing is only supported on macOS.
+  // On all other platforms `getInstructionsExecuted` returns 0.
+  #if os(macOS)
   // If the is no data, we just continue the test
   guard let data = try? Data(contentsOf: baselineURL) else {
     return


### PR DESCRIPTION
`os(Darwin)` always evaluated to `false`, meaning that the performance tests were never executed.