### PR TITLE
Introduce `then` statements

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -255,6 +255,7 @@ public enum Keyword: CaseIterable {
   case swift
   case `switch`
   case target
+  case then
   case `throw`
   case `throws`
   case transpose
@@ -644,6 +645,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("switch", isLexerClassified: true)
     case .target:
       return KeywordSpec("target")
+    case .then:
+      return KeywordSpec("then", isExperimental: true)
     case .throw:
       return KeywordSpec("throw", isLexerClassified: true)
     case .throws:

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -646,7 +646,7 @@ public enum Keyword: CaseIterable {
     case .target:
       return KeywordSpec("target")
     case .then:
-      return KeywordSpec("then", isExperimental: true)
+      return KeywordSpec("then")
     case .throw:
       return KeywordSpec("throw", isLexerClassified: true)
     case .throws:

--- a/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
@@ -613,4 +613,30 @@ public let STMT_NODES: [Node] = [
     ]
   ),
 
+  // then-stmt -> 'then' expr ';'?
+  Node(
+    kind: .thenStmt,
+    base: .stmt,
+    isExperimental: true,
+    nameForDiagnostics: "'then' statement",
+    documentation: """
+      A statement used to indicate the produced value from an if/switch
+      expression.
+
+       Written as:
+      ```swift
+      then <expr>
+      ```
+      """,
+    children: [
+      Child(
+        name: "thenKeyword",
+        kind: .token(choices: [.keyword(.then)])
+      ),
+      Child(
+        name: "expression",
+        kind: .node(kind: .expr)
+      ),
+    ]
+  ),
 ]

--- a/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
@@ -617,7 +617,8 @@ public let STMT_NODES: [Node] = [
   Node(
     kind: .thenStmt,
     base: .stmt,
-    isExperimental: true,
+    // FIXME: This should be marked experimental.
+    isExperimental: false,
     nameForDiagnostics: "'then' statement",
     documentation: """
       A statement used to indicate the produced value from an if/switch

--- a/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
@@ -267,6 +267,7 @@ public enum SyntaxNodeKind: String, CaseIterable {
   case switchDefaultLabel
   case switchExpr
   case ternaryExpr
+  case thenStmt
   case throwStmt
   case tryExpr
   case tupleExpr

--- a/Sources/SwiftParser/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/ExperimentalFeatures.swift
@@ -22,3 +22,8 @@ extension Parser {
     public static let referenceBindings = Self(rawValue: 1 << 0)
   }
 }
+
+extension Parser.ExperimentalFeatures {
+  /// Whether to enable the parsing of 'then' statements.
+  public static let thenStatements = Self(rawValue: 1 << 0)
+}

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -210,7 +210,7 @@ enum TokenPrecedence: Comparable {
       // Secondary parts of control-flow constructs
       .case, .catch, .default, .else,
       // Return-like statements
-      .break, .continue, .fallthrough, .return, .throw, .yield:
+      .break, .continue, .fallthrough, .return, .throw, .then, .yield:
       self = .stmtKeyword
     // MARK: Decl keywords
     case  // Types

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -237,13 +237,13 @@ extension Parser {
       return .decl(RawDeclSyntax(self.parsePoundSourceLocationDirective()))
     } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl) {
       return .decl(self.parseDeclaration())
-    } else if self.atStartOfStatement() {
+    } else if self.atStartOfStatement(preferExpr: false) {
       return self.parseStatementItem()
     } else if self.atStartOfExpression() {
       return .expr(self.parseExpression(flavor: .basic, pattern: .none))
     } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl, allowRecovery: true) {
       return .decl(self.parseDeclaration())
-    } else if self.atStartOfStatement(allowRecovery: true) {
+    } else if self.atStartOfStatement(allowRecovery: true, preferExpr: false) {
       return self.parseStatementItem()
     } else {
       return .expr(RawExprSyntax(RawMissingExprSyntax(arena: self.arena)))

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -1492,6 +1492,21 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     return .visitChildren
   }
 
+  @_spi(ExperimentalLanguageFeatures)
+  public override func visit(_ node: ThenStmtSyntax) -> SyntaxVisitorContinueKind {
+    if shouldSkip(node) {
+      return .skipChildren
+    }
+    exchangeTokens(
+      unexpected: node.unexpectedBeforeThenKeyword,
+      unexpectedTokenCondition: { $0.tokenKind == .keyword(.try) },
+      correctTokens: [node.expression.as(TryExprSyntax.self)?.tryKeyword],
+      message: { _ in .tryMustBePlacedOnThenExpr },
+      moveFixIt: { MoveTokensAfterFixIt(movedTokens: $0, after: .keyword(.then)) }
+    )
+    return .visitChildren
+  }
+
   public override func visit(_ node: SameTypeRequirementSyntax) -> SyntaxVisitorContinueKind {
     if shouldSkip(node) {
       return .skipChildren

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -249,6 +249,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var tryMustBePlacedOnThrownExpr: Self {
     .init("'try' must be placed on the thrown expression")
   }
+  public static var tryMustBePlacedOnThenExpr: Self {
+    .init("'try' must be placed on the produced expression")
+  }
   public static var tryOnInitialValueExpression: Self {
     .init("'try' must be placed on the initial value expression")
   }

--- a/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
@@ -357,6 +357,8 @@ extension SyntaxKind {
       return "'switch' statement"
     case .ternaryExpr:
       return "ternay expression"
+    case .thenStmt:
+      return "'then' statement"
     case .throwStmt:
       return "'throw' statement"
     case .tryExpr:

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -175,6 +175,7 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/LabeledStmtSyntax>
 - <doc:SwiftSyntax/RepeatStmtSyntax>
 - <doc:SwiftSyntax/ReturnStmtSyntax>
+- <doc:SwiftSyntax/ThenStmtSyntax>
 - <doc:SwiftSyntax/ThrowStmtSyntax>
 - <doc:SwiftSyntax/WhileStmtSyntax>
 - <doc:SwiftSyntax/YieldStmtSyntax>

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -3063,6 +3063,16 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "elseExpression"
   case \TernaryExprSyntax.unexpectedAfterElseExpression:
     return "unexpectedAfterElseExpression"
+  case \ThenStmtSyntax.unexpectedBeforeThenKeyword:
+    return "unexpectedBeforeThenKeyword"
+  case \ThenStmtSyntax.thenKeyword:
+    return "thenKeyword"
+  case \ThenStmtSyntax.unexpectedBetweenThenKeywordAndExpression:
+    return "unexpectedBetweenThenKeywordAndExpression"
+  case \ThenStmtSyntax.expression:
+    return "expression"
+  case \ThenStmtSyntax.unexpectedAfterExpression:
+    return "unexpectedAfterExpression"
   case \ThrowStmtSyntax.unexpectedBeforeThrowKeyword:
     return "unexpectedBeforeThrowKeyword"
   case \ThrowStmtSyntax.throwKeyword:

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -201,6 +201,7 @@ public enum Keyword: UInt8, Hashable {
   case swift
   case `switch`
   case target
+  case then
   case `throw`
   case `throws`
   case transpose
@@ -312,6 +313,8 @@ public enum Keyword: UInt8, Hashable {
         self = .Self
       case "some":
         self = .some
+      case "then":
+        self = .then
       case "true":
         self = .true
       case "Type":
@@ -956,6 +959,7 @@ public enum Keyword: UInt8, Hashable {
       "swift", 
       "switch", 
       "target", 
+      "then", 
       "throw", 
       "throws", 
       "transpose", 

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -2000,6 +2000,14 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
   
+  override open func visit(_ node: ThenStmtSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+  
+  override open func visitPost(_ node: ThenStmtSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  
   override open func visit(_ node: ThrowStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -512,7 +512,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
-    case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallThroughStmt, .forStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
+    case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallThroughStmt, .forStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatStmt, .returnStmt, .thenStmt, .throwStmt, .whileStmt, .yieldStmt:
       self._syntaxNode = node._syntaxNode
     default:
       return nil
@@ -525,7 +525,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     switch data.raw.kind {
-    case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallThroughStmt, .forStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
+    case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallThroughStmt, .forStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatStmt, .returnStmt, .thenStmt, .throwStmt, .whileStmt, .yieldStmt:
       break
     default:
       preconditionFailure("Unable to create StmtSyntax from \(data.raw.kind)")
@@ -576,6 +576,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           .node(MissingStmtSyntax.self),
           .node(RepeatStmtSyntax.self),
           .node(ReturnStmtSyntax.self),
+          .node(ThenStmtSyntax.self),
           .node(ThrowStmtSyntax.self),
           .node(WhileStmtSyntax.self),
           .node(YieldStmtSyntax.self)
@@ -966,6 +967,7 @@ extension Syntax {
           .node(SwitchDefaultLabelSyntax.self),
           .node(SwitchExprSyntax.self),
           .node(TernaryExprSyntax.self),
+          .node(ThenStmtSyntax.self),
           .node(ThrowStmtSyntax.self),
           .node(TryExprSyntax.self),
           .node(TupleExprSyntax.self),

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -258,6 +258,7 @@ public enum SyntaxEnum {
   case switchDefaultLabel(SwitchDefaultLabelSyntax)
   case switchExpr(SwitchExprSyntax)
   case ternaryExpr(TernaryExprSyntax)
+  case thenStmt(ThenStmtSyntax)
   case throwStmt(ThrowStmtSyntax)
   case tryExpr(TryExprSyntax)
   case tupleExpr(TupleExprSyntax)
@@ -784,6 +785,8 @@ public extension Syntax {
       return .switchExpr(SwitchExprSyntax(self)!)
     case .ternaryExpr:
       return .ternaryExpr(TernaryExprSyntax(self)!)
+    case .thenStmt:
+      return .thenStmt(ThenStmtSyntax(self)!)
     case .throwStmt:
       return .throwStmt(ThrowStmtSyntax(self)!)
     case .tryExpr:

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -258,6 +258,7 @@ public enum SyntaxKind: CaseIterable {
   case switchDefaultLabel
   case switchExpr
   case ternaryExpr
+  case thenStmt
   case throwStmt
   case tryExpr
   case tupleExpr
@@ -905,6 +906,8 @@ public enum SyntaxKind: CaseIterable {
       return SwitchExprSyntax.self
     case .ternaryExpr:
       return TernaryExprSyntax.self
+    case .thenStmt:
+      return ThenStmtSyntax.self
     case .throwStmt:
       return ThrowStmtSyntax.self
     case .tryExpr:

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -1781,6 +1781,13 @@ open class SyntaxRewriter {
     return ExprSyntax(visitChildren(node))
   }
   
+  /// Visit a ``ThenStmtSyntax``.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: ThenStmtSyntax) -> StmtSyntax {
+    return StmtSyntax(visitChildren(node))
+  }
+  
   /// Visit a ``ThrowStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -3061,6 +3068,10 @@ open class SyntaxRewriter {
       return {
         self.visitImpl($0, TernaryExprSyntax.self, self.visit)
       }
+    case .thenStmt:
+      return {
+        self.visitImpl($0, ThenStmtSyntax.self, self.visit)
+      }
     case .throwStmt:
       return {
         self.visitImpl($0, ThrowStmtSyntax.self, self.visit)
@@ -3685,6 +3696,8 @@ open class SyntaxRewriter {
       return visitImpl(data, SwitchExprSyntax.self, visit)
     case .ternaryExpr:
       return visitImpl(data, TernaryExprSyntax.self, visit)
+    case .thenStmt:
+      return visitImpl(data, ThenStmtSyntax.self, visit)
     case .throwStmt:
       return visitImpl(data, ThrowStmtSyntax.self, visit)
     case .tryExpr:

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -1235,6 +1235,11 @@ public protocol SyntaxTransformVisitor {
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: TernaryExprSyntax) -> ResultType
   
+  /// Visiting ``ThenStmtSyntax`` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: ThenStmtSyntax) -> ResultType
+  
   /// Visiting ``ThrowStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -3102,6 +3107,13 @@ extension SyntaxTransformVisitor {
     visitAny(Syntax(node))
   }
   
+  /// Visiting ``ThenStmtSyntax`` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: ThenStmtSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  
   /// Visiting ``ThrowStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -3815,6 +3827,8 @@ extension SyntaxTransformVisitor {
     case .switchExpr(let derived):
       return visit(derived)
     case .ternaryExpr(let derived):
+      return visit(derived)
+    case .thenStmt(let derived):
       return visit(derived)
     case .throwStmt(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -2950,6 +2950,18 @@ open class SyntaxVisitor {
   open func visitPost(_ node: TernaryExprSyntax) {
   }
   
+  /// Visiting ``ThenStmtSyntax`` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: ThenStmtSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  
+  /// The function called after visiting ``ThenStmtSyntax`` and its descendants.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: ThenStmtSyntax) {
+  }
+  
   /// Visiting ``ThrowStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4368,6 +4380,10 @@ open class SyntaxVisitor {
       return {
         self.visitImpl($0, TernaryExprSyntax.self, self.visit, self.visitPost)
       }
+    case .thenStmt:
+      return {
+        self.visitImpl($0, ThenStmtSyntax.self, self.visit, self.visitPost)
+      }
     case .throwStmt:
       return {
         self.visitImpl($0, ThrowStmtSyntax.self, self.visit, self.visitPost)
@@ -4995,6 +5011,8 @@ open class SyntaxVisitor {
       visitImpl(data, SwitchExprSyntax.self, visit, visitPost)
     case .ternaryExpr:
       visitImpl(data, TernaryExprSyntax.self, visit, visitPost)
+    case .thenStmt:
+      visitImpl(data, ThenStmtSyntax.self, visit, visitPost)
     case .throwStmt:
       visitImpl(data, ThrowStmtSyntax.self, visit, visitPost)
     case .tryExpr:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
@@ -1056,7 +1056,7 @@ public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol {
   
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     switch raw.kind {
-    case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallThroughStmt, .forStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
+    case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallThroughStmt, .forStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatStmt, .returnStmt, .thenStmt, .throwStmt, .whileStmt, .yieldStmt:
       return true
     default:
       return false

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
@@ -108,6 +108,76 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
 }
 
 @_spi(RawSyntax)
+public struct RawThenStmtSyntax: RawStmtSyntaxNodeProtocol {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+  
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .thenStmt
+  }
+  
+  public var raw: RawSyntax
+  
+  init(raw: RawSyntax) {
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
+    self.raw = raw
+  }
+  
+  public init?(_ other: some RawSyntaxNodeProtocol) {
+    guard Self.isKindOf(other.raw) else {
+      return nil
+    }
+    self.init(unchecked: other.raw)
+  }
+  
+  public init(
+      _ unexpectedBeforeThenKeyword: RawUnexpectedNodesSyntax? = nil, 
+      thenKeyword: RawTokenSyntax, 
+      _ unexpectedBetweenThenKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
+      expression: RawExprSyntax, 
+      _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
+      arena: __shared SyntaxArena
+    ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .thenStmt, uninitializedCount: 5, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeThenKeyword?.raw
+      layout[1] = thenKeyword.raw
+      layout[2] = unexpectedBetweenThenKeywordAndExpression?.raw
+      layout[3] = expression.raw
+      layout[4] = unexpectedAfterExpression?.raw
+    }
+    self.init(unchecked: raw)
+  }
+  
+  public var unexpectedBeforeThenKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var thenKeyword: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  
+  public var unexpectedBetweenThenKeywordAndExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var expression: RawExprSyntax {
+    layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
 public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol {
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2451,6 +2451,13 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 9, verify(layout[9], as: RawExprSyntax.self))
     assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
+  case .thenStmt:
+    assert(layout.count == 5)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.keyword("then")]))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawExprSyntax.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   case .throwStmt:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -216,6 +216,137 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 }
 
+// MARK: - ThenStmtSyntax
+
+/// A statement used to indicate the produced value from an if/switch
+/// expression.
+/// 
+///  Written as:
+/// ```swift
+/// then <expr>
+/// ```
+///
+/// ### Children
+/// 
+///  - `thenKeyword`: `'then'`
+///  - `expression`: ``ExprSyntax``
+public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+  
+  public init?(_ node: some SyntaxProtocol) {
+    guard node.raw.kind == .thenStmt else {
+      return nil
+    }
+    self._syntaxNode = node._syntaxNode
+  }
+  
+  /// Creates a ``ThenStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
+  internal init(_ data: SyntaxData) {
+    precondition(data.raw.kind == .thenStmt)
+    self._syntaxNode = Syntax(data)
+  }
+  
+  /// - Parameters:
+  ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
+  public init(
+      leadingTrivia: Trivia? = nil,
+      _ unexpectedBeforeThenKeyword: UnexpectedNodesSyntax? = nil,
+      thenKeyword: TokenSyntax = .keyword(.then),
+      _ unexpectedBetweenThenKeywordAndExpression: UnexpectedNodesSyntax? = nil,
+      expression: some ExprSyntaxProtocol,
+      _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+      trailingTrivia: Trivia? = nil
+    
+  ) {
+    // Extend the lifetime of all parameters so their arenas don't get destroyed
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
+            unexpectedBeforeThenKeyword, 
+            thenKeyword, 
+            unexpectedBetweenThenKeywordAndExpression, 
+            expression, 
+            unexpectedAfterExpression
+          ))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+          unexpectedBeforeThenKeyword?.raw, 
+          thenKeyword.raw, 
+          unexpectedBetweenThenKeywordAndExpression?.raw, 
+          expression.raw, 
+          unexpectedAfterExpression?.raw
+        ]
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.thenStmt,
+        from: layout,
+        arena: arena,
+        leadingTrivia: leadingTrivia,
+        trailingTrivia: trailingTrivia
+        
+      )
+      return SyntaxData.forRoot(raw, rawNodeArena: arena)
+    }
+    self.init(data)
+  }
+  
+  public var unexpectedBeforeThenKeyword: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 0).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = ThenStmtSyntax(data.replacingChild(at: 0, with: value?.data, arena: SyntaxArena()))
+    }
+  }
+  
+  public var thenKeyword: TokenSyntax {
+    get {
+      return TokenSyntax(data.child(at: 1)!)
+    }
+    set(value) {
+      self = ThenStmtSyntax(data.replacingChild(at: 1, with: value.data, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedBetweenThenKeywordAndExpression: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 2).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = ThenStmtSyntax(data.replacingChild(at: 2, with: value?.data, arena: SyntaxArena()))
+    }
+  }
+  
+  public var expression: ExprSyntax {
+    get {
+      return ExprSyntax(data.child(at: 3)!)
+    }
+    set(value) {
+      self = ThenStmtSyntax(data.replacingChild(at: 3, with: value.data, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 4).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = ThenStmtSyntax(data.replacingChild(at: 4, with: value?.data, arena: SyntaxArena()))
+    }
+  }
+  
+  public static var structure: SyntaxNodeStructure {
+    return .layout([
+          \Self.unexpectedBeforeThenKeyword, 
+          \Self.thenKeyword, 
+          \Self.unexpectedBetweenThenKeywordAndExpression, 
+          \Self.expression, 
+          \Self.unexpectedAfterExpression
+        ])
+  }
+}
+
 // MARK: - ThrowStmtSyntax
 
 /// ### Children

--- a/Tests/SwiftParserTest/ThenStatementTests.swift
+++ b/Tests/SwiftParserTest/ThenStatementTests.swift
@@ -1,0 +1,760 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
+import XCTest
+
+final class ThenStatementTests: ParserTestCase {
+  // Enable then statements by default.
+  override var experimentalFeatures: Parser.ExperimentalFeatures {
+    return .thenStatements
+  }
+
+  func testThenStmt1() {
+    assertParse(
+      """
+      then 0
+      """,
+      substructure: ThenStmtSyntax(expression: IntegerLiteralExprSyntax(0))
+    )
+  }
+
+  func testThenStmt2() {
+    assertParse(
+      """
+      then x
+      """,
+      substructure: ThenStmtSyntax(expression: DeclReferenceExprSyntax(baseName: "x"))
+    )
+  }
+
+  func testThenStmt3() {
+    assertParse(
+      """
+      then ()
+      """,
+      substructure: ThenStmtSyntax(expression: TupleExprSyntax(elements: .init([])))
+    )
+  }
+
+  func testThenStmt4() {
+    assertParse(
+      """
+      then (1)
+      """,
+      substructure:
+        ThenStmtSyntax(
+          expression: TupleExprSyntax(
+            elements: .init([
+              .init(expression: IntegerLiteralExprSyntax(1))
+            ])
+          )
+        )
+    )
+  }
+
+  func testThenStmt5() {
+    assertParse(
+      """
+      then (1, 2)
+      """,
+      substructure:
+        ThenStmtSyntax(
+          expression: TupleExprSyntax(
+            elements: .init([
+              .init(expression: IntegerLiteralExprSyntax(1), trailingComma: .commaToken()),
+              .init(expression: IntegerLiteralExprSyntax(2)),
+            ])
+          )
+        )
+    )
+  }
+
+  func testThenStmt6() {
+    assertParse(
+      """
+      then ""
+      """,
+      substructure: ThenStmtSyntax(expression: StringLiteralExprSyntax(content: ""))
+    )
+  }
+
+  func testThenStmt7() {
+    assertParse(
+      """
+      then []
+      """,
+      substructure: ThenStmtSyntax(expression: ArrayExprSyntax(elements: .init(expressions: [])))
+    )
+  }
+
+  func testThenStmt8() {
+    assertParse(
+      """
+      then [0]
+      """,
+      substructure:
+        ThenStmtSyntax(
+          expression: ArrayExprSyntax(
+            elements: .init(expressions: [
+              .init(IntegerLiteralExprSyntax(0))
+            ])
+          )
+        )
+    )
+  }
+
+  func testThenStmt9() {
+    assertParse(
+      """
+      then if .random() { 0 } else { 1 }
+      """
+    )
+  }
+
+  func testThenStmt10() {
+    assertParse(
+      """
+      then -1
+      """,
+      substructure:
+        ThenStmtSyntax(
+          expression: PrefixOperatorExprSyntax(
+            operator: .prefixOperator("-"),
+            expression: IntegerLiteralExprSyntax(1)
+          )
+        )
+    )
+  }
+
+  func testThenStmt11() {
+    assertParse(
+      """
+      then ~1
+      """,
+      substructure:
+        ThenStmtSyntax(
+          expression: PrefixOperatorExprSyntax(
+            operator: .prefixOperator("~"),
+            expression: IntegerLiteralExprSyntax(1)
+          )
+        )
+    )
+  }
+
+  func testThenStmt12() {
+    assertParse(
+      """
+      then /.../
+      """,
+      substructure: ThenStmtSyntax(expression: RegexLiteralExprSyntax(regex: .regexLiteralPattern("...")))
+    )
+  }
+
+  func testThenStmt13() {
+    // This is a a statement.
+    assertParse(
+      """
+      then .foo
+      """,
+      substructure: ThenStmtSyntax(expression: MemberAccessExprSyntax(name: .identifier("foo")))
+    )
+  }
+
+  func testThenStmt14() {
+    // This is a member access.
+    assertParse(
+      """
+      then.foo
+      """,
+      substructure:
+        MemberAccessExprSyntax(
+          base: DeclReferenceExprSyntax(baseName: .identifier("then")),
+          name: .identifier("foo")
+        )
+    )
+  }
+
+  func testThenStmt15() {
+    // This could be a member access too, but it seems rare enough to continue
+    // parsing as a statement.
+    assertParse(
+      """
+      then . foo
+      """,
+      substructure: ThenStmtSyntax(expression: MemberAccessExprSyntax(name: .identifier("foo")))
+    )
+  }
+
+  func testThenStmt16() {
+    // This will be diagnosed in ASTGen.
+    assertParse(
+      """
+      a: then 0
+      """,
+      substructure:
+        LabeledStmtSyntax(
+          label: .identifier("a"),
+          statement: ThenStmtSyntax(expression: IntegerLiteralExprSyntax(0))
+        )
+    )
+  }
+
+  func testThenStmt17() {
+    // This is a function call.
+    assertParse(
+      """
+      then()
+      """,
+      substructure:
+        FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("then")),
+          leftParen: .leftParenToken(),
+          arguments: .init([]),
+          rightParen: .rightParenToken()
+        )
+    )
+  }
+
+  func testThenStmt18() {
+    // This is a function call.
+    assertParse(
+      """
+      then(0)
+      """,
+      substructure:
+        FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("then")),
+          leftParen: .leftParenToken(),
+          arguments: .init([.init(expression: IntegerLiteralExprSyntax(0))]),
+          rightParen: .rightParenToken()
+        )
+    )
+  }
+
+  func testThenStmt19() {
+    // This is a function call.
+    assertParse(
+      """
+      then(x: 0)
+      """,
+      substructure:
+        FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("then")),
+          leftParen: .leftParenToken(),
+          arguments: .init([.init(label: "x", expression: IntegerLiteralExprSyntax(0))]),
+          rightParen: .rightParenToken()
+        )
+    )
+  }
+
+  func testThenStmt20() {
+    // This is a function call.
+    assertParse(
+      """
+      then{}
+      """,
+      substructure:
+        FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("then")),
+          arguments: .init([]),
+          trailingClosure: ClosureExprSyntax(statements: .init([]))
+        )
+    )
+  }
+
+  func testThenStmt21() {
+    // This is a function call.
+    assertParse(
+      """
+      then {}
+      """,
+      substructure:
+        FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("then")),
+          arguments: .init([]),
+          trailingClosure: ClosureExprSyntax(statements: .init([]))
+        )
+    )
+  }
+
+  func testThenStmt22() {
+    assertParse(
+      """
+      then1️⃣
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected expression in 'then' statement",
+          fixIts: ["insert expression"]
+        )
+      ],
+      fixedSource: "then <#expression#>"
+    )
+  }
+
+  func testThenStmt23() {
+    assertParse(
+      """
+      then1️⃣;
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected expression in 'then' statement",
+          fixIts: ["insert expression"]
+        )
+      ],
+      fixedSource: "then <#expression#>;"
+    )
+  }
+
+  func testThenStmt24() {
+    assertParse(
+      """
+      (then)
+      """,
+      substructure:
+        TupleExprSyntax(
+          elements: .init([
+            .init(expression: DeclReferenceExprSyntax(baseName: .identifier("then")))
+          ])
+        )
+    )
+  }
+
+  func testThenStmt25() {
+    assertParse(
+      """
+      then
+      0
+      """,
+      substructure: ThenStmtSyntax(expression: IntegerLiteralExprSyntax(0))
+    )
+  }
+
+  func testThenStmt26() {
+    assertParse(
+      """
+      let x = then
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("then"))
+    )
+  }
+
+  func testThenStmt27() {
+    assertParse(
+      """
+      self.then
+      """,
+      substructure:
+        MemberAccessExprSyntax(
+          base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
+          name: .identifier("then")
+        )
+    )
+  }
+
+  func testThenStmt28() {
+    assertParse(
+      """
+      then + 2
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          BinaryOperatorExprSyntax(operator: .binaryOperator("+"))
+          IntegerLiteralExprSyntax(2)
+        }
+    )
+  }
+
+  func testThenStmt29() {
+    assertParse(
+      """
+      then+2
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          BinaryOperatorExprSyntax(operator: .binaryOperator("+"))
+          IntegerLiteralExprSyntax(2)
+        }
+    )
+  }
+
+  func testThenStmt30() {
+    assertParse(
+      """
+      then = 2
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          AssignmentExprSyntax()
+          IntegerLiteralExprSyntax(2)
+        }
+    )
+  }
+
+  func testThenStmt31() {
+    assertParse(
+      """
+      then=2
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          AssignmentExprSyntax()
+          IntegerLiteralExprSyntax(2)
+        }
+    )
+  }
+
+  func testThenStmt32() {
+    assertParse(
+      """
+      then is Int
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          UnresolvedIsExprSyntax()
+          TypeExprSyntax(type: IdentifierTypeSyntax(name: .identifier("Int")))
+        }
+    )
+  }
+
+  func testThenStmt33() {
+    assertParse(
+      """
+      then as Int
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          UnresolvedAsExprSyntax()
+          TypeExprSyntax(type: IdentifierTypeSyntax(name: .identifier("Int")))
+        }
+    )
+  }
+
+  func testThenStmt34() {
+    assertParse(
+      """
+      then as? Int
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          UnresolvedAsExprSyntax(questionOrExclamationMark: .postfixQuestionMarkToken())
+          TypeExprSyntax(type: IdentifierTypeSyntax(name: .identifier("Int")))
+        }
+    )
+  }
+
+  func testThenStmt35() {
+    assertParse(
+      """
+      then as! Int
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          UnresolvedAsExprSyntax(questionOrExclamationMark: .exclamationMarkToken())
+          TypeExprSyntax(type: IdentifierTypeSyntax(name: .identifier("Int")))
+        }
+    )
+  }
+
+  func testThenStmt36() {
+    assertParse(
+      """
+      then ? 0 : 1
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          UnresolvedTernaryExprSyntax(thenExpression: IntegerLiteralExprSyntax(0))
+          IntegerLiteralExprSyntax(1)
+        }
+    )
+  }
+
+  func testThenStmt37() {
+    assertParse(
+      """
+      1️⃣try then 0
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "'try' must be placed on the produced expression",
+          fixIts: ["move 'try' after 'then'"]
+        )
+      ],
+      fixedSource: "then try 0"
+    )
+  }
+
+  func testThenStmt38() {
+    assertParse(
+      """
+      then try 0
+      """
+    )
+  }
+
+  func testThenStmt39() {
+    assertParse(
+      """
+      then!
+      """,
+      substructure:
+        ForceUnwrapExprSyntax(
+          expression: DeclReferenceExprSyntax(baseName: .identifier("then"))
+        )
+    )
+  }
+
+  func testThenStmt40() {
+    assertParse(
+      """
+      then?
+      """,
+      substructure:
+        OptionalChainingExprSyntax(
+          expression: DeclReferenceExprSyntax(baseName: .identifier("then"))
+        )
+    )
+  }
+
+  func testThenStmt41() {
+    assertParse(
+      """
+      then?.foo
+      """,
+      substructure:
+        MemberAccessExprSyntax(
+          base: OptionalChainingExprSyntax(
+            expression: DeclReferenceExprSyntax(baseName: .identifier("then"))
+          ),
+          name: .identifier("foo")
+        )
+    )
+  }
+
+  func testThenStmt42() {
+    assertParse(
+      """
+      then!.foo
+      """,
+      substructure:
+        MemberAccessExprSyntax(
+          base: ForceUnwrapExprSyntax(
+            expression: DeclReferenceExprSyntax(baseName: .identifier("then"))
+          ),
+          name: .identifier("foo")
+        )
+    )
+  }
+
+  func testThenStmt43() {
+    assertParse(
+      """
+      self.then(0)
+      """,
+      substructure:
+        MemberAccessExprSyntax(
+          base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
+          name: .identifier("then")
+        )
+    )
+  }
+
+  func testThenStmt44() {
+    assertParse(
+      """
+      then /^ then/
+      """,
+      substructure:
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .identifier("then"))
+          BinaryOperatorExprSyntax(operator: .binaryOperator("/^"))
+          PostfixOperatorExprSyntax(
+            expression: DeclReferenceExprSyntax(baseName: .identifier("then")),
+            operator: .postfixOperator("/")
+          )
+        }
+    )
+  }
+
+  func testThenStmt45() {
+    assertParse(
+      """
+      return then
+      """,
+      substructure:
+        ReturnStmtSyntax(expression: DeclReferenceExprSyntax(baseName: .identifier("then")))
+    )
+  }
+
+  func testThenStmt46() {
+    assertParse(
+      """
+      then[0]
+      """,
+      substructure:
+        SubscriptCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("then")),
+          arguments: .init([
+            .init(expression: IntegerLiteralExprSyntax(0))
+          ])
+        )
+    )
+  }
+
+  func testThenStmt47() {
+    assertParse(
+      """
+      then: for then in [] {
+        break then
+        continue then
+      }
+      """
+    )
+  }
+
+  func testThenStmt48() {
+    assertParse(
+      """
+      throw then
+      """,
+      substructure:
+        ThrowStmtSyntax(expression: DeclReferenceExprSyntax(baseName: .identifier("then")))
+    )
+  }
+
+  func testThenStmt49() {
+    assertParse(
+      """
+      try then()
+      """
+    )
+  }
+
+  func testThenStmt50() {
+    assertParse(
+      """
+      try then{}
+      """
+    )
+  }
+
+  func testThenStmt51() {
+    assertParse(
+      """
+      try then {}
+      """
+    )
+  }
+
+  func testThenStmt52() {
+    assertParse(
+      """
+      try then + 1
+      """
+    )
+  }
+
+  func testThenStmt53() {
+    assertParse(
+      """
+      then
+        .foo
+      """,
+      substructure: ThenStmtSyntax(expression: MemberAccessExprSyntax(name: .identifier("foo")))
+    )
+  }
+
+  func testThenStmt54() {
+    assertParse(
+      """
+      return try then
+      """,
+      substructure:
+        ReturnStmtSyntax(
+          expression: TryExprSyntax(
+            expression: DeclReferenceExprSyntax(baseName: .identifier("then"))
+          )
+        )
+    )
+  }
+
+  func testThenStmt55() {
+    assertParse(
+      """
+      let x = [
+        0,
+        then
+      ]
+      """
+    )
+  }
+
+  func testThenStmtDisabled1() {
+    // Make sure it's disabled by default.
+    assertParse(
+      """
+      then1️⃣ 0
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "consecutive statements on a line must be separated by newline or ';'",
+          fixIts: [
+            "insert newline",
+            "insert ';'",
+          ]
+        )
+      ],
+      fixedSource: """
+        then
+        0
+        """,
+      experimentalFeatures: []
+    )
+  }
+
+  func testThenStmtDisabled2() {
+    // Make sure it's disabled by default. This is specifically testing
+    // StmtSyntax.parse, since it will try to parse without checking
+    // `atStartOfThenStatement`.
+    assertParse(
+      """
+      1️⃣then 02️⃣
+      """,
+      { StmtSyntax.parse(from: &$0) },
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "unexpected code 'then 0' before statement"
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "expected statement",
+          fixIts: ["insert statement"]
+        ),
+      ],
+      fixedSource: "<#statement#>then 0",
+      experimentalFeatures: []
+    )
+  }
+}


### PR DESCRIPTION
These allow multi-statement `if`/`switch` expression branches that can produce a value at the end by saying `then <expr>`. This is gated behind an experimental feature option pending evolution discussion.