### PR TITLE
Disable performance testing in CI

### DIFF
--- a/Tests/PerformanceTest/ci-baselines.json
+++ b/Tests/PerformanceTest/ci-baselines.json
@@ -1,7 +1,0 @@
-{
-   "testNativeParsingPerformance": 307024328,
-   "testClassifierPerformance": 2624475912,
-   "testEmptyVisitorPerformance": 48502831,
-   "testEmptyRewriterPerformance": 54438776,
-   "testEmptyAnyVisitorPerformance": 49123765
-}

--- a/build-script.py
+++ b/build-script.py
@@ -465,10 +465,6 @@ def run_xctests(
     env["SWIFTCI_USE_LOCAL_DEPS"] = "1"
     env["SWIFT_SYNTAX_PARSER_LIB_SEARCH_PATH"] = \
         os.path.join(toolchain, "lib", "swift", "macosx")
-    if platform.system() == "Darwin" and platform.machine() == "i386":
-        # Only perform performance testing on Intel macOS machines because that’s what 
-        # the baselines are written for.
-        env["BASELINE_FILE"] = os.path.join(TESTS_DIR, "PerformanceTest", "ci-baselines.json") 
 
     check_call(swiftpm_call, env=env, verbose=verbose)
 


### PR DESCRIPTION
It turns out that regular changes to the compiler can cause fluctuations to these test cases that are sufficient to make them trip over so we can’t run them in CI. The test should still be valuable to bisect a performance regression after we find it or to verify that a change doesn’t cause a performance regression.