### PR TITLE
Introduce `peek(isAt:)`

### DIFF
--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -152,7 +152,7 @@ extension Parser {
       case (.star, _)?:
         entry = self.parseAvailabilitySpec()
       case (.identifier, let handle)?:
-        if self.peek().rawTokenKind == .comma {
+        if self.peek(isAt: .comma) {
           // An argument like `_iOS13Aligned` that isn't followed by a version.
           let version = self.eat(handle)
           entry = .token(version)

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -252,8 +252,8 @@ extension Parser {
       return RawDeclSyntax(self.parseMacroExpansionDeclaration(attrs, handle))
     case nil:
       if inMemberDeclList {
-        let isProbablyVarDecl = self.at(.identifier, .wildcard) && self.peek().rawTokenKind.is(.colon, .equal, .comma)
-        let isProbablyTupleDecl = self.at(.leftParen) && self.peek().rawTokenKind.is(.identifier, .wildcard)
+        let isProbablyVarDecl = self.at(.identifier, .wildcard) && self.peek(isAt: .colon, .equal, .comma)
+        let isProbablyTupleDecl = self.at(.leftParen) && self.peek(isAt: .identifier, .wildcard)
 
         if isProbablyVarDecl || isProbablyTupleDecl {
           return RawDeclSyntax(self.parseBindingDeclaration(attrs, .missing(.keyword(.var))))
@@ -1036,7 +1036,7 @@ extension Parser {
     let identifier: RawTokenSyntax
     if self.at(anyIn: Operator.self) != nil || self.at(.exclamationMark, .prefixAmpersand) {
       var name = self.currentToken.tokenText
-      if name.count > 1 && name.hasSuffix("<") && self.peek().rawTokenKind == .identifier {
+      if name.count > 1 && name.hasSuffix("<") && self.peek(isAt: .identifier) {
         name = SyntaxText(rebasing: name.dropLast())
       }
       unexpectedBeforeIdentifier = nil
@@ -1121,7 +1121,7 @@ extension Parser {
     let (unexpectedBeforeSubscriptKeyword, subscriptKeyword) = self.eat(handle)
 
     let unexpectedName: RawTokenSyntax?
-    if self.at(.identifier) && self.peek().tokenText.hasPrefix("<") || self.peek().rawTokenKind == .leftParen {
+    if self.at(.identifier) && self.peek().tokenText.hasPrefix("<") || self.peek(isAt: .leftParen) {
       unexpectedName = self.consumeAnyToken()
     } else {
       unexpectedName = nil

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -93,12 +93,10 @@ extension Parser {
 
     // Okay, let's look ahead and see if the next token is something that could
     // be in an arg label list...
-    let next = self.peek()
-
     // A close parenthesis, if empty lists are allowed.
-    let nextIsRParen = flags.contains(.zeroArgCompoundNames) && next.rawTokenKind == .rightParen
+    let nextIsRParen = flags.contains(.zeroArgCompoundNames) && peek(isAt: .rightParen)
     // An argument label.
-    let nextIsArgLabel = next.isArgumentLabel() || next.rawTokenKind == .colon
+    let nextIsArgLabel = peek().isArgumentLabel() || peek(isAt: .colon)
 
     guard nextIsRParen || nextIsArgLabel else {
       return nil
@@ -117,7 +115,7 @@ extension Parser {
       var loopProgress = LoopProgressCondition()
       while !self.at(.endOfFile, .rightParen) && self.hasProgressed(&loopProgress) {
         // Check to see if there is an argument label.
-        precondition(self.atArgumentLabel() && self.peek().rawTokenKind == .colon)
+        precondition(self.atArgumentLabel() && self.peek(isAt: .colon))
         let name = self.consumeAnyToken()
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
         elements.append(

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -181,7 +181,7 @@ extension Parser {
 
         /// If we have something like `x SomeType`, use the indication that `SomeType` starts with a capital letter (and is thus probably a type name)
         /// as an indication that the user forgot to write the colon instead of forgetting to write the comma to separate two elements.
-        if label == nil, colon == nil, self.at(.identifier), peek().rawTokenKind == .identifier, peek().tokenText.isStartingWithUppercase {
+        if label == nil, colon == nil, self.at(.identifier), peek(isAt: .identifier), peek().tokenText.isStartingWithUppercase {
           label = consume(if: .identifier)
           colon = self.missingToken(.colon)
         }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -177,7 +177,7 @@ extension Parser {
     guard
       self.at(.keyword(.let), .keyword(.var), .keyword(.case))
         || self.at(.keyword(.inout))
-        || (lastBindingKind != nil && self.peek().rawTokenKind == .equal)
+        || (lastBindingKind != nil && self.peek(isAt: .equal))
     else {
       // If we lack it, then this is theoretically a boolean condition.
       // However, we also need to handle migrating from Swift 2 syntax, in

--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -113,16 +113,6 @@ extension SyntaxText {
   }
 }
 
-extension RawTokenKind {
-  func `is`(_ kind1: RawTokenKind, _ kind2: RawTokenKind) -> Bool {
-    return self == kind1 || self == kind2
-  }
-
-  func `is`(_ kind1: RawTokenKind, _ kind2: RawTokenKind, _ kind3: RawTokenKind) -> Bool {
-    return self == kind1 || self == kind2 || self == kind3
-  }
-}
-
 extension RawTriviaPiece {
   var isIndentationWhitespace: Bool {
     switch self {

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -172,6 +172,57 @@ extension TokenConsumer {
   }
 }
 
+extension TokenConsumer {
+  /// Returns whether the next (peeked) token matches `spec`
+  @inline(__always)
+  mutating func peek(isAt spec: TokenSpec) -> Bool {
+    #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
+    if shouldRecordAlternativeTokenChoices {
+      recordAlternativeTokenChoice(for: self.peek(), choices: [spec])
+    }
+    #endif
+    return spec ~= self.peek()
+  }
+
+  /// Returns whether the next (peeked) token matches one of the two specs.
+  @inline(__always)
+  mutating func peek(
+    isAt spec1: TokenSpec,
+    _ spec2: TokenSpec
+  ) -> Bool {
+    #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
+    if shouldRecordAlternativeTokenChoices {
+      recordAlternativeTokenChoice(for: self.peek(), choices: [spec1, spec2])
+    }
+    #endif
+    switch self.peek() {
+    case spec1: return true
+    case spec2: return true
+    default: return false
+    }
+  }
+
+  /// Returns whether the next (peeked) token matches one of the three specs.
+  @inline(__always)
+  mutating func peek(
+    isAt spec1: TokenSpec,
+    _ spec2: TokenSpec,
+    _ spec3: TokenSpec
+  ) -> Bool {
+    #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
+    if shouldRecordAlternativeTokenChoices {
+      recordAlternativeTokenChoice(for: self.peek(), choices: [spec1, spec2, spec3])
+    }
+    #endif
+    switch self.peek() {
+    case spec1: return true
+    case spec2: return true
+    case spec3: return true
+    default: return false
+    }
+  }
+}
+
 // MARK: Consuming tokens (`consume`)
 
 extension TokenConsumer {

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -457,7 +457,7 @@ extension Parser {
             second = nil
             unexpectedBeforeColon = nil
             colon = parsedColon
-          } else if self.atArgumentLabel(allowDollarIdentifier: true) && self.peek().rawTokenKind == .colon {
+          } else if self.atArgumentLabel(allowDollarIdentifier: true) && self.peek(isAt: .colon) {
             (unexpectedBeforeSecond, second) = self.parseArgumentLabel()
             (unexpectedBeforeColon, colon) = self.expect(.colon)
           } else {


### PR DESCRIPTION
This makes it a lot easier to check if the next token is of a specific kind.