### PR TITLE
If no destination is passed in CodeGeneration, place generated files in parent swift-syntax package

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/GenerateSwiftSyntax.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/GenerateSwiftSyntax.swift
@@ -70,7 +70,15 @@ struct TemplateSpec {
 @main
 struct GenerateSwiftSyntax: ParsableCommand {
   @Argument(help: "The path to the source directory (i.e. 'swift-syntax/Sources') where the source files are to be generated")
-  var destination: String
+  var destination: String = {
+    let sourcesURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources")
+    return sourcesURL.path
+  }()
 
   @Flag(help: "Enable verbose output")
   var verbose: Bool = false


### PR DESCRIPTION
The parent swift-syntax package is the standard destination for CodeGeneration and you shouldn’t need to always specify it.