### PR TITLE
Add Swift Macros docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Mainline SwiftSyntax also includes
 - `SwiftParser` for natively parsing source code
 - `SwiftOperators` for folding SwiftSyntax trees containing operators
 - `SwiftSyntaxBuilder` for generating Swift code with a result builder-style interface
+- `SwiftSyntaxMacros` for providing syntactic macro support
 
 ### Releases
 
@@ -90,6 +91,7 @@ text editor, or IDE.
 - [SwiftSyntax](Sources/SwiftSyntax/Documentation.docc)
 - [SwiftParser](Sources/SwiftParser/SwiftParser.docc)
 - [SwiftOperators](Sources/SwiftOperators/SwiftOperators.docc)
+- [SwiftSyntaxMacros](Sources/SwiftSyntaxMacros/SwiftSyntaxMacros.docc)
 
 ## Contributing
 


### PR DESCRIPTION
It's nice to mention information about Swift Macros in README because some users expect to learn how to make Swift Macros by using SwiftSyntax. 