### PR TITLE
Convert `lit`-based syntax classification test to XCTest

### DIFF
--- a/Sources/SwiftIDEUtils/SyntaxClassification.swift
+++ b/Sources/SwiftIDEUtils/SyntaxClassification.swift
@@ -39,8 +39,6 @@ public enum SyntaxClassification {
   case lineComment
   /// The token should not receive syntax coloring.
   case none
-  /// An image, color, etc. literal.
-  case objectLiteral
   /// An identifier referring to an operator.
   case operatorIdentifier
   /// A `#` token like `#warning`.
@@ -66,7 +64,7 @@ extension SyntaxClassification {
   internal static func classify(_ keyPath: AnyKeyPath) -> (SyntaxClassification, Bool)? {
     switch keyPath {
     case \AttributeSyntax.attributeName:
-      return (.attribute, false)
+      return (.attribute, true)
     case \PlatformVersionItemSyntax.availabilityVersionRestriction:
       return (.keyword, false)
     case \AvailabilityVersionRestrictionSyntax.platform:

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -505,6 +505,16 @@ extension RawSyntax {
     lastToken(viewMode: .sourceAccurate)?.trailingTriviaByteLength ?? 0
   }
 
+  @_spi(RawSyntax)
+  public var leadingTriviaPieces: [RawTriviaPiece]? {
+    firstToken(viewMode: .sourceAccurate)?.leadingRawTriviaPieces
+  }
+
+  @_spi(RawSyntax)
+  public var trailingTriviaPieces: [RawTriviaPiece]? {
+    lastToken(viewMode: .sourceAccurate)?.trailingRawTriviaPieces
+  }
+
   /// The length of this node’s content, without the first leading and the last
   /// trailing trivia. Intermediate trivia inside a layout node is included in
   /// this.

--- a/Sources/lit-test-helper/ClassifiedSyntaxTreePrinter.swift
+++ b/Sources/lit-test-helper/ClassifiedSyntaxTreePrinter.swift
@@ -30,7 +30,6 @@ extension SyntaxClassification {
     case .poundDirective: return "#kw"
     case .buildConfigId: return "#id"
     case .attribute: return "attr-builtin"
-    case .objectLiteral: return "object-literal"
     case .editorPlaceholder: return "placeholder"
     case .lineComment: return "comment-line"
     case .blockComment: return "comment-block"

--- a/Tests/SwiftIDEUtilsTest/Assertions.swift
+++ b/Tests/SwiftIDEUtilsTest/Assertions.swift
@@ -71,7 +71,7 @@ func assertClassification(
       line: spec.line
     )
 
-    lastRangeUpperBound = source.index(source.startIndex, offsetBy: range.endOffset)
+    lastRangeUpperBound = source.utf8.index(source.utf8.startIndex, offsetBy: range.endOffset)
   }
 }
 


### PR DESCRIPTION
We should use the `assertClassification` to make these test cases look nicer and get rid of the dependency on `FileCheck` eventually.

I converted a subset of the original `lit`-tests since I think most of them are mutually covered. There are some tests not producing the expected results and I wrote down the reasons in `XCTExpectFailure`. Maybe we should determine whether changing the test cases or marking these as bugs to fix.