### PR TITLE
Only allow `postfixQuestionMark` as the question mark after `init`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -1267,7 +1267,6 @@ public let DECL_NODES: [Node] = [
         name: "optionalMark",
         kind: .token(choices: [
           .token(.postfixQuestionMark),
-          .token(.infixQuestionMark),
           .token(.exclamationMark),
         ]),
         documentation: "If the initializer is failable, a question mark to indicate that.",

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -922,7 +922,7 @@ extension Parser {
 
     // Parse the '!' or '?' for a failable initializer.
     let failable: RawTokenSyntax?
-    if let parsedFailable = self.consume(if: .exclamationMark, .postfixQuestionMark, .infixQuestionMark) {
+    if let parsedFailable = self.consume(if: .exclamationMark, .postfixQuestionMark, TokenSpec(.infixQuestionMark, remapping: .postfixQuestionMark)) {
       failable = parsedFailable
     } else if let parsedFailable = self.consumeIfContextualPunctuator("!", remapping: .exclamationMark) {
       failable = parsedFailable

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -1807,15 +1807,12 @@ extension InitializerDeclSyntax {
   @_spi(Diagnostics)
   public enum OptionalMarkOptions: TokenSpecSet {
     case postfixQuestionMark
-    case infixQuestionMark
     case exclamationMark
     
     init?(lexeme: Lexer.Lexeme) {
       switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.postfixQuestionMark):
         self = .postfixQuestionMark
-      case TokenSpec(.infixQuestionMark):
-        self = .infixQuestionMark
       case TokenSpec(.exclamationMark):
         self = .exclamationMark
       default:
@@ -1827,8 +1824,6 @@ extension InitializerDeclSyntax {
       switch self {
       case .postfixQuestionMark:
         return .postfixQuestionMark
-      case .infixQuestionMark:
-        return .infixQuestionMark
       case .exclamationMark:
         return .exclamationMark
       }
@@ -1842,8 +1837,6 @@ extension InitializerDeclSyntax {
       switch self {
       case .postfixQuestionMark:
         return .postfixQuestionMarkToken()
-      case .infixQuestionMark:
-        return .infixQuestionMarkToken()
       case .exclamationMark:
         return .exclamationMarkToken()
       }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1553,7 +1553,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [.keyword("init")]))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.postfixQuestionMark), .tokenKind(.infixQuestionMark), .tokenKind(.exclamationMark)]))
+    assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.postfixQuestionMark), .tokenKind(.exclamationMark)]))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 9, verify(layout[9], as: RawGenericParameterClauseSyntax?.self))
     assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
@@ -3787,7 +3787,7 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `attributes`: ``AttributeListSyntax``
 ///  - `modifiers`: ``DeclModifierListSyntax``
 ///  - `initKeyword`: `'init'`
-///  - `optionalMark`: (`'?'` | `'?'` | `'!'`)?
+///  - `optionalMark`: (`'?'` | `'!'`)?
 ///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
 ///  - `signature`: ``FunctionSignatureSyntax``
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?


### PR DESCRIPTION
We allowed both `postfixQuestionMark` and `infixQuestionMark` because we didn’t know as which token kind the lexer classified the question mark. But we can just remap the kind in the parser to simplify the syntax node.