### PR TITLE
Remove TupleTypeElementSyntax.initializer

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -501,11 +501,6 @@ public let TYPE_NODES: [Node] = [
         isOptional: true
       ),
       Child(
-        name: "Initializer",
-        kind: .node(kind: .initializerClause),
-        isOptional: true
-      ),
-      Child(
         name: "TrailingComma",
         kind: .token(choices: [.token(tokenKind: "CommaToken")]),
         isOptional: true

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -75,7 +75,6 @@ extension Parser {
               colon: nil,
               type: base,
               ellipsis: nil,
-              initializer: nil,
               trailingComma: nil,
               arena: self.arena
             )
@@ -491,7 +490,6 @@ extension Parser {
               colon: nil,
               type: RawTypeSyntax(RawIdentifierTypeSyntax(name: first, genericArgumentClause: nil, arena: self.arena)),
               ellipsis: nil,
-              initializer: nil,
               trailingComma: self.missingToken(.comma),
               arena: self.arena
             )
@@ -519,7 +517,6 @@ extension Parser {
             colon: colon,
             type: type,
             ellipsis: ellipsis,
-            initializer: nil,
             trailingComma: trailingComma,
             arena: self.arena
           )

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -3229,12 +3229,8 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "unexpectedBetweenTypeAndEllipsis"
   case \TupleTypeElementSyntax.ellipsis:
     return "ellipsis"
-  case \TupleTypeElementSyntax.unexpectedBetweenEllipsisAndInitializer:
-    return "unexpectedBetweenEllipsisAndInitializer"
-  case \TupleTypeElementSyntax.initializer:
-    return "initializer"
-  case \TupleTypeElementSyntax.unexpectedBetweenInitializerAndTrailingComma:
-    return "unexpectedBetweenInitializerAndTrailingComma"
+  case \TupleTypeElementSyntax.unexpectedBetweenEllipsisAndTrailingComma:
+    return "unexpectedBetweenEllipsisAndTrailingComma"
   case \TupleTypeElementSyntax.trailingComma:
     return "trailingComma"
   case \TupleTypeElementSyntax.unexpectedAfterTrailingComma:

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -8109,9 +8109,7 @@ extension TupleTypeElementSyntax {
       type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
       ellipsis: TokenSyntax? = nil,
-      _ unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? = nil,
-      initializer: InitializerClauseSyntax? = nil,
-      _ unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenEllipsisAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
@@ -8131,9 +8129,7 @@ extension TupleTypeElementSyntax {
         type: type, 
         unexpectedBetweenTypeAndEllipsis, 
         ellipsis: ellipsis, 
-        unexpectedBetweenEllipsisAndInitializer, 
-        initializer: initializer, 
-        unexpectedBetweenInitializerAndTrailingComma, 
+        unexpectedBetweenEllipsisAndTrailingComma, 
         trailingComma: trailingComma, 
         unexpectedAfterTrailingComma, 
         trailingTrivia: trailingTrivia

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -21199,15 +21199,13 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
       type: RawTypeSyntax, 
       _ unexpectedBetweenTypeAndEllipsis: RawUnexpectedNodesSyntax? = nil, 
       ellipsis: RawTokenSyntax?, 
-      _ unexpectedBetweenEllipsisAndInitializer: RawUnexpectedNodesSyntax? = nil, 
-      initializer: RawInitializerClauseSyntax?, 
-      _ unexpectedBetweenInitializerAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenEllipsisAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
       _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .tupleTypeElement, uninitializedCount: 17, arena: arena) { layout in
+      kind: .tupleTypeElement, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeInoutKeyword?.raw
       layout[1] = inoutKeyword?.raw
@@ -21221,11 +21219,9 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
       layout[9] = type.raw
       layout[10] = unexpectedBetweenTypeAndEllipsis?.raw
       layout[11] = ellipsis?.raw
-      layout[12] = unexpectedBetweenEllipsisAndInitializer?.raw
-      layout[13] = initializer?.raw
-      layout[14] = unexpectedBetweenInitializerAndTrailingComma?.raw
-      layout[15] = trailingComma?.raw
-      layout[16] = unexpectedAfterTrailingComma?.raw
+      layout[12] = unexpectedBetweenEllipsisAndTrailingComma?.raw
+      layout[13] = trailingComma?.raw
+      layout[14] = unexpectedAfterTrailingComma?.raw
     }
     self.init(unchecked: raw)
   }
@@ -21278,24 +21274,16 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
     layoutView.children[11].map(RawTokenSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenEllipsisAndInitializer: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenEllipsisAndTrailingComma: RawUnexpectedNodesSyntax? {
     layoutView.children[12].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var initializer: RawInitializerClauseSyntax? {
-    layoutView.children[13].map(RawInitializerClauseSyntax.init(raw:))
-  }
-  
-  public var unexpectedBetweenInitializerAndTrailingComma: RawUnexpectedNodesSyntax? {
-    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
   public var trailingComma: RawTokenSyntax? {
-    layoutView.children[15].map(RawTokenSyntax.init(raw:))
+    layoutView.children[13].map(RawTokenSyntax.init(raw:))
   }
   
   public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
-    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2551,7 +2551,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       assertNoError(kind, index, verify(element, as: RawTupleTypeElementSyntax.self))
     }
   case .tupleTypeElement:
-    assert(layout.count == 17)
+    assert(layout.count == 15)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.keyword("inout")]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
@@ -2565,10 +2565,8 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 11, verify(layout[11], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.ellipsis)]))
     assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 13, verify(layout[13], as: RawInitializerClauseSyntax?.self))
+    assertNoError(kind, 13, verify(layout[13], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
     assertNoError(kind, 14, verify(layout[14], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 15, verify(layout[15], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
-    assertNoError(kind, 16, verify(layout[16], as: RawUnexpectedNodesSyntax?.self))
   case .tupleType:
     assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -11601,7 +11601,6 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``MatchingPatternConditionSyntax``.``MatchingPatternConditionSyntax/initializer``
 ///  - ``OptionalBindingConditionSyntax``.``OptionalBindingConditionSyntax/initializer``
 ///  - ``PatternBindingSyntax``.``PatternBindingSyntax/initializer``
-///  - ``TupleTypeElementSyntax``.``TupleTypeElementSyntax/initializer``
 public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -18462,7 +18461,6 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `colon`: `':'`?
 ///  - `type`: ``TypeSyntax``
 ///  - `ellipsis`: `'...'`?
-///  - `initializer`: ``InitializerClauseSyntax``?
 ///  - `trailingComma`: `','`?
 ///
 /// ### Contained in
@@ -18503,9 +18501,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
       ellipsis: TokenSyntax? = nil,
-      _ unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? = nil,
-      initializer: InitializerClauseSyntax? = nil,
-      _ unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenEllipsisAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
@@ -18526,9 +18522,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
             type, 
             unexpectedBetweenTypeAndEllipsis, 
             ellipsis, 
-            unexpectedBetweenEllipsisAndInitializer, 
-            initializer, 
-            unexpectedBetweenInitializerAndTrailingComma, 
+            unexpectedBetweenEllipsisAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
           ))) { (arena, _) in
@@ -18545,9 +18539,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
           type.raw, 
           unexpectedBetweenTypeAndEllipsis?.raw, 
           ellipsis?.raw, 
-          unexpectedBetweenEllipsisAndInitializer?.raw, 
-          initializer?.raw, 
-          unexpectedBetweenInitializerAndTrailingComma?.raw, 
+          unexpectedBetweenEllipsisAndTrailingComma?.raw, 
           trailingComma?.raw, 
           unexpectedAfterTrailingComma?.raw
         ]
@@ -18672,7 +18664,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenEllipsisAndTrailingComma: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 12, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -18681,39 +18673,21 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var initializer: InitializerClauseSyntax? {
+  public var trailingComma: TokenSyntax? {
     get {
-      return data.child(at: 13, parent: Syntax(self)).map(InitializerClauseSyntax.init)
+      return data.child(at: 13, parent: Syntax(self)).map(TokenSyntax.init)
     }
     set(value) {
       self = TupleTypeElementSyntax(data.replacingChild(at: 13, with: value?.data, arena: SyntaxArena()))
     }
   }
   
-  public var unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? {
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 14, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
     set(value) {
       self = TupleTypeElementSyntax(data.replacingChild(at: 14, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public var trailingComma: TokenSyntax? {
-    get {
-      return data.child(at: 15, parent: Syntax(self)).map(TokenSyntax.init)
-    }
-    set(value) {
-      self = TupleTypeElementSyntax(data.replacingChild(at: 15, with: value?.data, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 16, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = TupleTypeElementSyntax(data.replacingChild(at: 16, with: value?.data, arena: SyntaxArena()))
     }
   }
   
@@ -18731,9 +18705,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
           \Self.type, 
           \Self.unexpectedBetweenTypeAndEllipsis, 
           \Self.ellipsis, 
-          \Self.unexpectedBetweenEllipsisAndInitializer, 
-          \Self.initializer, 
-          \Self.unexpectedBetweenInitializerAndTrailingComma, 
+          \Self.unexpectedBetweenEllipsisAndTrailingComma, 
           \Self.trailingComma, 
           \Self.unexpectedAfterTrailingComma
         ])


### PR DESCRIPTION
The child was never used and didn’t make any sense anyway. A type can’t have a default value.