### PR TITLE
Rename Parser.Lookahead functions from is* to at*

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -176,7 +176,7 @@ extension Parser {
     case .required:
       shouldParseArgument = true
     case .customAttribute:
-      shouldParseArgument = self.withLookahead { $0.isCustomAttributeArgument() } && self.at(TokenSpec(.leftParen, allowAtStartOfLine: false))
+      shouldParseArgument = self.withLookahead { $0.atCustomAttributeArgument() } && self.at(TokenSpec(.leftParen, allowAtStartOfLine: false))
     case .optional:
       shouldParseArgument = self.at(.leftParen)
     }
@@ -1140,7 +1140,7 @@ extension Parser {
 // MARK: Lookahead
 
 extension Parser.Lookahead {
-  mutating func isCustomAttributeArgument() -> Bool {
+  mutating func atCustomAttributeArgument() -> Bool {
     var lookahead = self.lookahead()
     lookahead.skipSingle()
 
@@ -1173,7 +1173,7 @@ extension Parser.Lookahead {
       return false
     }
 
-    if self.at(TokenSpec(.leftParen, allowAtStartOfLine: false)) && self.withLookahead({ $0.isCustomAttributeArgument() }) {
+    if self.at(TokenSpec(.leftParen, allowAtStartOfLine: false)) && self.withLookahead({ $0.atCustomAttributeArgument() }) {
       self.skipSingle()
     }
 

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1919,7 +1919,7 @@ extension Parser {
     let trailingClosure: RawClosureExprSyntax?
     let additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax?
     if self.at(.leftBrace),
-      self.withLookahead({ $0.isValidTrailingClosure(.trailingClosure) })
+      self.withLookahead({ $0.atValidTrailingClosure(.trailingClosure) })
     {
       (trailingClosure, additionalTrailingClosures) =
         self.parseTrailingClosures(.trailingClosure)

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -734,7 +734,7 @@ extension Parser {
         // If we can parse trailing closures, do so.
         let trailingClosure: RawClosureExprSyntax?
         let additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax?
-        if case .trailingClosure = flavor, self.at(.leftBrace), self.withLookahead({ $0.isValidTrailingClosure(flavor) }) {
+        if case .trailingClosure = flavor, self.at(.leftBrace), self.withLookahead({ $0.atValidTrailingClosure(flavor) }) {
           (trailingClosure, additionalTrailingClosures) = self.parseTrailingClosures(flavor)
         } else {
           trailingClosure = nil
@@ -770,7 +770,7 @@ extension Parser {
         // If we can parse trailing closures, do so.
         let trailingClosure: RawClosureExprSyntax?
         let additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax?
-        if case .trailingClosure = flavor, self.at(.leftBrace), self.withLookahead({ $0.isValidTrailingClosure(flavor) }) {
+        if case .trailingClosure = flavor, self.at(.leftBrace), self.withLookahead({ $0.atValidTrailingClosure(flavor) }) {
           (trailingClosure, additionalTrailingClosures) = self.parseTrailingClosures(flavor)
         } else {
           trailingClosure = nil
@@ -793,7 +793,7 @@ extension Parser {
       }
 
       // Check for a trailing closure, if allowed.
-      if self.at(.leftBrace) && self.withLookahead({ $0.isValidTrailingClosure(flavor) }) {
+      if self.at(.leftBrace) && self.withLookahead({ $0.atValidTrailingClosure(flavor) }) {
         // FIXME: if Result has a trailing closure, break out.
         // Add dummy blank argument list to the call expression syntax.
         let list = RawLabeledExprListSyntax(elements: [], arena: self.arena)
@@ -1321,7 +1321,7 @@ extension Parser {
     // Parse the optional trailing closures.
     let trailingClosure: RawClosureExprSyntax?
     let additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax?
-    if case .trailingClosure = flavor, self.at(.leftBrace), self.withLookahead({ $0.isValidTrailingClosure(flavor) }) {
+    if case .trailingClosure = flavor, self.at(.leftBrace), self.withLookahead({ $0.atValidTrailingClosure(flavor) }) {
       (trailingClosure, additionalTrailingClosures) = self.parseTrailingClosures(flavor)
     } else {
       trailingClosure = nil
@@ -1915,7 +1915,7 @@ extension Parser {
     // Parse labeled trailing closures.
     var elements = [RawMultipleTrailingClosureElementSyntax]()
     var loopProgress = LoopProgressCondition()
-    while self.withLookahead({ $0.isStartOfLabelledTrailingClosure() }) && self.hasProgressed(&loopProgress) {
+    while self.withLookahead({ $0.atStartOfLabelledTrailingClosure() }) && self.hasProgressed(&loopProgress) {
       let (unexpectedBeforeLabel, label) = self.parseArgumentLabel()
       let (unexpectedBeforeColon, colon) = self.expect(.colon)
       let closure = self.parseClosureExpression()
@@ -1937,7 +1937,7 @@ extension Parser {
 }
 
 extension Parser.Lookahead {
-  mutating func isStartOfLabelledTrailingClosure() -> Bool {
+  mutating func atStartOfLabelledTrailingClosure() -> Bool {
     // Fast path: the next two tokens must be a label and a colon.
     // But 'default:' is ambiguous with switch cases and we disallow it
     // (unless escaped) even outside of switches.
@@ -1967,12 +1967,12 @@ extension Parser.Lookahead {
   /// where the parser requires an expr-basic (which does not allow them).  We
   /// handle this by doing some lookahead in common situations. And later, Sema
   /// will emit a diagnostic with a fixit to add wrapping parens.
-  mutating func isValidTrailingClosure(_ flavor: Parser.ExprFlavor) -> Bool {
+  mutating func atValidTrailingClosure(_ flavor: Parser.ExprFlavor) -> Bool {
     precondition(self.at(.leftBrace), "Couldn't be a trailing closure")
 
     // If this is the start of a get/set accessor, then it isn't a trailing
     // closure.
-    guard !self.withLookahead({ $0.isStartOfGetSetAccessor() }) else {
+    guard !self.withLookahead({ $0.atStartOfGetSetAccessor() }) else {
       return false
     }
 
@@ -2149,7 +2149,7 @@ extension Parser {
     while !self.at(.endOfFile, .rightBrace) && !self.at(.poundEndif, .poundElseif, .poundElse)
       && self.hasProgressed(&elementsProgress)
     {
-      if self.withLookahead({ $0.isAtStartOfSwitchCase(allowRecovery: false) }) {
+      if self.withLookahead({ $0.atStartOfSwitchCase(allowRecovery: false) }) {
         elements.append(.switchCase(self.parseSwitchCase()))
       } else if self.canRecoverTo(.poundIf) != nil {
         // '#if' in 'case' position can enclose zero or more 'case' or 'default'
@@ -2206,7 +2206,7 @@ extension Parser {
             )
           )
         )
-      } else if self.withLookahead({ $0.isAtStartOfSwitchCase(allowRecovery: true) }) {
+      } else if self.withLookahead({ $0.atStartOfSwitchCase(allowRecovery: true) }) {
         elements.append(.switchCase(self.parseSwitchCase()))
       } else {
         break
@@ -2217,7 +2217,7 @@ extension Parser {
 
   mutating func parseSwitchCaseBody() -> RawCodeBlockItemListSyntax {
     parseCodeBlockItemList(until: {
-      $0.at(.rightBrace) || $0.at(.poundEndif, .poundElseif, .poundElse) || $0.withLookahead({ $0.isStartOfConditionalSwitchCases() })
+      $0.at(.rightBrace) || $0.at(.poundEndif, .poundElseif, .poundElse) || $0.withLookahead({ $0.atStartOfConditionalSwitchCases() })
     })
   }
 

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -246,7 +246,7 @@ extension Parser.Lookahead {
 // MARK: Lookahead
 
 extension Parser.Lookahead {
-  mutating func isStartOfGetSetAccessor() -> Bool {
+  mutating func atStartOfGetSetAccessor() -> Bool {
     precondition(self.at(.leftBrace), "not checking a brace?")
 
     // The only case this can happen is if the accessor label is immediately after

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -25,7 +25,7 @@ extension TokenConsumer {
       // misplaced attributes.
       _ = lookahead.consumeAttributeList()
     }
-    return lookahead.isStartOfStatement(allowRecovery: allowRecovery)
+    return lookahead.atStartOfStatement(allowRecovery: allowRecovery)
   }
 }
 
@@ -808,7 +808,7 @@ extension Parser.Lookahead {
   ///
   /// - Note: This function must be kept in sync with `parseStatement()`.
   /// - Seealso: ``Parser/parseStatement()``
-  mutating func isStartOfStatement(allowRecovery: Bool = false) -> Bool {
+  mutating func atStartOfStatement(allowRecovery: Bool = false) -> Bool {
     if (self.at(anyIn: SwitchCaseStart.self) != nil || self.at(.atSign)) && withLookahead({ $0.atStartOfSwitchCaseItem() }) {
       // We consider SwitchCaseItems statements so we don't parse the start of a new case item as trailing parts of an expression.
       return true
@@ -884,7 +884,7 @@ extension Parser.Lookahead {
 
   /// Returns whether the parser's current position is the start of a switch case,
   /// given that we're in the middle of a switch already.
-  mutating func isAtStartOfSwitchCase(allowRecovery: Bool = false) -> Bool {
+  mutating func atStartOfSwitchCase(allowRecovery: Bool = false) -> Bool {
     // Check for and consume attributes. The only valid attribute is `@unknown`
     // but that's a semantic restriction.
     var lookahead = self.lookahead()
@@ -916,9 +916,9 @@ extension Parser.Lookahead {
     }
   }
 
-  mutating func isStartOfConditionalSwitchCases() -> Bool {
+  mutating func atStartOfConditionalSwitchCases() -> Bool {
     guard self.at(.poundIf) else {
-      return self.isAtStartOfSwitchCase()
+      return self.atStartOfSwitchCase()
     }
 
     var lookahead = self.lookahead()
@@ -928,6 +928,6 @@ extension Parser.Lookahead {
       // just find the end of the line
       lookahead.skipUntilEndOfLine()
     } while lookahead.at(.poundIf, .poundElseif, .poundElse) && lookahead.hasProgressed(&loopProgress)
-    return lookahead.isAtStartOfSwitchCase()
+    return lookahead.atStartOfSwitchCase()
   }
 }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -45,7 +45,7 @@ extension Parser {
   mutating func parseTypeScalar(misplacedSpecifiers: [RawTokenSyntax] = []) -> RawTypeSyntax {
     let (specifier, unexpectedBeforeAttrList, attrList) = self.parseTypeAttributeList(misplacedSpecifiers: misplacedSpecifiers)
     var base = RawTypeSyntax(self.parseSimpleOrCompositionType())
-    if self.withLookahead({ $0.isAtFunctionTypeArrow() }) {
+    if self.withLookahead({ $0.atFunctionTypeArrow() }) {
       var effectSpecifiers = self.parseTypeEffectSpecifiers()
       let returnClause = self.parseFunctionReturnClause(effectSpecifiers: &effectSpecifiers, allowNamedOpaqueResultType: false)
 
@@ -623,7 +623,7 @@ extension Parser.Lookahead {
       return false
     }
 
-    if self.isAtFunctionTypeArrow() {
+    if self.atFunctionTypeArrow() {
       // Handle type-function if we have an '->' with optional
       // 'async' and/or 'throws'.
       var loopProgress = LoopProgressCondition()
@@ -781,7 +781,7 @@ extension Parser.Lookahead {
     return self.consume(if: .rightParen) != nil
   }
 
-  mutating func isAtFunctionTypeArrow() -> Bool {
+  mutating func atFunctionTypeArrow() -> Bool {
     if self.at(.arrow) {
       return true
     }
@@ -795,7 +795,7 @@ extension Parser.Lookahead {
         var backtrack = self.lookahead()
         backtrack.consumeAnyToken()
         backtrack.consumeAnyToken()
-        return backtrack.isAtFunctionTypeArrow()
+        return backtrack.atFunctionTypeArrow()
       }
 
       return false


### PR DESCRIPTION
**Motivation**

Closes #2001. Following up on #1996, renaming `Parser.Lookahead` function for consistency.

The change is that `Parser.Lookahead.isStartOfGetSetAccessor` is now `atStartOfGetSetAccessor`. 

@ahoppen, am I missing something? Thought there would be more.