### PR TITLE
Renamed isAt* funcs to at* in Parser and Parser.Lookahead

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -354,7 +354,7 @@ extension Parser {
   /// `copy` etc. are only contextually a keyword if they are followed by an
   /// identifier or keyword on the same line. We do this to ensure that we do
   /// not break any copy functions defined by users.
-  private mutating func isContextualExpressionModifier() -> Bool {
+  private mutating func atContextualExpressionModifier() -> Bool {
     return self.peek(
       isAt: TokenSpec(.identifier, allowAtStartOfLine: false),
       TokenSpec(.dollarIdentifier, allowAtStartOfLine: false),
@@ -444,7 +444,7 @@ extension Parser {
       )
 
     case (.copy, let handle)?:
-      if !isContextualExpressionModifier() {
+      if !atContextualExpressionModifier() {
         break EXPR_PREFIX
       }
 
@@ -463,7 +463,7 @@ extension Parser {
       )
 
     case (.consume, let handle)?:
-      if !isContextualExpressionModifier() {
+      if !atContextualExpressionModifier() {
         break EXPR_PREFIX
       }
 
@@ -486,7 +486,7 @@ extension Parser {
       return RawExprSyntax(parsePackExpansionExpr(repeatHandle: handle, flavor, pattern: pattern))
 
     case (.each, let handle)?:
-      if !isContextualExpressionModifier() {
+      if !atContextualExpressionModifier() {
         break EXPR_PREFIX
       }
 
@@ -501,7 +501,7 @@ extension Parser {
       )
 
     case (.any, _)?:
-      if !isContextualExpressionModifier() {
+      if !atContextualExpressionModifier() {
         break EXPR_PREFIX
       }
 
@@ -874,7 +874,7 @@ extension Parser {
             }
           } while lookahead.at(.poundIf) && lookahead.hasProgressed(&loopProgress)
 
-          guard lookahead.isAtStartOfPostfixExprSuffix() else {
+          guard lookahead.atStartOfPostfixExprSuffix() else {
             break
           }
         }
@@ -2149,7 +2149,7 @@ extension Parser {
     while !self.at(.endOfFile, .rightBrace) && !self.at(.poundEndif, .poundElseif, .poundElse)
       && self.hasProgressed(&elementsProgress)
     {
-      if self.withLookahead({ $0.isAtStartOfSwitchCase(allowRecovery: false) }) {
+      if self.withLookahead({ $0.atStartOfSwitchCase(allowRecovery: false) }) {
         elements.append(.switchCase(self.parseSwitchCase()))
       } else if self.canRecoverTo(.poundIf) != nil {
         // '#if' in 'case' position can enclose zero or more 'case' or 'default'
@@ -2206,7 +2206,7 @@ extension Parser {
             )
           )
         )
-      } else if self.withLookahead({ $0.isAtStartOfSwitchCase(allowRecovery: true) }) {
+      } else if self.withLookahead({ $0.atStartOfSwitchCase(allowRecovery: true) }) {
         elements.append(.switchCase(self.parseSwitchCase()))
       } else {
         break
@@ -2217,7 +2217,7 @@ extension Parser {
 
   mutating func parseSwitchCaseBody() -> RawCodeBlockItemListSyntax {
     parseCodeBlockItemList(until: {
-      $0.at(.rightBrace) || $0.at(.poundEndif, .poundElseif, .poundElse) || $0.withLookahead({ $0.isStartOfConditionalSwitchCases() })
+      $0.at(.rightBrace) || $0.at(.poundEndif, .poundElseif, .poundElse) || $0.withLookahead({ $0.atStartOfConditionalSwitchCases() })
     })
   }
 
@@ -2487,7 +2487,7 @@ extension Parser.Lookahead {
 extension Parser.Lookahead {
   // Helper function to see if we can parse member reference like suffixes
   // inside '#if'.
-  fileprivate mutating func isAtStartOfPostfixExprSuffix() -> Bool {
+  fileprivate mutating func atStartOfPostfixExprSuffix() -> Bool {
     guard self.at(.period) else {
       return false
     }

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -240,7 +240,7 @@ extension Parser {
     }
 
     let inheritance: RawInheritanceClauseSyntax?
-    if self.at(.colon) || self.isAtPythonStyleInheritanceClause() {
+    if self.at(.colon) || self.atPythonStyleInheritanceClause() {
       inheritance = self.parseInheritance()
     } else {
       inheritance = nil
@@ -363,7 +363,7 @@ extension Parser {
 }
 
 extension Parser {
-  private mutating func isAtPythonStyleInheritanceClause() -> Bool {
+  private mutating func atPythonStyleInheritanceClause() -> Bool {
     guard self.at(.leftParen) else { return false }
     return self.withLookahead {
       $0.consume(if: .leftParen)

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -88,8 +88,10 @@
 /// operates on a copy of the lexical stream, no input tokens are lost..
 public struct Parser {
   var arena: ParsingSyntaxArena
+
   /// A view of the sequence of lexemes in the input.
   var lexemes: Lexer.LexemeSequence
+
   /// The current token that should be consumed next.
   ///
   /// If the end of the source file is reached, this is `.endOfFile`.

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -25,7 +25,7 @@ extension TokenConsumer {
       // misplaced attributes.
       _ = lookahead.consumeAttributeList()
     }
-    return lookahead.isStartOfStatement(allowRecovery: allowRecovery)
+    return lookahead.atStartOfStatement(allowRecovery: allowRecovery)
   }
 }
 
@@ -808,7 +808,7 @@ extension Parser.Lookahead {
   ///
   /// - Note: This function must be kept in sync with `parseStatement()`.
   /// - Seealso: ``Parser/parseStatement()``
-  mutating func isStartOfStatement(allowRecovery: Bool = false) -> Bool {
+  mutating func atStartOfStatement(allowRecovery: Bool = false) -> Bool {
     if (self.at(anyIn: SwitchCaseStart.self) != nil || self.at(.atSign)) && withLookahead({ $0.atStartOfSwitchCaseItem() }) {
       // We consider SwitchCaseItems statements so we don't parse the start of a new case item as trailing parts of an expression.
       return true
@@ -884,7 +884,7 @@ extension Parser.Lookahead {
 
   /// Returns whether the parser's current position is the start of a switch case,
   /// given that we're in the middle of a switch already.
-  mutating func isAtStartOfSwitchCase(allowRecovery: Bool = false) -> Bool {
+  mutating func atStartOfSwitchCase(allowRecovery: Bool = false) -> Bool {
     // Check for and consume attributes. The only valid attribute is `@unknown`
     // but that's a semantic restriction.
     var lookahead = self.lookahead()
@@ -916,9 +916,9 @@ extension Parser.Lookahead {
     }
   }
 
-  mutating func isStartOfConditionalSwitchCases() -> Bool {
+  mutating func atStartOfConditionalSwitchCases() -> Bool {
     guard self.at(.poundIf) else {
-      return self.isAtStartOfSwitchCase()
+      return self.atStartOfSwitchCase()
     }
 
     var lookahead = self.lookahead()
@@ -928,6 +928,6 @@ extension Parser.Lookahead {
       // just find the end of the line
       lookahead.skipUntilEndOfLine()
     } while lookahead.at(.poundIf, .poundElseif, .poundElse) && lookahead.hasProgressed(&loopProgress)
-    return lookahead.isAtStartOfSwitchCase()
+    return lookahead.atStartOfSwitchCase()
   }
 }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -45,7 +45,7 @@ extension Parser {
   mutating func parseTypeScalar(misplacedSpecifiers: [RawTokenSyntax] = []) -> RawTypeSyntax {
     let (specifier, unexpectedBeforeAttrList, attrList) = self.parseTypeAttributeList(misplacedSpecifiers: misplacedSpecifiers)
     var base = RawTypeSyntax(self.parseSimpleOrCompositionType())
-    if self.withLookahead({ $0.isAtFunctionTypeArrow() }) {
+    if self.withLookahead({ $0.atFunctionTypeArrow() }) {
       var effectSpecifiers = self.parseTypeEffectSpecifiers()
       let returnClause = self.parseFunctionReturnClause(effectSpecifiers: &effectSpecifiers, allowNamedOpaqueResultType: false)
 
@@ -623,7 +623,7 @@ extension Parser.Lookahead {
       return false
     }
 
-    if self.isAtFunctionTypeArrow() {
+    if self.atFunctionTypeArrow() {
       // Handle type-function if we have an '->' with optional
       // 'async' and/or 'throws'.
       var loopProgress = LoopProgressCondition()
@@ -781,7 +781,7 @@ extension Parser.Lookahead {
     return self.consume(if: .rightParen) != nil
   }
 
-  mutating func isAtFunctionTypeArrow() -> Bool {
+  mutating func atFunctionTypeArrow() -> Bool {
     if self.at(.arrow) {
       return true
     }
@@ -795,7 +795,7 @@ extension Parser.Lookahead {
         var backtrack = self.lookahead()
         backtrack.consumeAnyToken()
         backtrack.consumeAnyToken()
-        return backtrack.isAtFunctionTypeArrow()
+        return backtrack.atFunctionTypeArrow()
       }
 
       return false


### PR DESCRIPTION
**Motivation**

Closes #1976. This pull request is a step towards making the Parser API consistent, and renaming some of the boolean `isAt*` functions with `at*`.

**Changes**
- [x] `Lexer.Cursor.isAtStringInterpolationAnchor` — private, so I'll rename it and change any spots where it's invoked. Deprecating the existing function should not be necessary.
- [x] `Lexer.Cursor.isAtEscapedNewline` — same as above.
- [x] `Parser.Lookahead` has two fileprivate functions `isAtStartOfPostfixExprSuffix` and `isInBindingPatternPosition` — I think it's best to rename both of them so the code in that particular extension is consistent. It would be weird to have `atStartOfPostfixExprSuffix` and `isIn*`. 
- [x] `Parser.isAtPythonStyleInheritanceClause`
- [x] In `SwiftParser/Statements.swift` we have `Parser.Lookahead` extension with `isAtStartOfSwitchCase`, `isStartOfStatement`, `isStartOfConditionalSwitchCases`. 
   - These are not marked as private, so I _think_ we should keep the original version and deprecate it.
   - Should I rename `isStartOf*` as well for consistency?
- [x] `SwiftParser/Types.swift` has `Parser.Lookahead.isAtFunctionTypeArrow` — also not marked as private.

**TODO**
- [x] Decide if we need deprecated versions for non-private funcs
- [x] Tests pass
- [x] Formatting OK