### PR TITLE
Only print line + column in `SyntaxProtocol.debugDescription`

### DIFF
--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -15,8 +15,7 @@ public struct SourceLocation: Hashable, Codable {
 
   /// The line in the file where this location resides. 1-based.
   ///
-  /// ### See also
-  /// ``SourceLocation/presumedLine``
+  /// - SeeAlso: ``SourceLocation/presumedLine``
   public var line: Int
 
   /// The UTF-8 byte offset from the beginning of the line where this location
@@ -28,8 +27,7 @@ public struct SourceLocation: Hashable, Codable {
 
   /// The file in which this location resides.
   ///
-  /// ### See also
-  /// ``SourceLocation/presumedFile``
+  /// - SeeAlso: ``SourceLocation/presumedFile``
   public let file: String
 
   /// The line of this location when respecting `#sourceLocation` directives.

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -738,7 +738,7 @@ public extension SyntaxProtocol {
 
     if let converter {
       let range = sourceRange(converter: converter)
-      target.write(" [\(range.start)...\(range.end)]")
+      target.write(" [\(range.start.line):\(range.start.column)...\(range.end.line):\(range.end.column)]")
     }
 
     if let tokenView = raw.tokenView, tokenView.presence == .missing {


### PR DESCRIPTION
When `SourceLocation` stopped conforming to `CustomStringConvertible` because we added `presumedLine` and `presumedColumn`, this started printing an initializer call to `SourceLocation`, which was very verbose and unreadable. Just print line and column for the debug description.