### PR TITLE
Add RenamedNodesCompatibility.swift to CMakeLists.txt

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
@@ -370,6 +370,8 @@ public enum SyntaxNodeKind: String, CaseIterable {
     }
   }
 
+  /// If the syntax kind has been renamed, the previous raw value that is now
+  /// deprecated.
   public var deprecatedRawValue: String? {
     switch self {
     case .importPathComponentList:

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -40,6 +40,7 @@ add_swift_host_library(SwiftSyntax
   generated/ChildNameForKeyPath.swift
   generated/Keyword.swift
   generated/RenamedChildrenCompatibility.swift
+  generated/RenamedNodesCompatibility.swift
   generated/SyntaxAnyVisitor.swift
   generated/SyntaxBaseNodes.swift
   generated/SyntaxCollections.swift


### PR DESCRIPTION
I forgot to add it in https://github.com/apple/swift-syntax/pull/1913.