### PR TITLE
Use `IdentifierExpr` in a couple more places instead of `DeclNameArguments`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -619,17 +619,11 @@ public let ATTRIBUTE_NODES: [Node] = [
         documentation: "The comma separating the type and method name"
       ),
       Child(
-        name: "DeclBaseName",
-        kind: .node(kind: .token),
-        nameForDiagnostics: "declaration base name",
-        documentation: "The base name of the protocol's requirement."
-      ),
-      Child(
-        name: "DeclNameArguments",
-        kind: .node(kind: .declNameArguments),
-        nameForDiagnostics: "declaration name arguments",
-        documentation: "The argument labels of the protocol's requirement if it is a function requirement.",
-        isOptional: true
+        name: "DeclName",
+        deprecatedName: "Declname",
+        kind: .node(kind: .identifierExpr),
+        nameForDiagnostics: "declaration name",
+        documentation: "The value for this argument"
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -777,23 +777,10 @@ public let ATTRIBUTE_NODES: [Node] = [
         isOptional: true
       ),
       Child(
-        name: "Name",
-        kind: .token(choices: [
-          .token(tokenKind: "IdentifierToken"),
-          .keyword(text: "self"),
-          .keyword(text: "Self"),
-          .keyword(text: "init"),
-          .token(tokenKind: "BinaryOperatorToken"),
-        ]),
-        nameForDiagnostics: "base name",
-        documentation: "The base name of the referenced function."
-      ),
-      Child(
-        name: "Arguments",
-        kind: .node(kind: .declNameArguments),
-        nameForDiagnostics: "arguments",
-        documentation: "The argument labels of the referenced function, optionally specified.",
-        isOptional: true
+        name: "DeclName",
+        kind: .node(kind: .declReferenceExpr),
+        nameForDiagnostics: "name",
+        documentation: "The name of the referenced function."
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -562,7 +562,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "DeclName",
         deprecatedName: "Declname",
-        kind: .node(kind: .identifierExpr)
+        kind: .node(kind: .declReferenceExpr)
       ),
     ]
   ),
@@ -621,7 +621,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "DeclName",
         deprecatedName: "Declname",
-        kind: .node(kind: .identifierExpr),
+        kind: .node(kind: .declReferenceExpr),
         nameForDiagnostics: "declaration name",
         documentation: "The value for this argument"
       ),
@@ -837,7 +837,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "DeclName",
         deprecatedName: "Declname",
-        kind: .node(kind: .identifierExpr),
+        kind: .node(kind: .declReferenceExpr),
         nameForDiagnostics: "declaration name",
         documentation: "The value for this argument"
       ),

--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -295,35 +295,6 @@ public let ATTRIBUTE_NODES: [Node] = [
     ]
   ),
 
-  Node(
-    kind: .declName,
-    base: .syntax,
-    nameForDiagnostics: "declaration name",
-    children: [
-      Child(
-        name: "BaseName",
-        deprecatedName: "DeclBaseName",
-        kind: .token(choices: [
-          .token(tokenKind: "IdentifierToken"),
-          .token(tokenKind: "BinaryOperatorToken"),
-          .keyword(text: "init"),
-          .keyword(text: "self"),
-          .keyword(text: "Self"),
-        ]),
-        nameForDiagnostics: "base name",
-        documentation: "The base name of the protocol's requirement."
-      ),
-      Child(
-        name: "Arguments",
-        deprecatedName: "DeclNameArguments",
-        kind: .node(kind: .declNameArguments),
-        nameForDiagnostics: "arguments",
-        documentation: "The argument labels of the protocol's requirement if it is a function requirement.",
-        isOptional: true
-      ),
-    ]
-  ),
-
   // The argument of the derivative registration attribute
   // '@derivative(of: ...)' and the transpose registration attribute
   // '@transpose(of: ...)'.
@@ -591,7 +562,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "DeclName",
         deprecatedName: "Declname",
-        kind: .node(kind: .declName)
+        kind: .node(kind: .identifierExpr)
       ),
     ]
   ),
@@ -872,7 +843,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "DeclName",
         deprecatedName: "Declname",
-        kind: .node(kind: .declName),
+        kind: .node(kind: .identifierExpr),
         nameForDiagnostics: "declaration name",
         documentation: "The value for this argument"
       ),

--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -851,6 +851,7 @@ public let EXPR_NODES: [Node] = [
           .keyword(text: "init"),
           .token(tokenKind: "DollarIdentifierToken"),
           .token(tokenKind: "BinaryOperatorToken"),
+          .token(tokenKind: "IntegerLiteralToken"),
         ])
       ),
       Child(
@@ -1091,22 +1092,9 @@ public let EXPR_NODES: [Node] = [
     nameForDiagnostics: "key path property component",
     children: [
       Child(
-        name: "Property",
+        name: "DeclName",
         deprecatedName: "Identifier",
-        kind: .token(choices: [
-          .token(tokenKind: "IdentifierToken"),
-          .keyword(text: "self"),
-          .keyword(text: "Self"),
-          .keyword(text: "init"),
-          .token(tokenKind: "DollarIdentifierToken"),
-          .token(tokenKind: "BinaryOperatorToken"),
-          .token(tokenKind: "IntegerLiteralToken"),
-        ])
-      ),
-      Child(
-        name: "DeclNameArguments",
-        kind: .node(kind: .declNameArguments),
-        isOptional: true
+        kind: .node(kind: .declReferenceExpr)
       ),
       Child(
         name: "GenericArgumentClause",
@@ -1213,14 +1201,9 @@ public let EXPR_NODES: [Node] = [
         kind: .token(choices: [.token(tokenKind: "PeriodToken")])
       ),
       Child(
-        name: "Name",
-        kind: .node(kind: .token),
+        name: "DeclName",
+        kind: .node(kind: .declReferenceExpr),
         nameForDiagnostics: "name"
-      ),
-      Child(
-        name: "DeclNameArguments",
-        kind: .node(kind: .declNameArguments),
-        isOptional: true
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -837,12 +837,13 @@ public let EXPR_NODES: [Node] = [
 
   // An identifier expression.
   Node(
-    kind: .identifierExpr,
+    kind: .declReferenceExpr,
     base: .expr,
     nameForDiagnostics: nil,
     children: [
       Child(
-        name: "Identifier",
+        name: "BaseName",
+        deprecatedName: "Identifier",
         kind: .token(choices: [
           .token(tokenKind: "IdentifierToken"),
           .keyword(text: "self"),
@@ -853,7 +854,8 @@ public let EXPR_NODES: [Node] = [
         ])
       ),
       Child(
-        name: "DeclNameArguments",
+        name: "ArgumentNames",
+        deprecatedName: "DeclNameArguments",
         kind: .node(kind: .declNameArguments),
         isOptional: true
       ),

--- a/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
@@ -84,7 +84,6 @@ public enum SyntaxNodeKind: String, CaseIterable {
   case declModifier
   case declModifierDetail
   case declModifierList
-  case declName
   case declNameArgument
   case declNameArgumentList
   case declNameArguments

--- a/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
@@ -87,6 +87,7 @@ public enum SyntaxNodeKind: String, CaseIterable {
   case declNameArgument
   case declNameArgumentList
   case declNameArguments
+  case declReferenceExpr
   case deferStmt
   case deinitializerDecl
   case deinitializerEffectSpecifiers
@@ -148,7 +149,6 @@ public enum SyntaxNodeKind: String, CaseIterable {
   case genericSpecializationExpr
   case genericWhereClause
   case guardStmt
-  case identifierExpr
   case identifierPattern
   case identifierType
   case ifConfigClause
@@ -383,6 +383,7 @@ public enum SyntaxNodeKind: String, CaseIterable {
     case .closureShorthandParameterList: return "closureParamList"
     case .consumeExpr: return "moveExpr"
     case .declModifierList: return "modifierList"
+    case .declReferenceExpr: return "identifierExpr"
     case .deinitializerEffectSpecifiers: return "deinitEffectSpecifiers"
     case .derivativeAttributeArguments: return "derivativeRegistrationAttributeArguments"
     case .designatedType: return "designatedTypeElement"

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -131,7 +131,7 @@ public extension Child {
       preconditionChoices.append(
         ExprSyntax(
           SequenceExprSyntax {
-            IdentifierExprSyntax(identifier: .identifier(varName))
+            DeclReferenceExprSyntax(baseName: .identifier(varName))
             BinaryOperatorExprSyntax(text: "==")
             NilLiteralExprSyntax()
           }
@@ -142,7 +142,7 @@ public extension Child {
       preconditionChoices.append(
         ExprSyntax(
           SequenceExprSyntax {
-            MemberAccessExprSyntax(base: type.forceUnwrappedIfNeeded(expr: IdentifierExprSyntax(identifier: .identifier(varName))), name: "text")
+            MemberAccessExprSyntax(base: type.forceUnwrappedIfNeeded(expr: DeclReferenceExprSyntax(baseName: .identifier(varName))), name: "text")
             BinaryOperatorExprSyntax(text: "==")
             StringLiteralExprSyntax(content: textChoice)
           }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RenamedChildrenCompatibilityFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RenamedChildrenCompatibilityFile.swift
@@ -76,7 +76,7 @@ let renamedChildrenCompatibilityFile = try! SourceFileSyntax(leadingTrivia: copy
               LabeledExprSyntax(
                 label: child.varOrCaseName,
                 colon: .colonToken(),
-                expression: IdentifierExprSyntax(identifier: child.deprecatedVarName ?? child.varOrCaseName)
+                expression: DeclReferenceExprSyntax(baseName: child.deprecatedVarName ?? child.varOrCaseName)
               )
             }
           }

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -457,18 +457,6 @@ class ValidateSyntaxNodes: XCTestCase {
     assertFailuresMatchXFails(
       failures,
       expectedFailures: [
-        // MARK: DeclNameArguments
-        // FIXME: IdentifierExprSyntax etc. should probably use DeclName as child instead of Name and Arguments
-        ValidationFailure(
-          node: .qualifiedDeclName,
-          message:
-            "child 'Arguments' is named inconsistently with 'KeyPathPropertyComponentSyntax.DeclNameArguments', which has the same type ('DeclNameArgumentsSyntax')"
-        ),
-        ValidationFailure(
-          node: .declReferenceExpr,
-          message:
-            "child 'ArgumentNames' is named inconsistently with 'KeyPathPropertyComponentSyntax.DeclNameArguments', which has the same type ('DeclNameArgumentsSyntax')"
-        ),
         // MARK: Alternate names for InitializerClauseSyntax
         // The cases below don’t have intializers but just a syntactic element that happens to be spelled the same
         ValidationFailure(

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -464,11 +464,6 @@ class ValidateSyntaxNodes: XCTestCase {
           message:
             "child 'Arguments' is named inconsistently with 'IdentifierExprSyntax.DeclNameArguments', which has the same type ('DeclNameArgumentsSyntax')"
         ),
-        ValidationFailure(
-          node: .declName,
-          message:
-            "child 'Arguments' is named inconsistently with 'IdentifierExprSyntax.DeclNameArguments', which has the same type ('DeclNameArgumentsSyntax')"
-        ),
         // MARK: Alternate names for InitializerClauseSyntax
         // The cases below don’t have intializers but just a syntactic element that happens to be spelled the same
         ValidationFailure(

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -462,7 +462,12 @@ class ValidateSyntaxNodes: XCTestCase {
         ValidationFailure(
           node: .qualifiedDeclName,
           message:
-            "child 'Arguments' is named inconsistently with 'IdentifierExprSyntax.DeclNameArguments', which has the same type ('DeclNameArgumentsSyntax')"
+            "child 'Arguments' is named inconsistently with 'KeyPathPropertyComponentSyntax.DeclNameArguments', which has the same type ('DeclNameArgumentsSyntax')"
+        ),
+        ValidationFailure(
+          node: .declReferenceExpr,
+          message:
+            "child 'ArgumentNames' is named inconsistently with 'KeyPathPropertyComponentSyntax.DeclNameArguments', which has the same type ('DeclNameArgumentsSyntax')"
         ),
         // MARK: Alternate names for InitializerClauseSyntax
         // The cases below don’t have intializers but just a syntactic element that happens to be spelled the same
@@ -628,8 +633,7 @@ class ValidateSyntaxNodes: XCTestCase {
       failures,
       expectedFailures: [
         // The identifier expr / pattern nodes do actually have a child that’s the identifier
-        ValidationFailure(node: .identifierExpr, message: "child 'Identifier' should generally not contain 'Identifier'"),
-        ValidationFailure(node: .identifierPattern, message: "child 'Identifier' should generally not contain 'Identifier'"),
+        ValidationFailure(node: .identifierPattern, message: "child 'Identifier' should generally not contain 'Identifier'")
       ]
     )
   }

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -353,10 +353,10 @@ extension Parser {
       label: nil,
       colon: nil,
       expression: RawExprSyntax(
-        RawIdentifierExprSyntax(
+        RawDeclReferenceExprSyntax(
           unexpectedBeforeRole,
-          identifier: role,
-          declNameArguments: nil,
+          baseName: role,
+          argumentNames: nil,
           arena: self.arena
         )
       ),
@@ -682,9 +682,9 @@ extension Parser {
         let ident = self.eat(handle)
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
         let (targetFunction, args) = self.parseDeclNameRef([.zeroArgCompoundNames, .keywordsUsingSpecialNames, .operators])
-        let declName = RawIdentifierExprSyntax(
-          identifier: targetFunction,
-          declNameArguments: args,
+        let declName = RawDeclReferenceExprSyntax(
+          baseName: targetFunction,
+          argumentNames: args,
           arena: self.arena
         )
         let comma = self.consume(if: .comma)
@@ -827,9 +827,9 @@ extension Parser {
       .zeroArgCompoundNames,
       .operators,
     ])
-    let declName = RawIdentifierExprSyntax(
-      identifier: name,
-      declNameArguments: args,
+    let declName = RawDeclReferenceExprSyntax(
+      baseName: name,
+      argumentNames: args,
       arena: self.arena
     )
     return RawImplementsAttributeArgumentsSyntax(
@@ -1025,17 +1025,21 @@ extension Parser {
   mutating func parseDynamicReplacementAttributeArguments() -> RawDynamicReplacementAttributeArgumentsSyntax {
     let (unexpectedBeforeLabel, label) = self.expect(.keyword(.for))
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
-    let base: RawTokenSyntax
-    let args: RawDeclNameArgumentsSyntax?
+    let baseName: RawTokenSyntax
+    let argumentNames: RawDeclNameArgumentsSyntax?
     if label.isMissing && colon.isMissing && self.atStartOfLine {
-      base = RawTokenSyntax(missing: .identifier, arena: self.arena)
-      args = nil
+      baseName = RawTokenSyntax(missing: .identifier, arena: self.arena)
+      argumentNames = nil
     } else {
-      (base, args) = self.parseDeclNameRef([
+      (baseName, argumentNames) = self.parseDeclNameRef([
         .zeroArgCompoundNames, .keywordsUsingSpecialNames, .operators,
       ])
     }
-    let method = RawIdentifierExprSyntax(identifier: base, declNameArguments: args, arena: self.arena)
+    let method = RawDeclReferenceExprSyntax(
+      baseName: baseName,
+      argumentNames: argumentNames,
+      arena: self.arena
+    )
     return RawDynamicReplacementAttributeArgumentsSyntax(
       unexpectedBeforeLabel,
       forLabel: label,

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -682,9 +682,9 @@ extension Parser {
         let ident = self.eat(handle)
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
         let (targetFunction, args) = self.parseDeclNameRef([.zeroArgCompoundNames, .keywordsUsingSpecialNames, .operators])
-        let declName = RawDeclNameSyntax(
-          baseName: targetFunction,
-          arguments: args,
+        let declName = RawIdentifierExprSyntax(
+          identifier: targetFunction,
+          declNameArguments: args,
           arena: self.arena
         )
         let comma = self.consume(if: .comma)
@@ -1031,7 +1031,7 @@ extension Parser {
         .zeroArgCompoundNames, .keywordsUsingSpecialNames, .operators,
       ])
     }
-    let method = RawDeclNameSyntax(baseName: base, arguments: args, arena: self.arena)
+    let method = RawIdentifierExprSyntax(identifier: base, declNameArguments: args, arena: self.arena)
     return RawDynamicReplacementAttributeArgumentsSyntax(
       unexpectedBeforeLabel,
       forLabel: label,

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -827,12 +827,16 @@ extension Parser {
       .zeroArgCompoundNames,
       .operators,
     ])
+    let declName = RawIdentifierExprSyntax(
+      identifier: name,
+      declNameArguments: args,
+      arena: self.arena
+    )
     return RawImplementsAttributeArgumentsSyntax(
       type: type,
       unexpectedBeforeComma,
       comma: comma,
-      declBaseName: name,
-      declNameArguments: args,
+      declName: declName,
       arena: self.arena
     )
   }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1166,10 +1166,10 @@ extension Parser {
     case (.poundAvailable, _)?, (.poundUnavailable, _)?:
       let poundAvailable = self.parsePoundAvailableConditionElement()
       return RawExprSyntax(
-        RawIdentifierExprSyntax(
+        RawDeclReferenceExprSyntax(
           RawUnexpectedNodesSyntax([poundAvailable], arena: self.arena),
-          identifier: missingToken(.identifier),
-          declNameArguments: nil,
+          baseName: missingToken(.identifier),
+          argumentNames: nil,
           arena: self.arena
         )
       )
@@ -1247,28 +1247,28 @@ extension Parser {
 extension Parser {
   /// Parse an identifier as an expression.
   mutating func parseIdentifierExpression() -> RawExprSyntax {
-    let (name, args) = self.parseDeclNameRef(.compoundNames)
+    let (baseName, argumentNames) = self.parseDeclNameRef(.compoundNames)
     guard self.withLookahead({ $0.canParseAsGenericArgumentList() }) else {
-      if name.tokenText.isEditorPlaceholder && args == nil {
+      if baseName.tokenText.isEditorPlaceholder && argumentNames == nil {
         return RawExprSyntax(
           RawEditorPlaceholderExprSyntax(
-            placeholder: name,
+            placeholder: baseName,
             arena: self.arena
           )
         )
       }
       return RawExprSyntax(
-        RawIdentifierExprSyntax(
-          identifier: name,
-          declNameArguments: args,
+        RawDeclReferenceExprSyntax(
+          baseName: baseName,
+          argumentNames: argumentNames,
           arena: self.arena
         )
       )
     }
 
-    let identifier = RawIdentifierExprSyntax(
-      identifier: name,
-      declNameArguments: args,
+    let identifier = RawDeclReferenceExprSyntax(
+      baseName: baseName,
+      argumentNames: argumentNames,
       arena: self.arena
     )
     let generics = self.parseGenericArguments()
@@ -1634,12 +1634,12 @@ extension Parser {
 }
 
 extension Parser {
-  mutating func parseAnonymousClosureArgument() -> RawIdentifierExprSyntax {
-    let (unexpectedBeforeIdent, ident) = self.expect(.dollarIdentifier)
-    return RawIdentifierExprSyntax(
-      unexpectedBeforeIdent,
-      identifier: ident,
-      declNameArguments: nil,
+  mutating func parseAnonymousClosureArgument() -> RawDeclReferenceExprSyntax {
+    let (unexpectedBeforeBaseName, baseName) = self.expect(.dollarIdentifier)
+    return RawDeclReferenceExprSyntax(
+      unexpectedBeforeBaseName,
+      baseName: baseName,
+      argumentNames: nil,
       arena: self.arena
     )
   }
@@ -1898,11 +1898,11 @@ extension Parser {
       // follows a proper subexpression.
       let expr: RawExprSyntax
       if self.at(.binaryOperator) && self.peek(isAt: .comma, .rightParen, .rightSquare) {
-        let (ident, args) = self.parseDeclNameRef(.operators)
+        let (baseName, argumentNames) = self.parseDeclNameRef(.operators)
         expr = RawExprSyntax(
-          RawIdentifierExprSyntax(
-            identifier: ident,
-            declNameArguments: args,
+          RawDeclReferenceExprSyntax(
+            baseName: baseName,
+            argumentNames: argumentNames,
             arena: self.arena
           )
         )

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -160,8 +160,11 @@ extension Parser {
     return RawQualifiedDeclNameSyntax(
       baseType: type,
       period: period,
-      name: name,
-      arguments: args,
+      declName: RawDeclReferenceExprSyntax(
+        baseName: name,
+        argumentNames: args,
+        arena: self.arena
+      ),
       arena: self.arena
     )
   }

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -63,7 +63,7 @@ extension Parser {
     static let zeroArgCompoundNames: Self = [.compoundNames, Self(rawValue: 1 << 5)]
   }
 
-  mutating func parseDeclNameRef(_ flags: DeclNameOptions = []) -> (baseName: RawTokenSyntax, argumentNames: RawDeclNameArgumentsSyntax?) {
+  mutating func parseDeclReferenceExpr(_ flags: DeclNameOptions = []) -> RawDeclReferenceExprSyntax {
     // Consume the base name.
     let base: RawTokenSyntax
     if let identOrSelf = self.consume(if: .identifier, .keyword(.self), .keyword(.Self)) ?? self.consume(if: .keyword(.`init`)) {
@@ -78,7 +78,11 @@ extension Parser {
 
     // Parse an argument list, if the flags allow it and it's present.
     let args = self.parseArgLabelList(flags)
-    return (base, args)
+    return RawDeclReferenceExprSyntax(
+      baseName: base,
+      argumentNames: args,
+      arena: self.arena
+    )
   }
 
   mutating func parseArgLabelList(_ flags: DeclNameOptions) -> RawDeclNameArgumentsSyntax? {
@@ -152,7 +156,7 @@ extension Parser {
       period = nil
     }
 
-    let (name, args) = self.parseDeclNameRef([
+    let declName = self.parseDeclReferenceExpr([
       .zeroArgCompoundNames,
       .keywordsUsingSpecialNames,
       .operators,
@@ -160,11 +164,7 @@ extension Parser {
     return RawQualifiedDeclNameSyntax(
       baseType: type,
       period: period,
-      declName: RawDeclReferenceExprSyntax(
-        baseName: name,
-        argumentNames: args,
-        arena: self.arena
-      ),
+      declName: declName,
       arena: self.arena
     )
   }

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -63,7 +63,7 @@ extension Parser {
     static let zeroArgCompoundNames: Self = [.compoundNames, Self(rawValue: 1 << 5)]
   }
 
-  mutating func parseDeclNameRef(_ flags: DeclNameOptions = []) -> (RawTokenSyntax, RawDeclNameArgumentsSyntax?) {
+  mutating func parseDeclNameRef(_ flags: DeclNameOptions = []) -> (baseName: RawTokenSyntax, argumentNames: RawDeclNameArgumentsSyntax?) {
     // Consume the base name.
     let base: RawTokenSyntax
     if let identOrSelf = self.consume(if: .identifier, .keyword(.self), .keyword(.Self)) ?? self.consume(if: .keyword(.`init`)) {

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -1659,48 +1659,6 @@ extension PrecedenceGroupRelationSyntax {
   }
 }
 
-extension QualifiedDeclNameSyntax {
-  enum NameOptions: TokenSpecSet {
-    case identifier
-    case `self`
-    case `Self`
-    case `init`
-    case binaryOperator
-    
-    init?(lexeme: Lexer.Lexeme) {
-      switch PrepareForKeywordMatch(lexeme) {
-      case TokenSpec(.identifier):
-        self = .identifier
-      case TokenSpec(.`self`):
-        self = .`self`
-      case TokenSpec(.`Self`):
-        self = .`Self`
-      case TokenSpec(.`init`):
-        self = .`init`
-      case TokenSpec(.binaryOperator):
-        self = .binaryOperator
-      default:
-        return nil
-      }
-    }
-    
-    var spec: TokenSpec {
-      switch self {
-      case .identifier:
-        return .identifier
-      case .`self`:
-        return .keyword(.`self`)
-      case .`Self`:
-        return .keyword(.`Self`)
-      case .`init`:
-        return .keyword(.`init`)
-      case .binaryOperator:
-        return .binaryOperator
-      }
-    }
-  }
-}
-
 extension SameTypeRequirementSyntax {
   enum EqualOptions: TokenSpecSet {
     case binaryOperator

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -660,6 +660,7 @@ extension DeclReferenceExprSyntax {
     case `init`
     case dollarIdentifier
     case binaryOperator
+    case integerLiteral
     
     init?(lexeme: Lexer.Lexeme) {
       switch PrepareForKeywordMatch(lexeme) {
@@ -675,6 +676,8 @@ extension DeclReferenceExprSyntax {
         self = .dollarIdentifier
       case TokenSpec(.binaryOperator):
         self = .binaryOperator
+      case TokenSpec(.integerLiteral):
+        self = .integerLiteral
       default:
         return nil
       }
@@ -694,6 +697,8 @@ extension DeclReferenceExprSyntax {
         return .dollarIdentifier
       case .binaryOperator:
         return .binaryOperator
+      case .integerLiteral:
+        return .integerLiteral
       }
     }
   }
@@ -1302,58 +1307,6 @@ extension KeyPathOptionalComponentSyntax {
         return .postfixQuestionMark
       case .exclamationMark:
         return .exclamationMark
-      }
-    }
-  }
-}
-
-extension KeyPathPropertyComponentSyntax {
-  enum PropertyOptions: TokenSpecSet {
-    case identifier
-    case `self`
-    case `Self`
-    case `init`
-    case dollarIdentifier
-    case binaryOperator
-    case integerLiteral
-    
-    init?(lexeme: Lexer.Lexeme) {
-      switch PrepareForKeywordMatch(lexeme) {
-      case TokenSpec(.identifier):
-        self = .identifier
-      case TokenSpec(.`self`):
-        self = .`self`
-      case TokenSpec(.`Self`):
-        self = .`Self`
-      case TokenSpec(.`init`):
-        self = .`init`
-      case TokenSpec(.dollarIdentifier):
-        self = .dollarIdentifier
-      case TokenSpec(.binaryOperator):
-        self = .binaryOperator
-      case TokenSpec(.integerLiteral):
-        self = .integerLiteral
-      default:
-        return nil
-      }
-    }
-    
-    var spec: TokenSpec {
-      switch self {
-      case .identifier:
-        return .identifier
-      case .`self`:
-        return .keyword(.`self`)
-      case .`Self`:
-        return .keyword(.`Self`)
-      case .`init`:
-        return .keyword(.`init`)
-      case .dollarIdentifier:
-        return .dollarIdentifier
-      case .binaryOperator:
-        return .binaryOperator
-      case .integerLiteral:
-        return .integerLiteral
       }
     }
   }

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -652,6 +652,53 @@ extension DeclModifierSyntax {
   }
 }
 
+extension DeclReferenceExprSyntax {
+  enum BaseNameOptions: TokenSpecSet {
+    case identifier
+    case `self`
+    case `Self`
+    case `init`
+    case dollarIdentifier
+    case binaryOperator
+    
+    init?(lexeme: Lexer.Lexeme) {
+      switch PrepareForKeywordMatch(lexeme) {
+      case TokenSpec(.identifier):
+        self = .identifier
+      case TokenSpec(.`self`):
+        self = .`self`
+      case TokenSpec(.`Self`):
+        self = .`Self`
+      case TokenSpec(.`init`):
+        self = .`init`
+      case TokenSpec(.dollarIdentifier):
+        self = .dollarIdentifier
+      case TokenSpec(.binaryOperator):
+        self = .binaryOperator
+      default:
+        return nil
+      }
+    }
+    
+    var spec: TokenSpec {
+      switch self {
+      case .identifier:
+        return .identifier
+      case .`self`:
+        return .keyword(.`self`)
+      case .`Self`:
+        return .keyword(.`Self`)
+      case .`init`:
+        return .keyword(.`init`)
+      case .dollarIdentifier:
+        return .dollarIdentifier
+      case .binaryOperator:
+        return .binaryOperator
+      }
+    }
+  }
+}
+
 extension DerivativeAttributeArgumentsSyntax {
   enum AccessorSpecifierOptions: TokenSpecSet {
     case get
@@ -991,53 +1038,6 @@ extension FunctionParameterSyntax {
         return .identifier
       case .wildcard:
         return .wildcard
-      }
-    }
-  }
-}
-
-extension IdentifierExprSyntax {
-  enum IdentifierOptions: TokenSpecSet {
-    case identifier
-    case `self`
-    case `Self`
-    case `init`
-    case dollarIdentifier
-    case binaryOperator
-    
-    init?(lexeme: Lexer.Lexeme) {
-      switch PrepareForKeywordMatch(lexeme) {
-      case TokenSpec(.identifier):
-        self = .identifier
-      case TokenSpec(.`self`):
-        self = .`self`
-      case TokenSpec(.`Self`):
-        self = .`Self`
-      case TokenSpec(.`init`):
-        self = .`init`
-      case TokenSpec(.dollarIdentifier):
-        self = .dollarIdentifier
-      case TokenSpec(.binaryOperator):
-        self = .binaryOperator
-      default:
-        return nil
-      }
-    }
-    
-    var spec: TokenSpec {
-      switch self {
-      case .identifier:
-        return .identifier
-      case .`self`:
-        return .keyword(.`self`)
-      case .`Self`:
-        return .keyword(.`Self`)
-      case .`init`:
-        return .keyword(.`init`)
-      case .dollarIdentifier:
-        return .dollarIdentifier
-      case .binaryOperator:
-        return .binaryOperator
       }
     }
   }

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -652,48 +652,6 @@ extension DeclModifierSyntax {
   }
 }
 
-extension DeclNameSyntax {
-  enum BaseNameOptions: TokenSpecSet {
-    case identifier
-    case binaryOperator
-    case `init`
-    case `self`
-    case `Self`
-    
-    init?(lexeme: Lexer.Lexeme) {
-      switch PrepareForKeywordMatch(lexeme) {
-      case TokenSpec(.identifier):
-        self = .identifier
-      case TokenSpec(.binaryOperator):
-        self = .binaryOperator
-      case TokenSpec(.`init`):
-        self = .`init`
-      case TokenSpec(.`self`):
-        self = .`self`
-      case TokenSpec(.`Self`):
-        self = .`Self`
-      default:
-        return nil
-      }
-    }
-    
-    var spec: TokenSpec {
-      switch self {
-      case .identifier:
-        return .identifier
-      case .binaryOperator:
-        return .binaryOperator
-      case .`init`:
-        return .keyword(.`init`)
-      case .`self`:
-        return .keyword(.`self`)
-      case .`Self`:
-        return .keyword(.`Self`)
-      }
-    }
-  }
-}
-
 extension DerivativeAttributeArgumentsSyntax {
   enum AccessorSpecifierOptions: TokenSpecSet {
     case get

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -1034,13 +1034,13 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     return .visitChildren
   }
 
-  public override func visit(_ node: IdentifierExprSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
     if shouldSkip(node) {
       return .skipChildren
     }
-    if node.identifier.isMissing, let unexpected = node.unexpectedBeforeIdentifier {
+    if node.baseName.isMissing, let unexpected = node.unexpectedBeforeBaseName {
       if unexpected.first?.as(TokenSyntax.self)?.tokenKind == .pound {
-        addDiagnostic(unexpected, UnknownDirectiveError(unexpected: unexpected), handledNodes: [unexpected.id, node.identifier.id])
+        addDiagnostic(unexpected, UnknownDirectiveError(unexpected: unexpected), handledNodes: [unexpected.id, node.baseName.id])
       } else if let availability = unexpected.first?.as(AvailabilityConditionSyntax.self) {
         if let prefixOperatorExpr = node.parent?.as(PrefixOperatorExprSyntax.self),
           let operatorToken = prefixOperatorExpr.operator,
@@ -1065,10 +1065,10 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
                 ]
               )
             ],
-            handledNodes: [unexpected.id, node.identifier.id]
+            handledNodes: [unexpected.id, node.baseName.id]
           )
         } else {
-          addDiagnostic(unexpected, AvailabilityConditionInExpression(availabilityCondition: availability), handledNodes: [unexpected.id, node.identifier.id])
+          addDiagnostic(unexpected, AvailabilityConditionInExpression(availabilityCondition: availability), handledNodes: [unexpected.id, node.baseName.id])
         }
       }
     }

--- a/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
@@ -180,10 +180,8 @@ private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
     return "else body"
   case \ImplementsAttributeArgumentsSyntax.type:
     return "type"
-  case \ImplementsAttributeArgumentsSyntax.declBaseName:
-    return "declaration base name"
-  case \ImplementsAttributeArgumentsSyntax.declNameArguments:
-    return "declaration name arguments"
+  case \ImplementsAttributeArgumentsSyntax.declName:
+    return "declaration name"
   case \ImportDeclSyntax.attributes:
     return "attributes"
   case \ImportDeclSyntax.modifiers:

--- a/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
@@ -78,10 +78,6 @@ private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
     return "statements"
   case \ContinueStmtSyntax.label:
     return "label"
-  case \DeclNameSyntax.baseName:
-    return "base name"
-  case \DeclNameSyntax.arguments:
-    return "arguments"
   case \DeinitializerDeclSyntax.attributes:
     return "attributes"
   case \DeinitializerDeclSyntax.modifiers:

--- a/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
@@ -236,7 +236,7 @@ private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
     return "modifiers"
   case \MemberAccessExprSyntax.base:
     return "base"
-  case \MemberAccessExprSyntax.name:
+  case \MemberAccessExprSyntax.declName:
     return "name"
   case \MemberTypeSyntax.baseType:
     return "base type"

--- a/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
@@ -284,10 +284,8 @@ private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
     return "generic where clause"
   case \QualifiedDeclNameSyntax.baseType:
     return "base type"
-  case \QualifiedDeclNameSyntax.name:
-    return "base name"
-  case \QualifiedDeclNameSyntax.arguments:
-    return "arguments"
+  case \QualifiedDeclNameSyntax.declName:
+    return "name"
   case \RepeatStmtSyntax.body:
     return "body"
   case \RepeatStmtSyntax.condition:

--- a/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
@@ -105,8 +105,6 @@ extension SyntaxKind {
       return "'copy' expression"
     case .declModifier:
       return "modifier"
-    case .declName:
-      return "declaration name"
     case .deferStmt:
       return "'defer' statement"
     case .deinitializerDecl:

--- a/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
+++ b/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
@@ -43,9 +43,9 @@ public struct MigrateToNewIfLetSyntax: SyntaxRefactoringProvider {
         // ... that binds an identifier (and not a tuple) ...
         let bindingIdentifier = binding.pattern.as(IdentifierPatternSyntax.self),
         // ... and has an initializer that is also an identifier ...
-        let initializerIdentifier = binding.initializer?.value.as(IdentifierExprSyntax.self),
+        let initializerIdentifier = binding.initializer?.value.as(DeclReferenceExprSyntax.self),
         // ... and both sides of the assignment are the same identifiers.
-        bindingIdentifier.identifier.text == initializerIdentifier.identifier.text
+        bindingIdentifier.identifier.text == initializerIdentifier.baseName.text
       {
         // Remove the initializer ...
         binding.initializer = nil

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -11,6 +11,7 @@ add_swift_host_library(SwiftSyntax
   Assert.swift
   BumpPtrAllocator.swift
   CommonAncestor.swift
+  Convenience.swift
   MemoryLayout.swift
   MissingNodeInitializers.swift
   Trivia.swift

--- a/Sources/SwiftSyntax/Convenience.swift
+++ b/Sources/SwiftSyntax/Convenience.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension MemberAccessExprSyntax {
+  /// Creates a new ``MemberAccessExprSyntax`` where the accessed member is represented by
+  /// an identifier without specifying argument labels.
+  ///
+  /// A member access can specify function argument labels, which is required
+  /// when the name would be ambiguous otherwise. For example, given multiple overloads
+  /// ```swift
+  /// struct Person {
+  ///   func consume(drink: Drink) {}
+  ///   func consume(food: Food) {}
+  /// }
+  /// ```
+  ///
+  /// `consume(drink:)` is required to explicitly reference the consume function
+  /// that takes a drink.
+  ///
+  /// Given how common it is to not need the argument names, this initializer is
+  /// provided as a convenience to avoid having to create a ``DeclReferenceExpr``
+  /// for the member name.
+  public init(
+    leadingTrivia: Trivia? = nil,
+    base: (some ExprSyntaxProtocol)? = ExprSyntax?.none,
+    period: TokenSyntax = .periodToken(),
+    name: TokenSyntax,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      base: base,
+      period: period,
+      declName: DeclReferenceExprSyntax(baseName: name),
+      trailingTrivia: trailingTrivia
+    )
+  }
+}

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -106,6 +106,7 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/ClosureExprSyntax>
 - <doc:SwiftSyntax/ConsumeExprSyntax>
 - <doc:SwiftSyntax/CopyExprSyntax>
+- <doc:SwiftSyntax/DeclReferenceExprSyntax>
 - <doc:SwiftSyntax/DictionaryExprSyntax>
 - <doc:SwiftSyntax/DiscardAssignmentExprSyntax>
 - <doc:SwiftSyntax/EditorPlaceholderExprSyntax>
@@ -113,7 +114,6 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/ForceUnwrapExprSyntax>
 - <doc:SwiftSyntax/FunctionCallExprSyntax>
 - <doc:SwiftSyntax/GenericSpecializationExprSyntax>
-- <doc:SwiftSyntax/IdentifierExprSyntax>
 - <doc:SwiftSyntax/IfExprSyntax>
 - <doc:SwiftSyntax/InOutExprSyntax>
 - <doc:SwiftSyntax/InfixOperatorExprSyntax>

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -321,7 +321,6 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/ConventionWitnessMethodAttributeArgumentsSyntax>
 - <doc:SwiftSyntax/DeclModifierDetailSyntax>
 - <doc:SwiftSyntax/DeclNameArgumentsSyntax>
-- <doc:SwiftSyntax/DeclNameSyntax>
 - <doc:SwiftSyntax/DeinitializerEffectSpecifiersSyntax>
 - <doc:SwiftSyntax/DerivativeAttributeArgumentsSyntax>
 - <doc:SwiftSyntax/DifferentiabilityArgumentsSyntax>

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -77,6 +77,51 @@ extension IdentifiedDeclSyntax where Self: NamedDeclSyntax {
   }
 }
 
+extension MemberAccessExprSyntax {
+  @available(*, deprecated, renamed: "declName.baseName")
+  public var name: TokenSyntax {
+    return declName.baseName
+  }
+
+  @available(*, deprecated, renamed: "declName.argumentNames")
+  public var declNameArguments: DeclNameArgumentsSyntax? {
+    return declName.argumentNames
+  }
+
+  @available(*, deprecated, message: "Use initializer taking `DeclReferenceExprSyntax` instead")
+  @_disfavoredOverload
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
+    base: (some ExprSyntaxProtocol)? = ExprSyntax?.none,
+    _ unexpectedBetweenBaseAndPeriod: UnexpectedNodesSyntax? = nil,
+    dot: TokenSyntax = .periodToken(),
+    _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
+    declNameArguments: DeclNameArgumentsSyntax? = nil,
+    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    let declName = DeclReferenceExprSyntax(
+      baseName: name,
+      unexpectedBetweenNameAndDeclNameArguments,
+      argumentNames: declNameArguments
+    )
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeBase,
+      base: base,
+      unexpectedBetweenBaseAndPeriod,
+      period: dot,
+      unexpectedBetweenPeriodAndName,
+      declName: declName,
+      unexpectedAfterDeclNameArguments,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
 public extension SyntaxProtocol {
   @available(*, deprecated, message: "Use detached computed property instead.")
   func detach() -> Self {

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -793,16 +793,6 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "rightParen"
   case \DeclNameArgumentsSyntax.unexpectedAfterRightParen:
     return "unexpectedAfterRightParen"
-  case \DeclNameSyntax.unexpectedBeforeBaseName:
-    return "unexpectedBeforeBaseName"
-  case \DeclNameSyntax.baseName:
-    return "baseName"
-  case \DeclNameSyntax.unexpectedBetweenBaseNameAndArguments:
-    return "unexpectedBetweenBaseNameAndArguments"
-  case \DeclNameSyntax.arguments:
-    return "arguments"
-  case \DeclNameSyntax.unexpectedAfterArguments:
-    return "unexpectedAfterArguments"
   case \DeferStmtSyntax.unexpectedBeforeDeferKeyword:
     return "unexpectedBeforeDeferKeyword"
   case \DeferStmtSyntax.deferKeyword:

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -1873,16 +1873,12 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "questionOrExclamationMark"
   case \KeyPathOptionalComponentSyntax.unexpectedAfterQuestionOrExclamationMark:
     return "unexpectedAfterQuestionOrExclamationMark"
-  case \KeyPathPropertyComponentSyntax.unexpectedBeforeProperty:
-    return "unexpectedBeforeProperty"
-  case \KeyPathPropertyComponentSyntax.property:
-    return "property"
-  case \KeyPathPropertyComponentSyntax.unexpectedBetweenPropertyAndDeclNameArguments:
-    return "unexpectedBetweenPropertyAndDeclNameArguments"
-  case \KeyPathPropertyComponentSyntax.declNameArguments:
-    return "declNameArguments"
-  case \KeyPathPropertyComponentSyntax.unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause:
-    return "unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause"
+  case \KeyPathPropertyComponentSyntax.unexpectedBeforeDeclName:
+    return "unexpectedBeforeDeclName"
+  case \KeyPathPropertyComponentSyntax.declName:
+    return "declName"
+  case \KeyPathPropertyComponentSyntax.unexpectedBetweenDeclNameAndGenericArgumentClause:
+    return "unexpectedBetweenDeclNameAndGenericArgumentClause"
   case \KeyPathPropertyComponentSyntax.genericArgumentClause:
     return "genericArgumentClause"
   case \KeyPathPropertyComponentSyntax.unexpectedAfterGenericArgumentClause:
@@ -2121,16 +2117,12 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "unexpectedBetweenBaseAndPeriod"
   case \MemberAccessExprSyntax.period:
     return "period"
-  case \MemberAccessExprSyntax.unexpectedBetweenPeriodAndName:
-    return "unexpectedBetweenPeriodAndName"
-  case \MemberAccessExprSyntax.name:
-    return "name"
-  case \MemberAccessExprSyntax.unexpectedBetweenNameAndDeclNameArguments:
-    return "unexpectedBetweenNameAndDeclNameArguments"
-  case \MemberAccessExprSyntax.declNameArguments:
-    return "declNameArguments"
-  case \MemberAccessExprSyntax.unexpectedAfterDeclNameArguments:
-    return "unexpectedAfterDeclNameArguments"
+  case \MemberAccessExprSyntax.unexpectedBetweenPeriodAndDeclName:
+    return "unexpectedBetweenPeriodAndDeclName"
+  case \MemberAccessExprSyntax.declName:
+    return "declName"
+  case \MemberAccessExprSyntax.unexpectedAfterDeclName:
+    return "unexpectedAfterDeclName"
   case \MemberBlockItemSyntax.unexpectedBeforeDecl:
     return "unexpectedBeforeDecl"
   case \MemberBlockItemSyntax.decl:

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -1677,16 +1677,12 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "unexpectedBetweenTypeAndComma"
   case \ImplementsAttributeArgumentsSyntax.comma:
     return "comma"
-  case \ImplementsAttributeArgumentsSyntax.unexpectedBetweenCommaAndDeclBaseName:
-    return "unexpectedBetweenCommaAndDeclBaseName"
-  case \ImplementsAttributeArgumentsSyntax.declBaseName:
-    return "declBaseName"
-  case \ImplementsAttributeArgumentsSyntax.unexpectedBetweenDeclBaseNameAndDeclNameArguments:
-    return "unexpectedBetweenDeclBaseNameAndDeclNameArguments"
-  case \ImplementsAttributeArgumentsSyntax.declNameArguments:
-    return "declNameArguments"
-  case \ImplementsAttributeArgumentsSyntax.unexpectedAfterDeclNameArguments:
-    return "unexpectedAfterDeclNameArguments"
+  case \ImplementsAttributeArgumentsSyntax.unexpectedBetweenCommaAndDeclName:
+    return "unexpectedBetweenCommaAndDeclName"
+  case \ImplementsAttributeArgumentsSyntax.declName:
+    return "declName"
+  case \ImplementsAttributeArgumentsSyntax.unexpectedAfterDeclName:
+    return "unexpectedAfterDeclName"
   case \ImplicitlyUnwrappedOptionalTypeSyntax.unexpectedBeforeWrappedType:
     return "unexpectedBeforeWrappedType"
   case \ImplicitlyUnwrappedOptionalTypeSyntax.wrappedType:

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -2683,16 +2683,12 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "unexpectedBetweenBaseTypeAndPeriod"
   case \QualifiedDeclNameSyntax.period:
     return "period"
-  case \QualifiedDeclNameSyntax.unexpectedBetweenPeriodAndName:
-    return "unexpectedBetweenPeriodAndName"
-  case \QualifiedDeclNameSyntax.name:
-    return "name"
-  case \QualifiedDeclNameSyntax.unexpectedBetweenNameAndArguments:
-    return "unexpectedBetweenNameAndArguments"
-  case \QualifiedDeclNameSyntax.arguments:
-    return "arguments"
-  case \QualifiedDeclNameSyntax.unexpectedAfterArguments:
-    return "unexpectedAfterArguments"
+  case \QualifiedDeclNameSyntax.unexpectedBetweenPeriodAndDeclName:
+    return "unexpectedBetweenPeriodAndDeclName"
+  case \QualifiedDeclNameSyntax.declName:
+    return "declName"
+  case \QualifiedDeclNameSyntax.unexpectedAfterDeclName:
+    return "unexpectedAfterDeclName"
   case \RegexLiteralExprSyntax.unexpectedBeforeOpeningPounds:
     return "unexpectedBeforeOpeningPounds"
   case \RegexLiteralExprSyntax.openingPounds:

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -793,6 +793,16 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "rightParen"
   case \DeclNameArgumentsSyntax.unexpectedAfterRightParen:
     return "unexpectedAfterRightParen"
+  case \DeclReferenceExprSyntax.unexpectedBeforeBaseName:
+    return "unexpectedBeforeBaseName"
+  case \DeclReferenceExprSyntax.baseName:
+    return "baseName"
+  case \DeclReferenceExprSyntax.unexpectedBetweenBaseNameAndArgumentNames:
+    return "unexpectedBetweenBaseNameAndArgumentNames"
+  case \DeclReferenceExprSyntax.argumentNames:
+    return "argumentNames"
+  case \DeclReferenceExprSyntax.unexpectedAfterArgumentNames:
+    return "unexpectedAfterArgumentNames"
   case \DeferStmtSyntax.unexpectedBeforeDeferKeyword:
     return "unexpectedBeforeDeferKeyword"
   case \DeferStmtSyntax.deferKeyword:
@@ -1597,16 +1607,6 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "body"
   case \GuardStmtSyntax.unexpectedAfterBody:
     return "unexpectedAfterBody"
-  case \IdentifierExprSyntax.unexpectedBeforeIdentifier:
-    return "unexpectedBeforeIdentifier"
-  case \IdentifierExprSyntax.identifier:
-    return "identifier"
-  case \IdentifierExprSyntax.unexpectedBetweenIdentifierAndDeclNameArguments:
-    return "unexpectedBetweenIdentifierAndDeclNameArguments"
-  case \IdentifierExprSyntax.declNameArguments:
-    return "declNameArguments"
-  case \IdentifierExprSyntax.unexpectedAfterDeclNameArguments:
-    return "unexpectedAfterDeclNameArguments"
   case \IdentifierPatternSyntax.unexpectedBeforeIdentifier:
     return "unexpectedBeforeIdentifier"
   case \IdentifierPatternSyntax.identifier:

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -4405,45 +4405,43 @@ extension IsExprSyntax {
 }
 
 extension KeyPathPropertyComponentSyntax {
-  @available(*, deprecated, renamed: "unexpectedBeforeProperty")
+  @available(*, deprecated, renamed: "unexpectedBeforeDeclName")
   public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
     get {
-      return unexpectedBeforeProperty
+      return unexpectedBeforeDeclName
     }
     set {
-      unexpectedBeforeProperty = newValue
+      unexpectedBeforeDeclName = newValue
     }
   }
   
-  @available(*, deprecated, renamed: "property")
-  public var identifier: TokenSyntax {
+  @available(*, deprecated, renamed: "declName")
+  public var identifier: DeclReferenceExprSyntax {
     get {
-      return property
+      return declName
     }
     set {
-      property = newValue
+      declName = newValue
     }
   }
   
-  @available(*, deprecated, renamed: "unexpectedBetweenPropertyAndDeclNameArguments")
-  public var unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? {
+  @available(*, deprecated, renamed: "unexpectedBetweenDeclNameAndGenericArgumentClause")
+  public var unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? {
     get {
-      return unexpectedBetweenPropertyAndDeclNameArguments
+      return unexpectedBetweenDeclNameAndGenericArgumentClause
     }
     set {
-      unexpectedBetweenPropertyAndDeclNameArguments = newValue
+      unexpectedBetweenDeclNameAndGenericArgumentClause = newValue
     }
   }
   
-  @available(*, deprecated, message: "Use an initializer with property argument(s).")
+  @available(*, deprecated, message: "Use an initializer with declName argument(s).")
   @_disfavoredOverload
   public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
-      identifier: TokenSyntax,
-      _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-      declNameArguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
+      identifier: DeclReferenceExprSyntax,
+      _ unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
       genericArgumentClause: GenericArgumentClauseSyntax? = nil,
       _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
@@ -4452,10 +4450,8 @@ extension KeyPathPropertyComponentSyntax {
     self.init(
         leadingTrivia: leadingTrivia, 
         unexpectedBeforeIdentifier, 
-        property: identifier, 
-        unexpectedBetweenIdentifierAndDeclNameArguments, 
-        declNameArguments: declNameArguments, 
-        unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause, 
+        declName: identifier, 
+        unexpectedBetweenIdentifierAndGenericArgumentClause, 
         genericArgumentClause: genericArgumentClause, 
         unexpectedAfterGenericArgumentClause, 
         trailingTrivia: trailingTrivia
@@ -5156,13 +5152,13 @@ extension MemberAccessExprSyntax {
     }
   }
   
-  @available(*, deprecated, renamed: "unexpectedBetweenPeriodAndName")
-  public var unexpectedBetweenDotAndName: UnexpectedNodesSyntax? {
+  @available(*, deprecated, renamed: "unexpectedBetweenPeriodAndDeclName")
+  public var unexpectedBetweenDotAndDeclName: UnexpectedNodesSyntax? {
     get {
-      return unexpectedBetweenPeriodAndName
+      return unexpectedBetweenPeriodAndDeclName
     }
     set {
-      unexpectedBetweenPeriodAndName = newValue
+      unexpectedBetweenPeriodAndDeclName = newValue
     }
   }
   
@@ -5174,11 +5170,9 @@ extension MemberAccessExprSyntax {
       base: (some ExprSyntaxProtocol)? = ExprSyntax?.none,
       _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil,
       dot: TokenSyntax = .periodToken(),
-      _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
-      name: TokenSyntax,
-      _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-      declNameArguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenDotAndDeclName: UnexpectedNodesSyntax? = nil,
+      declName: DeclReferenceExprSyntax,
+      _ unexpectedAfterDeclName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -5188,11 +5182,9 @@ extension MemberAccessExprSyntax {
         base: base, 
         unexpectedBetweenBaseAndDot, 
         period: dot, 
-        unexpectedBetweenDotAndName, 
-        name: name, 
-        unexpectedBetweenNameAndDeclNameArguments, 
-        declNameArguments: declNameArguments, 
-        unexpectedAfterDeclNameArguments, 
+        unexpectedBetweenDotAndDeclName, 
+        declName: declName, 
+        unexpectedAfterDeclName, 
         trailingTrivia: trailingTrivia
       )
   }

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -6616,13 +6616,13 @@ extension QualifiedDeclNameSyntax {
     }
   }
   
-  @available(*, deprecated, renamed: "unexpectedBetweenPeriodAndName")
-  public var unexpectedBetweenDotAndName: UnexpectedNodesSyntax? {
+  @available(*, deprecated, renamed: "unexpectedBetweenPeriodAndDeclName")
+  public var unexpectedBetweenDotAndDeclName: UnexpectedNodesSyntax? {
     get {
-      return unexpectedBetweenPeriodAndName
+      return unexpectedBetweenPeriodAndDeclName
     }
     set {
-      unexpectedBetweenPeriodAndName = newValue
+      unexpectedBetweenPeriodAndDeclName = newValue
     }
   }
   
@@ -6634,11 +6634,9 @@ extension QualifiedDeclNameSyntax {
       baseType: (some TypeSyntaxProtocol)? = TypeSyntax?.none,
       _ unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? = nil,
       dot: TokenSyntax? = nil,
-      _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
-      name: TokenSyntax,
-      _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil,
-      arguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenDotAndDeclName: UnexpectedNodesSyntax? = nil,
+      declName: DeclReferenceExprSyntax,
+      _ unexpectedAfterDeclName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -6648,11 +6646,9 @@ extension QualifiedDeclNameSyntax {
         baseType: baseType, 
         unexpectedBetweenBaseTypeAndDot, 
         period: dot, 
-        unexpectedBetweenDotAndName, 
-        name: name, 
-        unexpectedBetweenNameAndArguments, 
-        arguments: arguments, 
-        unexpectedAfterArguments, 
+        unexpectedBetweenDotAndDeclName, 
+        declName: declName, 
+        unexpectedAfterDeclName, 
         trailingTrivia: trailingTrivia
       )
   }

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -1558,81 +1558,6 @@ extension ConsumeExprSyntax {
   }
 }
 
-extension DeclNameSyntax {
-  @available(*, deprecated, renamed: "unexpectedBeforeBaseName")
-  public var unexpectedBeforeDeclBaseName: UnexpectedNodesSyntax? {
-    get {
-      return unexpectedBeforeBaseName
-    }
-    set {
-      unexpectedBeforeBaseName = newValue
-    }
-  }
-  
-  @available(*, deprecated, renamed: "baseName")
-  public var declBaseName: TokenSyntax {
-    get {
-      return baseName
-    }
-    set {
-      baseName = newValue
-    }
-  }
-  
-  @available(*, deprecated, renamed: "unexpectedBetweenBaseNameAndArguments")
-  public var unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? {
-    get {
-      return unexpectedBetweenBaseNameAndArguments
-    }
-    set {
-      unexpectedBetweenBaseNameAndArguments = newValue
-    }
-  }
-  
-  @available(*, deprecated, renamed: "arguments")
-  public var declNameArguments: DeclNameArgumentsSyntax? {
-    get {
-      return arguments
-    }
-    set {
-      arguments = newValue
-    }
-  }
-  
-  @available(*, deprecated, renamed: "unexpectedAfterArguments")
-  public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
-    get {
-      return unexpectedAfterArguments
-    }
-    set {
-      unexpectedAfterArguments = newValue
-    }
-  }
-  
-  @available(*, deprecated, message: "Use an initializer with baseName, arguments argument(s).")
-  @_disfavoredOverload
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeDeclBaseName: UnexpectedNodesSyntax? = nil,
-      declBaseName: TokenSyntax,
-      _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-      declNameArguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia, 
-        unexpectedBeforeDeclBaseName, 
-        baseName: declBaseName, 
-        unexpectedBetweenDeclBaseNameAndDeclNameArguments, 
-        arguments: declNameArguments, 
-        unexpectedAfterDeclNameArguments, 
-        trailingTrivia: trailingTrivia
-      )
-  }
-}
-
 extension DerivativeAttributeArgumentsSyntax {
   @available(*, deprecated, renamed: "unexpectedBetweenPeriodAndAccessorSpecifier")
   public var unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodesSyntax? {
@@ -2300,7 +2225,7 @@ extension DynamicReplacementAttributeArgumentsSyntax {
   }
   
   @available(*, deprecated, renamed: "declName")
-  public var declname: DeclNameSyntax {
+  public var declname: IdentifierExprSyntax {
     get {
       return declName
     }
@@ -2328,7 +2253,7 @@ extension DynamicReplacementAttributeArgumentsSyntax {
       _ unexpectedBetweenForLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? = nil,
-      declname: DeclNameSyntax,
+      declname: IdentifierExprSyntax,
       _ unexpectedAfterDeclname: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -7118,7 +7043,7 @@ extension SpecializeTargetFunctionArgumentSyntax {
   }
   
   @available(*, deprecated, renamed: "declName")
-  public var declname: DeclNameSyntax {
+  public var declname: IdentifierExprSyntax {
     get {
       return declName
     }
@@ -7146,7 +7071,7 @@ extension SpecializeTargetFunctionArgumentSyntax {
       _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? = nil,
-      declname: DeclNameSyntax,
+      declname: IdentifierExprSyntax,
       _ unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -1558,6 +1558,81 @@ extension ConsumeExprSyntax {
   }
 }
 
+extension DeclReferenceExprSyntax {
+  @available(*, deprecated, renamed: "unexpectedBeforeBaseName")
+  public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBeforeBaseName
+    }
+    set {
+      unexpectedBeforeBaseName = newValue
+    }
+  }
+  
+  @available(*, deprecated, renamed: "baseName")
+  public var identifier: TokenSyntax {
+    get {
+      return baseName
+    }
+    set {
+      baseName = newValue
+    }
+  }
+  
+  @available(*, deprecated, renamed: "unexpectedBetweenBaseNameAndArgumentNames")
+  public var unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenBaseNameAndArgumentNames
+    }
+    set {
+      unexpectedBetweenBaseNameAndArgumentNames = newValue
+    }
+  }
+  
+  @available(*, deprecated, renamed: "argumentNames")
+  public var declNameArguments: DeclNameArgumentsSyntax? {
+    get {
+      return argumentNames
+    }
+    set {
+      argumentNames = newValue
+    }
+  }
+  
+  @available(*, deprecated, renamed: "unexpectedAfterArgumentNames")
+  public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedAfterArgumentNames
+    }
+    set {
+      unexpectedAfterArgumentNames = newValue
+    }
+  }
+  
+  @available(*, deprecated, message: "Use an initializer with baseName, argumentNames argument(s).")
+  @_disfavoredOverload
+  public init(
+      leadingTrivia: Trivia? = nil,
+      _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
+      identifier: TokenSyntax,
+      _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
+      declNameArguments: DeclNameArgumentsSyntax? = nil,
+      _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
+      trailingTrivia: Trivia? = nil
+    
+  ) {
+    self.init(
+        leadingTrivia: leadingTrivia, 
+        unexpectedBeforeIdentifier, 
+        baseName: identifier, 
+        unexpectedBetweenIdentifierAndDeclNameArguments, 
+        argumentNames: declNameArguments, 
+        unexpectedAfterDeclNameArguments, 
+        trailingTrivia: trailingTrivia
+      )
+  }
+}
+
 extension DerivativeAttributeArgumentsSyntax {
   @available(*, deprecated, renamed: "unexpectedBetweenPeriodAndAccessorSpecifier")
   public var unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodesSyntax? {
@@ -2225,7 +2300,7 @@ extension DynamicReplacementAttributeArgumentsSyntax {
   }
   
   @available(*, deprecated, renamed: "declName")
-  public var declname: IdentifierExprSyntax {
+  public var declname: DeclReferenceExprSyntax {
     get {
       return declName
     }
@@ -2253,7 +2328,7 @@ extension DynamicReplacementAttributeArgumentsSyntax {
       _ unexpectedBetweenForLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? = nil,
-      declname: IdentifierExprSyntax,
+      declname: DeclReferenceExprSyntax,
       _ unexpectedAfterDeclname: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -3841,7 +3916,7 @@ extension ImplementsAttributeArgumentsSyntax {
   }
   
   @available(*, deprecated, renamed: "declName")
-  public var declname: IdentifierExprSyntax {
+  public var declname: DeclReferenceExprSyntax {
     get {
       return declName
     }
@@ -3869,7 +3944,7 @@ extension ImplementsAttributeArgumentsSyntax {
       _ unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? = nil,
       comma: TokenSyntax = .commaToken(),
       _ unexpectedBetweenCommaAndDeclname: UnexpectedNodesSyntax? = nil,
-      declname: IdentifierExprSyntax,
+      declname: DeclReferenceExprSyntax,
       _ unexpectedAfterDeclname: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -7102,7 +7177,7 @@ extension SpecializeTargetFunctionArgumentSyntax {
   }
   
   @available(*, deprecated, renamed: "declName")
-  public var declname: IdentifierExprSyntax {
+  public var declname: DeclReferenceExprSyntax {
     get {
       return declName
     }
@@ -7130,7 +7205,7 @@ extension SpecializeTargetFunctionArgumentSyntax {
       _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? = nil,
-      declname: IdentifierExprSyntax,
+      declname: DeclReferenceExprSyntax,
       _ unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -3829,6 +3829,65 @@ extension GenericWhereClauseSyntax {
   }
 }
 
+extension ImplementsAttributeArgumentsSyntax {
+  @available(*, deprecated, renamed: "unexpectedBetweenCommaAndDeclName")
+  public var unexpectedBetweenCommaAndDeclname: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedBetweenCommaAndDeclName
+    }
+    set {
+      unexpectedBetweenCommaAndDeclName = newValue
+    }
+  }
+  
+  @available(*, deprecated, renamed: "declName")
+  public var declname: IdentifierExprSyntax {
+    get {
+      return declName
+    }
+    set {
+      declName = newValue
+    }
+  }
+  
+  @available(*, deprecated, renamed: "unexpectedAfterDeclName")
+  public var unexpectedAfterDeclname: UnexpectedNodesSyntax? {
+    get {
+      return unexpectedAfterDeclName
+    }
+    set {
+      unexpectedAfterDeclName = newValue
+    }
+  }
+  
+  @available(*, deprecated, message: "Use an initializer with declName argument(s).")
+  @_disfavoredOverload
+  public init(
+      leadingTrivia: Trivia? = nil,
+      _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
+      type: some TypeSyntaxProtocol,
+      _ unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? = nil,
+      comma: TokenSyntax = .commaToken(),
+      _ unexpectedBetweenCommaAndDeclname: UnexpectedNodesSyntax? = nil,
+      declname: IdentifierExprSyntax,
+      _ unexpectedAfterDeclname: UnexpectedNodesSyntax? = nil,
+      trailingTrivia: Trivia? = nil
+    
+  ) {
+    self.init(
+        leadingTrivia: leadingTrivia, 
+        unexpectedBeforeType, 
+        type: type, 
+        unexpectedBetweenTypeAndComma, 
+        comma: comma, 
+        unexpectedBetweenCommaAndDeclname, 
+        declName: declname, 
+        unexpectedAfterDeclname, 
+        trailingTrivia: trailingTrivia
+      )
+  }
+}
+
 extension ImportDeclSyntax {
   @available(*, deprecated, renamed: "unexpectedBetweenModifiersAndImportKeyword")
   public var unexpectedBetweenModifiersAndImportTok: UnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/RenamedNodesCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedNodesCompatibility.swift
@@ -114,6 +114,9 @@ public typealias ForInStmtSyntax = ForStmtSyntax
 @available(*, deprecated, renamed: "ForceUnwrapExprSyntax")
 public typealias ForcedValueExprSyntax = ForceUnwrapExprSyntax
 
+@available(*, deprecated, renamed: "DeclReferenceExprSyntax")
+public typealias IdentifierExprSyntax = DeclReferenceExprSyntax
+
 @available(*, deprecated, renamed: "LabeledSpecializeArgumentSyntax")
 public typealias LabeledSpecializeEntrySyntax = LabeledSpecializeArgumentSyntax
 
@@ -342,6 +345,10 @@ public extension SyntaxKind {
   
   static var forcedValueExpr: Self {
     return .forceUnwrapExpr
+  }
+  
+  static var identifierExpr: Self {
+    return .declReferenceExpr
   }
   
   static var labeledSpecializeEntry: Self {

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -581,6 +581,14 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
   
+  override open func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+  
+  override open func visitPost(_ node: DeclReferenceExprSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  
   override open func visit(_ node: DeferStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
@@ -1058,14 +1066,6 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   }
   
   override open func visitPost(_ node: GuardStmtSyntax) {
-    visitAnyPost(node._syntaxNode)
-  }
-  
-  override open func visit(_ node: IdentifierExprSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(node._syntaxNode)
-  }
-  
-  override open func visitPost(_ node: IdentifierExprSyntax) {
     visitAnyPost(node._syntaxNode)
   }
   

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -581,14 +581,6 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
   
-  override open func visit(_ node: DeclNameSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(node._syntaxNode)
-  }
-  
-  override open func visitPost(_ node: DeclNameSyntax) {
-    visitAnyPost(node._syntaxNode)
-  }
-  
   override open func visit(_ node: DeferStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -753,7 +753,6 @@ extension Syntax {
           .node(DeclNameArgumentListSyntax.self),
           .node(DeclNameArgumentSyntax.self),
           .node(DeclNameArgumentsSyntax.self),
-          .node(DeclNameSyntax.self),
           .node(DeferStmtSyntax.self),
           .node(DeinitializerDeclSyntax.self),
           .node(DeinitializerEffectSpecifiersSyntax.self),

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -206,7 +206,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
-    case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .canImportExpr, .canImportVersionInfo, .closureExpr, .consumeExpr, .copyExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forceUnwrapExpr, .functionCallExpr, .genericSpecializationExpr, .identifierExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .patternExpr, .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .stringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:
+    case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .canImportExpr, .canImportVersionInfo, .closureExpr, .consumeExpr, .copyExpr, .declReferenceExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forceUnwrapExpr, .functionCallExpr, .genericSpecializationExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .patternExpr, .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .stringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:
       self._syntaxNode = node._syntaxNode
     default:
       return nil
@@ -218,7 +218,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// is undefined.
   internal init(_ data: SyntaxData) {
     switch data.raw.kind {
-    case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .canImportExpr, .canImportVersionInfo, .closureExpr, .consumeExpr, .copyExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forceUnwrapExpr, .functionCallExpr, .genericSpecializationExpr, .identifierExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .patternExpr, .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .stringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:
+    case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .canImportExpr, .canImportVersionInfo, .closureExpr, .consumeExpr, .copyExpr, .declReferenceExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forceUnwrapExpr, .functionCallExpr, .genericSpecializationExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .patternExpr, .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .stringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:
       break
     default:
       preconditionFailure("Unable to create ExprSyntax from \(data.raw.kind)")
@@ -267,6 +267,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           .node(ClosureExprSyntax.self),
           .node(ConsumeExprSyntax.self),
           .node(CopyExprSyntax.self),
+          .node(DeclReferenceExprSyntax.self),
           .node(DictionaryExprSyntax.self),
           .node(DiscardAssignmentExprSyntax.self),
           .node(EditorPlaceholderExprSyntax.self),
@@ -274,7 +275,6 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           .node(ForceUnwrapExprSyntax.self),
           .node(FunctionCallExprSyntax.self),
           .node(GenericSpecializationExprSyntax.self),
-          .node(IdentifierExprSyntax.self),
           .node(IfExprSyntax.self),
           .node(InOutExprSyntax.self),
           .node(InfixOperatorExprSyntax.self),
@@ -753,6 +753,7 @@ extension Syntax {
           .node(DeclNameArgumentListSyntax.self),
           .node(DeclNameArgumentSyntax.self),
           .node(DeclNameArgumentsSyntax.self),
+          .node(DeclReferenceExprSyntax.self),
           .node(DeferStmtSyntax.self),
           .node(DeinitializerDeclSyntax.self),
           .node(DeinitializerEffectSpecifiersSyntax.self),
@@ -813,7 +814,6 @@ extension Syntax {
           .node(GenericSpecializationExprSyntax.self),
           .node(GenericWhereClauseSyntax.self),
           .node(GuardStmtSyntax.self),
-          .node(IdentifierExprSyntax.self),
           .node(IdentifierPatternSyntax.self),
           .node(IdentifierTypeSyntax.self),
           .node(IfConfigClauseListSyntax.self),

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -81,7 +81,6 @@ public enum SyntaxEnum {
   case declNameArgumentList(DeclNameArgumentListSyntax)
   case declNameArgument(DeclNameArgumentSyntax)
   case declNameArguments(DeclNameArgumentsSyntax)
-  case declName(DeclNameSyntax)
   case deferStmt(DeferStmtSyntax)
   case deinitializerDecl(DeinitializerDeclSyntax)
   case deinitializerEffectSpecifiers(DeinitializerEffectSpecifiersSyntax)
@@ -430,8 +429,6 @@ public extension Syntax {
       return .declNameArgument(DeclNameArgumentSyntax(self)!)
     case .declNameArguments:
       return .declNameArguments(DeclNameArgumentsSyntax(self)!)
-    case .declName:
-      return .declName(DeclNameSyntax(self)!)
     case .deferStmt:
       return .deferStmt(DeferStmtSyntax(self)!)
     case .deinitializerDecl:

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -81,6 +81,7 @@ public enum SyntaxEnum {
   case declNameArgumentList(DeclNameArgumentListSyntax)
   case declNameArgument(DeclNameArgumentSyntax)
   case declNameArguments(DeclNameArgumentsSyntax)
+  case declReferenceExpr(DeclReferenceExprSyntax)
   case deferStmt(DeferStmtSyntax)
   case deinitializerDecl(DeinitializerDeclSyntax)
   case deinitializerEffectSpecifiers(DeinitializerEffectSpecifiersSyntax)
@@ -141,7 +142,6 @@ public enum SyntaxEnum {
   case genericSpecializationExpr(GenericSpecializationExprSyntax)
   case genericWhereClause(GenericWhereClauseSyntax)
   case guardStmt(GuardStmtSyntax)
-  case identifierExpr(IdentifierExprSyntax)
   case identifierPattern(IdentifierPatternSyntax)
   case identifierType(IdentifierTypeSyntax)
   case ifConfigClauseList(IfConfigClauseListSyntax)
@@ -429,6 +429,8 @@ public extension Syntax {
       return .declNameArgument(DeclNameArgumentSyntax(self)!)
     case .declNameArguments:
       return .declNameArguments(DeclNameArgumentsSyntax(self)!)
+    case .declReferenceExpr:
+      return .declReferenceExpr(DeclReferenceExprSyntax(self)!)
     case .deferStmt:
       return .deferStmt(DeferStmtSyntax(self)!)
     case .deinitializerDecl:
@@ -549,8 +551,6 @@ public extension Syntax {
       return .genericWhereClause(GenericWhereClauseSyntax(self)!)
     case .guardStmt:
       return .guardStmt(GuardStmtSyntax(self)!)
-    case .identifierExpr:
-      return .identifierExpr(IdentifierExprSyntax(self)!)
     case .identifierPattern:
       return .identifierPattern(IdentifierPatternSyntax(self)!)
     case .identifierType:

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -81,7 +81,6 @@ public enum SyntaxKind: CaseIterable {
   case declNameArgumentList
   case declNameArgument
   case declNameArguments
-  case declName
   case deferStmt
   case deinitializerDecl
   case deinitializerEffectSpecifiers
@@ -549,8 +548,6 @@ public enum SyntaxKind: CaseIterable {
       return DeclNameArgumentSyntax.self
     case .declNameArguments:
       return DeclNameArgumentsSyntax.self
-    case .declName:
-      return DeclNameSyntax.self
     case .deferStmt:
       return DeferStmtSyntax.self
     case .deinitializerDecl:

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -81,6 +81,7 @@ public enum SyntaxKind: CaseIterable {
   case declNameArgumentList
   case declNameArgument
   case declNameArguments
+  case declReferenceExpr
   case deferStmt
   case deinitializerDecl
   case deinitializerEffectSpecifiers
@@ -141,7 +142,6 @@ public enum SyntaxKind: CaseIterable {
   case genericSpecializationExpr
   case genericWhereClause
   case guardStmt
-  case identifierExpr
   case identifierPattern
   case identifierType
   case ifConfigClauseList
@@ -548,6 +548,8 @@ public enum SyntaxKind: CaseIterable {
       return DeclNameArgumentSyntax.self
     case .declNameArguments:
       return DeclNameArgumentsSyntax.self
+    case .declReferenceExpr:
+      return DeclReferenceExprSyntax.self
     case .deferStmt:
       return DeferStmtSyntax.self
     case .deinitializerDecl:
@@ -668,8 +670,6 @@ public enum SyntaxKind: CaseIterable {
       return GenericWhereClauseSyntax.self
     case .guardStmt:
       return GuardStmtSyntax.self
-    case .identifierExpr:
-      return IdentifierExprSyntax.self
     case .identifierPattern:
       return IdentifierPatternSyntax.self
     case .identifierType:

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -542,13 +542,6 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node)).cast(DeclNameArgumentsSyntax.self)
   }
   
-  /// Visit a ``DeclNameSyntax``.
-  ///   - Parameter node: the node that is being visited
-  ///   - Returns: the rewritten node
-  open func visit(_ node: DeclNameSyntax) -> DeclNameSyntax {
-    return Syntax(visitChildren(node)).cast(DeclNameSyntax.self)
-  }
-  
   /// Visit a ``DeferStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -2953,20 +2946,6 @@ open class SyntaxRewriter {
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplDeclNameArgumentsSyntax(_ data: SyntaxData) -> Syntax {
     let node = DeclNameArgumentsSyntax(data)
-    // Accessing _syntaxNode directly is faster than calling Syntax(node)
-    visitPre(node._syntaxNode)
-    defer {
-      visitPost(node._syntaxNode)
-    }
-    if let newNode = visitAny(node._syntaxNode) {
-      return newNode
-    }
-    return Syntax(visit(node))
-  }
-  
-  /// Implementation detail of visit(_:). Do not call directly.
-  private func visitImplDeclNameSyntax(_ data: SyntaxData) -> Syntax {
-    let node = DeclNameSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
     visitPre(node._syntaxNode)
     defer {
@@ -6064,8 +6043,6 @@ open class SyntaxRewriter {
       return visitImplDeclNameArgumentSyntax
     case .declNameArguments:
       return visitImplDeclNameArgumentsSyntax
-    case .declName:
-      return visitImplDeclNameSyntax
     case .deferStmt:
       return visitImplDeferStmtSyntax
     case .deinitializerDecl:
@@ -6624,8 +6601,6 @@ open class SyntaxRewriter {
       return visitImplDeclNameArgumentSyntax(data)
     case .declNameArguments:
       return visitImplDeclNameArgumentsSyntax(data)
-    case .declName:
-      return visitImplDeclNameSyntax(data)
     case .deferStmt:
       return visitImplDeferStmtSyntax(data)
     case .deinitializerDecl:

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -542,6 +542,13 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node)).cast(DeclNameArgumentsSyntax.self)
   }
   
+  /// Visit a ``DeclReferenceExprSyntax``.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
+    return ExprSyntax(visitChildren(node))
+  }
+  
   /// Visit a ``DeferStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -960,13 +967,6 @@ open class SyntaxRewriter {
   ///   - Returns: the rewritten node
   open func visit(_ node: GuardStmtSyntax) -> StmtSyntax {
     return StmtSyntax(visitChildren(node))
-  }
-  
-  /// Visit a ``IdentifierExprSyntax``.
-  ///   - Parameter node: the node that is being visited
-  ///   - Returns: the rewritten node
-  open func visit(_ node: IdentifierExprSyntax) -> ExprSyntax {
-    return ExprSyntax(visitChildren(node))
   }
   
   /// Visit a ``IdentifierPatternSyntax``.
@@ -2958,6 +2958,20 @@ open class SyntaxRewriter {
   }
   
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplDeclReferenceExprSyntax(_ data: SyntaxData) -> Syntax {
+    let node = DeclReferenceExprSyntax(data)
+    // Accessing _syntaxNode directly is faster than calling Syntax(node)
+    visitPre(node._syntaxNode)
+    defer {
+      visitPost(node._syntaxNode)
+    }
+    if let newNode = visitAny(node._syntaxNode) {
+      return newNode
+    }
+    return Syntax(visit(node))
+  }
+  
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplDeferStmtSyntax(_ data: SyntaxData) -> Syntax {
     let node = DeferStmtSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -3786,20 +3800,6 @@ open class SyntaxRewriter {
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplGuardStmtSyntax(_ data: SyntaxData) -> Syntax {
     let node = GuardStmtSyntax(data)
-    // Accessing _syntaxNode directly is faster than calling Syntax(node)
-    visitPre(node._syntaxNode)
-    defer {
-      visitPost(node._syntaxNode)
-    }
-    if let newNode = visitAny(node._syntaxNode) {
-      return newNode
-    }
-    return Syntax(visit(node))
-  }
-  
-  /// Implementation detail of visit(_:). Do not call directly.
-  private func visitImplIdentifierExprSyntax(_ data: SyntaxData) -> Syntax {
-    let node = IdentifierExprSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
     visitPre(node._syntaxNode)
     defer {
@@ -6043,6 +6043,8 @@ open class SyntaxRewriter {
       return visitImplDeclNameArgumentSyntax
     case .declNameArguments:
       return visitImplDeclNameArgumentsSyntax
+    case .declReferenceExpr:
+      return visitImplDeclReferenceExprSyntax
     case .deferStmt:
       return visitImplDeferStmtSyntax
     case .deinitializerDecl:
@@ -6163,8 +6165,6 @@ open class SyntaxRewriter {
       return visitImplGenericWhereClauseSyntax
     case .guardStmt:
       return visitImplGuardStmtSyntax
-    case .identifierExpr:
-      return visitImplIdentifierExprSyntax
     case .identifierPattern:
       return visitImplIdentifierPatternSyntax
     case .identifierType:
@@ -6601,6 +6601,8 @@ open class SyntaxRewriter {
       return visitImplDeclNameArgumentSyntax(data)
     case .declNameArguments:
       return visitImplDeclNameArgumentsSyntax(data)
+    case .declReferenceExpr:
+      return visitImplDeclReferenceExprSyntax(data)
     case .deferStmt:
       return visitImplDeferStmtSyntax(data)
     case .deinitializerDecl:
@@ -6721,8 +6723,6 @@ open class SyntaxRewriter {
       return visitImplGenericWhereClauseSyntax(data)
     case .guardStmt:
       return visitImplGuardStmtSyntax(data)
-    case .identifierExpr:
-      return visitImplIdentifierExprSyntax(data)
     case .identifierPattern:
       return visitImplIdentifierPatternSyntax(data)
     case .identifierType:

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -349,6 +349,11 @@ public protocol SyntaxTransformVisitor {
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: DeclNameArgumentsSyntax) -> ResultType
   
+  /// Visiting ``DeclReferenceExprSyntax`` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: DeclReferenceExprSyntax) -> ResultType
+  
   /// Visiting ``DeferStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -648,11 +653,6 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: GuardStmtSyntax) -> ResultType
-  
-  /// Visiting ``IdentifierExprSyntax`` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: the sum of whatever the child visitors return.
-  func visit(_ node: IdentifierExprSyntax) -> ResultType
   
   /// Visiting ``IdentifierPatternSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
@@ -1857,6 +1857,13 @@ extension SyntaxTransformVisitor {
     visitAny(Syntax(node))
   }
   
+  /// Visiting ``DeclReferenceExprSyntax`` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: DeclReferenceExprSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  
   /// Visiting ``DeferStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -2274,13 +2281,6 @@ extension SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
   public func visit(_ node: GuardStmtSyntax) -> ResultType {
-    visitAny(Syntax(node))
-  }
-  
-  /// Visiting ``IdentifierExprSyntax`` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: nil by default.
-  public func visit(_ node: IdentifierExprSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
   
@@ -3449,6 +3449,8 @@ extension SyntaxTransformVisitor {
       return visit(derived)
     case .declNameArguments(let derived):
       return visit(derived)
+    case .declReferenceExpr(let derived):
+      return visit(derived)
     case .deferStmt(let derived):
       return visit(derived)
     case .deinitializerDecl(let derived):
@@ -3568,8 +3570,6 @@ extension SyntaxTransformVisitor {
     case .genericWhereClause(let derived):
       return visit(derived)
     case .guardStmt(let derived):
-      return visit(derived)
-    case .identifierExpr(let derived):
       return visit(derived)
     case .identifierPattern(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -349,11 +349,6 @@ public protocol SyntaxTransformVisitor {
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: DeclNameArgumentsSyntax) -> ResultType
   
-  /// Visiting ``DeclNameSyntax`` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: the sum of whatever the child visitors return.
-  func visit(_ node: DeclNameSyntax) -> ResultType
-  
   /// Visiting ``DeferStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -1859,13 +1854,6 @@ extension SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
   public func visit(_ node: DeclNameArgumentsSyntax) -> ResultType {
-    visitAny(Syntax(node))
-  }
-  
-  /// Visiting ``DeclNameSyntax`` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: nil by default.
-  public func visit(_ node: DeclNameSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
   
@@ -3460,8 +3448,6 @@ extension SyntaxTransformVisitor {
     case .declNameArgument(let derived):
       return visit(derived)
     case .declNameArguments(let derived):
-      return visit(derived)
-    case .declName(let derived):
       return visit(derived)
     case .deferStmt(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -826,6 +826,18 @@ open class SyntaxVisitor {
   open func visitPost(_ node: DeclNameArgumentsSyntax) {
   }
   
+  /// Visiting ``DeclReferenceExprSyntax`` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  
+  /// The function called after visiting ``DeclReferenceExprSyntax`` and its descendants.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: DeclReferenceExprSyntax) {
+  }
+  
   /// Visiting ``DeferStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -1544,18 +1556,6 @@ open class SyntaxVisitor {
   /// The function called after visiting ``GuardStmtSyntax`` and its descendants.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: GuardStmtSyntax) {
-  }
-  
-  /// Visiting ``IdentifierExprSyntax`` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: how should we continue visiting.
-  open func visit(_ node: IdentifierExprSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-  
-  /// The function called after visiting ``IdentifierExprSyntax`` and its descendants.
-  ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: IdentifierExprSyntax) {
   }
   
   /// Visiting ``IdentifierPatternSyntax`` specifically.
@@ -4061,6 +4061,17 @@ open class SyntaxVisitor {
   }
   
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplDeclReferenceExprSyntax(_ data: SyntaxData) {
+    let node = DeclReferenceExprSyntax(data)
+    let needsChildren = (visit(node) == .visitChildren)
+    // Avoid calling into visitChildren if possible.
+    if needsChildren && !node.raw.layoutView!.children.isEmpty {
+      visitChildren(node)
+    }
+    visitPost(node)
+  }
+  
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplDeferStmtSyntax(_ data: SyntaxData) {
     let node = DeferStmtSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
@@ -4712,17 +4723,6 @@ open class SyntaxVisitor {
   /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplGuardStmtSyntax(_ data: SyntaxData) {
     let node = GuardStmtSyntax(data)
-    let needsChildren = (visit(node) == .visitChildren)
-    // Avoid calling into visitChildren if possible.
-    if needsChildren && !node.raw.layoutView!.children.isEmpty {
-      visitChildren(node)
-    }
-    visitPost(node)
-  }
-  
-  /// Implementation detail of doVisit(_:_:). Do not call directly.
-  private func visitImplIdentifierExprSyntax(_ data: SyntaxData) {
-    let node = IdentifierExprSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
     // Avoid calling into visitChildren if possible.
     if needsChildren && !node.raw.layoutView!.children.isEmpty {
@@ -6487,6 +6487,8 @@ open class SyntaxVisitor {
       visitImplDeclNameArgumentSyntax(data)
     case .declNameArguments:
       visitImplDeclNameArgumentsSyntax(data)
+    case .declReferenceExpr:
+      visitImplDeclReferenceExprSyntax(data)
     case .deferStmt:
       visitImplDeferStmtSyntax(data)
     case .deinitializerDecl:
@@ -6607,8 +6609,6 @@ open class SyntaxVisitor {
       visitImplGenericWhereClauseSyntax(data)
     case .guardStmt:
       visitImplGuardStmtSyntax(data)
-    case .identifierExpr:
-      visitImplIdentifierExprSyntax(data)
     case .identifierPattern:
       visitImplIdentifierPatternSyntax(data)
     case .identifierType:

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -826,18 +826,6 @@ open class SyntaxVisitor {
   open func visitPost(_ node: DeclNameArgumentsSyntax) {
   }
   
-  /// Visiting ``DeclNameSyntax`` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: how should we continue visiting.
-  open func visit(_ node: DeclNameSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-  
-  /// The function called after visiting ``DeclNameSyntax`` and its descendants.
-  ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: DeclNameSyntax) {
-  }
-  
   /// Visiting ``DeferStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4073,17 +4061,6 @@ open class SyntaxVisitor {
   }
   
   /// Implementation detail of doVisit(_:_:). Do not call directly.
-  private func visitImplDeclNameSyntax(_ data: SyntaxData) {
-    let node = DeclNameSyntax(data)
-    let needsChildren = (visit(node) == .visitChildren)
-    // Avoid calling into visitChildren if possible.
-    if needsChildren && !node.raw.layoutView!.children.isEmpty {
-      visitChildren(node)
-    }
-    visitPost(node)
-  }
-  
-  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplDeferStmtSyntax(_ data: SyntaxData) {
     let node = DeferStmtSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
@@ -6510,8 +6487,6 @@ open class SyntaxVisitor {
       visitImplDeclNameArgumentSyntax(data)
     case .declNameArguments:
       visitImplDeclNameArgumentsSyntax(data)
-    case .declName:
-      visitImplDeclNameSyntax(data)
     case .deferStmt:
       visitImplDeferStmtSyntax(data)
     case .deinitializerDecl:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -17778,25 +17778,21 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol {
       baseType: RawTypeSyntax?, 
       _ unexpectedBetweenBaseTypeAndPeriod: RawUnexpectedNodesSyntax? = nil, 
       period: RawTokenSyntax?, 
-      _ unexpectedBetweenPeriodAndName: RawUnexpectedNodesSyntax? = nil, 
-      name: RawTokenSyntax, 
-      _ unexpectedBetweenNameAndArguments: RawUnexpectedNodesSyntax? = nil, 
-      arguments: RawDeclNameArgumentsSyntax?, 
-      _ unexpectedAfterArguments: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenPeriodAndDeclName: RawUnexpectedNodesSyntax? = nil, 
+      declName: RawDeclReferenceExprSyntax, 
+      _ unexpectedAfterDeclName: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .qualifiedDeclName, uninitializedCount: 9, arena: arena) { layout in
+      kind: .qualifiedDeclName, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBaseType?.raw
       layout[1] = baseType?.raw
       layout[2] = unexpectedBetweenBaseTypeAndPeriod?.raw
       layout[3] = period?.raw
-      layout[4] = unexpectedBetweenPeriodAndName?.raw
-      layout[5] = name.raw
-      layout[6] = unexpectedBetweenNameAndArguments?.raw
-      layout[7] = arguments?.raw
-      layout[8] = unexpectedAfterArguments?.raw
+      layout[4] = unexpectedBetweenPeriodAndDeclName?.raw
+      layout[5] = declName.raw
+      layout[6] = unexpectedAfterDeclName?.raw
     }
     self.init(unchecked: raw)
   }
@@ -17817,24 +17813,16 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenPeriodAndName: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenPeriodAndDeclName: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var name: RawTokenSyntax {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  public var declName: RawDeclReferenceExprSyntax {
+    layoutView.children[5].map(RawDeclReferenceExprSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenNameAndArguments: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterDeclName: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var arguments: RawDeclNameArgumentsSyntax? {
-    layoutView.children[7].map(RawDeclNameArgumentsSyntax.init(raw:))
-  }
-  
-  public var unexpectedAfterArguments: RawUnexpectedNodesSyntax? {
-    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -5530,6 +5530,76 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol {
 }
 
 @_spi(RawSyntax)
+public struct RawDeclReferenceExprSyntax: RawExprSyntaxNodeProtocol {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+  
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .declReferenceExpr
+  }
+  
+  public var raw: RawSyntax
+  
+  init(raw: RawSyntax) {
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
+    self.raw = raw
+  }
+  
+  public init?(_ other: some RawSyntaxNodeProtocol) {
+    guard Self.isKindOf(other.raw) else {
+      return nil
+    }
+    self.init(unchecked: other.raw)
+  }
+  
+  public init(
+      _ unexpectedBeforeBaseName: RawUnexpectedNodesSyntax? = nil, 
+      baseName: RawTokenSyntax, 
+      _ unexpectedBetweenBaseNameAndArgumentNames: RawUnexpectedNodesSyntax? = nil, 
+      argumentNames: RawDeclNameArgumentsSyntax?, 
+      _ unexpectedAfterArgumentNames: RawUnexpectedNodesSyntax? = nil, 
+      arena: __shared SyntaxArena
+    ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .declReferenceExpr, uninitializedCount: 5, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeBaseName?.raw
+      layout[1] = baseName.raw
+      layout[2] = unexpectedBetweenBaseNameAndArgumentNames?.raw
+      layout[3] = argumentNames?.raw
+      layout[4] = unexpectedAfterArgumentNames?.raw
+    }
+    self.init(unchecked: raw)
+  }
+  
+  public var unexpectedBeforeBaseName: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var baseName: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  
+  public var unexpectedBetweenBaseNameAndArgumentNames: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var argumentNames: RawDeclNameArgumentsSyntax? {
+    layoutView.children[3].map(RawDeclNameArgumentsSyntax.init(raw:))
+  }
+  
+  public var unexpectedAfterArgumentNames: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
 public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol {
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {
@@ -7253,7 +7323,7 @@ public struct RawDynamicReplacementAttributeArgumentsSyntax: RawSyntaxNodeProtoc
       _ unexpectedBetweenForLabelAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndDeclName: RawUnexpectedNodesSyntax? = nil, 
-      declName: RawIdentifierExprSyntax, 
+      declName: RawDeclReferenceExprSyntax, 
       _ unexpectedAfterDeclName: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -7291,8 +7361,8 @@ public struct RawDynamicReplacementAttributeArgumentsSyntax: RawSyntaxNodeProtoc
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var declName: RawIdentifierExprSyntax {
-    layoutView.children[5].map(RawIdentifierExprSyntax.init(raw:))!
+  public var declName: RawDeclReferenceExprSyntax {
+    layoutView.children[5].map(RawDeclReferenceExprSyntax.init(raw:))!
   }
   
   public var unexpectedAfterDeclName: RawUnexpectedNodesSyntax? {
@@ -8273,7 +8343,7 @@ public struct RawExprSyntax: RawExprSyntaxNodeProtocol {
   
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     switch raw.kind {
-    case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .canImportExpr, .canImportVersionInfo, .closureExpr, .consumeExpr, .copyExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forceUnwrapExpr, .functionCallExpr, .genericSpecializationExpr, .identifierExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .patternExpr, .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .stringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:
+    case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .canImportExpr, .canImportVersionInfo, .closureExpr, .consumeExpr, .copyExpr, .declReferenceExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forceUnwrapExpr, .functionCallExpr, .genericSpecializationExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .patternExpr, .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .stringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:
       return true
     default:
       return false
@@ -10667,76 +10737,6 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol {
 }
 
 @_spi(RawSyntax)
-public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol {
-  @_spi(RawSyntax)
-  public var layoutView: RawSyntaxLayoutView {
-    return raw.layoutView!
-  }
-  
-  public static func isKindOf(_ raw: RawSyntax) -> Bool {
-    return raw.kind == .identifierExpr
-  }
-  
-  public var raw: RawSyntax
-  
-  init(raw: RawSyntax) {
-    precondition(Self.isKindOf(raw))
-    self.raw = raw
-  }
-  
-  private init(unchecked raw: RawSyntax) {
-    self.raw = raw
-  }
-  
-  public init?(_ other: some RawSyntaxNodeProtocol) {
-    guard Self.isKindOf(other.raw) else {
-      return nil
-    }
-    self.init(unchecked: other.raw)
-  }
-  
-  public init(
-      _ unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? = nil, 
-      identifier: RawTokenSyntax, 
-      _ unexpectedBetweenIdentifierAndDeclNameArguments: RawUnexpectedNodesSyntax? = nil, 
-      declNameArguments: RawDeclNameArgumentsSyntax?, 
-      _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil, 
-      arena: __shared SyntaxArena
-    ) {
-    let raw = RawSyntax.makeLayout(
-      kind: .identifierExpr, uninitializedCount: 5, arena: arena) { layout in
-      layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeIdentifier?.raw
-      layout[1] = identifier.raw
-      layout[2] = unexpectedBetweenIdentifierAndDeclNameArguments?.raw
-      layout[3] = declNameArguments?.raw
-      layout[4] = unexpectedAfterDeclNameArguments?.raw
-    }
-    self.init(unchecked: raw)
-  }
-  
-  public var unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? {
-    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var identifier: RawTokenSyntax {
-    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
-  }
-  
-  public var unexpectedBetweenIdentifierAndDeclNameArguments: RawUnexpectedNodesSyntax? {
-    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var declNameArguments: RawDeclNameArgumentsSyntax? {
-    layoutView.children[3].map(RawDeclNameArgumentsSyntax.init(raw:))
-  }
-  
-  public var unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? {
-    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-}
-
-@_spi(RawSyntax)
 public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol {
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {
@@ -11288,7 +11288,7 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBetweenTypeAndComma: RawUnexpectedNodesSyntax? = nil, 
       comma: RawTokenSyntax, 
       _ unexpectedBetweenCommaAndDeclName: RawUnexpectedNodesSyntax? = nil, 
-      declName: RawIdentifierExprSyntax, 
+      declName: RawDeclReferenceExprSyntax, 
       _ unexpectedAfterDeclName: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -11326,8 +11326,8 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var declName: RawIdentifierExprSyntax {
-    layoutView.children[5].map(RawIdentifierExprSyntax.init(raw:))!
+  public var declName: RawDeclReferenceExprSyntax {
+    layoutView.children[5].map(RawDeclReferenceExprSyntax.init(raw:))!
   }
   
   public var unexpectedAfterDeclName: RawUnexpectedNodesSyntax? {
@@ -18705,7 +18705,7 @@ public struct RawSpecializeTargetFunctionArgumentSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBetweenTargetLabelAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndDeclName: RawUnexpectedNodesSyntax? = nil, 
-      declName: RawIdentifierExprSyntax, 
+      declName: RawDeclReferenceExprSyntax, 
       _ unexpectedBetweenDeclNameAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
       _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -18747,8 +18747,8 @@ public struct RawSpecializeTargetFunctionArgumentSyntax: RawSyntaxNodeProtocol {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var declName: RawIdentifierExprSyntax {
-    layoutView.children[5].map(RawIdentifierExprSyntax.init(raw:))!
+  public var declName: RawDeclReferenceExprSyntax {
+    layoutView.children[5].map(RawDeclReferenceExprSyntax.init(raw:))!
   }
   
   public var unexpectedBetweenDeclNameAndTrailingComma: RawUnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -11287,25 +11287,21 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
       type: RawTypeSyntax, 
       _ unexpectedBetweenTypeAndComma: RawUnexpectedNodesSyntax? = nil, 
       comma: RawTokenSyntax, 
-      _ unexpectedBetweenCommaAndDeclBaseName: RawUnexpectedNodesSyntax? = nil, 
-      declBaseName: RawTokenSyntax, 
-      _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: RawUnexpectedNodesSyntax? = nil, 
-      declNameArguments: RawDeclNameArgumentsSyntax?, 
-      _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenCommaAndDeclName: RawUnexpectedNodesSyntax? = nil, 
+      declName: RawIdentifierExprSyntax, 
+      _ unexpectedAfterDeclName: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .implementsAttributeArguments, uninitializedCount: 9, arena: arena) { layout in
+      kind: .implementsAttributeArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeType?.raw
       layout[1] = type.raw
       layout[2] = unexpectedBetweenTypeAndComma?.raw
       layout[3] = comma.raw
-      layout[4] = unexpectedBetweenCommaAndDeclBaseName?.raw
-      layout[5] = declBaseName.raw
-      layout[6] = unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw
-      layout[7] = declNameArguments?.raw
-      layout[8] = unexpectedAfterDeclNameArguments?.raw
+      layout[4] = unexpectedBetweenCommaAndDeclName?.raw
+      layout[5] = declName.raw
+      layout[6] = unexpectedAfterDeclName?.raw
     }
     self.init(unchecked: raw)
   }
@@ -11326,24 +11322,16 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenCommaAndDeclBaseName: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenCommaAndDeclName: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var declBaseName: RawTokenSyntax {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  public var declName: RawIdentifierExprSyntax {
+    layoutView.children[5].map(RawIdentifierExprSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenDeclBaseNameAndDeclNameArguments: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterDeclName: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var declNameArguments: RawDeclNameArgumentsSyntax? {
-    layoutView.children[7].map(RawDeclNameArgumentsSyntax.init(raw:))
-  }
-  
-  public var unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? {
-    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -12722,55 +12722,43 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol {
   }
   
   public init(
-      _ unexpectedBeforeProperty: RawUnexpectedNodesSyntax? = nil, 
-      property: RawTokenSyntax, 
-      _ unexpectedBetweenPropertyAndDeclNameArguments: RawUnexpectedNodesSyntax? = nil, 
-      declNameArguments: RawDeclNameArgumentsSyntax?, 
-      _ unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeDeclName: RawUnexpectedNodesSyntax? = nil, 
+      declName: RawDeclReferenceExprSyntax, 
+      _ unexpectedBetweenDeclNameAndGenericArgumentClause: RawUnexpectedNodesSyntax? = nil, 
       genericArgumentClause: RawGenericArgumentClauseSyntax?, 
       _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .keyPathPropertyComponent, uninitializedCount: 7, arena: arena) { layout in
+      kind: .keyPathPropertyComponent, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeProperty?.raw
-      layout[1] = property.raw
-      layout[2] = unexpectedBetweenPropertyAndDeclNameArguments?.raw
-      layout[3] = declNameArguments?.raw
-      layout[4] = unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause?.raw
-      layout[5] = genericArgumentClause?.raw
-      layout[6] = unexpectedAfterGenericArgumentClause?.raw
+      layout[0] = unexpectedBeforeDeclName?.raw
+      layout[1] = declName.raw
+      layout[2] = unexpectedBetweenDeclNameAndGenericArgumentClause?.raw
+      layout[3] = genericArgumentClause?.raw
+      layout[4] = unexpectedAfterGenericArgumentClause?.raw
     }
     self.init(unchecked: raw)
   }
   
-  public var unexpectedBeforeProperty: RawUnexpectedNodesSyntax? {
+  public var unexpectedBeforeDeclName: RawUnexpectedNodesSyntax? {
     layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var property: RawTokenSyntax {
-    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  public var declName: RawDeclReferenceExprSyntax {
+    layoutView.children[1].map(RawDeclReferenceExprSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenPropertyAndDeclNameArguments: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenDeclNameAndGenericArgumentClause: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var declNameArguments: RawDeclNameArgumentsSyntax? {
-    layoutView.children[3].map(RawDeclNameArgumentsSyntax.init(raw:))
-  }
-  
-  public var unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: RawUnexpectedNodesSyntax? {
-    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
   public var genericArgumentClause: RawGenericArgumentClauseSyntax? {
-    layoutView.children[5].map(RawGenericArgumentClauseSyntax.init(raw:))
+    layoutView.children[3].map(RawGenericArgumentClauseSyntax.init(raw:))
   }
   
   public var unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? {
-    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13896,25 +13884,21 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol {
       base: RawExprSyntax?, 
       _ unexpectedBetweenBaseAndPeriod: RawUnexpectedNodesSyntax? = nil, 
       period: RawTokenSyntax, 
-      _ unexpectedBetweenPeriodAndName: RawUnexpectedNodesSyntax? = nil, 
-      name: RawTokenSyntax, 
-      _ unexpectedBetweenNameAndDeclNameArguments: RawUnexpectedNodesSyntax? = nil, 
-      declNameArguments: RawDeclNameArgumentsSyntax?, 
-      _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenPeriodAndDeclName: RawUnexpectedNodesSyntax? = nil, 
+      declName: RawDeclReferenceExprSyntax, 
+      _ unexpectedAfterDeclName: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .memberAccessExpr, uninitializedCount: 9, arena: arena) { layout in
+      kind: .memberAccessExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBase?.raw
       layout[1] = base?.raw
       layout[2] = unexpectedBetweenBaseAndPeriod?.raw
       layout[3] = period.raw
-      layout[4] = unexpectedBetweenPeriodAndName?.raw
-      layout[5] = name.raw
-      layout[6] = unexpectedBetweenNameAndDeclNameArguments?.raw
-      layout[7] = declNameArguments?.raw
-      layout[8] = unexpectedAfterDeclNameArguments?.raw
+      layout[4] = unexpectedBetweenPeriodAndDeclName?.raw
+      layout[5] = declName.raw
+      layout[6] = unexpectedAfterDeclName?.raw
     }
     self.init(unchecked: raw)
   }
@@ -13935,24 +13919,16 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenPeriodAndName: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenPeriodAndDeclName: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var name: RawTokenSyntax {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  public var declName: RawDeclReferenceExprSyntax {
+    layoutView.children[5].map(RawDeclReferenceExprSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenNameAndDeclNameArguments: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterDeclName: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var declNameArguments: RawDeclNameArgumentsSyntax? {
-    layoutView.children[7].map(RawDeclNameArgumentsSyntax.init(raw:))
-  }
-  
-  public var unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? {
-    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -5530,76 +5530,6 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol {
 }
 
 @_spi(RawSyntax)
-public struct RawDeclNameSyntax: RawSyntaxNodeProtocol {
-  @_spi(RawSyntax)
-  public var layoutView: RawSyntaxLayoutView {
-    return raw.layoutView!
-  }
-  
-  public static func isKindOf(_ raw: RawSyntax) -> Bool {
-    return raw.kind == .declName
-  }
-  
-  public var raw: RawSyntax
-  
-  init(raw: RawSyntax) {
-    precondition(Self.isKindOf(raw))
-    self.raw = raw
-  }
-  
-  private init(unchecked raw: RawSyntax) {
-    self.raw = raw
-  }
-  
-  public init?(_ other: some RawSyntaxNodeProtocol) {
-    guard Self.isKindOf(other.raw) else {
-      return nil
-    }
-    self.init(unchecked: other.raw)
-  }
-  
-  public init(
-      _ unexpectedBeforeBaseName: RawUnexpectedNodesSyntax? = nil, 
-      baseName: RawTokenSyntax, 
-      _ unexpectedBetweenBaseNameAndArguments: RawUnexpectedNodesSyntax? = nil, 
-      arguments: RawDeclNameArgumentsSyntax?, 
-      _ unexpectedAfterArguments: RawUnexpectedNodesSyntax? = nil, 
-      arena: __shared SyntaxArena
-    ) {
-    let raw = RawSyntax.makeLayout(
-      kind: .declName, uninitializedCount: 5, arena: arena) { layout in
-      layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeBaseName?.raw
-      layout[1] = baseName.raw
-      layout[2] = unexpectedBetweenBaseNameAndArguments?.raw
-      layout[3] = arguments?.raw
-      layout[4] = unexpectedAfterArguments?.raw
-    }
-    self.init(unchecked: raw)
-  }
-  
-  public var unexpectedBeforeBaseName: RawUnexpectedNodesSyntax? {
-    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var baseName: RawTokenSyntax {
-    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
-  }
-  
-  public var unexpectedBetweenBaseNameAndArguments: RawUnexpectedNodesSyntax? {
-    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var arguments: RawDeclNameArgumentsSyntax? {
-    layoutView.children[3].map(RawDeclNameArgumentsSyntax.init(raw:))
-  }
-  
-  public var unexpectedAfterArguments: RawUnexpectedNodesSyntax? {
-    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-}
-
-@_spi(RawSyntax)
 public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol {
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {
@@ -7323,7 +7253,7 @@ public struct RawDynamicReplacementAttributeArgumentsSyntax: RawSyntaxNodeProtoc
       _ unexpectedBetweenForLabelAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndDeclName: RawUnexpectedNodesSyntax? = nil, 
-      declName: RawDeclNameSyntax, 
+      declName: RawIdentifierExprSyntax, 
       _ unexpectedAfterDeclName: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -7361,8 +7291,8 @@ public struct RawDynamicReplacementAttributeArgumentsSyntax: RawSyntaxNodeProtoc
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var declName: RawDeclNameSyntax {
-    layoutView.children[5].map(RawDeclNameSyntax.init(raw:))!
+  public var declName: RawIdentifierExprSyntax {
+    layoutView.children[5].map(RawIdentifierExprSyntax.init(raw:))!
   }
   
   public var unexpectedAfterDeclName: RawUnexpectedNodesSyntax? {
@@ -18787,7 +18717,7 @@ public struct RawSpecializeTargetFunctionArgumentSyntax: RawSyntaxNodeProtocol {
       _ unexpectedBetweenTargetLabelAndColon: RawUnexpectedNodesSyntax? = nil, 
       colon: RawTokenSyntax, 
       _ unexpectedBetweenColonAndDeclName: RawUnexpectedNodesSyntax? = nil, 
-      declName: RawDeclNameSyntax, 
+      declName: RawIdentifierExprSyntax, 
       _ unexpectedBetweenDeclNameAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
       _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil, 
@@ -18829,8 +18759,8 @@ public struct RawSpecializeTargetFunctionArgumentSyntax: RawSyntaxNodeProtocol {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var declName: RawDeclNameSyntax {
-    layoutView.children[5].map(RawDeclNameSyntax.init(raw:))!
+  public var declName: RawIdentifierExprSyntax {
+    layoutView.children[5].map(RawIdentifierExprSyntax.init(raw:))!
   }
   
   public var unexpectedBetweenDeclNameAndTrailingComma: RawUnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -835,7 +835,8 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("Self"), 
             .keyword("init"), 
             .tokenKind(.dollarIdentifier), 
-            .tokenKind(.binaryOperator)
+            .tokenKind(.binaryOperator), 
+            .tokenKind(.integerLiteral)
           ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawDeclNameArgumentsSyntax?.self))
@@ -1611,22 +1612,12 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.postfixQuestionMark), .tokenKind(.exclamationMark)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
   case .keyPathPropertyComponent:
-    assert(layout.count == 7)
+    assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .keyword("self"), 
-            .keyword("Self"), 
-            .keyword("init"), 
-            .tokenKind(.dollarIdentifier), 
-            .tokenKind(.binaryOperator), 
-            .tokenKind(.integerLiteral)
-          ]))
+    assertNoError(kind, 1, verify(layout[1], as: RawDeclReferenceExprSyntax.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawDeclNameArgumentsSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawGenericArgumentClauseSyntax?.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawGenericArgumentClauseSyntax?.self))
-    assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .keyPathSubscriptComponent:
     assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
@@ -1771,16 +1762,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 7, verify(layout[7], as: RawInitializerClauseSyntax.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
   case .memberAccessExpr:
-    assert(layout.count == 9)
+    assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawExprSyntax?.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.period)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawDeclReferenceExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 7, verify(layout[7], as: RawDeclNameArgumentsSyntax?.self))
-    assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
   case .memberBlockItemList:
     for (index, element) in layout.enumerated() {
       assertNoError(kind, index, verify(element, as: RawMemberBlockItemSyntax.self))

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -826,6 +826,20 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.rightParen)]))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
+  case .declReferenceExpr:
+    assert(layout.count == 5)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
+            .tokenKind(.identifier), 
+            .keyword("self"), 
+            .keyword("Self"), 
+            .keyword("init"), 
+            .tokenKind(.dollarIdentifier), 
+            .tokenKind(.binaryOperator)
+          ]))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawDeclNameArgumentsSyntax?.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   case .deferStmt:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
@@ -1004,7 +1018,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawIdentifierExprSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawDeclReferenceExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .editorPlaceholderDecl:
     assert(layout.count == 7)
@@ -1381,20 +1395,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawCodeBlockSyntax.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
-  case .identifierExpr:
-    assert(layout.count == 5)
-    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .keyword("self"), 
-            .keyword("Self"), 
-            .keyword("init"), 
-            .tokenKind(.dollarIdentifier), 
-            .tokenKind(.binaryOperator)
-          ]))
-    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawDeclNameArgumentsSyntax?.self))
-    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   case .identifierPattern:
     assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
@@ -1455,7 +1455,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.comma)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawIdentifierExprSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawDeclReferenceExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .implicitlyUnwrappedOptionalType:
     assert(layout.count == 5)
@@ -2286,7 +2286,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawIdentifierExprSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawDeclReferenceExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1449,16 +1449,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
         verify(layout[9], as: RawSyntax?.self)])
     assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
   case .implementsAttributeArguments:
-    assert(layout.count == 9)
+    assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawTypeSyntax.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.comma)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawIdentifierExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 7, verify(layout[7], as: RawDeclNameArgumentsSyntax?.self))
-    assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
   case .implicitlyUnwrappedOptionalType:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -826,19 +826,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.rightParen)]))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
-  case .declName:
-    assert(layout.count == 5)
-    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .tokenKind(.binaryOperator), 
-            .keyword("init"), 
-            .keyword("self"), 
-            .keyword("Self")
-          ]))
-    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawDeclNameArgumentsSyntax?.self))
-    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   case .deferStmt:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
@@ -1017,7 +1004,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawDeclNameSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawIdentifierExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .editorPlaceholderDecl:
     assert(layout.count == 7)
@@ -2301,7 +2288,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawDeclNameSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawIdentifierExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2166,22 +2166,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 15, verify(layout[15], as: RawMemberBlockSyntax.self))
     assertNoError(kind, 16, verify(layout[16], as: RawUnexpectedNodesSyntax?.self))
   case .qualifiedDeclName:
-    assert(layout.count == 9)
+    assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawTypeSyntax?.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.period)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .keyword("self"), 
-            .keyword("Self"), 
-            .keyword("init"), 
-            .tokenKind(.binaryOperator)
-          ]))
+    assertNoError(kind, 5, verify(layout[5], as: RawDeclReferenceExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 7, verify(layout[7], as: RawDeclNameArgumentsSyntax?.self))
-    assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
   case .regexLiteralExpr:
     assert(layout.count == 11)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -2779,6 +2779,11 @@ public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashabl
 /// 
 ///  - `identifier`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<dollarIdentifier>` | `<binaryOperator>`)
 ///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
+///
+/// ### Contained in
+/// 
+///  - ``DynamicReplacementAttributeArgumentsSyntax``.``DynamicReplacementAttributeArgumentsSyntax/declName``
+///  - ``SpecializeTargetFunctionArgumentSyntax``.``SpecializeTargetFunctionArgumentSyntax/declName``
 public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -1815,13 +1815,15 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 /// ### Children
 /// 
-///  - `baseName`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<dollarIdentifier>` | `<binaryOperator>`)
+///  - `baseName`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<dollarIdentifier>` | `<binaryOperator>` | `<integerLiteral>`)
 ///  - `argumentNames`: ``DeclNameArgumentsSyntax``?
 ///
 /// ### Contained in
 /// 
 ///  - ``DynamicReplacementAttributeArgumentsSyntax``.``DynamicReplacementAttributeArgumentsSyntax/declName``
 ///  - ``ImplementsAttributeArgumentsSyntax``.``ImplementsAttributeArgumentsSyntax/declName``
+///  - ``KeyPathPropertyComponentSyntax``.``KeyPathPropertyComponentSyntax/declName``
+///  - ``MemberAccessExprSyntax``.``MemberAccessExprSyntax/declName``
 ///  - ``SpecializeTargetFunctionArgumentSyntax``.``SpecializeTargetFunctionArgumentSyntax/declName``
 public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
@@ -4204,8 +4206,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `base`: ``ExprSyntax``?
 ///  - `period`: `'.'`
-///  - `name`: ``TokenSyntax``
-///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
+///  - `declName`: ``DeclReferenceExprSyntax``
 public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4233,11 +4234,9 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       base: (some ExprSyntaxProtocol)? = ExprSyntax?.none,
       _ unexpectedBetweenBaseAndPeriod: UnexpectedNodesSyntax? = nil,
       period: TokenSyntax = .periodToken(),
-      _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil,
-      name: TokenSyntax,
-      _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-      declNameArguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenPeriodAndDeclName: UnexpectedNodesSyntax? = nil,
+      declName: DeclReferenceExprSyntax,
+      _ unexpectedAfterDeclName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -4248,22 +4247,18 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
             base, 
             unexpectedBetweenBaseAndPeriod, 
             period, 
-            unexpectedBetweenPeriodAndName, 
-            name, 
-            unexpectedBetweenNameAndDeclNameArguments, 
-            declNameArguments, 
-            unexpectedAfterDeclNameArguments
+            unexpectedBetweenPeriodAndDeclName, 
+            declName, 
+            unexpectedAfterDeclName
           ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBase?.raw, 
           base?.raw, 
           unexpectedBetweenBaseAndPeriod?.raw, 
           period.raw, 
-          unexpectedBetweenPeriodAndName?.raw, 
-          name.raw, 
-          unexpectedBetweenNameAndDeclNameArguments?.raw, 
-          declNameArguments?.raw, 
-          unexpectedAfterDeclNameArguments?.raw
+          unexpectedBetweenPeriodAndDeclName?.raw, 
+          declName.raw, 
+          unexpectedAfterDeclName?.raw
         ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.memberAccessExpr,
@@ -4314,7 +4309,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenPeriodAndDeclName: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -4323,39 +4318,21 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var name: TokenSyntax {
+  public var declName: DeclReferenceExprSyntax {
     get {
-      return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)
+      return DeclReferenceExprSyntax(data.child(at: 5, parent: Syntax(self))!)
     }
     set(value) {
       self = MemberAccessExprSyntax(data.replacingChild(at: 5, with: value.data, arena: SyntaxArena()))
     }
   }
   
-  public var unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? {
+  public var unexpectedAfterDeclName: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 6, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
     set(value) {
       self = MemberAccessExprSyntax(data.replacingChild(at: 6, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public var declNameArguments: DeclNameArgumentsSyntax? {
-    get {
-      return data.child(at: 7, parent: Syntax(self)).map(DeclNameArgumentsSyntax.init)
-    }
-    set(value) {
-      self = MemberAccessExprSyntax(data.replacingChild(at: 7, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 8, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = MemberAccessExprSyntax(data.replacingChild(at: 8, with: value?.data, arena: SyntaxArena()))
     }
   }
   
@@ -4365,11 +4342,9 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           \Self.base, 
           \Self.unexpectedBetweenBaseAndPeriod, 
           \Self.period, 
-          \Self.unexpectedBetweenPeriodAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndDeclNameArguments, 
-          \Self.declNameArguments, 
-          \Self.unexpectedAfterDeclNameArguments
+          \Self.unexpectedBetweenPeriodAndDeclName, 
+          \Self.declName, 
+          \Self.unexpectedAfterDeclName
         ])
   }
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -1824,6 +1824,7 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - ``ImplementsAttributeArgumentsSyntax``.``ImplementsAttributeArgumentsSyntax/declName``
 ///  - ``KeyPathPropertyComponentSyntax``.``KeyPathPropertyComponentSyntax/declName``
 ///  - ``MemberAccessExprSyntax``.``MemberAccessExprSyntax/declName``
+///  - ``QualifiedDeclNameSyntax``.``QualifiedDeclNameSyntax/declName``
 ///  - ``SpecializeTargetFunctionArgumentSyntax``.``SpecializeTargetFunctionArgumentSyntax/declName``
 public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -2783,6 +2783,7 @@ public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashabl
 /// ### Contained in
 /// 
 ///  - ``DynamicReplacementAttributeArgumentsSyntax``.``DynamicReplacementAttributeArgumentsSyntax/declName``
+///  - ``ImplementsAttributeArgumentsSyntax``.``ImplementsAttributeArgumentsSyntax/declName``
 ///  - ``SpecializeTargetFunctionArgumentSyntax``.``SpecializeTargetFunctionArgumentSyntax/declName``
 public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -5352,7 +5352,6 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 ///
 /// ### Contained in
 /// 
-///  - ``DeclNameSyntax``.``DeclNameSyntax/arguments``
 ///  - ``IdentifierExprSyntax``.``IdentifierExprSyntax/declNameArguments``
 ///  - ``ImplementsAttributeArgumentsSyntax``.``ImplementsAttributeArgumentsSyntax/declNameArguments``
 ///  - ``KeyPathPropertyComponentSyntax``.``KeyPathPropertyComponentSyntax/declNameArguments``
@@ -5520,137 +5519,6 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
           \Self.unexpectedBetweenArgumentsAndRightParen, 
           \Self.rightParen, 
           \Self.unexpectedAfterRightParen
-        ])
-  }
-}
-
-// MARK: - DeclNameSyntax
-
-/// ### Children
-/// 
-///  - `baseName`: (`<identifier>` | `<binaryOperator>` | `'init'` | `'self'` | `'Self'`)
-///  - `arguments`: ``DeclNameArgumentsSyntax``?
-///
-/// ### Contained in
-/// 
-///  - ``DynamicReplacementAttributeArgumentsSyntax``.``DynamicReplacementAttributeArgumentsSyntax/declName``
-///  - ``SpecializeTargetFunctionArgumentSyntax``.``SpecializeTargetFunctionArgumentSyntax/declName``
-public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
-  public let _syntaxNode: Syntax
-  
-  public init?(_ node: some SyntaxProtocol) {
-    guard node.raw.kind == .declName else {
-      return nil
-    }
-    self._syntaxNode = node._syntaxNode
-  }
-  
-  /// Creates a ``DeclNameSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
-  internal init(_ data: SyntaxData) {
-    precondition(data.raw.kind == .declName)
-    self._syntaxNode = Syntax(data)
-  }
-  
-  /// - Parameters:
-  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  ///   - baseName: The base name of the protocol's requirement.
-  ///   - arguments: The argument labels of the protocol's requirement if it is a function requirement.
-  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeBaseName: UnexpectedNodesSyntax? = nil,
-      baseName: TokenSyntax,
-      _ unexpectedBetweenBaseNameAndArguments: UnexpectedNodesSyntax? = nil,
-      arguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    // Extend the lifetime of all parameters so their arenas don't get destroyed
-    // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
-            unexpectedBeforeBaseName, 
-            baseName, 
-            unexpectedBetweenBaseNameAndArguments, 
-            arguments, 
-            unexpectedAfterArguments
-          ))) { (arena, _) in
-      let layout: [RawSyntax?] = [
-          unexpectedBeforeBaseName?.raw, 
-          baseName.raw, 
-          unexpectedBetweenBaseNameAndArguments?.raw, 
-          arguments?.raw, 
-          unexpectedAfterArguments?.raw
-        ]
-      let raw = RawSyntax.makeLayout(
-        kind: SyntaxKind.declName,
-        from: layout,
-        arena: arena,
-        leadingTrivia: leadingTrivia,
-        trailingTrivia: trailingTrivia
-        
-      )
-      return SyntaxData.forRoot(raw, rawNodeArena: arena)
-    }
-    self.init(data)
-  }
-  
-  public var unexpectedBeforeBaseName: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = DeclNameSyntax(data.replacingChild(at: 0, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  /// The base name of the protocol's requirement.
-  public var baseName: TokenSyntax {
-    get {
-      return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
-    }
-    set(value) {
-      self = DeclNameSyntax(data.replacingChild(at: 1, with: value.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedBetweenBaseNameAndArguments: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = DeclNameSyntax(data.replacingChild(at: 2, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  /// The argument labels of the protocol's requirement if it is a function requirement.
-  public var arguments: DeclNameArgumentsSyntax? {
-    get {
-      return data.child(at: 3, parent: Syntax(self)).map(DeclNameArgumentsSyntax.init)
-    }
-    set(value) {
-      self = DeclNameSyntax(data.replacingChild(at: 3, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedAfterArguments: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = DeclNameSyntax(data.replacingChild(at: 4, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeBaseName, 
-          \Self.baseName, 
-          \Self.unexpectedBetweenBaseNameAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedAfterArguments
         ])
   }
 }
@@ -7280,7 +7148,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
 /// 
 ///  - `forLabel`: `'for'`
 ///  - `colon`: `':'`
-///  - `declName`: ``DeclNameSyntax``
+///  - `declName`: ``IdentifierExprSyntax``
 ///
 /// ### Contained in
 /// 
@@ -7313,7 +7181,7 @@ public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       _ unexpectedBetweenForLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndDeclName: UnexpectedNodesSyntax? = nil,
-      declName: DeclNameSyntax,
+      declName: IdentifierExprSyntax,
       _ unexpectedAfterDeclName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -7396,9 +7264,9 @@ public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     }
   }
   
-  public var declName: DeclNameSyntax {
+  public var declName: IdentifierExprSyntax {
     get {
-      return DeclNameSyntax(data.child(at: 5, parent: Syntax(self))!)
+      return IdentifierExprSyntax(data.child(at: 5, parent: Syntax(self))!)
     }
     set(value) {
       self = DynamicReplacementAttributeArgumentsSyntax(data.replacingChild(at: 5, with: value.data, arena: SyntaxArena()))
@@ -16765,7 +16633,7 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
 /// 
 ///  - `targetLabel`: `'target'`
 ///  - `colon`: `':'`
-///  - `declName`: ``DeclNameSyntax``
+///  - `declName`: ``IdentifierExprSyntax``
 ///  - `trailingComma`: `','`?
 ///
 /// ### Contained in
@@ -16803,7 +16671,7 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
       _ unexpectedBetweenTargetLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndDeclName: UnexpectedNodesSyntax? = nil,
-      declName: DeclNameSyntax,
+      declName: IdentifierExprSyntax,
       _ unexpectedBetweenDeclNameAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -16895,9 +16763,9 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
   }
   
   /// The value for this argument
-  public var declName: DeclNameSyntax {
+  public var declName: IdentifierExprSyntax {
     get {
-      return DeclNameSyntax(data.child(at: 5, parent: Syntax(self))!)
+      return IdentifierExprSyntax(data.child(at: 5, parent: Syntax(self))!)
     }
     set(value) {
       self = SpecializeTargetFunctionArgumentSyntax(data.replacingChild(at: 5, with: value.data, arena: SyntaxArena()))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -5353,7 +5353,6 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``IdentifierExprSyntax``.``IdentifierExprSyntax/declNameArguments``
-///  - ``ImplementsAttributeArgumentsSyntax``.``ImplementsAttributeArgumentsSyntax/declNameArguments``
 ///  - ``KeyPathPropertyComponentSyntax``.``KeyPathPropertyComponentSyntax/declNameArguments``
 ///  - ``MemberAccessExprSyntax``.``MemberAccessExprSyntax/declNameArguments``
 ///  - ``QualifiedDeclNameSyntax``.``QualifiedDeclNameSyntax/arguments``
@@ -10549,8 +10548,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `type`: ``TypeSyntax``
 ///  - `comma`: `','`
-///  - `declBaseName`: ``TokenSyntax``
-///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
+///  - `declName`: ``IdentifierExprSyntax``
 ///
 /// ### Contained in
 /// 
@@ -10577,8 +10575,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - type: The type for which the method with this attribute implements a requirement.
   ///   - comma: The comma separating the type and method name
-  ///   - declBaseName: The base name of the protocol's requirement.
-  ///   - declNameArguments: The argument labels of the protocol's requirement if it is a function requirement.
+  ///   - declName: The value for this argument
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -10586,11 +10583,9 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? = nil,
       comma: TokenSyntax = .commaToken(),
-      _ unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? = nil,
-      declBaseName: TokenSyntax,
-      _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-      declNameArguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenCommaAndDeclName: UnexpectedNodesSyntax? = nil,
+      declName: IdentifierExprSyntax,
+      _ unexpectedAfterDeclName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -10601,22 +10596,18 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
             type, 
             unexpectedBetweenTypeAndComma, 
             comma, 
-            unexpectedBetweenCommaAndDeclBaseName, 
-            declBaseName, 
-            unexpectedBetweenDeclBaseNameAndDeclNameArguments, 
-            declNameArguments, 
-            unexpectedAfterDeclNameArguments
+            unexpectedBetweenCommaAndDeclName, 
+            declName, 
+            unexpectedAfterDeclName
           ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeType?.raw, 
           type.raw, 
           unexpectedBetweenTypeAndComma?.raw, 
           comma.raw, 
-          unexpectedBetweenCommaAndDeclBaseName?.raw, 
-          declBaseName.raw, 
-          unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw, 
-          declNameArguments?.raw, 
-          unexpectedAfterDeclNameArguments?.raw
+          unexpectedBetweenCommaAndDeclName?.raw, 
+          declName.raw, 
+          unexpectedAfterDeclName?.raw
         ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.implementsAttributeArguments,
@@ -10669,7 +10660,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  public var unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenCommaAndDeclName: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -10678,41 +10669,22 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     }
   }
   
-  /// The base name of the protocol's requirement.
-  public var declBaseName: TokenSyntax {
+  /// The value for this argument
+  public var declName: IdentifierExprSyntax {
     get {
-      return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)
+      return IdentifierExprSyntax(data.child(at: 5, parent: Syntax(self))!)
     }
     set(value) {
       self = ImplementsAttributeArgumentsSyntax(data.replacingChild(at: 5, with: value.data, arena: SyntaxArena()))
     }
   }
   
-  public var unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? {
+  public var unexpectedAfterDeclName: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 6, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
     set(value) {
       self = ImplementsAttributeArgumentsSyntax(data.replacingChild(at: 6, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  /// The argument labels of the protocol's requirement if it is a function requirement.
-  public var declNameArguments: DeclNameArgumentsSyntax? {
-    get {
-      return data.child(at: 7, parent: Syntax(self)).map(DeclNameArgumentsSyntax.init)
-    }
-    set(value) {
-      self = ImplementsAttributeArgumentsSyntax(data.replacingChild(at: 7, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 8, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = ImplementsAttributeArgumentsSyntax(data.replacingChild(at: 8, with: value?.data, arena: SyntaxArena()))
     }
   }
   
@@ -10722,11 +10694,9 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
           \Self.type, 
           \Self.unexpectedBetweenTypeAndComma, 
           \Self.comma, 
-          \Self.unexpectedBetweenCommaAndDeclBaseName, 
-          \Self.declBaseName, 
-          \Self.unexpectedBetweenDeclBaseNameAndDeclNameArguments, 
-          \Self.declNameArguments, 
-          \Self.unexpectedAfterDeclNameArguments
+          \Self.unexpectedBetweenCommaAndDeclName, 
+          \Self.declName, 
+          \Self.unexpectedAfterDeclName
         ])
   }
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -5353,8 +5353,6 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``DeclReferenceExprSyntax``.``DeclReferenceExprSyntax/argumentNames``
-///  - ``KeyPathPropertyComponentSyntax``.``KeyPathPropertyComponentSyntax/declNameArguments``
-///  - ``MemberAccessExprSyntax``.``MemberAccessExprSyntax/declNameArguments``
 ///  - ``QualifiedDeclNameSyntax``.``QualifiedDeclNameSyntax/arguments``
 public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
@@ -11511,8 +11509,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
 
 /// ### Children
 /// 
-///  - `property`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<dollarIdentifier>` | `<binaryOperator>` | `<integerLiteral>`)
-///  - `declNameArguments`: ``DeclNameArgumentsSyntax``?
+///  - `declName`: ``DeclReferenceExprSyntax``
 ///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``?
 ///
 /// ### Contained in
@@ -11541,11 +11538,9 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeProperty: UnexpectedNodesSyntax? = nil,
-      property: TokenSyntax,
-      _ unexpectedBetweenPropertyAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-      declNameArguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBeforeDeclName: UnexpectedNodesSyntax? = nil,
+      declName: DeclReferenceExprSyntax,
+      _ unexpectedBetweenDeclNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
       genericArgumentClause: GenericArgumentClauseSyntax? = nil,
       _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
@@ -11554,20 +11549,16 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
     let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
-            unexpectedBeforeProperty, 
-            property, 
-            unexpectedBetweenPropertyAndDeclNameArguments, 
-            declNameArguments, 
-            unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause, 
+            unexpectedBeforeDeclName, 
+            declName, 
+            unexpectedBetweenDeclNameAndGenericArgumentClause, 
             genericArgumentClause, 
             unexpectedAfterGenericArgumentClause
           ))) { (arena, _) in
       let layout: [RawSyntax?] = [
-          unexpectedBeforeProperty?.raw, 
-          property.raw, 
-          unexpectedBetweenPropertyAndDeclNameArguments?.raw, 
-          declNameArguments?.raw, 
-          unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause?.raw, 
+          unexpectedBeforeDeclName?.raw, 
+          declName.raw, 
+          unexpectedBetweenDeclNameAndGenericArgumentClause?.raw, 
           genericArgumentClause?.raw, 
           unexpectedAfterGenericArgumentClause?.raw
         ]
@@ -11584,7 +11575,7 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     self.init(data)
   }
   
-  public var unexpectedBeforeProperty: UnexpectedNodesSyntax? {
+  public var unexpectedBeforeDeclName: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -11593,16 +11584,16 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var property: TokenSyntax {
+  public var declName: DeclReferenceExprSyntax {
     get {
-      return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
+      return DeclReferenceExprSyntax(data.child(at: 1, parent: Syntax(self))!)
     }
     set(value) {
       self = KeyPathPropertyComponentSyntax(data.replacingChild(at: 1, with: value.data, arena: SyntaxArena()))
     }
   }
   
-  public var unexpectedBetweenPropertyAndDeclNameArguments: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenDeclNameAndGenericArgumentClause: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -11611,16 +11602,16 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var declNameArguments: DeclNameArgumentsSyntax? {
+  public var genericArgumentClause: GenericArgumentClauseSyntax? {
     get {
-      return data.child(at: 3, parent: Syntax(self)).map(DeclNameArgumentsSyntax.init)
+      return data.child(at: 3, parent: Syntax(self)).map(GenericArgumentClauseSyntax.init)
     }
     set(value) {
       self = KeyPathPropertyComponentSyntax(data.replacingChild(at: 3, with: value?.data, arena: SyntaxArena()))
     }
   }
   
-  public var unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: UnexpectedNodesSyntax? {
+  public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -11629,31 +11620,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var genericArgumentClause: GenericArgumentClauseSyntax? {
-    get {
-      return data.child(at: 5, parent: Syntax(self)).map(GenericArgumentClauseSyntax.init)
-    }
-    set(value) {
-      self = KeyPathPropertyComponentSyntax(data.replacingChild(at: 5, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 6, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = KeyPathPropertyComponentSyntax(data.replacingChild(at: 6, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
   public static var structure: SyntaxNodeStructure {
     return .layout([
-          \Self.unexpectedBeforeProperty, 
-          \Self.property, 
-          \Self.unexpectedBetweenPropertyAndDeclNameArguments, 
-          \Self.declNameArguments, 
-          \Self.unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause, 
+          \Self.unexpectedBeforeDeclName, 
+          \Self.declName, 
+          \Self.unexpectedBetweenDeclNameAndGenericArgumentClause, 
           \Self.genericArgumentClause, 
           \Self.unexpectedAfterGenericArgumentClause
         ])

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -5352,7 +5352,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 ///
 /// ### Contained in
 /// 
-///  - ``IdentifierExprSyntax``.``IdentifierExprSyntax/declNameArguments``
+///  - ``DeclReferenceExprSyntax``.``DeclReferenceExprSyntax/argumentNames``
 ///  - ``KeyPathPropertyComponentSyntax``.``KeyPathPropertyComponentSyntax/declNameArguments``
 ///  - ``MemberAccessExprSyntax``.``MemberAccessExprSyntax/declNameArguments``
 ///  - ``QualifiedDeclNameSyntax``.``QualifiedDeclNameSyntax/arguments``
@@ -7147,7 +7147,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
 /// 
 ///  - `forLabel`: `'for'`
 ///  - `colon`: `':'`
-///  - `declName`: ``IdentifierExprSyntax``
+///  - `declName`: ``DeclReferenceExprSyntax``
 ///
 /// ### Contained in
 /// 
@@ -7180,7 +7180,7 @@ public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       _ unexpectedBetweenForLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndDeclName: UnexpectedNodesSyntax? = nil,
-      declName: IdentifierExprSyntax,
+      declName: DeclReferenceExprSyntax,
       _ unexpectedAfterDeclName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -7263,9 +7263,9 @@ public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     }
   }
   
-  public var declName: IdentifierExprSyntax {
+  public var declName: DeclReferenceExprSyntax {
     get {
-      return IdentifierExprSyntax(data.child(at: 5, parent: Syntax(self))!)
+      return DeclReferenceExprSyntax(data.child(at: 5, parent: Syntax(self))!)
     }
     set(value) {
       self = DynamicReplacementAttributeArgumentsSyntax(data.replacingChild(at: 5, with: value.data, arena: SyntaxArena()))
@@ -10548,7 +10548,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `type`: ``TypeSyntax``
 ///  - `comma`: `','`
-///  - `declName`: ``IdentifierExprSyntax``
+///  - `declName`: ``DeclReferenceExprSyntax``
 ///
 /// ### Contained in
 /// 
@@ -10584,7 +10584,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       _ unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? = nil,
       comma: TokenSyntax = .commaToken(),
       _ unexpectedBetweenCommaAndDeclName: UnexpectedNodesSyntax? = nil,
-      declName: IdentifierExprSyntax,
+      declName: DeclReferenceExprSyntax,
       _ unexpectedAfterDeclName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -10670,9 +10670,9 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   }
   
   /// The value for this argument
-  public var declName: IdentifierExprSyntax {
+  public var declName: DeclReferenceExprSyntax {
     get {
-      return IdentifierExprSyntax(data.child(at: 5, parent: Syntax(self))!)
+      return DeclReferenceExprSyntax(data.child(at: 5, parent: Syntax(self))!)
     }
     set(value) {
       self = ImplementsAttributeArgumentsSyntax(data.replacingChild(at: 5, with: value.data, arena: SyntaxArena()))
@@ -16603,7 +16603,7 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
 /// 
 ///  - `targetLabel`: `'target'`
 ///  - `colon`: `':'`
-///  - `declName`: ``IdentifierExprSyntax``
+///  - `declName`: ``DeclReferenceExprSyntax``
 ///  - `trailingComma`: `','`?
 ///
 /// ### Contained in
@@ -16641,7 +16641,7 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
       _ unexpectedBetweenTargetLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndDeclName: UnexpectedNodesSyntax? = nil,
-      declName: IdentifierExprSyntax,
+      declName: DeclReferenceExprSyntax,
       _ unexpectedBetweenDeclNameAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -16733,9 +16733,9 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
   }
   
   /// The value for this argument
-  public var declName: IdentifierExprSyntax {
+  public var declName: DeclReferenceExprSyntax {
     get {
-      return IdentifierExprSyntax(data.child(at: 5, parent: Syntax(self))!)
+      return DeclReferenceExprSyntax(data.child(at: 5, parent: Syntax(self))!)
     }
     set(value) {
       self = SpecializeTargetFunctionArgumentSyntax(data.replacingChild(at: 5, with: value.data, arena: SyntaxArena()))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -5353,7 +5353,6 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``DeclReferenceExprSyntax``.``DeclReferenceExprSyntax/argumentNames``
-///  - ``QualifiedDeclNameSyntax``.``QualifiedDeclNameSyntax/arguments``
 public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -15748,8 +15747,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `baseType`: ``TypeSyntax``?
 ///  - `period`: `'.'`?
-///  - `name`: (`<identifier>` | `'self'` | `'Self'` | `'init'` | `<binaryOperator>`)
-///  - `arguments`: ``DeclNameArgumentsSyntax``?
+///  - `declName`: ``DeclReferenceExprSyntax``
 ///
 /// ### Contained in
 /// 
@@ -15775,8 +15773,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - baseType: The base type of the qualified name, optionally specified.
-  ///   - name: The base name of the referenced function.
-  ///   - arguments: The argument labels of the referenced function, optionally specified.
+  ///   - declName: The name of the referenced function.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -15784,11 +15781,9 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       baseType: (some TypeSyntaxProtocol)? = TypeSyntax?.none,
       _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil,
       period: TokenSyntax? = nil,
-      _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil,
-      name: TokenSyntax,
-      _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil,
-      arguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenPeriodAndDeclName: UnexpectedNodesSyntax? = nil,
+      declName: DeclReferenceExprSyntax,
+      _ unexpectedAfterDeclName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -15799,22 +15794,18 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
             baseType, 
             unexpectedBetweenBaseTypeAndPeriod, 
             period, 
-            unexpectedBetweenPeriodAndName, 
-            name, 
-            unexpectedBetweenNameAndArguments, 
-            arguments, 
-            unexpectedAfterArguments
+            unexpectedBetweenPeriodAndDeclName, 
+            declName, 
+            unexpectedAfterDeclName
           ))) { (arena, _) in
       let layout: [RawSyntax?] = [
           unexpectedBeforeBaseType?.raw, 
           baseType?.raw, 
           unexpectedBetweenBaseTypeAndPeriod?.raw, 
           period?.raw, 
-          unexpectedBetweenPeriodAndName?.raw, 
-          name.raw, 
-          unexpectedBetweenNameAndArguments?.raw, 
-          arguments?.raw, 
-          unexpectedAfterArguments?.raw
+          unexpectedBetweenPeriodAndDeclName?.raw, 
+          declName.raw, 
+          unexpectedAfterDeclName?.raw
         ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.qualifiedDeclName,
@@ -15866,7 +15857,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenPeriodAndDeclName: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -15875,41 +15866,22 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// The base name of the referenced function.
-  public var name: TokenSyntax {
+  /// The name of the referenced function.
+  public var declName: DeclReferenceExprSyntax {
     get {
-      return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)
+      return DeclReferenceExprSyntax(data.child(at: 5, parent: Syntax(self))!)
     }
     set(value) {
       self = QualifiedDeclNameSyntax(data.replacingChild(at: 5, with: value.data, arena: SyntaxArena()))
     }
   }
   
-  public var unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? {
+  public var unexpectedAfterDeclName: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 6, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
     set(value) {
       self = QualifiedDeclNameSyntax(data.replacingChild(at: 6, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  /// The argument labels of the referenced function, optionally specified.
-  public var arguments: DeclNameArgumentsSyntax? {
-    get {
-      return data.child(at: 7, parent: Syntax(self)).map(DeclNameArgumentsSyntax.init)
-    }
-    set(value) {
-      self = QualifiedDeclNameSyntax(data.replacingChild(at: 7, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedAfterArguments: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 8, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = QualifiedDeclNameSyntax(data.replacingChild(at: 8, with: value?.data, arena: SyntaxArena()))
     }
   }
   
@@ -15919,11 +15891,9 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
           \Self.baseType, 
           \Self.unexpectedBetweenBaseTypeAndPeriod, 
           \Self.period, 
-          \Self.unexpectedBetweenPeriodAndName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndArguments, 
-          \Self.arguments, 
-          \Self.unexpectedAfterArguments
+          \Self.unexpectedBetweenPeriodAndDeclName, 
+          \Self.declName, 
+          \Self.unexpectedAfterDeclName
         ])
   }
 }

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -377,7 +377,7 @@ extension Optional: ExpressibleByLiteralSyntax where Wrapped: ExpressibleByLiter
 
       if let call = expr.as(FunctionCallExprSyntax.self),
         let memberAccess = call.calledExpression.as(MemberAccessExprSyntax.self),
-        memberAccess.name.text == "some",
+        memberAccess.declName.baseName.text == "some",
         let argument = call.arguments.first?.expression
       {
         return containsNil(argument)

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -192,7 +192,7 @@ extension MacroDeclSyntax {
       let base = memberAccess.base,
       let baseName = base.as(DeclReferenceExprSyntax.self)?.baseName
     {
-      let memberName = memberAccess.name
+      let memberName = memberAccess.declName.baseName
       return .deprecatedExternal(
         node: Syntax(memberAccess),
         module: baseName.trimmedDescription,

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -53,7 +53,7 @@ extension MacroDefinition {
   /// A replacement that occurs as part of an expanded macro definition.
   public struct Replacement {
     /// A reference to a parameter as it occurs in the macro expansion expression.
-    public let reference: IdentifierExprSyntax
+    public let reference: DeclReferenceExprSyntax
 
     /// The index of the parameter in the defining macro.
     public let parameterIndex: Int
@@ -112,12 +112,12 @@ fileprivate class ParameterReplacementVisitor: SyntaxAnyVisitor {
 
   // References to declarations. Only accept those that refer to a parameter
   // of a macro.
-  override func visit(_ node: IdentifierExprSyntax) -> SyntaxVisitorContinueKind {
-    let identifier = node.identifier
+  override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+    let baseName = node.baseName
     let signature = macro.signature
 
     let matchedParameter = signature.parameterClause.parameters.enumerated().first { (index, parameter) in
-      if identifier.text == "_" {
+      if baseName.text == "_" {
         return false
       }
 
@@ -125,15 +125,15 @@ fileprivate class ParameterReplacementVisitor: SyntaxAnyVisitor {
         return false
       }
 
-      return identifier.text == parameterName.text
+      return baseName.text == parameterName.text
     }
 
     guard let (parameterIndex, _) = matchedParameter else {
       // We have a reference to something that isn't a parameter of the macro.
       diagnostics.append(
         Diagnostic(
-          node: Syntax(identifier),
-          message: MacroExpanderError.nonParameterReference(identifier)
+          node: Syntax(baseName),
+          message: MacroExpanderError.nonParameterReference(baseName)
         )
       )
 
@@ -190,7 +190,7 @@ extension MacroDeclSyntax {
     /// handle this themselves.
     if let memberAccess = originalDefinition.as(MemberAccessExprSyntax.self),
       let base = memberAccess.base,
-      let baseName = base.as(IdentifierExprSyntax.self)?.identifier
+      let baseName = base.as(DeclReferenceExprSyntax.self)?.baseName
     {
       let memberName = memberAccess.name
       return .deprecatedExternal(
@@ -225,16 +225,16 @@ extension MacroDeclSyntax {
 /// Syntax rewrite that performs macro expansion by textually replacing
 /// uses of macro parameters with their corresponding arguments.
 private final class MacroExpansionRewriter: SyntaxRewriter {
-  let parameterReplacements: [IdentifierExprSyntax: Int]
+  let parameterReplacements: [DeclReferenceExprSyntax: Int]
   let arguments: [ExprSyntax]
 
-  init(parameterReplacements: [IdentifierExprSyntax: Int], arguments: [ExprSyntax]) {
+  init(parameterReplacements: [DeclReferenceExprSyntax: Int], arguments: [ExprSyntax]) {
     self.parameterReplacements = parameterReplacements
     self.arguments = arguments
     super.init(viewMode: .sourceAccurate)
   }
 
-  override func visit(_ node: IdentifierExprSyntax) -> ExprSyntax {
+  override func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
     guard let parameterIndex = parameterReplacements[node] else {
       return super.visit(node)
     }

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -136,7 +136,7 @@ extension SyntaxProtocol {
     if case .collection(let collectionElementType) = self.syntaxNodeType.structure {
       let typeName = String(describing: type(of: self))
       return ExprSyntax(
-        FunctionCallExprSyntax(callee: IdentifierExprSyntax(identifier: .identifier(typeName))) {
+        FunctionCallExprSyntax(callee: DeclReferenceExprSyntax(baseName: .identifier(typeName))) {
           LabeledExprSyntax(
             expression: ArrayExprSyntax {
               for child in self.children(viewMode: .all) {
@@ -195,7 +195,7 @@ extension SyntaxProtocol {
     } else if case .layout(let layout) = self.syntaxNodeType.structure {
       let typeName = String(describing: type(of: self))
       return ExprSyntax(
-        FunctionCallExprSyntax(callee: IdentifierExprSyntax(identifier: .identifier(typeName))) {
+        FunctionCallExprSyntax(callee: DeclReferenceExprSyntax(baseName: .identifier(typeName))) {
           for keyPath in layout {
             let label = childName(keyPath) ?? ""
             let value = self[keyPath: keyPath as! PartialKeyPath<Self>] as! SyntaxProtocol?

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -2203,11 +2203,11 @@ final class DeclarationTests: XCTestCase {
       """,
       substructure: Syntax(
         FunctionCallExprSyntax(
-          calledExpression: IdentifierExprSyntax(identifier: .identifier("open")),
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("open")),
           leftParen: .leftParenToken(),
           arguments: LabeledExprListSyntax([
             LabeledExprSyntax(
-              expression: IdentifierExprSyntax(identifier: .identifier("set"))
+              expression: DeclReferenceExprSyntax(baseName: .identifier("set"))
             )
           ]),
           rightParen: .rightParenToken()

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -396,7 +396,7 @@ final class ExpressionTests: XCTestCase {
           ),
           colon: .colonToken(),
           value: FunctionCallExprSyntax(
-            calledExpression: IdentifierExprSyntax(identifier: .identifier("Calendar")),
+            calledExpression: DeclReferenceExprSyntax(baseName: .identifier("Calendar")),
             leftParen: .leftParenToken(),
             arguments: LabeledExprListSyntax([
               LabeledExprSyntax(
@@ -1539,7 +1539,7 @@ final class StatementExpressionTests: XCTestCase {
       SwitchExprSyntax(
         subject: FunctionCallExprSyntax(
           callee: MemberAccessExprSyntax(
-            base: IdentifierExprSyntax(identifier: .identifier("Bool")),
+            base: DeclReferenceExprSyntax(baseName: .identifier("Bool")),
             name: "random"
           )
         ),
@@ -2598,7 +2598,7 @@ final class StatementExpressionTests: XCTestCase {
       """,
       substructure: Syntax(
         FunctionCallExprSyntax(
-          calledExpression: IdentifierExprSyntax(identifier: .keyword(.init("init")!)),
+          calledExpression: DeclReferenceExprSyntax(baseName: .keyword(.init("init")!)),
           leftParen: .leftParenToken(),
           arguments: LabeledExprListSyntax([]),
           rightParen: .rightParenToken()

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -132,7 +132,7 @@ final class ExpressionTests: XCTestCase {
                     period: .periodToken(),
                     component: .init(
                       KeyPathPropertyComponentSyntax(
-                        property: .identifier("foo")
+                        declName: DeclReferenceExprSyntax(baseName: .identifier("foo"))
                       )
                     )
                   ),
@@ -281,7 +281,9 @@ final class ExpressionTests: XCTestCase {
               KeyPathComponentSyntax(
                 period: .periodToken(),
                 component: .init(
-                  KeyPathPropertyComponentSyntax(property: .identifier("y"))
+                  KeyPathPropertyComponentSyntax(
+                    declName: DeclReferenceExprSyntax(baseName: .identifier("y"))
+                  )
                 )
               )
             ])

--- a/Tests/SwiftParserTest/PatternTests.swift
+++ b/Tests/SwiftParserTest/PatternTests.swift
@@ -24,7 +24,7 @@ final class PatternTests: XCTestCase {
           expression: FunctionCallExprSyntax(
             calledExpression: MemberAccessExprSyntax(
               base: GenericSpecializationExprSyntax(
-                expression: IdentifierExprSyntax(identifier: .identifier("E")),
+                expression: DeclReferenceExprSyntax(baseName: .identifier("E")),
                 genericArgumentClause: GenericArgumentClauseSyntax(
                   arguments: .init([
                     .init(argument: IdentifierTypeSyntax(name: .identifier("Int")))
@@ -79,7 +79,7 @@ final class PatternTests: XCTestCase {
             elements: .init([
               .init(
                 expression: SubscriptCallExprSyntax(
-                  calledExpression: IdentifierExprSyntax(identifier: .identifier("y")),
+                  calledExpression: DeclReferenceExprSyntax(baseName: .identifier("y")),
                   leftSquare: .leftSquareToken(),
                   arguments: LabeledExprListSyntax([
                     .init(expression: IntegerLiteralExprSyntax(literal: .integerLiteral("0")))
@@ -128,7 +128,7 @@ final class PatternTests: XCTestCase {
         bindingSpecifier: .keyword(.let),
         pattern: ExpressionPatternSyntax(
           expression: SubscriptCallExprSyntax(
-            calledExpression: IdentifierExprSyntax(identifier: .identifier("y")),
+            calledExpression: DeclReferenceExprSyntax(baseName: .identifier("y")),
             leftSquare: .leftSquareToken(),
             arguments: LabeledExprListSyntax([
               .init(

--- a/Tests/SwiftParserTest/RegexLiteralTests.swift
+++ b/Tests/SwiftParserTest/RegexLiteralTests.swift
@@ -990,11 +990,11 @@ final class RegexLiteralTests: XCTestCase {
           .init(
             label: "a",
             colon: .colonToken(),
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/")),
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
           ),
         ])
       )
@@ -1010,15 +1010,15 @@ final class RegexLiteralTests: XCTestCase {
       substructure: Syntax(
         LabeledExprListSyntax([
           .init(
-            expression: IdentifierExprSyntax(identifier: "a"),
+            expression: DeclReferenceExprSyntax(baseName: "a"),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/")),
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
           ),
         ])
       )
@@ -1034,15 +1034,15 @@ final class RegexLiteralTests: XCTestCase {
       substructure: Syntax(
         LabeledExprListSyntax([
           .init(
-            expression: IdentifierExprSyntax(identifier: "a"),
+            expression: DeclReferenceExprSyntax(baseName: "a"),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("^/")),
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
           ),
         ])
       )
@@ -1060,11 +1060,11 @@ final class RegexLiteralTests: XCTestCase {
           .init(
             label: "a",
             colon: .colonToken(),
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("^/")),
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
           ),
         ])
       )
@@ -1080,11 +1080,11 @@ final class RegexLiteralTests: XCTestCase {
       substructure: Syntax(
         LabeledExprListSyntax([
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("^/")),
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
           ),
         ])
       )
@@ -1100,11 +1100,11 @@ final class RegexLiteralTests: XCTestCase {
       substructure: Syntax(
         LabeledExprListSyntax([
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("^/")),
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
           ),
         ])
       )
@@ -1120,11 +1120,11 @@ final class RegexLiteralTests: XCTestCase {
       substructure: Syntax(
         LabeledExprListSyntax([
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/")),
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
           ),
         ])
       )
@@ -1140,11 +1140,11 @@ final class RegexLiteralTests: XCTestCase {
       substructure: Syntax(
         LabeledExprListSyntax([
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/")),
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
           ),
         ])
       )
@@ -1160,11 +1160,11 @@ final class RegexLiteralTests: XCTestCase {
       substructure: Syntax(
         LabeledExprListSyntax([
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("^/")),
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
             trailingComma: .commaToken()
           ),
           .init(
-            expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))
+            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
           ),
         ])
       )

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -55,7 +55,7 @@ final class StatementTests: XCTestCase {
                 OptionalBindingConditionSyntax(
                   bindingSpecifier: .keyword(.let),
                   pattern: IdentifierPatternSyntax(identifier: .keyword(.self)),
-                  initializer: InitializerClauseSyntax(equal: .equalToken(), value: IdentifierExprSyntax(identifier: .keyword(.self)))
+                  initializer: InitializerClauseSyntax(equal: .equalToken(), value: DeclReferenceExprSyntax(baseName: .keyword(.self)))
                 )
               )
             )
@@ -392,7 +392,7 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(
         GenericSpecializationExprSyntax(
-          expression: IdentifierExprSyntax(identifier: .identifier("Optional")),
+          expression: DeclReferenceExprSyntax(baseName: .identifier("Optional")),
           genericArgumentClause: GenericArgumentClauseSyntax(
             leftAngle: .leftAngleToken(),
             arguments: GenericArgumentListSyntax([
@@ -414,7 +414,7 @@ final class StatementTests: XCTestCase {
       1️⃣yield
       print("huh")
       """,
-      substructure: Syntax(IdentifierExprSyntax(identifier: .identifier("yield"))),
+      substructure: Syntax(DeclReferenceExprSyntax(baseName: .identifier("yield"))),
       substructureAfterMarker: "1️⃣"
     )
   }
@@ -435,7 +435,7 @@ final class StatementTests: XCTestCase {
           yieldedExpressions: .init(
             InOutExprSyntax(
               ampersand: .prefixAmpersandToken(),
-              expression: IdentifierExprSyntax(identifier: .identifier("x"))
+              expression: DeclReferenceExprSyntax(baseName: .identifier("x"))
             )
           )
         )
@@ -470,11 +470,11 @@ final class StatementTests: XCTestCase {
             InOutExprSyntax(
               ampersand: .prefixAmpersandToken(),
               expression: SubscriptCallExprSyntax(
-                calledExpression: IdentifierExprSyntax(identifier: .identifier("native")),
+                calledExpression: DeclReferenceExprSyntax(baseName: .identifier("native")),
                 leftSquare: .leftSquareToken(),
                 arguments: LabeledExprListSyntax([
                   LabeledExprSyntax(
-                    expression: IdentifierExprSyntax(identifier: .identifier("key")),
+                    expression: DeclReferenceExprSyntax(baseName: .identifier("key")),
                     trailingComma: .commaToken()
                   ),
                   LabeledExprSyntax(
@@ -503,7 +503,7 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(
         FunctionCallExprSyntax(
-          calledExpression: IdentifierExprSyntax(identifier: .identifier("yield")),
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("yield")),
           leftParen: .leftParenToken(),
           arguments: LabeledExprListSyntax([]),
           rightParen: .rightParenToken()
@@ -522,7 +522,7 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(
         FunctionCallExprSyntax(
-          calledExpression: IdentifierExprSyntax(identifier: .identifier("yield")),
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("yield")),
           leftParen: .leftParenToken(),
           arguments: LabeledExprListSyntax([]),
           rightParen: .rightParenToken()
@@ -537,7 +537,7 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(
         FunctionCallExprSyntax(
-          calledExpression: IdentifierExprSyntax(identifier: .identifier("yield")),
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("yield")),
           leftParen: .leftParenToken(),
           arguments: LabeledExprListSyntax([
             LabeledExprSyntax(
@@ -562,7 +562,7 @@ final class StatementTests: XCTestCase {
       substructure: Syntax(
         SequenceExprSyntax(
           elements: ExprListSyntax([
-            IdentifierExprSyntax(identifier: .identifier("yield")),
+            DeclReferenceExprSyntax(baseName: .identifier("yield")),
             BinaryOperatorExprSyntax(operator: .binaryOperator("&")),
             IntegerLiteralExprSyntax(5),
           ])
@@ -580,7 +580,7 @@ final class StatementTests: XCTestCase {
       substructure: Syntax(
         SequenceExprSyntax(
           elements: ExprListSyntax([
-            IdentifierExprSyntax(identifier: .identifier("yield")),
+            DeclReferenceExprSyntax(baseName: .identifier("yield")),
             BinaryOperatorExprSyntax(operator: .binaryOperator("&")),
             IntegerLiteralExprSyntax(5),
           ])
@@ -599,7 +599,7 @@ final class StatementTests: XCTestCase {
       substructure: Syntax(
         DiscardStmtSyntax(
           discardKeyword: .keyword(._forget),
-          expression: IdentifierExprSyntax(identifier: .keyword(.`self`))
+          expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
         )
       )
     )
@@ -611,7 +611,7 @@ final class StatementTests: XCTestCase {
       substructure: Syntax(
         DiscardStmtSyntax(
           discardKeyword: .keyword(.discard),
-          expression: IdentifierExprSyntax(identifier: .keyword(.`self`))
+          expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
         )
       )
     )
@@ -623,7 +623,7 @@ final class StatementTests: XCTestCase {
       substructure: Syntax(
         DiscardStmtSyntax(
           discardKeyword: .keyword(.discard),
-          expression: IdentifierExprSyntax(identifier: .keyword(.Self))
+          expression: DeclReferenceExprSyntax(baseName: .keyword(.Self))
         )
       )
     )
@@ -635,7 +635,7 @@ final class StatementTests: XCTestCase {
       substructure: Syntax(
         DiscardStmtSyntax(
           discardKeyword: .keyword(.discard),
-          expression: IdentifierExprSyntax(identifier: .identifier("SarahMarshall"))
+          expression: DeclReferenceExprSyntax(baseName: .identifier("SarahMarshall"))
         )
       )
     )
@@ -664,13 +664,13 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(
         FunctionCallExprSyntax(
-          callee: IdentifierExprSyntax(
-            identifier: .identifier("discard")
+          callee: DeclReferenceExprSyntax(
+            baseName: .identifier("discard")
           ),
           argumentList: {
             LabeledExprListSyntax([
               LabeledExprSyntax(
-                expression: IdentifierExprSyntax(identifier: .keyword(.`self`))
+                expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
               )
             ])
           }
@@ -690,11 +690,11 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(
         SubscriptCallExprSyntax(
-          calledExpression: IdentifierExprSyntax(identifier: .identifier("data")),
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("data")),
           leftSquare: .leftSquareToken(),
           arguments: LabeledExprListSyntax([
             LabeledExprSyntax(
-              expression: IdentifierExprSyntax(identifier: .identifier("position")),
+              expression: DeclReferenceExprSyntax(baseName: .identifier("position")),
               trailingComma: .commaToken()
             ),
             LabeledExprSyntax(

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -26,8 +26,8 @@ final class VariadicGenericsTests: XCTestCase {
           repeatKeyword: .keyword(.repeat),
           repetitionPattern: PackElementExprSyntax(
             eachKeyword: .keyword(.each),
-            pack: IdentifierExprSyntax(
-              identifier: .identifier("t")
+            pack: DeclReferenceExprSyntax(
+              baseName: .identifier("t")
             )
           )
         )
@@ -139,15 +139,15 @@ final class VariadicGenericsTests: XCTestCase {
 
   func testEachExprKeyword() {
     let callExpr = FunctionCallExprSyntax(
-      calledExpression: IdentifierExprSyntax(
-        identifier: .identifier("each")
+      calledExpression: DeclReferenceExprSyntax(
+        baseName: .identifier("each")
       ),
       leftParen: .leftParenToken(),
       arguments: LabeledExprListSyntax([
         .init(
           expression:
-            IdentifierExprSyntax(
-              identifier: .identifier("x")
+            DeclReferenceExprSyntax(
+              baseName: .identifier("x")
             )
         )
       ]),
@@ -183,8 +183,8 @@ final class VariadicGenericsTests: XCTestCase {
       substructure: Syntax(
         PackElementExprSyntax(
           eachKeyword: .keyword(.each),
-          pack: IdentifierExprSyntax(
-            identifier: .identifier("x")
+          pack: DeclReferenceExprSyntax(
+            baseName: .identifier("x")
           )
         )
       ),
@@ -210,8 +210,8 @@ final class VariadicGenericsTests: XCTestCase {
                     LabeledExprSyntax(
                       expression: PackElementExprSyntax(
                         eachKeyword: .keyword(.each),
-                        pack: IdentifierExprSyntax(
-                          identifier: .identifier("t")
+                        pack: DeclReferenceExprSyntax(
+                          baseName: .identifier("t")
                         )
                       )
                     )
@@ -239,8 +239,8 @@ final class VariadicGenericsTests: XCTestCase {
             eachKeyword: .keyword(.each),
             pack: MemberAccessExprSyntax(
               base: ExprSyntax(
-                IdentifierExprSyntax(
-                  identifier: .identifier("t")
+                DeclReferenceExprSyntax(
+                  baseName: .identifier("t")
                 )
               ),
               name: "member"
@@ -263,8 +263,8 @@ final class VariadicGenericsTests: XCTestCase {
           repetitionPattern: SequenceExprSyntax(
             elements: .init([
               ExprSyntax(
-                IdentifierExprSyntax(
-                  identifier: .identifier("x")
+                DeclReferenceExprSyntax(
+                  baseName: .identifier("x")
                 )
               ),
               ExprSyntax(
@@ -275,8 +275,8 @@ final class VariadicGenericsTests: XCTestCase {
               ExprSyntax(
                 PackElementExprSyntax(
                   eachKeyword: .keyword(.each),
-                  pack: IdentifierExprSyntax(
-                    identifier: .identifier("t")
+                  pack: DeclReferenceExprSyntax(
+                    baseName: .identifier("t")
                   )
                 )
               ),

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
@@ -372,7 +372,7 @@ final class ForwardSlashRegexTests: XCTestCase {
               )
             ),
             BinaryOperatorExprSyntax(operator: .binaryOperator("/")),
-            PostfixOperatorExprSyntax(expression: IdentifierExprSyntax(identifier: "x"), operator: .postfixOperator("/")),
+            PostfixOperatorExprSyntax(expression: DeclReferenceExprSyntax(baseName: "x"), operator: .postfixOperator("/")),
           ])
         )
       )
@@ -1058,7 +1058,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = /x// comment
       """,
-      substructure: Syntax(PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: IdentifierExprSyntax(identifier: "x")))
+      substructure: Syntax(PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: DeclReferenceExprSyntax(baseName: "x")))
     )
   }
 
@@ -1067,7 +1067,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = /x // comment
       """,
-      substructure: Syntax(PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: IdentifierExprSyntax(identifier: "x")))
+      substructure: Syntax(PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: DeclReferenceExprSyntax(baseName: "x")))
     )
   }
 
@@ -1076,7 +1076,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = /x/*comment*/
       """,
-      substructure: Syntax(PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: IdentifierExprSyntax(identifier: "x")))
+      substructure: Syntax(PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: DeclReferenceExprSyntax(baseName: "x")))
     )
   }
 
@@ -1088,8 +1088,8 @@ final class ForwardSlashRegexTests: XCTestCase {
       """,
       substructure: Syntax(
         LabeledExprListSyntax([
-          .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/")), trailingComma: .commaToken()),
-          .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))),
+          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")), trailingComma: .commaToken()),
+          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
         ])
       )
     )
@@ -1111,12 +1111,12 @@ final class ForwardSlashRegexTests: XCTestCase {
           .init(
             expression: TupleExprSyntax(
               elements: .init([
-                .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/")))
+                .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")))
               ])
             ),
             trailingComma: .commaToken()
           ),
-          .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))),
+          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
         ])
       )
     )
@@ -1129,8 +1129,8 @@ final class ForwardSlashRegexTests: XCTestCase {
       """,
       substructure: Syntax(
         LabeledExprListSyntax([
-          .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/^")), trailingComma: .commaToken()),
-          .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))),
+          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/^")), trailingComma: .commaToken()),
+          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
         ])
       )
     )
@@ -1152,12 +1152,12 @@ final class ForwardSlashRegexTests: XCTestCase {
           .init(
             expression: TupleExprSyntax(
               elements: .init([
-                .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/^")))
+                .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/^")))
               ])
             ),
             trailingComma: .commaToken()
           ),
-          .init(expression: IdentifierExprSyntax(identifier: .binaryOperator("/"))),
+          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
         ])
       )
     )

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -655,7 +655,7 @@ final class IfconfigExprTests: XCTestCase {
       """,
       substructure: Syntax(
         FunctionCallExprSyntax(
-          calledExpression: IdentifierExprSyntax(identifier: .identifier("compiler")),
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("compiler")),
           leftParen: .leftParenToken(),
           arguments: LabeledExprListSyntax([
             LabeledExprSyntax(
@@ -711,7 +711,7 @@ final class IfconfigExprTests: XCTestCase {
         IfConfigClauseSyntax(
           poundKeyword: .poundIfToken(),
           condition: FunctionCallExprSyntax(
-            calledExpression: IdentifierExprSyntax(identifier: .identifier("hasFeature")),
+            calledExpression: DeclReferenceExprSyntax(baseName: .identifier("hasFeature")),
             leftParen: .leftParenToken(),
             arguments: LabeledExprListSyntax([
               LabeledExprSyntax(

--- a/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
@@ -812,7 +812,7 @@ final class MultilineErrorsTests: XCTestCase {
         """
         abc
       """##,
-      substructure: Syntax(IdentifierExprSyntax(identifier: .identifier("abc"))),
+      substructure: Syntax(DeclReferenceExprSyntax(baseName: .identifier("abc"))),
       diagnostics: [
         DiagnosticSpec(
           locationMarker: "3️⃣",

--- a/Tests/SwiftParserTest/translated/OptionalTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalTests.swift
@@ -45,7 +45,7 @@ final class OptionalTests: XCTestCase {
       """,
       substructure: Syntax(
         OptionalChainingExprSyntax(
-          expression: IdentifierExprSyntax(identifier: .identifier("a")),
+          expression: DeclReferenceExprSyntax(baseName: .identifier("a")),
           questionMark: .postfixQuestionMarkToken()
         )
       )

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -224,9 +224,9 @@ final class FunctionTests: XCTestCase {
               ReturnStmtSyntax(
                 expression: SequenceExprSyntax(
                   elements: ExprListSyntax {
-                    IdentifierExprSyntax(identifier: .identifier("lhs"))
+                    DeclReferenceExprSyntax(baseName: .identifier("lhs"))
                     BinaryOperatorExprSyntax(operator: .binaryOperator("<"))
-                    IdentifierExprSyntax(identifier: .identifier("rhs"))
+                    DeclReferenceExprSyntax(baseName: .identifier("rhs"))
                   }
                 )
               )

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
@@ -566,11 +566,11 @@ public struct UnwrapMacro: CodeItemMacro {
     let errorThrower = node.trailingClosure
     let identifiers = try node.argumentList.map { argument in
       guard let tupleElement = argument.as(LabeledExprSyntax.self),
-        let identifierExpr = tupleElement.expression.as(IdentifierExprSyntax.self)
+        let declReferenceExpr = tupleElement.expression.as(DeclReferenceExprSyntax.self)
       else {
         throw CustomError.message("Arguments must be identifiers")
       }
-      return identifierExpr.identifier
+      return declReferenceExpr.baseName
     }
 
     func elseBlock(_ token: TokenSyntax) -> CodeBlockSyntax {

--- a/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
+++ b/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
@@ -183,7 +183,7 @@ public class DebugDescriptionTests: XCTestCase {
       SourceFileSyntax(
           statements: CodeBlockItemListSyntax([
                 CodeBlockItemSyntax(item: CodeBlockItemSyntax.Item(FunctionCallExprSyntax(
-                        calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("test"))),
+                        calledExpression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("test"))),
                         leftParen: .leftParenToken(),
                         arguments: LabeledExprListSyntax([
                               LabeledExprSyntax(
@@ -206,7 +206,7 @@ public class DebugDescriptionTests: XCTestCase {
       SourceFileSyntax(
           statements: CodeBlockItemListSyntax([
                 CodeBlockItemSyntax(item: CodeBlockItemSyntax.Item(FunctionCallExprSyntax(
-                        calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("test"))),
+                        calledExpression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("test"))),
                         leftParen: .leftParenToken(),
                         arguments: LabeledExprListSyntax([
                               LabeledExprSyntax(

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -38,8 +38,8 @@ public class MultithreadingTests: XCTestCase {
     // 'base.member()'
     let methodCall = FunctionCallExprSyntax(
       calledExpression: MemberAccessExprSyntax(
-        base: IdentifierExprSyntax(
-          identifier: .identifier("base")
+        base: DeclReferenceExprSyntax(
+          baseName: .identifier("base")
         ),
         period: .periodToken(),
         name: .identifier("member")
@@ -53,8 +53,8 @@ public class MultithreadingTests: XCTestCase {
       var copied = methodCall
       copied
         .calledExpression[as: MemberAccessExprSyntax.self]
-        .base![as: IdentifierExprSyntax.self]
-        .identifier = .identifier("ident\(i)")
+        .base![as: DeclReferenceExprSyntax.self]
+        .baseName = .identifier("ident\(i)")
       copied = copied.with(\.leadingTrivia, [.newlines(1)])
 
       XCTAssertEqual(copied.description, "\nident\(i).member()")

--- a/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
@@ -113,7 +113,7 @@ public class SyntaxCreationTests: XCTestCase {
       segments: StringLiteralSegmentListSyntax([.stringSegment(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
       closingQuote: .stringQuoteToken()
     )
-    let printID = IdentifierExprSyntax(identifier: .identifier("print"))
+    let printID = DeclReferenceExprSyntax(baseName: .identifier("print"))
     let arg = LabeledExprSyntax(expression: string)
     let call = FunctionCallExprSyntax(
       calledExpression: printID,
@@ -158,7 +158,7 @@ public class SyntaxCreationTests: XCTestCase {
       closingQuote: .stringQuoteToken(),
       closingPounds: nil
     )
-    let printID = IdentifierExprSyntax(identifier: .identifier("print"))
+    let printID = DeclReferenceExprSyntax(baseName: .identifier("print"))
     let arg = LabeledExprSyntax(expression: string)
     let call1 = FunctionCallExprSyntax(
       calledExpression: printID,

--- a/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
@@ -177,7 +177,7 @@ public class SyntaxVisitorTests: XCTestCase {
         return nil
       }
     }
-    let parsed = IdentifierExprSyntax(identifier: .identifier("n"))
+    let parsed = DeclReferenceExprSyntax(baseName: .identifier("n"))
     let rewriter = VisitAnyRewriter(transform: { _ in
       return TokenSyntax.identifier("")
     })


### PR DESCRIPTION
- `DeclName` was essentially a copy of `IdentifierExpr` that was just used for attributes. Kill it and replace it with `IdentifierExpr`.
- Also use `IdentifierExpr` in `ImplementAttributeArgumentsSytnax`