### PR TITLE
Generate documentation for the SwiftSyntaxMacroExpansion module on swiftpackageindex.com

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -19,4 +19,5 @@ builder:
       - SwiftRefactor
       - SwiftSyntaxBuilder
       - SwiftSyntaxMacros
+      - SwiftSyntaxMacroExpansion
       - SwiftSyntaxMacrosTestSupport

--- a/Package.swift
+++ b/Package.swift
@@ -284,7 +284,7 @@ let package = Package(
     .testTarget(
       name: "PerformanceTest",
       dependencies: ["_InstructionCounter", "SwiftIDEUtils", "SwiftParser", "SwiftSyntax"],
-      exclude: ["Inputs", "ci-baselines.json"]
+      exclude: ["Inputs"]
     ),
   ]
 )


### PR DESCRIPTION
This module was missing from .spi.yml

This will be caught by the check from https://github.com/apple/swift-syntax/pull/1635 once the CI nodes have been updated so that we can use Swift regex on them.