### PR TITLE
Add methods from `RangeReplaceableCollection` to `SyntaxCollection` and remove `add*` methods on syntax nodes that have a collection as child

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -203,6 +203,7 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
               ///                  `\(child.varOrCaseName)` collection.
               /// - returns: A copy of the receiver with the provided `\(raw: childElt)`
               ///            appended to its `\(child.varOrCaseName)` collection.
+              @available(*, deprecated, message: "Use node.\(child.varOrCaseName).append(newElement) instead")
               public func add\(raw: childElt)(_ element: \(raw: childEltType)) -> \(node.kind.syntaxType) {
                 var collection: RawSyntax
                 let arena = SyntaxArena()

--- a/Sources/SwiftSyntax/SyntaxCollection.swift
+++ b/Sources/SwiftSyntax/SyntaxCollection.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public protocol SyntaxCollection: SyntaxProtocol, BidirectionalCollection, MutableCollection where Element: SyntaxProtocol {
+public protocol SyntaxCollection: SyntaxProtocol, BidirectionalCollection where Element: SyntaxProtocol, Index == SyntaxChildrenIndex {
   associatedtype Iterator = SyntaxCollectionIterator<Element>
 
   /// The ``SyntaxKind`` of the syntax node that conforms to ``SyntaxCollection``.
@@ -31,6 +31,17 @@ extension SyntaxCollection {
   /// is undefined.
   internal init(_ data: SyntaxData) {
     self.init(Syntax(data))!
+  }
+
+  /// Initialize the collection from a collection of the same type.
+  ///
+  /// - Note: This initializer is needed to improve source compatibility after
+  ///   the `+` operators have been added. Previously, they created an array
+  ///   that was converted to a ``SyntaxCollection`` and now they create a
+  ///   ``SyntaxCollection``, which makes the initializer a no-op.
+  @available(*, deprecated, message: "Call to initializer is not necessary.")
+  public init(_ collection: Self) {
+    self = collection
   }
 
   public init<Children: Sequence>(_ children: Children) where Children.Element == Element {
@@ -205,6 +216,170 @@ public struct SyntaxCollectionIterator<E: SyntaxProtocol>: IteratorProtocol {
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: parent)
     return Syntax(data).cast(Element.self)
+  }
+}
+
+// MARK: Functions analogous to RangeReplaceableCollection
+
+/// Defines functions that are similar to those in `RangeReplaceableCollection`.
+///
+/// SyntaxCollection doesn’t conform to `RangeReplaceableCollection` because of
+/// two reasons:
+///  - `RangeReplaceableCollection` assumes that creating a new colleciton and
+///    adding all elements from another collection to it results in the same
+///    collection. This is not true for `SyntaxCollection` because the new
+///    collection wouldn’t have a parent. This causes eg. the default
+///    implementation of `filter` to misbehave.
+///  - It can’t make the complexity guarantees that `RangeReplaceableCollection`
+///    requires, e.g. `append` is `O(tree depth)` instead of `O(1)`.
+extension SyntaxCollection {
+  /// Replace the nodes in `subrange` by `newElements`.
+  public mutating func replaceSubrange(_ subrange: Range<Self.Index>, with newElements: some Collection<Element>) {
+    // We only access the raw nodes of `newElements` below.
+    // Keep `newElements` alive so their arena doesn't get deallocated.
+    withExtendedLifetime(newElements) {
+      var newLayout = layoutView.formLayoutArray()
+      let layoutRangeLowerBound = (subrange.lowerBound.data?.indexInParent).map(Int.init) ?? newLayout.endIndex
+      let layoutRangeUpperBound = (subrange.upperBound.data?.indexInParent).map(Int.init) ?? newLayout.endIndex
+      newLayout.replaceSubrange(layoutRangeLowerBound..<layoutRangeUpperBound, with: newElements.map { $0.raw })
+      self = replacingLayout(newLayout)
+    }
+  }
+
+  /// Adds an element to the end of the collection.
+  ///
+  /// - Parameter newElement: The element to append to the collection.
+  public mutating func append(_ newElement: Element) {
+    insert(newElement, at: endIndex)
+  }
+
+  /// Adds the elements of a sequence to the end of this collection.
+  ///
+  /// - Parameter newElements: The elements to append to the collection.
+  public mutating func append(contentsOf newElements: some Sequence<Element>) {
+    insert(contentsOf: Array(newElements), at: endIndex)
+  }
+
+  /// Inserts a new element into the collection at the specified position.
+  ///
+  /// - Parameter newElement: The new element to insert into the collection.
+  /// - Parameter i: The position at which to insert the new element.
+  ///   `index` must be a valid index into the collection.
+  public mutating func insert(_ newElement: Element, at i: Index) {
+    replaceSubrange(i..<i, with: CollectionOfOne(newElement))
+  }
+
+  /// Inserts the elements of a sequence into the collection at the specified
+  /// position.
+  ///
+  /// - Parameter newElements: The new elements to insert into the collection.
+  /// - Parameter i: The position at which to insert the new elements. `index`
+  ///   must be a valid index of the collection.
+  public mutating func insert(contentsOf newElements: some Collection<Element>, at i: Index) {
+    replaceSubrange(i..<i, with: newElements)
+  }
+
+  /// Removes and returns the element at the specified position.
+  ///
+  /// - Parameter position: The position of the element to remove. `position`
+  ///   must be a valid index of the collection that is not equal to the
+  ///   collection's end index.
+  /// - Returns: The removed element.
+  @discardableResult
+  public mutating func remove(at position: Index) -> Element {
+    precondition(!isEmpty, "Can't remove from an empty collection")
+    let result: Element = self[position]
+    replaceSubrange(position..<index(after: position), with: EmptyCollection())
+    return result
+  }
+
+  /// Removes the elements in the specified subrange from the collection.
+  ///
+  /// - Parameter bounds: The range of the collection to be removed. The
+  ///   bounds of the range must be valid indices of the collection.
+  public mutating func removeSubrange(_ bounds: Range<Index>) {
+    replaceSubrange(bounds, with: EmptyCollection())
+  }
+
+  /// Creates a new collection by concatenating the elements of a collection and
+  /// a sequence.
+  ///
+  /// - Parameters:
+  ///   - lhs: A ``SyntaxCollection``
+  ///   - rhs: A collection or finite sequence.
+  public static func + (lhs: Self, rhs: some Sequence<Element>) -> Self {
+    var result = lhs
+    result.append(contentsOf: rhs)
+    return result
+  }
+
+  /// Creates a new collection by concatenating the elements of a collection and
+  /// a sequence.
+  ///
+  /// - Parameters:
+  ///   - lhs: A ``SyntaxCollection``
+  ///   - rhs: A collection or finite sequence.
+  ///
+  /// - Note: This overload exists to resolve when adding an array to a ``SyntaxCollection``.
+  public static func + (lhs: Self, rhs: some RangeReplaceableCollection<Element>) -> Self {
+    var result = lhs
+    result.append(contentsOf: rhs)
+    return result
+  }
+
+  /// Creates a new collection by concatenating the elements of a sequence and a
+  /// collection.
+  ///
+  /// - Parameters:
+  ///   - lhs: A collection or finite sequence.
+  ///   - rhs: A range-replaceable collection.
+  public static func + (lhs: some Sequence<Element>, rhs: Self) -> Self {
+    var result = rhs
+    result.insert(contentsOf: Array(lhs), at: result.startIndex)
+    return result
+  }
+
+  /// Creates a new collection by concatenating the elements of a sequence and a
+  /// collection.
+  ///
+  /// - Parameters:
+  ///   - lhs: A collection or finite sequence.
+  ///   - rhs: A range-replaceable collection.
+  ///
+  /// - Note: This overload exists to resolve when adding an array to a ``SyntaxCollection``.
+  public static func + (lhs: some RangeReplaceableCollection<Element>, rhs: Self) -> Self {
+    var result = rhs
+    result.insert(contentsOf: Array(lhs), at: result.startIndex)
+    return result
+  }
+
+  /// Appends the elements of a sequence to a range-replaceable collection.
+  ///
+  /// - Parameters:
+  ///   - lhs: The ``SyntaxCollection`` to append to.
+  ///   - rhs: A collection or finite sequence.
+  ///
+  /// - Note: This will result in an allocation of a copy of this node.
+  public static func += (lhs: inout Self, rhs: some Sequence<Element>) {
+    lhs.append(contentsOf: rhs)
+  }
+
+  /// Returns a new ``SyntaxCollection`` that just contains the elements
+  /// satisfying the given predicate.
+  ///
+  /// - Parameter isIncluded: A closure that takes an element of the
+  ///   collection as its argument and returns a Boolean value indicating
+  ///   whether the element should be included in the returned collection.
+  /// - Returns: A ``SyntaxCollection`` of the elements that `isIncluded` allowed.
+  ///
+  /// - Note: This creates a new ``SyntaxCollection`` node. If the resulting node
+  ///   is not needed (e.g. because it’s only being iterated), convert the
+  ///   ``SyntaxCollection`` to an array first or use the `where` clause in
+  ///   a `for` statement.
+  public func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> Self {
+    var result = self
+    result.replaceSubrange(self.startIndex..<self.endIndex, with: try Array(self).filter(isIncluded))
+    return result
   }
 }
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -134,6 +134,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> AccessorDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -404,6 +405,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> ActorDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -446,6 +448,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> ActorDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -763,6 +766,7 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> AssociatedTypeDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -806,6 +810,7 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> AssociatedTypeDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1112,6 +1117,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> ClassDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1155,6 +1161,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> ClassDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1442,6 +1449,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> DeinitializerDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1485,6 +1493,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> DeinitializerDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1688,6 +1697,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> EditorPlaceholderDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1731,6 +1741,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> EditorPlaceholderDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1901,6 +1912,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> EnumCaseDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1944,6 +1956,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> EnumCaseDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2006,6 +2019,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
   ///            appended to its `elements` collection.
+  @available(*, deprecated, message: "Use node.elements.append(newElement) instead")
   public func addElement(_ element: EnumCaseElementSyntax) -> EnumCaseDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2191,6 +2205,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> EnumDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2234,6 +2249,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> EnumDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2524,6 +2540,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> ExtensionDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2566,6 +2583,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> ExtensionDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2839,6 +2857,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> FunctionDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2881,6 +2900,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> FunctionDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3137,6 +3157,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `clauses` collection.
   /// - returns: A copy of the receiver with the provided `Clause`
   ///            appended to its `clauses` collection.
+  @available(*, deprecated, message: "Use node.clauses.append(newElement) instead")
   public func addClause(_ element: IfConfigClauseSyntax) -> IfConfigDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3316,6 +3337,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> ImportDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3359,6 +3381,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> ImportDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3440,6 +3463,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `path` collection.
   /// - returns: A copy of the receiver with the provided `PathComponent`
   ///            appended to its `path` collection.
+  @available(*, deprecated, message: "Use node.path.append(newElement) instead")
   public func addPathComponent(_ element: ImportPathComponentSyntax) -> ImportDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3634,6 +3658,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> InitializerDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3677,6 +3702,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> InitializerDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3975,6 +4001,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> MacroDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4017,6 +4044,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> MacroDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4324,6 +4352,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> MacroExpansionDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4366,6 +4395,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> MacroExpansionDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4481,6 +4511,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
   ///            appended to its `arguments` collection.
+  @available(*, deprecated, message: "Use node.arguments.append(newElement) instead")
   public func addArgument(_ element: LabeledExprSyntax) -> MacroExpansionDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4559,6 +4590,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `additionalTrailingClosures` collection.
   /// - returns: A copy of the receiver with the provided `AdditionalTrailingClosure`
   ///            appended to its `additionalTrailingClosures` collection.
+  @available(*, deprecated, message: "Use node.additionalTrailingClosures.append(newElement) instead")
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> MacroExpansionDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4716,6 +4748,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> MissingDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4759,6 +4792,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> MissingDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -5310,6 +5344,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> PrecedenceGroupDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -5353,6 +5388,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> PrecedenceGroupDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -5451,6 +5487,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `groupAttributes` collection.
   /// - returns: A copy of the receiver with the provided `GroupAttribute`
   ///            appended to its `groupAttributes` collection.
+  @available(*, deprecated, message: "Use node.groupAttributes.append(newElement) instead")
   public func addGroupAttribute(_ element: Syntax) -> PrecedenceGroupDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -5666,6 +5703,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> ProtocolDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -5709,6 +5747,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> ProtocolDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6070,6 +6109,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> StructDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6113,6 +6153,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> StructDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6411,6 +6452,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> SubscriptDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6453,6 +6495,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> SubscriptDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6740,6 +6783,7 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> TypeAliasDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6782,6 +6826,7 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> TypeAliasDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -7026,6 +7071,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> VariableDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -7068,6 +7114,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> VariableDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -7128,6 +7175,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `bindings` collection.
   /// - returns: A copy of the receiver with the provided `Binding`
   ///            appended to its `bindings` collection.
+  @available(*, deprecated, message: "Use node.bindings.append(newElement) instead")
   public func addBinding(_ element: PatternBindingSyntax) -> VariableDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -127,6 +127,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
   ///            appended to its `elements` collection.
+  @available(*, deprecated, message: "Use node.elements.append(newElement) instead")
   public func addElement(_ element: ArrayElementSyntax) -> ArrayExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1507,6 +1508,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `statements` collection.
   /// - returns: A copy of the receiver with the provided `Statement`
   ///            appended to its `statements` collection.
+  @available(*, deprecated, message: "Use node.statements.append(newElement) instead")
   public func addStatement(_ element: CodeBlockItemSyntax) -> ClosureExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2658,6 +2660,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
   ///            appended to its `arguments` collection.
+  @available(*, deprecated, message: "Use node.arguments.append(newElement) instead")
   public func addArgument(_ element: LabeledExprSyntax) -> FunctionCallExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2736,6 +2739,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `additionalTrailingClosures` collection.
   /// - returns: A copy of the receiver with the provided `AdditionalTrailingClosure`
   ///            appended to its `additionalTrailingClosures` collection.
+  @available(*, deprecated, message: "Use node.additionalTrailingClosures.append(newElement) instead")
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> FunctionCallExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3079,6 +3083,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `conditions` collection.
   /// - returns: A copy of the receiver with the provided `Condition`
   ///            appended to its `conditions` collection.
+  @available(*, deprecated, message: "Use node.conditions.append(newElement) instead")
   public func addCondition(_ element: ConditionElementSyntax) -> IfExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3827,6 +3832,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `components` collection.
   /// - returns: A copy of the receiver with the provided `KeyPathComponent`
   ///            appended to its `components` collection.
+  @available(*, deprecated, message: "Use node.components.append(newElement) instead")
   public func addKeyPathComponent(_ element: KeyPathComponentSyntax) -> KeyPathExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4073,6 +4079,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
   ///            appended to its `arguments` collection.
+  @available(*, deprecated, message: "Use node.arguments.append(newElement) instead")
   public func addArgument(_ element: LabeledExprSyntax) -> MacroExpansionExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4151,6 +4158,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `additionalTrailingClosures` collection.
   /// - returns: A copy of the receiver with the provided `AdditionalTrailingClosure`
   ///            appended to its `additionalTrailingClosures` collection.
+  @available(*, deprecated, message: "Use node.additionalTrailingClosures.append(newElement) instead")
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> MacroExpansionExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -5615,6 +5623,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
   ///            appended to its `elements` collection.
+  @available(*, deprecated, message: "Use node.elements.append(newElement) instead")
   public func addElement(_ element: ExprSyntax) -> SequenceExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -5807,6 +5816,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `segments` collection.
   /// - returns: A copy of the receiver with the provided `Segment`
   ///            appended to its `segments` collection.
+  @available(*, deprecated, message: "Use node.segments.append(newElement) instead")
   public func addSegment(_ element: Syntax) -> StringLiteralExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6041,6 +6051,7 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
   ///            appended to its `arguments` collection.
+  @available(*, deprecated, message: "Use node.arguments.append(newElement) instead")
   public func addArgument(_ element: LabeledExprSyntax) -> SubscriptCallExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6119,6 +6130,7 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `additionalTrailingClosures` collection.
   /// - returns: A copy of the receiver with the provided `AdditionalTrailingClosure`
   ///            appended to its `additionalTrailingClosures` collection.
+  @available(*, deprecated, message: "Use node.additionalTrailingClosures.append(newElement) instead")
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> SubscriptCallExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6413,6 +6425,7 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `cases` collection.
   /// - returns: A copy of the receiver with the provided `Case`
   ///            appended to its `cases` collection.
+  @available(*, deprecated, message: "Use node.cases.append(newElement) instead")
   public func addCase(_ element: Syntax) -> SwitchExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6942,6 +6955,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
   ///            appended to its `elements` collection.
+  @available(*, deprecated, message: "Use node.elements.append(newElement) instead")
   public func addElement(_ element: LabeledExprSyntax) -> TupleExprSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -1423,6 +1423,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `availabilityArguments` collection.
   /// - returns: A copy of the receiver with the provided `AvailabilityArgument`
   ///            appended to its `availabilityArguments` collection.
+  @available(*, deprecated, message: "Use node.availabilityArguments.append(newElement) instead")
   public func addAvailabilityArgument(_ element: AvailabilityArgumentSyntax) -> AvailabilityConditionSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1831,6 +1832,7 @@ public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashab
   ///                  `platforms` collection.
   /// - returns: A copy of the receiver with the provided `Platform`
   ///            appended to its `platforms` collection.
+  @available(*, deprecated, message: "Use node.platforms.append(newElement) instead")
   public func addPlatform(_ element: PlatformVersionItemSyntax) -> BackDeployedAttributeArgumentsSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1990,6 +1992,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `catchItems` collection.
   /// - returns: A copy of the receiver with the provided `CatchItem`
   ///            appended to its `catchItems` collection.
+  @available(*, deprecated, message: "Use node.catchItems.append(newElement) instead")
   public func addCatchItem(_ element: CatchItemSyntax) -> CatchClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2320,6 +2323,7 @@ public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `items` collection.
   /// - returns: A copy of the receiver with the provided `Item`
   ///            appended to its `items` collection.
+  @available(*, deprecated, message: "Use node.items.append(newElement) instead")
   public func addItem(_ element: ClosureCaptureSyntax) -> ClosureCaptureClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2889,6 +2893,7 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
   ///            appended to its `parameters` collection.
+  @available(*, deprecated, message: "Use node.parameters.append(newElement) instead")
   public func addParameter(_ element: ClosureParameterSyntax) -> ClosureParameterClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3090,6 +3095,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> ClosureParameterSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3132,6 +3138,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> ClosureParameterSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -3586,6 +3593,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> ClosureSignatureSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -4038,6 +4046,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `statements` collection.
   /// - returns: A copy of the receiver with the provided `Statement`
   ///            appended to its `statements` collection.
+  @available(*, deprecated, message: "Use node.statements.append(newElement) instead")
   public func addStatement(_ element: CodeBlockItemSyntax) -> CodeBlockSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -5461,6 +5470,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
   ///            appended to its `arguments` collection.
+  @available(*, deprecated, message: "Use node.arguments.append(newElement) instead")
   public func addArgument(_ element: DeclNameArgumentSyntax) -> DeclNameArgumentsSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -6437,6 +6447,7 @@ public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
   ///            appended to its `arguments` collection.
+  @available(*, deprecated, message: "Use node.arguments.append(newElement) instead")
   public func addArgument(_ element: DifferentiabilityArgumentSyntax) -> DifferentiabilityArgumentsSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -7605,6 +7616,7 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
   ///            appended to its `parameters` collection.
+  @available(*, deprecated, message: "Use node.parameters.append(newElement) instead")
   public func addParameter(_ element: EnumCaseParameterSyntax) -> EnumCaseParameterClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -7797,6 +7809,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> EnumCaseParameterSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -8281,6 +8294,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `expressions` collection.
   /// - returns: A copy of the receiver with the provided `Expression`
   ///            appended to its `expressions` collection.
+  @available(*, deprecated, message: "Use node.expressions.append(newElement) instead")
   public func addExpression(_ element: LabeledExprSyntax) -> ExpressionSegmentSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -8589,6 +8603,7 @@ public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
   ///            appended to its `parameters` collection.
+  @available(*, deprecated, message: "Use node.parameters.append(newElement) instead")
   public func addParameter(_ element: FunctionParameterSyntax) -> FunctionParameterClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -8790,6 +8805,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> FunctionParameterSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -8832,6 +8848,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
   ///            appended to its `modifiers` collection.
+  @available(*, deprecated, message: "Use node.modifiers.append(newElement) instead")
   public func addModifier(_ element: DeclModifierSyntax) -> FunctionParameterSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -9289,6 +9306,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
   ///            appended to its `arguments` collection.
+  @available(*, deprecated, message: "Use node.arguments.append(newElement) instead")
   public func addArgument(_ element: GenericArgumentSyntax) -> GenericArgumentClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -9616,6 +9634,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
   ///            appended to its `parameters` collection.
+  @available(*, deprecated, message: "Use node.parameters.append(newElement) instead")
   public func addParameter(_ element: GenericParameterSyntax) -> GenericParameterClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -9818,6 +9837,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> GenericParameterSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -10265,6 +10285,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `requirements` collection.
   /// - returns: A copy of the receiver with the provided `Requirement`
   ///            appended to its `requirements` collection.
+  @available(*, deprecated, message: "Use node.requirements.append(newElement) instead")
   public func addRequirement(_ element: GenericRequirementSyntax) -> GenericWhereClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -10942,6 +10963,7 @@ public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `inheritedTypes` collection.
   /// - returns: A copy of the receiver with the provided `InheritedType`
   ///            appended to its `inheritedTypes` collection.
+  @available(*, deprecated, message: "Use node.inheritedTypes.append(newElement) instead")
   public func addInheritedType(_ element: InheritedTypeSyntax) -> InheritanceClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -11749,6 +11771,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
   ///            appended to its `arguments` collection.
+  @available(*, deprecated, message: "Use node.arguments.append(newElement) instead")
   public func addArgument(_ element: LabeledExprSyntax) -> KeyPathSubscriptComponentSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -12901,6 +12924,7 @@ public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `members` collection.
   /// - returns: A copy of the receiver with the provided `Member`
   ///            appended to its `members` collection.
+  @available(*, deprecated, message: "Use node.members.append(newElement) instead")
   public func addMember(_ element: MemberBlockItemSyntax) -> MemberBlockSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -13631,6 +13655,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `designatedTypes` collection.
   /// - returns: A copy of the receiver with the provided `DesignatedTypeElement`
   ///            appended to its `designatedTypes` collection.
+  @available(*, deprecated, message: "Use node.designatedTypes.append(newElement) instead")
   public func addDesignatedTypeElement(_ element: DesignatedTypeSyntax) -> OperatorPrecedenceAndTypesSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -14040,6 +14065,7 @@ public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, Synta
   ///                  `platforms` collection.
   /// - returns: A copy of the receiver with the provided `Platform`
   ///            appended to its `platforms` collection.
+  @available(*, deprecated, message: "Use node.platforms.append(newElement) instead")
   public func addPlatform(_ element: PlatformVersionItemSyntax) -> OriginallyDefinedInAttributeArgumentsSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -15396,6 +15422,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `precedenceGroups` collection.
   /// - returns: A copy of the receiver with the provided `OtherName`
   ///            appended to its `precedenceGroups` collection.
+  @available(*, deprecated, message: "Use node.precedenceGroups.append(newElement) instead")
   public func addOtherName(_ element: PrecedenceGroupNameSyntax) -> PrecedenceGroupRelationSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -15555,6 +15582,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   ///                  `primaryAssociatedTypes` collection.
   /// - returns: A copy of the receiver with the provided `PrimaryAssociatedType`
   ///            appended to its `primaryAssociatedTypes` collection.
+  @available(*, deprecated, message: "Use node.primaryAssociatedTypes.append(newElement) instead")
   public func addPrimaryAssociatedType(_ element: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -16270,6 +16298,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `statements` collection.
   /// - returns: A copy of the receiver with the provided `Statement`
   ///            appended to its `statements` collection.
+  @available(*, deprecated, message: "Use node.statements.append(newElement) instead")
   public func addStatement(_ element: CodeBlockItemSyntax) -> SourceFileSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -16476,6 +16505,7 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
   ///                  `availabilityArguments` collection.
   /// - returns: A copy of the receiver with the provided `AvailabilityArgument`
   ///            appended to its `availabilityArguments` collection.
+  @available(*, deprecated, message: "Use node.availabilityArguments.append(newElement) instead")
   public func addAvailabilityArgument(_ element: AvailabilityArgumentSyntax) -> SpecializeAvailabilityArgumentSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -17085,6 +17115,7 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `caseItems` collection.
   /// - returns: A copy of the receiver with the provided `CaseItem`
   ///            appended to its `caseItems` collection.
+  @available(*, deprecated, message: "Use node.caseItems.append(newElement) instead")
   public func addCaseItem(_ element: SwitchCaseItemSyntax) -> SwitchCaseLabelSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -17324,6 +17355,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `statements` collection.
   /// - returns: A copy of the receiver with the provided `Statement`
   ///            appended to its `statements` collection.
+  @available(*, deprecated, message: "Use node.statements.append(newElement) instead")
   public func addStatement(_ element: CodeBlockItemSyntax) -> SwitchCaseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -18878,6 +18910,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `components` collection.
   /// - returns: A copy of the receiver with the provided `VersionComponent`
   ///            appended to its `components` collection.
+  @available(*, deprecated, message: "Use node.components.append(newElement) instead")
   public func addVersionComponent(_ element: VersionComponentSyntax) -> VersionTupleSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -19289,6 +19322,7 @@ public struct YieldedExpressionsClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
   ///            appended to its `elements` collection.
+  @available(*, deprecated, message: "Use node.elements.append(newElement) instead")
   public func addElement(_ element: YieldedExpressionSyntax) -> YieldedExpressionsClauseSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -504,6 +504,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
   ///            appended to its `elements` collection.
+  @available(*, deprecated, message: "Use node.elements.append(newElement) instead")
   public func addElement(_ element: TuplePatternElementSyntax) -> TuplePatternSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -633,6 +633,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                  `catchClauses` collection.
   /// - returns: A copy of the receiver with the provided `CatchClause`
   ///            appended to its `catchClauses` collection.
+  @available(*, deprecated, message: "Use node.catchClauses.append(newElement) instead")
   public func addCatchClause(_ element: CatchClauseSyntax) -> DoStmtSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -1299,6 +1300,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                  `conditions` collection.
   /// - returns: A copy of the receiver with the provided `Condition`
   ///            appended to its `conditions` collection.
+  @available(*, deprecated, message: "Use node.conditions.append(newElement) instead")
   public func addCondition(_ element: ConditionElementSyntax) -> GuardStmtSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2150,6 +2152,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                  `conditions` collection.
   /// - returns: A copy of the receiver with the provided `Condition`
   ///            appended to its `conditions` collection.
+  @available(*, deprecated, message: "Use node.conditions.append(newElement) instead")
   public func addCondition(_ element: ConditionElementSyntax) -> WhileStmtSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -276,6 +276,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
   ///            appended to its `attributes` collection.
+  @available(*, deprecated, message: "Use node.attributes.append(newElement) instead")
   public func addAttribute(_ element: Syntax) -> AttributedTypeSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -492,6 +493,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
   ///            appended to its `elements` collection.
+  @available(*, deprecated, message: "Use node.elements.append(newElement) instead")
   public func addElement(_ element: CompositionTypeElementSyntax) -> CompositionTypeSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -856,6 +858,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
   ///            appended to its `parameters` collection.
+  @available(*, deprecated, message: "Use node.parameters.append(newElement) instead")
   public func addParameter(_ element: TupleTypeElementSyntax) -> FunctionTypeSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
@@ -2461,6 +2464,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
   ///            appended to its `elements` collection.
+  @available(*, deprecated, message: "Use node.elements.append(newElement) instead")
   public func addElement(_ element: TupleTypeElementSyntax) -> TupleTypeSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -928,7 +928,7 @@ private extension AccessorBlockSyntax {
     var result = self
     switch self.accessors {
     case .accessors(let accessors):
-      result.accessors = .accessors(AccessorDeclListSyntax(accessors + Array(newAccessors)))
+      result.accessors = .accessors(accessors + Array(newAccessors))
     case .getter(let getter):
       if newAccessors.isEmpty {
         return self

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
@@ -340,9 +340,7 @@ public struct AddCompletionHandler: PeerMacro {
         ]
       newParameterList = FunctionParameterListSyntax(newParameterListElements)
     } else {
-      newParameterList = FunctionParameterListSyntax(
-        parameterList + [completionHandlerParam]
-      )
+      newParameterList = parameterList + [completionHandlerParam]
     }
 
     let callArguments: [String] = parameterList.map { param in


### PR DESCRIPTION
Especially the `+` operators make manipulation of `SyntaxCollection` a lot easier.

`SyntaxCollection` doesn’t conform to `RangeReplaceableCollection` because of two reasons:
 - `RangeReplaceableCollection` assumes that creating a new colleciton and adding all elements from another collection to it results in the same collection. This is not true for `SyntaxCollection` because the new collection wouldn’t have a parent. This causes eg. the default implementation of `filter` to misbehave.
 - It can’t make the complexity guarantees that `RangeReplaceableCollection` requires, e.g. `append` is `O(tree depth)` instead of `O(1)`.

For the same reason, also remove the conformance to `MutableCollection`.

With those operators and methods, we no longer need the `add*` methods on syntax nodes that have a syntax collection as their child.