### PR TITLE
Simplify `TokenSpec` in CodeGeneration

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
@@ -23,7 +23,7 @@ struct GrammarGenerator {
       if let tokenText = token.text {
         return "`'\(tokenText)'`"
       } else {
-        return "`<\(token.swiftKind)>`"
+        return "`<\(token.varOrCaseName)>`"
       }
     }
   }

--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
@@ -12,28 +12,32 @@
 
 /// Represents the specification for a Token in the TokenSyntax file.
 public struct TokenSpec {
+  public enum Kind {
+    case punctuation
+    /// The `keyword` TokenKind that contains the actual keyword as an associated value
+    case keyword
+    case other
+  }
+
   public let name: String
   public let nameForDiagnostics: String
   public let text: String?
-  public let isPunctuation: Bool
-  public let associatedValueClass: String?
+  public let kind: Kind
 
   public var swiftKind: String {
     return lowercaseFirstWord(name: self.name)
   }
 
-  private init(
+  fileprivate init(
     name: String,
     nameForDiagnostics: String,
     text: String? = nil,
-    isPunctuation: Bool,
-    associatedValueClass: String? = nil
+    kind: Kind
   ) {
     self.name = name
     self.nameForDiagnostics = nameForDiagnostics
     self.text = text
-    self.isPunctuation = isPunctuation
-    self.associatedValueClass = associatedValueClass
+    self.kind = kind
   }
 
   static func punctuator(name: String, text: String) -> TokenSpec {
@@ -41,8 +45,7 @@ public struct TokenSpec {
       name: name,
       nameForDiagnostics: text,
       text: text,
-      isPunctuation: true,
-      associatedValueClass: nil
+      kind: .punctuation
     )
   }
 
@@ -51,20 +54,17 @@ public struct TokenSpec {
       name: name,
       nameForDiagnostics: text,
       text: text,
-      isPunctuation: false,
-      associatedValueClass: nil
+      kind: .other
     )
   }
 
-  static func other(name: String, nameForDiagnostics: String, text: String? = nil, associatedValueClass: String? = nil) -> TokenSpec {
+  static func other(name: String, nameForDiagnostics: String, text: String? = nil) -> TokenSpec {
     TokenSpec(
       name: name,
       nameForDiagnostics: nameForDiagnostics,
       text: text,
-      isPunctuation: false,
-      associatedValueClass: associatedValueClass
+      kind: .other
     )
-
   }
 }
 
@@ -86,7 +86,7 @@ public let SYNTAX_TOKENS: [TokenSpec] = [
   .other(name: "Identifier", nameForDiagnostics: "identifier"),
   .punctuator(name: "InfixQuestionMark", text: "?"),
   .other(name: "IntegerLiteral", nameForDiagnostics: "integer literal"),
-  .other(name: "Keyword", nameForDiagnostics: "keyword", associatedValueClass: "Keyword"),
+  TokenSpec(name: "Keyword", nameForDiagnostics: "keyword", text: nil, kind: .keyword),
   .punctuator(name: "LeftAngle", text: "<"),
   .punctuator(name: "LeftBrace", text: "{"),
   .punctuator(name: "LeftParen", text: "("),

--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftSyntax
+
 /// Represents the specification for a Token in the TokenSyntax file.
 public struct TokenSpec {
   public enum Kind {
@@ -19,14 +21,10 @@ public struct TokenSpec {
     case other
   }
 
-  public let name: String
+  public let varOrCaseName: TokenSyntax
   public let nameForDiagnostics: String
   public let text: String?
   public let kind: Kind
-
-  public var swiftKind: String {
-    return lowercaseFirstWord(name: self.name)
-  }
 
   fileprivate init(
     name: String,
@@ -34,7 +32,7 @@ public struct TokenSpec {
     text: String? = nil,
     kind: Kind
   ) {
-    self.name = name
+    self.varOrCaseName = .identifier(name)
     self.nameForDiagnostics = nameForDiagnostics
     self.text = text
     self.kind = kind
@@ -69,57 +67,57 @@ public struct TokenSpec {
 }
 
 public let SYNTAX_TOKENS: [TokenSpec] = [
-  .punctuator(name: "Arrow", text: "->"),
-  .punctuator(name: "AtSign", text: "@"),
-  .punctuator(name: "Backslash", text: "\\"),
-  .punctuator(name: "Backtick", text: "`"),
-  .other(name: "BinaryOperator", nameForDiagnostics: "binary operator"),
-  .punctuator(name: "Colon", text: ":"),
-  .punctuator(name: "Comma", text: ","),
-  .other(name: "DollarIdentifier", nameForDiagnostics: "dollar identifier"),
-  .punctuator(name: "Ellipsis", text: "..."),
-  .other(name: "EndOfFile", nameForDiagnostics: "end of file", text: ""),
-  .punctuator(name: "Equal", text: "="),
-  .punctuator(name: "ExclamationMark", text: "!"),
-  .other(name: "ExtendedRegexDelimiter", nameForDiagnostics: "extended delimiter"),
-  .other(name: "FloatingLiteral", nameForDiagnostics: "floating literal"),
-  .other(name: "Identifier", nameForDiagnostics: "identifier"),
-  .punctuator(name: "InfixQuestionMark", text: "?"),
-  .other(name: "IntegerLiteral", nameForDiagnostics: "integer literal"),
-  TokenSpec(name: "Keyword", nameForDiagnostics: "keyword", text: nil, kind: .keyword),
-  .punctuator(name: "LeftAngle", text: "<"),
-  .punctuator(name: "LeftBrace", text: "{"),
-  .punctuator(name: "LeftParen", text: "("),
-  .punctuator(name: "LeftSquare", text: "["),
-  .punctuator(name: "MultilineStringQuote", text: "\"\"\""),
-  .punctuator(name: "Period", text: "."),
-  .other(name: "PostfixOperator", nameForDiagnostics: "postfix operator"),
-  .punctuator(name: "PostfixQuestionMark", text: "?"),
-  .punctuator(name: "Pound", text: "#"),
-  .poundKeyword(name: "PoundAvailable", text: "#available"),
-  .poundKeyword(name: "PoundElse", text: "#else"),
-  .poundKeyword(name: "PoundElseif", text: "#elseif"),
-  .poundKeyword(name: "PoundEndif", text: "#endif"),
-  .poundKeyword(name: "PoundIf", text: "#if"),
-  .poundKeyword(name: "PoundSourceLocation", text: "#sourceLocation"),
-  .poundKeyword(name: "PoundUnavailable", text: "#unavailable"),
-  .punctuator(name: "PrefixAmpersand", text: "&"),
-  .other(name: "PrefixOperator", nameForDiagnostics: "prefix operator"),
-  .other(name: "RawStringDelimiter", nameForDiagnostics: "raw string delimiter"),
-  .other(name: "RegexLiteralPattern", nameForDiagnostics: "regex pattern"),
-  .punctuator(name: "RegexSlash", text: "/"),
-  .punctuator(name: "RightAngle", text: ">"),
-  .punctuator(name: "RightBrace", text: "}"),
-  .punctuator(name: "RightParen", text: ")"),
-  .punctuator(name: "RightSquare", text: "]"),
-  .punctuator(name: "Semicolon", text: ";"),
-  .punctuator(name: "SingleQuote", text: "\'"),
-  .punctuator(name: "StringQuote", text: "\""),
-  .other(name: "StringSegment", nameForDiagnostics: "string segment"),
-  .other(name: "Unknown", nameForDiagnostics: "token"),
-  .other(name: "Wildcard", nameForDiagnostics: "wildcard", text: "_"),
+  .punctuator(name: "arrow", text: "->"),
+  .punctuator(name: "atSign", text: "@"),
+  .punctuator(name: "backslash", text: "\\"),
+  .punctuator(name: "backtick", text: "`"),
+  .other(name: "binaryOperator", nameForDiagnostics: "binary operator"),
+  .punctuator(name: "colon", text: ":"),
+  .punctuator(name: "comma", text: ","),
+  .other(name: "dollarIdentifier", nameForDiagnostics: "dollar identifier"),
+  .punctuator(name: "ellipsis", text: "..."),
+  .other(name: "endOfFile", nameForDiagnostics: "end of file", text: ""),
+  .punctuator(name: "equal", text: "="),
+  .punctuator(name: "exclamationMark", text: "!"),
+  .other(name: "extendedRegexDelimiter", nameForDiagnostics: "extended delimiter"),
+  .other(name: "floatingLiteral", nameForDiagnostics: "floating literal"),
+  .other(name: "identifier", nameForDiagnostics: "identifier"),
+  .punctuator(name: "infixQuestionMark", text: "?"),
+  .other(name: "integerLiteral", nameForDiagnostics: "integer literal"),
+  TokenSpec(name: "keyword", nameForDiagnostics: "keyword", text: nil, kind: .keyword),
+  .punctuator(name: "leftAngle", text: "<"),
+  .punctuator(name: "leftBrace", text: "{"),
+  .punctuator(name: "leftParen", text: "("),
+  .punctuator(name: "leftSquare", text: "["),
+  .punctuator(name: "multilineStringQuote", text: "\"\"\""),
+  .punctuator(name: "period", text: "."),
+  .other(name: "postfixOperator", nameForDiagnostics: "postfix operator"),
+  .punctuator(name: "postfixQuestionMark", text: "?"),
+  .punctuator(name: "pound", text: "#"),
+  .poundKeyword(name: "poundAvailable", text: "#available"),
+  .poundKeyword(name: "poundElse", text: "#else"),
+  .poundKeyword(name: "poundElseif", text: "#elseif"),
+  .poundKeyword(name: "poundEndif", text: "#endif"),
+  .poundKeyword(name: "poundIf", text: "#if"),
+  .poundKeyword(name: "poundSourceLocation", text: "#sourceLocation"),
+  .poundKeyword(name: "poundUnavailable", text: "#unavailable"),
+  .punctuator(name: "prefixAmpersand", text: "&"),
+  .other(name: "prefixOperator", nameForDiagnostics: "prefix operator"),
+  .other(name: "rawStringDelimiter", nameForDiagnostics: "raw string delimiter"),
+  .other(name: "regexLiteralPattern", nameForDiagnostics: "regex pattern"),
+  .punctuator(name: "regexSlash", text: "/"),
+  .punctuator(name: "rightAngle", text: ">"),
+  .punctuator(name: "rightBrace", text: "}"),
+  .punctuator(name: "rightParen", text: ")"),
+  .punctuator(name: "rightSquare", text: "]"),
+  .punctuator(name: "semicolon", text: ";"),
+  .punctuator(name: "singleQuote", text: "\'"),
+  .punctuator(name: "stringQuote", text: "\""),
+  .other(name: "stringSegment", nameForDiagnostics: "string segment"),
+  .other(name: "unknown", nameForDiagnostics: "token"),
+  .other(name: "wildcard", nameForDiagnostics: "wildcard", text: "_"),
 ]
 
 public let SYNTAX_TOKEN_MAP = Dictionary(
-  uniqueKeysWithValues: SYNTAX_TOKENS.map { ("\($0.name)Token", $0) }
+  uniqueKeysWithValues: SYNTAX_TOKENS.map { ("\($0.varOrCaseName.description.withFirstCharacterUppercased)Token", $0) }
 )

--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
@@ -11,154 +11,113 @@
 //===----------------------------------------------------------------------===//
 
 /// Represents the specification for a Token in the TokenSyntax file.
-public class TokenSpec {
+public struct TokenSpec {
   public let name: String
   public let nameForDiagnostics: String
   public let text: String?
+  public let isPunctuation: Bool
   public let associatedValueClass: String?
 
   public var swiftKind: String {
     return lowercaseFirstWord(name: self.name)
   }
 
-  init(
+  private init(
     name: String,
     nameForDiagnostics: String,
     text: String? = nil,
+    isPunctuation: Bool,
     associatedValueClass: String? = nil
   ) {
     self.name = name
     self.nameForDiagnostics = nameForDiagnostics
     self.text = text
+    self.isPunctuation = isPunctuation
     self.associatedValueClass = associatedValueClass
   }
-}
 
-public class PoundSpec: TokenSpec {
-  init(
-    name: String,
-    nameForDiagnostics: String? = nil,
-    text: String
-  ) {
-    super.init(
-      name: name,
-      nameForDiagnostics: nameForDiagnostics ?? text,
-      text: text
-    )
-  }
-}
-
-public class PoundObjectLiteralSpec: PoundSpec {
-  let `protocol`: String
-
-  init(
-    name: String,
-    text: String,
-    nameForDiagnostics: String,
-    `protocol`: String
-  ) {
-    self.`protocol` = `protocol`
-    super.init(
-      name: name,
-      nameForDiagnostics: nameForDiagnostics,
-      text: text
-    )
-  }
-}
-
-public class PoundConfigSpec: PoundSpec {}
-
-public class PoundDirectiveSpec: PoundSpec {
-  init(
-    name: String,
-    text: String
-  ) {
-    super.init(
-      name: name,
-      text: text
-    )
-  }
-}
-
-public class PoundConditionalDirectiveSpec: PoundDirectiveSpec {
-  override init(
-    name: String,
-    text: String
-  ) {
-    super.init(
-      name: name,
-      text: text
-    )
-  }
-}
-
-public class PunctuatorSpec: TokenSpec {
-  init(
-    name: String,
-    text: String
-  ) {
-    super.init(
+  static func punctuator(name: String, text: String) -> TokenSpec {
+    return TokenSpec(
       name: name,
       nameForDiagnostics: text,
-      text: text
+      text: text,
+      isPunctuation: true,
+      associatedValueClass: nil
     )
+  }
+
+  static func poundKeyword(name: String, text: String) -> TokenSpec {
+    return TokenSpec(
+      name: name,
+      nameForDiagnostics: text,
+      text: text,
+      isPunctuation: false,
+      associatedValueClass: nil
+    )
+  }
+
+  static func other(name: String, nameForDiagnostics: String, text: String? = nil, associatedValueClass: String? = nil) -> TokenSpec {
+    TokenSpec(
+      name: name,
+      nameForDiagnostics: nameForDiagnostics,
+      text: text,
+      isPunctuation: false,
+      associatedValueClass: associatedValueClass
+    )
+
   }
 }
 
-public class LiteralSpec: TokenSpec {}
-
-public class MiscSpec: TokenSpec {}
-
 public let SYNTAX_TOKENS: [TokenSpec] = [
-  PunctuatorSpec(name: "Arrow", text: "->"),
-  PunctuatorSpec(name: "AtSign", text: "@"),
-  PunctuatorSpec(name: "Backslash", text: "\\"),
-  PunctuatorSpec(name: "Backtick", text: "`"),
-  MiscSpec(name: "BinaryOperator", nameForDiagnostics: "binary operator"),
-  PunctuatorSpec(name: "Colon", text: ":"),
-  PunctuatorSpec(name: "Comma", text: ","),
-  MiscSpec(name: "DollarIdentifier", nameForDiagnostics: "dollar identifier"),
-  PunctuatorSpec(name: "Ellipsis", text: "..."),
-  MiscSpec(name: "EndOfFile", nameForDiagnostics: "end of file", text: ""),
-  PunctuatorSpec(name: "Equal", text: "="),
-  PunctuatorSpec(name: "ExclamationMark", text: "!"),
-  MiscSpec(name: "ExtendedRegexDelimiter", nameForDiagnostics: "extended delimiter"),
-  LiteralSpec(name: "FloatingLiteral", nameForDiagnostics: "floating literal"),
-  MiscSpec(name: "Identifier", nameForDiagnostics: "identifier"),
-  PunctuatorSpec(name: "InfixQuestionMark", text: "?"),
-  LiteralSpec(name: "IntegerLiteral", nameForDiagnostics: "integer literal"),
-  MiscSpec(name: "Keyword", nameForDiagnostics: "keyword", associatedValueClass: "Keyword"),
-  PunctuatorSpec(name: "LeftAngle", text: "<"),
-  PunctuatorSpec(name: "LeftBrace", text: "{"),
-  PunctuatorSpec(name: "LeftParen", text: "("),
-  PunctuatorSpec(name: "LeftSquare", text: "["),
-  PunctuatorSpec(name: "MultilineStringQuote", text: "\"\"\""),
-  PunctuatorSpec(name: "Period", text: "."),
-  MiscSpec(name: "PostfixOperator", nameForDiagnostics: "postfix operator"),
-  PunctuatorSpec(name: "PostfixQuestionMark", text: "?"),
-  PunctuatorSpec(name: "Pound", text: "#"),
-  PoundConfigSpec(name: "PoundAvailable", text: "#available"),
-  PoundConditionalDirectiveSpec(name: "PoundElse", text: "#else"),
-  PoundConditionalDirectiveSpec(name: "PoundElseif", text: "#elseif"),
-  PoundConditionalDirectiveSpec(name: "PoundEndif", text: "#endif"),
-  PoundConditionalDirectiveSpec(name: "PoundIf", text: "#if"),
-  PoundDirectiveSpec(name: "PoundSourceLocation", text: "#sourceLocation"),
-  PoundConfigSpec(name: "PoundUnavailable", text: "#unavailable"),
-  PunctuatorSpec(name: "PrefixAmpersand", text: "&"),
-  MiscSpec(name: "PrefixOperator", nameForDiagnostics: "prefix operator"),
-  MiscSpec(name: "RawStringDelimiter", nameForDiagnostics: "raw string delimiter"),
-  MiscSpec(name: "RegexLiteralPattern", nameForDiagnostics: "regex pattern"),
-  PunctuatorSpec(name: "RegexSlash", text: "/"),
-  PunctuatorSpec(name: "RightAngle", text: ">"),
-  PunctuatorSpec(name: "RightBrace", text: "}"),
-  PunctuatorSpec(name: "RightParen", text: ")"),
-  PunctuatorSpec(name: "RightSquare", text: "]"),
-  PunctuatorSpec(name: "Semicolon", text: ";"),
-  PunctuatorSpec(name: "SingleQuote", text: "\'"),
-  PunctuatorSpec(name: "StringQuote", text: "\""),
-  MiscSpec(name: "StringSegment", nameForDiagnostics: "string segment"),
-  MiscSpec(name: "Unknown", nameForDiagnostics: "token"),
-  MiscSpec(name: "Wildcard", nameForDiagnostics: "wildcard", text: "_"),
+  .punctuator(name: "Arrow", text: "->"),
+  .punctuator(name: "AtSign", text: "@"),
+  .punctuator(name: "Backslash", text: "\\"),
+  .punctuator(name: "Backtick", text: "`"),
+  .other(name: "BinaryOperator", nameForDiagnostics: "binary operator"),
+  .punctuator(name: "Colon", text: ":"),
+  .punctuator(name: "Comma", text: ","),
+  .other(name: "DollarIdentifier", nameForDiagnostics: "dollar identifier"),
+  .punctuator(name: "Ellipsis", text: "..."),
+  .other(name: "EndOfFile", nameForDiagnostics: "end of file", text: ""),
+  .punctuator(name: "Equal", text: "="),
+  .punctuator(name: "ExclamationMark", text: "!"),
+  .other(name: "ExtendedRegexDelimiter", nameForDiagnostics: "extended delimiter"),
+  .other(name: "FloatingLiteral", nameForDiagnostics: "floating literal"),
+  .other(name: "Identifier", nameForDiagnostics: "identifier"),
+  .punctuator(name: "InfixQuestionMark", text: "?"),
+  .other(name: "IntegerLiteral", nameForDiagnostics: "integer literal"),
+  .other(name: "Keyword", nameForDiagnostics: "keyword", associatedValueClass: "Keyword"),
+  .punctuator(name: "LeftAngle", text: "<"),
+  .punctuator(name: "LeftBrace", text: "{"),
+  .punctuator(name: "LeftParen", text: "("),
+  .punctuator(name: "LeftSquare", text: "["),
+  .punctuator(name: "MultilineStringQuote", text: "\"\"\""),
+  .punctuator(name: "Period", text: "."),
+  .other(name: "PostfixOperator", nameForDiagnostics: "postfix operator"),
+  .punctuator(name: "PostfixQuestionMark", text: "?"),
+  .punctuator(name: "Pound", text: "#"),
+  .poundKeyword(name: "PoundAvailable", text: "#available"),
+  .poundKeyword(name: "PoundElse", text: "#else"),
+  .poundKeyword(name: "PoundElseif", text: "#elseif"),
+  .poundKeyword(name: "PoundEndif", text: "#endif"),
+  .poundKeyword(name: "PoundIf", text: "#if"),
+  .poundKeyword(name: "PoundSourceLocation", text: "#sourceLocation"),
+  .poundKeyword(name: "PoundUnavailable", text: "#unavailable"),
+  .punctuator(name: "PrefixAmpersand", text: "&"),
+  .other(name: "PrefixOperator", nameForDiagnostics: "prefix operator"),
+  .other(name: "RawStringDelimiter", nameForDiagnostics: "raw string delimiter"),
+  .other(name: "RegexLiteralPattern", nameForDiagnostics: "regex pattern"),
+  .punctuator(name: "RegexSlash", text: "/"),
+  .punctuator(name: "RightAngle", text: ">"),
+  .punctuator(name: "RightBrace", text: "}"),
+  .punctuator(name: "RightParen", text: ")"),
+  .punctuator(name: "RightSquare", text: "]"),
+  .punctuator(name: "Semicolon", text: ";"),
+  .punctuator(name: "SingleQuote", text: "\'"),
+  .punctuator(name: "StringQuote", text: "\""),
+  .other(name: "StringSegment", nameForDiagnostics: "string segment"),
+  .other(name: "Unknown", nameForDiagnostics: "token"),
+  .other(name: "Wildcard", nameForDiagnostics: "wildcard", text: "_"),
 ]
 
 public let SYNTAX_TOKEN_MAP = Dictionary(

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -69,7 +69,7 @@ public extension Child {
       return type.defaultValue
     }
     if token.text != nil {
-      return ExprSyntax(".\(raw: token.swiftKind)Token()")
+      return ExprSyntax(".\(token.varOrCaseName)Token()")
     }
     guard case .token(let choices, _, _) = kind, choices.count == 1, token.kind == .keyword else {
       return nil
@@ -82,7 +82,7 @@ public extension Child {
     if textChoice == "init" {
       textChoice = "`init`"
     }
-    return ExprSyntax(".\(raw: token.swiftKind)(.\(raw: textChoice))")
+    return ExprSyntax(".\(token.varOrCaseName)(.\(raw: textChoice))")
   }
 
   /// If the child node has a default value, return an expression of the form

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -71,7 +71,7 @@ public extension Child {
     if token.text != nil {
       return ExprSyntax(".\(raw: token.swiftKind)Token()")
     }
-    guard case .token(let choices, _, _) = kind, choices.count == 1, token.associatedValueClass != nil else {
+    guard case .token(let choices, _, _) = kind, choices.count == 1, token.kind == .keyword else {
       return nil
     }
     var textChoice: String

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -64,7 +64,7 @@ public struct SyntaxBuildableType: Hashable {
       return ExprSyntax(NilLiteralExprSyntax())
     } else if let token = token {
       if token.text != nil {
-        return ExprSyntax(".\(raw: lowercaseFirstWord(name: token.name))Token()")
+        return ExprSyntax(".\(token.varOrCaseName)Token()")
       }
     }
     return nil

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserTokenSpecSetFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserTokenSpecSetFile.swift
@@ -30,7 +30,7 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                 DeclSyntax("case \(raw: keyword.escapedName)")
               case .token(let tokenText):
                 let token = SYNTAX_TOKEN_MAP[tokenText]!
-                DeclSyntax("case \(raw: token.swiftKind)")
+                DeclSyntax("case \(token.varOrCaseName)")
               }
             }
 
@@ -44,7 +44,7 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                   case .token(let tokenText):
                     let token = SYNTAX_TOKEN_MAP[tokenText]!
                     SwitchCaseSyntax(
-                      "case TokenSpec(.\(raw: token.swiftKind)): self = .\(raw: token.swiftKind)"
+                      "case TokenSpec(.\(token.varOrCaseName)): self = .\(token.varOrCaseName)"
                     )
                   }
                 }
@@ -64,7 +64,7 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                   case .token(let tokenText):
                     let token = SYNTAX_TOKEN_MAP[tokenText]!
                     SwitchCaseSyntax(
-                      "case .\(raw: token.swiftKind): return .\(raw: token.swiftKind)"
+                      "case .\(token.varOrCaseName): return .\(token.varOrCaseName)"
                     )
                   }
                 }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TokenSpecStaticMembersFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TokenSpecStaticMembersFile.swift
@@ -19,8 +19,8 @@ let tokenSpecStaticMembersFile = SourceFileSyntax(leadingTrivia: copyrightHeader
   DeclSyntax("@_spi(RawSyntax) import SwiftSyntax")
 
   try! ExtensionDeclSyntax("extension TokenSpec") {
-    for token in SYNTAX_TOKENS where token.swiftKind != "keyword" {
-      DeclSyntax("static var \(raw: token.swiftKind): TokenSpec { return TokenSpec(.\(raw: token.swiftKind)) }")
+    for token in SYNTAX_TOKENS where token.kind != .keyword {
+      DeclSyntax("static var \(token.varOrCaseName): TokenSpec { return TokenSpec(.\(token.varOrCaseName)) }")
     }
 
     DeclSyntax("static func keyword(_ keyword: Keyword) -> TokenSpec { return TokenSpec(keyword) }")

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
@@ -21,9 +21,9 @@ let tokenNameForDiagnosticFile = SourceFileSyntax(leadingTrivia: copyrightHeader
   try! ExtensionDeclSyntax("extension TokenKind") {
     try! VariableDeclSyntax("var nameForDiagnostics: String") {
       try! SwitchExprSyntax("switch self") {
-        for token in SYNTAX_TOKENS where token.swiftKind != "keyword" {
-          SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
-            StmtSyntax("return #\"\(raw: token.nameForDiagnostics)\"#")
+        for token in SYNTAX_TOKENS where token.kind != .keyword {
+          SwitchCaseSyntax("case .\(token.varOrCaseName):") {
+            StmtSyntax("return \(literal: token.nameForDiagnostics)")
           }
         }
         SwitchCaseSyntax("case .keyword(let keyword):") {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
@@ -216,7 +216,7 @@ let rawSyntaxValidationFile = try! SourceFileSyntax(leadingTrivia: copyrightHead
                               case .keyword(text: let text):
                                 ArrayElementSyntax(expression: ExprSyntax(#".keyword("\#(raw: text)")"#))
                               case .token(tokenKind: let tokenKind):
-                                ArrayElementSyntax(expression: ExprSyntax(".tokenKind(.\(raw: SYNTAX_TOKEN_MAP[tokenKind]!.swiftKind))"))
+                                ArrayElementSyntax(expression: ExprSyntax(".tokenKind(.\(SYNTAX_TOKEN_MAP[tokenKind]!.varOrCaseName))"))
                               }
                             }
                           }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -99,7 +99,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       try SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
           SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
-            StmtSyntax("return \(raw: type(of: token) == PunctuatorSpec.self)")
+            StmtSyntax("return \(raw: token.isPunctuation)")
           }
         }
       }
@@ -177,7 +177,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       try! SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
           SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
-            StmtSyntax("return \(raw: type(of: token) == PunctuatorSpec.self)")
+            StmtSyntax("return \(raw: token.isPunctuation)")
           }
         }
       }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -26,11 +26,11 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       // Tokens that don't have a set text have an associated value that
       // contains their text.
       if token.kind == .keyword {
-        DeclSyntax("case \(raw: token.swiftKind)(Keyword)")
+        DeclSyntax("case \(token.varOrCaseName)(Keyword)")
       } else if token.text == nil {
-        DeclSyntax("case \(raw: token.swiftKind)(String)")
+        DeclSyntax("case \(token.varOrCaseName)(String)")
       } else {
-        DeclSyntax("case \(raw: token.swiftKind)")
+        DeclSyntax("case \(token.varOrCaseName)")
       }
     }
 
@@ -44,15 +44,15 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       try SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
           if token.kind == .keyword {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind)(let assoc):") {
+            SwitchCaseSyntax("case .\(token.varOrCaseName)(let assoc):") {
               StmtSyntax("return String(syntaxText: assoc.defaultText)")
             }
           } else if let text = token.text {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
+            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
               StmtSyntax("return #\"\(raw: text)\"#")
             }
           } else {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind)(let text):") {
+            SwitchCaseSyntax("case .\(token.varOrCaseName)(let text):") {
               StmtSyntax("return text")
             }
           }
@@ -70,11 +70,11 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       try SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
           if token.kind == .keyword {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind)(let assoc):") {
+            SwitchCaseSyntax("case .\(token.varOrCaseName)(let assoc):") {
               StmtSyntax("return assoc.defaultText")
             }
           } else if let text = token.text {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
+            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
               StmtSyntax("return #\"\(raw: text)\"#")
             }
           }
@@ -98,7 +98,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     ) {
       try SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
-          SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
+          SwitchCaseSyntax("case .\(token.varOrCaseName):") {
             StmtSyntax("return \(raw: token.kind == .punctuation)")
           }
         }
@@ -111,11 +111,11 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       try SwitchExprSyntax("switch (lhs, rhs)") {
         for token in SYNTAX_TOKENS {
           if token.text != nil {
-            SwitchCaseSyntax("case (.\(raw: token.swiftKind), .\(raw: token.swiftKind)):") {
+            SwitchCaseSyntax("case (.\(token.varOrCaseName), .\(token.varOrCaseName)):") {
               StmtSyntax("return true")
             }
           } else {
-            SwitchCaseSyntax("case (.\(raw: token.swiftKind)(let lhsText), .\(raw: token.swiftKind)(let rhsText)):") {
+            SwitchCaseSyntax("case (.\(token.varOrCaseName)(let lhsText), .\(token.varOrCaseName)(let rhsText)):") {
               StmtSyntax("return lhsText == rhsText")
             }
           }
@@ -140,7 +140,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     """
   ) {
     for token in SYNTAX_TOKENS {
-      DeclSyntax("case \(raw: token.swiftKind)")
+      DeclSyntax("case \(token.varOrCaseName)")
     }
 
     try VariableDeclSyntax(
@@ -152,7 +152,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       try! SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
           if let text = token.text {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
+            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
               StmtSyntax("return #\"\(raw: text)\"#")
             }
           }
@@ -176,7 +176,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     ) {
       try! SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
-          SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
+          SwitchCaseSyntax("case .\(token.varOrCaseName):") {
             StmtSyntax("return \(raw: token.kind == .punctuation)")
           }
         }
@@ -194,8 +194,8 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     ) {
       try! SwitchExprSyntax("switch rawKind") {
         for token in SYNTAX_TOKENS {
-          if token.swiftKind == "keyword" {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
+          if token.kind == .keyword {
+            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
               DeclSyntax("var text = text")
               StmtSyntax(
                 """
@@ -206,13 +206,13 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
               )
             }
           } else if token.text != nil {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
+            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
               ExprSyntax("precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)")
-              StmtSyntax("return .\(raw: token.swiftKind)")
+              StmtSyntax("return .\(token.varOrCaseName)")
             }
           } else {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
-              StmtSyntax("return .\(raw: token.swiftKind)(text)")
+            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
+              StmtSyntax("return .\(token.varOrCaseName)(text)")
             }
           }
         }
@@ -229,17 +229,17 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     ) {
       try! SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
-          if token.swiftKind == "keyword" {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind)(let keyword):") {
-              StmtSyntax("return (.\(raw: token.swiftKind), String(syntaxText: keyword.defaultText))")
+          if token.kind == .keyword {
+            SwitchCaseSyntax("case .\(token.varOrCaseName)(let keyword):") {
+              StmtSyntax("return (.\(token.varOrCaseName), String(syntaxText: keyword.defaultText))")
             }
           } else if token.text != nil {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
-              StmtSyntax("return (.\(raw: token.swiftKind), nil)")
+            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
+              StmtSyntax("return (.\(token.varOrCaseName), nil)")
             }
           } else {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind)(let str):") {
-              StmtSyntax("return (.\(raw: token.swiftKind), str)")
+            SwitchCaseSyntax("case .\(token.varOrCaseName)(let str):") {
+              StmtSyntax("return (.\(token.varOrCaseName), str)")
             }
           }
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -25,8 +25,8 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     for token in SYNTAX_TOKENS {
       // Tokens that don't have a set text have an associated value that
       // contains their text.
-      if let associatedValueClass = token.associatedValueClass {
-        DeclSyntax("case \(raw: token.swiftKind)(\(raw: associatedValueClass))")
+      if token.kind == .keyword {
+        DeclSyntax("case \(raw: token.swiftKind)(Keyword)")
       } else if token.text == nil {
         DeclSyntax("case \(raw: token.swiftKind)(String)")
       } else {
@@ -43,7 +43,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     ) {
       try SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
-          if token.associatedValueClass != nil {
+          if token.kind == .keyword {
             SwitchCaseSyntax("case .\(raw: token.swiftKind)(let assoc):") {
               StmtSyntax("return String(syntaxText: assoc.defaultText)")
             }
@@ -69,7 +69,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     ) {
       try SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
-          if token.associatedValueClass != nil {
+          if token.kind == .keyword {
             SwitchCaseSyntax("case .\(raw: token.swiftKind)(let assoc):") {
               StmtSyntax("return assoc.defaultText")
             }
@@ -99,7 +99,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       try SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
           SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
-            StmtSyntax("return \(raw: token.isPunctuation)")
+            StmtSyntax("return \(raw: token.kind == .punctuation)")
           }
         }
       }
@@ -177,7 +177,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       try! SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
           SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
-            StmtSyntax("return \(raw: token.isPunctuation)")
+            StmtSyntax("return \(raw: token.kind == .punctuation)")
           }
         }
       }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
@@ -21,13 +21,13 @@ let tokensFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       if let text = token.text {
         DeclSyntax(
           """
-          public static func \(raw: token.swiftKind)Token(
+          public static func \(token.varOrCaseName)Token(
             leadingTrivia: Trivia = [],
             trailingTrivia: Trivia = [],
             presence: SourcePresence = .present
           ) -> TokenSyntax {
             return TokenSyntax(
-              .\(raw: token.swiftKind),
+              .\(token.varOrCaseName),
               leadingTrivia: leadingTrivia,
               trailingTrivia: trailingTrivia,
               presence: presence
@@ -38,14 +38,14 @@ let tokensFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       } else if token.kind == .keyword {
         DeclSyntax(
           """
-          public static func \(raw: token.swiftKind)(
+          public static func \(token.varOrCaseName)(
             _ value: Keyword,
             leadingTrivia: Trivia = [],
             trailingTrivia: Trivia = [],
             presence: SourcePresence = .present
           ) -> TokenSyntax {
             return TokenSyntax(
-              .\(raw: token.swiftKind)(value),
+              .\(token.varOrCaseName)(value),
               leadingTrivia: leadingTrivia,
               trailingTrivia: trailingTrivia,
               presence: presence
@@ -56,14 +56,14 @@ let tokensFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       } else {
         DeclSyntax(
           """
-          public static func \(raw: token.swiftKind)(
+          public static func \(token.varOrCaseName)(
             _ text: String,
             leadingTrivia: Trivia = [],
             trailingTrivia: Trivia = [],
             presence: SourcePresence = .present
           ) -> TokenSyntax {
             return TokenSyntax(
-              .\(raw: token.swiftKind)(text),
+              .\(token.varOrCaseName)(text),
               leadingTrivia: leadingTrivia,
               trailingTrivia: trailingTrivia,
               presence: presence

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
@@ -35,11 +35,11 @@ let tokensFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           }
           """
         )
-      } else if let associatedValueClass = token.associatedValueClass {
+      } else if token.kind == .keyword {
         DeclSyntax(
           """
           public static func \(raw: token.swiftKind)(
-            _ value: \(raw: associatedValueClass),
+            _ value: Keyword,
             leadingTrivia: Trivia = [],
             trailingTrivia: Trivia = [],
             presence: SourcePresence = .present

--- a/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
@@ -18,101 +18,101 @@ extension TokenKind {
   var nameForDiagnostics: String {
     switch self {
     case .arrow:
-      return #"->"#
+      return "->"
     case .atSign:
-      return #"@"#
+      return "@"
     case .backslash:
       return #"\"#
     case .backtick:
-      return #"`"#
+      return "`"
     case .binaryOperator:
-      return #"binary operator"#
+      return "binary operator"
     case .colon:
-      return #":"#
+      return ":"
     case .comma:
-      return #","#
+      return ","
     case .dollarIdentifier:
-      return #"dollar identifier"#
+      return "dollar identifier"
     case .ellipsis:
-      return #"..."#
+      return "..."
     case .endOfFile:
-      return #"end of file"#
+      return "end of file"
     case .equal:
-      return #"="#
+      return "="
     case .exclamationMark:
-      return #"!"#
+      return "!"
     case .extendedRegexDelimiter:
-      return #"extended delimiter"#
+      return "extended delimiter"
     case .floatingLiteral:
-      return #"floating literal"#
+      return "floating literal"
     case .identifier:
-      return #"identifier"#
+      return "identifier"
     case .infixQuestionMark:
-      return #"?"#
+      return "?"
     case .integerLiteral:
-      return #"integer literal"#
+      return "integer literal"
     case .leftAngle:
-      return #"<"#
+      return "<"
     case .leftBrace:
-      return #"{"#
+      return "{"
     case .leftParen:
-      return #"("#
+      return "("
     case .leftSquare:
-      return #"["#
+      return "["
     case .multilineStringQuote:
       return #"""""#
     case .period:
-      return #"."#
+      return "."
     case .postfixOperator:
-      return #"postfix operator"#
+      return "postfix operator"
     case .postfixQuestionMark:
-      return #"?"#
+      return "?"
     case .pound:
-      return #"#"#
+      return "#"
     case .poundAvailable:
-      return #"#available"#
+      return "#available"
     case .poundElse:
-      return #"#else"#
+      return "#else"
     case .poundElseif:
-      return #"#elseif"#
+      return "#elseif"
     case .poundEndif:
-      return #"#endif"#
+      return "#endif"
     case .poundIf:
-      return #"#if"#
+      return "#if"
     case .poundSourceLocation:
-      return #"#sourceLocation"#
+      return "#sourceLocation"
     case .poundUnavailable:
-      return #"#unavailable"#
+      return "#unavailable"
     case .prefixAmpersand:
-      return #"&"#
+      return "&"
     case .prefixOperator:
-      return #"prefix operator"#
+      return "prefix operator"
     case .rawStringDelimiter:
-      return #"raw string delimiter"#
+      return "raw string delimiter"
     case .regexLiteralPattern:
-      return #"regex pattern"#
+      return "regex pattern"
     case .regexSlash:
-      return #"/"#
+      return "/"
     case .rightAngle:
-      return #">"#
+      return ">"
     case .rightBrace:
-      return #"}"#
+      return "}"
     case .rightParen:
-      return #")"#
+      return ")"
     case .rightSquare:
-      return #"]"#
+      return "]"
     case .semicolon:
-      return #";"#
+      return ";"
     case .singleQuote:
-      return #"'"#
+      return "'"
     case .stringQuote:
       return #"""#
     case .stringSegment:
-      return #"string segment"#
+      return "string segment"
     case .unknown:
-      return #"token"#
+      return "token"
     case .wildcard:
-      return #"wildcard"#
+      return "wildcard"
     case .keyword(let keyword):
       return String(syntaxText: keyword.defaultText)
     }


### PR DESCRIPTION
Three cleanups to `TokenSpec`:
- Flatten the `TokenSpec` class hierarchy (which dates back to the Python days) into a single struct
- Remove `TokenSpec.associatedValueClass`: At some point I introduce the abstraction with the idea to also have a `TokenKind` with associated values for pound keywords and operators but that never happened
- Rename `TokenSpec.swiftKind` to `varOrCaseName` and change it from a string to `TokenSyntax`.