### PR TITLE
Do not format blank lines in multiline string literals

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -508,6 +508,17 @@ open class BasicFormat: SyntaxRewriter {
       return token
     }
 
+    if token.text == "\n" && token.leadingTrivia.isEmpty && token.trailingTrivia.isEmpty {
+      return token
+    }
+    if token.text.isEmpty
+        && token.leadingTrivia.isEmpty
+        && token.trailingTrivia.startsWithNewline
+        && token.trailingTrivia.endsWithNewline
+        && previousTokenWillEndWithNewline {
+      return token
+    }
+
     return token.detached.with(\.leadingTrivia, leadingTrivia).with(\.trailingTrivia, trailingTrivia)
   }
 }

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -250,6 +250,27 @@ final class BasicFormatTest: XCTestCase {
     )
   }
 
+  func testMultilineStringLiteralWithBlackLines() {
+    assertFormatted(
+      source: #"""
+        assertionFailure("""
+          First line
+
+          Second line
+
+          """)
+        """#,
+      expected: #"""
+        assertionFailure("""
+          First line
+
+          Second line
+
+          """)
+        """#
+    )
+  }
+
   func testNestedUserDefinedIndentation() {
     assertFormatted(
       source: """


### PR DESCRIPTION
Fixes https://github.com/apple/swift-syntax/issues/1959

For an example, see the following code

```swift
assertionFailure("""
  First line

  Second line

  """)
```

There are blank lines in line 3 and 5.

The conditions for a blank line are that StringSegments is only a newline character with no trivia (line 3), or that StringSegments is a zero-length string and the trailing trivia is a newline (line 5).

However, this condition would also match empty StringSegments immediately after string interpolation in the following code. (This case is covered by [`testStringInterpolationAtStartOfMultiLineStringLiteral`](https://github.com/apple/swift-syntax/blob/c2f6b9d18ed8c49b6e515b5e1f34b0fb5594eec7/Tests/SwiftBasicFormatTest/BasicFormatTests.swift#L211-L234).)

```swift
assertionFailure("""
  ABC
  \(myVar)
  """)
```

Therefore, I also added the condition that the previous token must be ended by a newline.