### PR TITLE
Fix string interpolation parsing errors in CodeGeneration

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
@@ -198,5 +198,5 @@ fileprivate func convertFromSyntaxProtocolToSyntaxType(child: Child, useDeprecat
   if child.type.isBaseType && !child.kind.isNodeChoices {
     return ExprSyntax("\(raw: child.type.syntaxBaseName)(fromProtocol: \(raw: childName))")
   }
-  return ExprSyntax("\(raw: childName)")
+  return ExprSyntax("\(raw: childName.backtickedIfNeeded)")
 }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -52,7 +52,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     try! StructDeclSyntax(
       """
       @_spi(RawSyntax)
-      public struct \(node.kind.rawType): \(node.kind.isBase ? node.kind.rawProtocolType : node.base.rawProtocolType))
+      public struct \(node.kind.rawType): \(node.kind.isBase ? node.kind.rawProtocolType : node.base.rawProtocolType)
       """
     ) {
       for (name, choices) in node.childrenChoicesEnums {


### PR DESCRIPTION
Running CodeGeneration causes syntax errors to be logged using `os_log`. Fix those.