### PR TITLE
Replace string-based token references with `Token` enum in CodeGeneration

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -39,7 +39,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "AtSign",
         deprecatedName: "AtSignToken",
-        kind: .token(choices: [.token(tokenKind: "AtSignToken")]),
+        kind: .token(choices: [.token(.atSign)]),
         documentation: "The `@` sign."
       ),
       Child(
@@ -50,7 +50,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")]),
+        kind: .token(choices: [.token(.leftParen)]),
         documentation: "If the attribute takes arguments, the opening parenthesis.",
         isOptional: true
       ),
@@ -144,7 +144,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")]),
+        kind: .token(choices: [.token(.rightParen)]),
         documentation: "If the attribute takes arguments, the closing parenthesis.",
         isOptional: true
       ),
@@ -166,7 +166,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         documentation: "The colon separating the label and the value"
       ),
       Child(
@@ -176,7 +176,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Semicolon",
-        kind: .token(choices: [.token(tokenKind: "SemicolonToken")])
+        kind: .token(choices: [.token(.semicolon)])
       ),
     ]
   ),
@@ -196,7 +196,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "A trailing comma if the argument is followed by another argument",
         isOptional: true
       ),
@@ -227,7 +227,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         documentation: "The colon separating \"before\" and the parameter list."
       ),
       Child(
@@ -248,12 +248,12 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "ConventionLabel",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: "The convention label."
       ),
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
       Child(
@@ -263,7 +263,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         isOptional: true
       ),
       Child(
@@ -287,11 +287,11 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "ProtocolName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(.identifier)])
       ),
     ]
   ),
@@ -316,7 +316,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         documentation: "The colon separating the \"of\" label and the original declaration name."
       ),
       Child(
@@ -326,7 +326,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Period",
-        kind: .token(choices: [.token(tokenKind: "PeriodToken")]),
+        kind: .token(choices: [.token(.period)]),
         documentation: "The period separating the original declaration name and the accessor name.",
         isOptional: true
       ),
@@ -339,7 +339,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
       Child(
@@ -373,11 +373,11 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "Argument",
         deprecatedName: "Parameter",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "IntegerLiteralToken"), .keyword(text: "self")])
+        kind: .token(choices: [.token(.identifier), .token(.integerLiteral), .keyword(text: "self")])
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -398,7 +398,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         documentation: "The colon separating \"wrt\" and the parameter list."
       ),
       Child(
@@ -430,7 +430,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Arguments",
@@ -440,7 +440,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -465,7 +465,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "KindSpecifierComma",
         deprecatedName: "DiffKindComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "The comma following the differentiability kind, if it exists.",
         isOptional: true
       ),
@@ -478,7 +478,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "ArgumentsComma",
         deprecatedName: "DiffParamsComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "The comma following the differentiability arguments clause, if it exists.",
         isOptional: true
       ),
@@ -507,7 +507,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Value",
@@ -515,7 +515,7 @@ public let ATTRIBUTE_NODES: [Node] = [
           Child(
             name: "Token",
             kind: .token(choices: [
-              .token(tokenKind: "IdentifierToken"),
+              .token(.identifier),
               .keyword(text: "private"),
               .keyword(text: "fileprivate"),
               .keyword(text: "internal"),
@@ -531,7 +531,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "A trailing comma if this argument is followed by another one",
         isOptional: true
       ),
@@ -558,7 +558,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "DeclName",
@@ -588,7 +588,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
       Child(
@@ -616,7 +616,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "The comma separating the type and method name"
       ),
       Child(
@@ -656,7 +656,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         documentation: "The colon separating the label and the value"
       ),
       Child(
@@ -667,7 +667,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "A trailing comma if this argument is followed by another one",
         isOptional: true
       ),
@@ -690,7 +690,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         isOptional: true
       ),
     ]
@@ -718,11 +718,11 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")])
+        kind: .token(choices: [.token(.comma)])
       ),
       Child(
         name: "Ordinal",
-        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")]),
+        kind: .token(choices: [.token(.integerLiteral)]),
         documentation: "The ordinal corresponding to the 'some' keyword that introduced this opaque type."
       ),
     ]
@@ -740,7 +740,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "ModuleName",
@@ -748,7 +748,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")])
+        kind: .token(choices: [.token(.comma)])
       ),
       Child(
         name: "Platforms",
@@ -782,7 +782,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "Period",
         deprecatedName: "Dot",
-        kind: .token(choices: [.token(tokenKind: "PeriodToken")]),
+        kind: .token(choices: [.token(.period)]),
         isOptional: true
       ),
       Child(
@@ -827,7 +827,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         documentation: "The colon separating the label and the value"
       ),
       Child(
@@ -839,7 +839,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "A trailing comma if this argument is followed by another one",
         isOptional: true
       ),
@@ -858,7 +858,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Message",
@@ -879,7 +879,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Filename",

--- a/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
@@ -30,7 +30,7 @@ public let AVAILABILITY_NODES: [Node] = [
           Child(
             name: "Token",
             kind: .token(
-              choices: [.token(tokenKind: "BinaryOperatorToken"), .token(tokenKind: "IdentifierToken")],
+              choices: [.token(.binaryOperator), .token(.identifier)],
               requiresLeadingSpace: false,
               requiresTrailingSpace: false
             )
@@ -48,7 +48,7 @@ public let AVAILABILITY_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "A trailing comma if the argument is followed by another argument",
         isOptional: true
       ),
@@ -77,7 +77,7 @@ public let AVAILABILITY_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         documentation: "The colon separating label and value"
       ),
       Child(
@@ -116,7 +116,7 @@ public let AVAILABILITY_NODES: [Node] = [
     children: [
       Child(
         name: "Platform",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "platform",
         documentation:
           "The name of the OS on which the availability should be restricted or 'swift' if the availability should be restricted based on a Swift version."
@@ -139,12 +139,12 @@ public let AVAILABILITY_NODES: [Node] = [
     children: [
       Child(
         name: "Period",
-        kind: .token(choices: [.token(tokenKind: "PeriodToken")]),
+        kind: .token(choices: [.token(.period)]),
         documentation: "The period of this version component"
       ),
       Child(
         name: "Number",
-        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")]),
+        kind: .token(choices: [.token(.integerLiteral)]),
         documentation: "The version number of this component"
       ),
     ]
@@ -167,7 +167,7 @@ public let AVAILABILITY_NODES: [Node] = [
     children: [
       Child(
         name: "Major",
-        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")]),
+        kind: .token(choices: [.token(.integerLiteral)]),
         documentation: "The major version."
       ),
       Child(

--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -47,7 +47,7 @@ public let COMMON_NODES: [Node] = [
       ),
       Child(
         name: "Semicolon",
-        kind: .token(choices: [.token(tokenKind: "SemicolonToken")]),
+        kind: .token(choices: [.token(.semicolon)]),
         documentation: "If present, the trailing semicolon at the end of the item.",
         isOptional: true
       ),
@@ -66,7 +66,7 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "LeftBrace",
-        kind: .token(choices: [.token(tokenKind: "LeftBraceToken")])
+        kind: .token(choices: [.token(.leftBrace)])
       ),
       Child(
         name: "Statements",
@@ -75,7 +75,7 @@ public let COMMON_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
+        kind: .token(choices: [.token(.rightBrace)])
       ),
     ]
   ),
@@ -178,7 +178,7 @@ public let COMMON_NODES: [Node] = [
       ),
       Child(
         name: "Placeholder",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
+        kind: .token(choices: [.token(.identifier)], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#decl#>`, that can be inserted into the source code to represent the missing declaration.
 
@@ -199,7 +199,7 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "Placeholder",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
+        kind: .token(choices: [.token(.identifier)], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#expression#>`, that can be inserted into the source code to represent the missing expression.
 
@@ -220,7 +220,7 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "Placeholder",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
+        kind: .token(choices: [.token(.identifier)], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#pattern#>`, that can be inserted into the source code to represent the missing pattern.
 
@@ -241,7 +241,7 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "Placeholder",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
+        kind: .token(choices: [.token(.identifier)], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#statement#>`, that can be inserted into the source code to represent the missing pattern.
 
@@ -262,7 +262,7 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "Placeholder",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
+        kind: .token(choices: [.token(.identifier)], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#syntax#>`, that can be inserted into the source code to represent the missing pattern.
 
@@ -283,7 +283,7 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "Placeholder",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")], requiresLeadingSpace: false, requiresTrailingSpace: false),
+        kind: .token(choices: [.token(.identifier)], requiresLeadingSpace: false, requiresTrailingSpace: false),
         documentation: """
           A placeholder, i.e. `<#type#>`, that can be inserted into the source code to represent the missing type.
 

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -19,17 +19,17 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         kind: .token(choices: [
-          .token(tokenKind: "IdentifierToken"),
-          .token(tokenKind: "BinaryOperatorToken"),
-          .token(tokenKind: "PrefixOperatorToken"),
-          .token(tokenKind: "PostfixOperatorToken"),
+          .token(.identifier),
+          .token(.binaryOperator),
+          .token(.prefixOperator),
+          .token(.postfixOperator),
         ]),
         nameForDiagnostics: "name"
       ),
       Child(
         name: "TrailingPeriod",
         deprecatedName: "TrailingDot",
-        kind: .token(choices: [.token(tokenKind: "PeriodToken")]),
+        kind: .token(choices: [.token(.period)]),
         isOptional: true
       ),
     ]
@@ -53,7 +53,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "LeftBrace",
-        kind: .token(choices: [.token(tokenKind: "LeftBraceToken")])
+        kind: .token(choices: [.token(.leftBrace)])
       ),
       Child(
         name: "Accessors",
@@ -70,7 +70,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
+        kind: .token(choices: [.token(.rightBrace)])
       ),
     ]
   ),
@@ -151,16 +151,16 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Name",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "name"
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -203,7 +203,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(.identifier)])
       ),
       Child(
         name: "GenericParameterClause",
@@ -294,7 +294,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: "The name of this associated type."
       ),
       Child(
@@ -384,7 +384,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: "The name of the class."
       ),
       Child(
@@ -427,15 +427,15 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Detail",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(.identifier)])
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -550,7 +550,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "LeadingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")])
+        kind: .token(choices: [.token(.comma)])
       ),
       Child(
         name: "Name",
@@ -595,7 +595,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Placeholder",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: """
           The actual editor placeholder that starts with `<#` and ends with `#>`.
           """
@@ -613,7 +613,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")]),
+        kind: .token(choices: [.token(.leftParen)]),
         documentation: "The '(' to open the parameter clause."
       ),
       Child(
@@ -625,7 +625,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")]),
+        kind: .token(choices: [.token(.rightParen)]),
         documentation: "The ')' to close the parameter clause."
       ),
     ]
@@ -653,17 +653,17 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "FirstName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)]),
         isOptional: true
       ),
       Child(
         name: "SecondName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)]),
         isOptional: true
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         documentation: "If the parameter has a label, the colon separating the label from the type.",
         isOptional: true
       ),
@@ -683,7 +683,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "If the parameter is followed by another parameter, the comma separating them.",
         isOptional: true
       ),
@@ -748,7 +748,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: "The name of this case."
       ),
       Child(
@@ -767,7 +767,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "The trailing comma of this element, if the case has multiple elements.",
         isOptional: true
       ),
@@ -809,7 +809,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: "Declares the name of this enum. If the name matches a reserved keyword use backticks to escape it."
       ),
       Child(
@@ -930,10 +930,10 @@ public let DECL_NODES: [Node] = [
         name: "Name",
         deprecatedName: "Identifier",
         kind: .token(choices: [
-          .token(tokenKind: "IdentifierToken"),
-          .token(tokenKind: "BinaryOperatorToken"),
-          .token(tokenKind: "PrefixOperatorToken"),
-          .token(tokenKind: "PostfixOperatorToken"),
+          .token(.identifier),
+          .token(.binaryOperator),
+          .token(.prefixOperator),
+          .token(.postfixOperator),
         ])
       ),
       Child(
@@ -994,19 +994,19 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "FirstName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")])
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)])
       ),
       // One of these two names needs be optional, we choose the second
       // name to avoid backtracking.
       Child(
         name: "SecondName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")], requiresLeadingSpace: true),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)], requiresLeadingSpace: true),
         nameForDiagnostics: "internal name",
         isOptional: true
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Type",
@@ -1015,7 +1015,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "Ellipsis",
-        kind: .token(choices: [.token(tokenKind: "EllipsisToken")]),
+        kind: .token(choices: [.token(.ellipsis)]),
         isOptional: true
       ),
       Child(
@@ -1027,7 +1027,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -1075,7 +1075,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "PoundKeyword",
-        kind: .token(choices: [.token(tokenKind: "PoundIfToken"), .token(tokenKind: "PoundElseifToken"), .token(tokenKind: "PoundElseToken")])
+        kind: .token(choices: [.token(.poundIf), .token(.poundElseif), .token(.poundElse)])
       ),
       Child(
         name: "Condition",
@@ -1125,7 +1125,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "PoundEndif",
-        kind: .token(choices: [.token(tokenKind: "PoundEndifToken")])
+        kind: .token(choices: [.token(.poundEndif)])
       ),
     ]
   ),
@@ -1213,7 +1213,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -1227,7 +1227,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "Equal",
-        kind: .token(choices: [.token(tokenKind: "EqualToken")])
+        kind: .token(choices: [.token(.equal)])
       ),
       Child(
         name: "Value",
@@ -1278,9 +1278,9 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "OptionalMark",
         kind: .token(choices: [
-          .token(tokenKind: "PostfixQuestionMarkToken"),
-          .token(tokenKind: "InfixQuestionMarkToken"),
-          .token(tokenKind: "ExclamationMarkToken"),
+          .token(.postfixQuestionMark),
+          .token(.infixQuestionMark),
+          .token(.exclamationMark),
         ]),
         documentation: "If the initializer is failable, a question mark to indicate that.",
         isOptional: true
@@ -1344,7 +1344,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(.identifier)])
       ),
       Child(
         name: "GenericParameterClause",
@@ -1400,13 +1400,13 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Pound",
         deprecatedName: "PoundToken",
-        kind: .token(choices: [.token(tokenKind: "PoundToken")]),
+        kind: .token(choices: [.token(.pound)]),
         documentation: "The `#` sign."
       ),
       Child(
         name: "MacroName",
         deprecatedName: "Macro",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(.identifier)])
       ),
       Child(
         name: "GenericArgumentClause",
@@ -1416,7 +1416,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")]),
+        kind: .token(choices: [.token(.leftParen)]),
         isOptional: true
       ),
       Child(
@@ -1426,7 +1426,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")]),
+        kind: .token(choices: [.token(.rightParen)]),
         isOptional: true
       ),
       Child(
@@ -1451,7 +1451,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "LeftBrace",
-        kind: .token(choices: [.token(tokenKind: "LeftBraceToken")])
+        kind: .token(choices: [.token(.leftBrace)])
       ),
       Child(
         name: "Members",
@@ -1459,7 +1459,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
+        kind: .token(choices: [.token(.rightBrace)])
       ),
     ]
   ),
@@ -1478,7 +1478,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "Semicolon",
-        kind: .token(choices: [.token(tokenKind: "SemicolonToken")]),
+        kind: .token(choices: [.token(.semicolon)]),
         documentation: "An optional trailing semicolon.",
         isOptional: true
       ),
@@ -1546,7 +1546,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "BinaryOperatorToken"), .token(tokenKind: "PrefixOperatorToken"), .token(tokenKind: "PostfixOperatorToken")])
+        kind: .token(choices: [.token(.binaryOperator), .token(.prefixOperator), .token(.postfixOperator)])
       ),
       Child(
         name: "OperatorPrecedenceAndTypes",
@@ -1566,11 +1566,11 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "PrecedenceGroup",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "precedence group",
         documentation: "The precedence group for this operator"
       ),
@@ -1592,7 +1592,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Parameters",
@@ -1602,7 +1602,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -1646,7 +1646,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -1665,7 +1665,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "FileColon",
         deprecatedName: "FileArgColon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "FileName",
@@ -1674,7 +1674,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")])
+        kind: .token(choices: [.token(.comma)])
       ),
       Child(
         name: "LineLabel",
@@ -1684,11 +1684,11 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "LineColon",
         deprecatedName: "LineArgColon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "LineNumber",
-        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")]),
+        kind: .token(choices: [.token(.integerLiteral)]),
         nameForDiagnostics: "line number"
       ),
     ]
@@ -1704,11 +1704,11 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "PoundSourceLocation",
-        kind: .token(choices: [.token(tokenKind: "PoundSourceLocationToken")])
+        kind: .token(choices: [.token(.poundSourceLocation)])
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Arguments",
@@ -1719,7 +1719,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -1739,7 +1739,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Value",
@@ -1766,7 +1766,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Value",
@@ -1821,12 +1821,12 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: "The name of this precedence group."
       ),
       Child(
         name: "LeftBrace",
-        kind: .token(choices: [.token(tokenKind: "LeftBraceToken")])
+        kind: .token(choices: [.token(.leftBrace)])
       ),
       Child(
         name: "GroupAttributes",
@@ -1835,7 +1835,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
+        kind: .token(choices: [.token(.rightBrace)])
       ),
     ]
   ),
@@ -1848,12 +1848,12 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "Name",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "name"
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -1884,7 +1884,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "PrecedenceGroups",
@@ -1937,7 +1937,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: "The name of the protocol."
       ),
       Child(
@@ -1978,7 +1978,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "Arrow",
-        kind: .token(choices: [.token(tokenKind: "ArrowToken")])
+        kind: .token(choices: [.token(.arrow)])
       ),
       Child(
         name: "Type",
@@ -2004,7 +2004,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "EndOfFileToken",
         deprecatedName: "EOFToken",
-        kind: .token(choices: [.token(tokenKind: "EndOfFileToken")])
+        kind: .token(choices: [.token(.endOfFile)])
       ),
     ]
   ),
@@ -2107,7 +2107,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: "Declares the name of this struct. If the name matches a reserved keyword use backticks to escape it."
       ),
       Child(
@@ -2207,7 +2207,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "InheritedTypes",
@@ -2225,7 +2225,7 @@ public let DECL_NODES: [Node] = [
     children: [
       Child(
         name: "Equal",
-        kind: .token(choices: [.token(tokenKind: "EqualToken")])
+        kind: .token(choices: [.token(.equal)])
       ),
       Child(
         name: "Value",
@@ -2269,7 +2269,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "Name",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(.identifier)])
       ),
       Child(
         name: "GenericParameterClause",

--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -34,7 +34,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -49,7 +49,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "LeftSquare",
         deprecatedName: "LeftSquareBracket",
-        kind: .token(choices: [.token(tokenKind: "LeftSquareToken")])
+        kind: .token(choices: [.token(.leftSquare)])
       ),
       Child(
         name: "Elements",
@@ -58,7 +58,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "RightSquare",
         deprecatedName: "RightSquareBracket",
-        kind: .token(choices: [.token(tokenKind: "RightSquareToken")])
+        kind: .token(choices: [.token(.rightSquare)])
       ),
     ]
   ),
@@ -78,7 +78,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Arrow",
         deprecatedName: "ArrowToken",
-        kind: .token(choices: [.token(tokenKind: "ArrowToken")])
+        kind: .token(choices: [.token(.arrow)])
       ),
     ]
   ),
@@ -103,7 +103,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "QuestionOrExclamationMark",
-        kind: .token(choices: [.token(tokenKind: "PostfixQuestionMarkToken"), .token(tokenKind: "ExclamationMarkToken")]),
+        kind: .token(choices: [.token(.postfixQuestionMark), .token(.exclamationMark)]),
         isOptional: true
       ),
       Child(
@@ -123,7 +123,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Equal",
         deprecatedName: "AssignToken",
-        kind: .token(choices: [.token(tokenKind: "EqualToken")])
+        kind: .token(choices: [.token(.equal)])
       )
     ]
   ),
@@ -156,7 +156,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Operator",
         deprecatedName: "OperatorToken",
-        kind: .token(choices: [.token(tokenKind: "BinaryOperatorToken")])
+        kind: .token(choices: [.token(.binaryOperator)])
       )
     ]
   ),
@@ -204,11 +204,11 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "ImportPath",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(.identifier)])
       ),
       Child(
         name: "VersionInfo",
@@ -217,7 +217,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -229,7 +229,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")])
+        kind: .token(choices: [.token(.comma)])
       ),
       Child(
         name: "Label",
@@ -237,7 +237,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Version",
@@ -267,7 +267,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -291,7 +291,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")]),
+        kind: .token(choices: [.token(.leftParen)]),
         isOptional: true
       ),
       Child(
@@ -301,7 +301,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")]),
+        kind: .token(choices: [.token(.rightParen)]),
         isOptional: true
       ),
     ]
@@ -322,13 +322,13 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "Name",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         isOptional: true
       ),
       Child(
         name: "Equal",
         deprecatedName: "AssignToken",
-        kind: .token(choices: [.token(tokenKind: "EqualToken")]),
+        kind: .token(choices: [.token(.equal)]),
         isOptional: true
       ),
       Child(
@@ -337,7 +337,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -350,7 +350,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "LeftSquare",
-        kind: .token(choices: [.token(tokenKind: "LeftSquareToken")])
+        kind: .token(choices: [.token(.leftSquare)])
       ),
       Child(
         name: "Items",
@@ -359,7 +359,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightSquare",
-        kind: .token(choices: [.token(tokenKind: "RightSquareToken")])
+        kind: .token(choices: [.token(.rightSquare)])
       ),
     ]
   ),
@@ -385,19 +385,19 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "FirstName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)]),
         documentation: "The label of this parameter that will be used when the closure is called."
       ),
       Child(
         name: "SecondName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)]),
         documentation:
           "If this is specified, it is the name by which the parameter can be referenced inside the closure body. If it is `nil`, the closure parameter is referenced by the first name.",
         isOptional: true
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         documentation: "The colon separating the parameter's name and type.",
         isOptional: true
       ),
@@ -410,13 +410,13 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "Ellipsis",
-        kind: .token(choices: [.token(tokenKind: "EllipsisToken")]),
+        kind: .token(choices: [.token(.ellipsis)]),
         documentation: "If the parameter is variadic, `...` to indicate that.",
         isOptional: true
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         documentation: "If the parameter is followed by another parameter, the comma separating them.",
         isOptional: true
       ),
@@ -440,7 +440,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")]),
+        kind: .token(choices: [.token(.leftParen)]),
         documentation: "The '(' to open the parameter clause."
       ),
       Child(
@@ -452,7 +452,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")]),
+        kind: .token(choices: [.token(.rightParen)]),
         documentation: "The ')' to close the parameter clause."
       ),
     ]
@@ -469,7 +469,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "LeftBrace",
-        kind: .token(choices: [.token(tokenKind: "LeftBraceToken")])
+        kind: .token(choices: [.token(.leftBrace)])
       ),
       Child(
         name: "Signature",
@@ -482,7 +482,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
+        kind: .token(choices: [.token(.rightBrace)])
       ),
     ]
   ),
@@ -505,12 +505,12 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Name",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)]),
         nameForDiagnostics: "name"
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -591,7 +591,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")], requiresTrailingSpace: false)
+        kind: .token(choices: [.token(.colon)], requiresTrailingSpace: false)
       ),
     ]
   ),
@@ -606,7 +606,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Arguments",
@@ -614,7 +614,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -643,7 +643,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Value",
@@ -653,7 +653,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -667,14 +667,14 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "LeftSquare",
-        kind: .token(choices: [.token(tokenKind: "LeftSquareToken")])
+        kind: .token(choices: [.token(.leftSquare)])
       ),
       Child(
         name: "Content",
         kind: .nodeChoices(choices: [
           Child(
             name: "Colon",
-            kind: .token(choices: [.token(tokenKind: "ColonToken")], requiresTrailingSpace: false)
+            kind: .token(choices: [.token(.colon)], requiresTrailingSpace: false)
           ),
           Child(
             name: "Elements",
@@ -684,7 +684,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightSquare",
-        kind: .token(choices: [.token(tokenKind: "RightSquareToken")])
+        kind: .token(choices: [.token(.rightSquare)])
       ),
     ]
   ),
@@ -697,7 +697,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Wildcard",
-        kind: .token(choices: [.token(tokenKind: "WildcardToken")])
+        kind: .token(choices: [.token(.wildcard)])
       )
     ]
   ),
@@ -711,7 +711,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Placeholder",
         deprecatedName: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(.identifier)])
       )
     ]
   ),
@@ -735,17 +735,17 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Backslash",
-        kind: .token(choices: [.token(tokenKind: "BackslashToken")])
+        kind: .token(choices: [.token(.backslash)])
       ),
       Child(
         name: "Pounds",
         deprecatedName: "Delimiter",
-        kind: .token(choices: [.token(tokenKind: "RawStringPoundDelimiterToken")]),
+        kind: .token(choices: [.token(.rawStringPoundDelimiter)]),
         isOptional: true
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Expressions",
@@ -753,7 +753,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -770,7 +770,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Literal",
         deprecatedName: "FloatingDigits",
-        kind: .token(choices: [.token(tokenKind: "FloatLiteralToken")])
+        kind: .token(choices: [.token(.floatLiteral)])
       )
     ]
   ),
@@ -787,7 +787,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "ExclamationMark",
-        kind: .token(choices: [.token(tokenKind: "ExclamationMarkToken")])
+        kind: .token(choices: [.token(.exclamationMark)])
       ),
     ]
   ),
@@ -806,7 +806,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")]),
+        kind: .token(choices: [.token(.leftParen)]),
         isOptional: true
       ),
       Child(
@@ -817,7 +817,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")]),
+        kind: .token(choices: [.token(.rightParen)]),
         isOptional: true
       ),
       Child(
@@ -845,13 +845,13 @@ public let EXPR_NODES: [Node] = [
         name: "BaseName",
         deprecatedName: "Identifier",
         kind: .token(choices: [
-          .token(tokenKind: "IdentifierToken"),
+          .token(.identifier),
           .keyword(text: "self"),
           .keyword(text: "Self"),
           .keyword(text: "init"),
-          .token(tokenKind: "DollarIdentifierToken"),
-          .token(tokenKind: "BinaryOperatorToken"),
-          .token(tokenKind: "IntegerLiteralToken"),
+          .token(.dollarIdentifier),
+          .token(.binaryOperator),
+          .token(.integerLiteral),
         ])
       ),
       Child(
@@ -921,7 +921,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Ampersand",
-        kind: .token(choices: [.token(tokenKind: "PrefixAmpersandToken")])
+        kind: .token(choices: [.token(.prefixAmpersand)])
       ),
       Child(
         name: "Expression",
@@ -967,7 +967,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Literal",
         deprecatedName: "Digits",
-        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")])
+        kind: .token(choices: [.token(.integerLiteral)])
       )
     ]
   ),
@@ -1026,7 +1026,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Period",
-        kind: .token(choices: [.token(tokenKind: "PeriodToken")]),
+        kind: .token(choices: [.token(.period)]),
         isOptional: true
       ),
       Child(
@@ -1057,7 +1057,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Backslash",
-        kind: .token(choices: [.token(tokenKind: "BackslashToken")])
+        kind: .token(choices: [.token(.backslash)])
       ),
       Child(
         name: "Root",
@@ -1080,7 +1080,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "QuestionOrExclamationMark",
-        kind: .token(choices: [.token(tokenKind: "PostfixQuestionMarkToken"), .token(tokenKind: "ExclamationMarkToken")])
+        kind: .token(choices: [.token(.postfixQuestionMark), .token(.exclamationMark)])
       )
     ]
   ),
@@ -1113,7 +1113,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "LeftSquare",
         deprecatedName: "LeftBracket",
-        kind: .token(choices: [.token(tokenKind: "LeftSquareToken")])
+        kind: .token(choices: [.token(.leftSquare)])
       ),
       Child(
         name: "Arguments",
@@ -1124,7 +1124,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "RightSquare",
         deprecatedName: "RightBracket",
-        kind: .token(choices: [.token(tokenKind: "RightSquareToken")])
+        kind: .token(choices: [.token(.rightSquare)])
       ),
     ]
   ),
@@ -1141,13 +1141,13 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Pound",
         deprecatedName: "PoundToken",
-        kind: .token(choices: [.token(tokenKind: "PoundToken")]),
+        kind: .token(choices: [.token(.pound)]),
         documentation: "The `#` sign."
       ),
       Child(
         name: "MacroName",
         deprecatedName: "Macro",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(.identifier)])
       ),
       Child(
         name: "GenericArgumentClause",
@@ -1157,7 +1157,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")]),
+        kind: .token(choices: [.token(.leftParen)]),
         isOptional: true
       ),
       Child(
@@ -1167,7 +1167,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")]),
+        kind: .token(choices: [.token(.rightParen)]),
         isOptional: true
       ),
       Child(
@@ -1198,7 +1198,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Period",
         deprecatedName: "Dot",
-        kind: .token(choices: [.token(tokenKind: "PeriodToken")])
+        kind: .token(choices: [.token(.period)])
       ),
       Child(
         name: "DeclName",
@@ -1257,12 +1257,12 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Label",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)]),
         nameForDiagnostics: "label"
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Closure",
@@ -1296,7 +1296,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "QuestionMark",
-        kind: .token(choices: [.token(tokenKind: "PostfixQuestionMarkToken")])
+        kind: .token(choices: [.token(.postfixQuestionMark)])
       ),
     ]
   ),
@@ -1368,7 +1368,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Operator",
         deprecatedName: "OperatorToken",
-        kind: .token(choices: [.token(tokenKind: "PostfixOperatorToken")])
+        kind: .token(choices: [.token(.postfixOperator)])
       ),
     ]
   ),
@@ -1384,7 +1384,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Operator",
         deprecatedName: "OperatorToken",
-        kind: .token(choices: [.token(tokenKind: "PrefixOperatorToken")])
+        kind: .token(choices: [.token(.prefixOperator)])
       ),
       Child(
         name: "Expression",
@@ -1403,27 +1403,27 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "OpeningPounds",
-        kind: .token(choices: [.token(tokenKind: "RegexPoundDelimiterToken")]),
+        kind: .token(choices: [.token(.regexPoundDelimiter)]),
         isOptional: true
       ),
       Child(
         name: "OpeningSlash",
         deprecatedName: "OpenSlash",
-        kind: .token(choices: [.token(tokenKind: "RegexSlashToken")])
+        kind: .token(choices: [.token(.regexSlash)])
       ),
       Child(
         name: "Regex",
         deprecatedName: "RegexPattern",
-        kind: .token(choices: [.token(tokenKind: "RegexLiteralPatternToken")])
+        kind: .token(choices: [.token(.regexLiteralPattern)])
       ),
       Child(
         name: "ClosingSlash",
         deprecatedName: "CloseSlash",
-        kind: .token(choices: [.token(tokenKind: "RegexSlashToken")])
+        kind: .token(choices: [.token(.regexSlash)])
       ),
       Child(
         name: "ClosingPounds",
-        kind: .token(choices: [.token(tokenKind: "RegexPoundDelimiterToken")]),
+        kind: .token(choices: [.token(.regexPoundDelimiter)]),
         isOptional: true
       ),
     ]
@@ -1468,13 +1468,13 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "OpeningPounds",
         deprecatedName: "OpenDelimiter",
-        kind: .token(choices: [.token(tokenKind: "RawStringPoundDelimiterToken")]),
+        kind: .token(choices: [.token(.rawStringPoundDelimiter)]),
         isOptional: true
       ),
       Child(
         name: "OpeningQuote",
         deprecatedName: "OpenQuote",
-        kind: .token(choices: [.token(tokenKind: "StringQuoteToken"), .token(tokenKind: "MultilineStringQuoteToken"), .token(tokenKind: "SingleQuoteToken")])
+        kind: .token(choices: [.token(.stringQuote), .token(.multilineStringQuote), .token(.singleQuote)])
       ),
       Child(
         name: "Segments",
@@ -1483,12 +1483,12 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "ClosingQuote",
         deprecatedName: "CloseQuote",
-        kind: .token(choices: [.token(tokenKind: "StringQuoteToken"), .token(tokenKind: "MultilineStringQuoteToken"), .token(tokenKind: "SingleQuoteToken")])
+        kind: .token(choices: [.token(.stringQuote), .token(.multilineStringQuote), .token(.singleQuote)])
       ),
       Child(
         name: "ClosingPounds",
         deprecatedName: "CloseDelimiter",
-        kind: .token(choices: [.token(tokenKind: "RawStringPoundDelimiterToken")]),
+        kind: .token(choices: [.token(.rawStringPoundDelimiter)]),
         isOptional: true
       ),
     ]
@@ -1509,7 +1509,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Content",
-        kind: .token(choices: [.token(tokenKind: "StringSegmentToken")])
+        kind: .token(choices: [.token(.stringSegment)])
       )
     ]
   ),
@@ -1528,7 +1528,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "LeftSquare",
         deprecatedName: "LeftBracket",
-        kind: .token(choices: [.token(tokenKind: "LeftSquareToken")])
+        kind: .token(choices: [.token(.leftSquare)])
       ),
       Child(
         name: "Arguments",
@@ -1539,7 +1539,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "RightSquare",
         deprecatedName: "RightBracket",
-        kind: .token(choices: [.token(tokenKind: "RightSquareToken")])
+        kind: .token(choices: [.token(.rightSquare)])
       ),
       Child(
         name: "TrailingClosure",
@@ -1585,7 +1585,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")], requiresTrailingSpace: false)
+        kind: .token(choices: [.token(.colon)], requiresTrailingSpace: false)
       ),
     ]
   ),
@@ -1647,7 +1647,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")], requiresTrailingSpace: false)
+        kind: .token(choices: [.token(.colon)], requiresTrailingSpace: false)
       ),
     ]
   ),
@@ -1676,7 +1676,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "LeftBrace",
-        kind: .token(choices: [.token(tokenKind: "LeftBraceToken")])
+        kind: .token(choices: [.token(.leftBrace)])
       ),
       Child(
         name: "Cases",
@@ -1684,7 +1684,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightBrace",
-        kind: .token(choices: [.token(tokenKind: "RightBraceToken")])
+        kind: .token(choices: [.token(.rightBrace)])
       ),
     ]
   ),
@@ -1706,7 +1706,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "QuestionMark",
-        kind: .token(choices: [.token(tokenKind: "InfixQuestionMarkToken")])
+        kind: .token(choices: [.token(.infixQuestionMark)])
       ),
       Child(
         name: "ThenExpression",
@@ -1717,7 +1717,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Colon",
         deprecatedName: "ColonMark",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "ElseExpression",
@@ -1743,7 +1743,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "QuestionOrExclamationMark",
-        kind: .token(choices: [.token(tokenKind: "PostfixQuestionMarkToken"), .token(tokenKind: "ExclamationMarkToken")], requiresTrailingSpace: true),
+        kind: .token(choices: [.token(.postfixQuestionMark), .token(.exclamationMark)], requiresTrailingSpace: true),
         isOptional: true
       ),
       Child(
@@ -1771,13 +1771,13 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "Label",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)]),
         nameForDiagnostics: "label",
         isOptional: true
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         isOptional: true
       ),
       Child(
@@ -1787,7 +1787,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -1803,7 +1803,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Elements",
@@ -1812,7 +1812,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -1845,7 +1845,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "QuestionOrExclamationMark",
-        kind: .token(choices: [.token(tokenKind: "PostfixQuestionMarkToken"), .token(tokenKind: "ExclamationMarkToken")]),
+        kind: .token(choices: [.token(.postfixQuestionMark), .token(.exclamationMark)]),
         isOptional: true
       ),
     ]
@@ -1889,7 +1889,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "QuestionMark",
-        kind: .token(choices: [.token(tokenKind: "InfixQuestionMarkToken")])
+        kind: .token(choices: [.token(.infixQuestionMark)])
       ),
       Child(
         name: "ThenExpression",
@@ -1899,7 +1899,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "Colon",
         deprecatedName: "ColonMark",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
     ]
   ),
@@ -1915,7 +1915,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]

--- a/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
@@ -24,7 +24,7 @@ public let GENERIC_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "RightType",
@@ -45,7 +45,7 @@ public let GENERIC_NODES: [Node] = [
       Child(
         name: "LeftAngle",
         deprecatedName: "LeftAngleBracket",
-        kind: .token(choices: [.token(tokenKind: "LeftAngleToken")]),
+        kind: .token(choices: [.token(.leftAngle)]),
         documentation: "The opening angle bracket (`<`) of the generic parameter clause."
       ),
       Child(
@@ -63,7 +63,7 @@ public let GENERIC_NODES: [Node] = [
       Child(
         name: "RightAngle",
         deprecatedName: "RightAngleBracket",
-        kind: .token(choices: [.token(tokenKind: "RightAngleToken")]),
+        kind: .token(choices: [.token(.rightAngle)]),
         documentation: "The closing angle bracket (`>`) of the generic parameter clause."
       ),
     ]
@@ -102,12 +102,12 @@ public let GENERIC_NODES: [Node] = [
       ),
       Child(
         name: "Name",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "name"
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         isOptional: true
       ),
       Child(
@@ -118,7 +118,7 @@ public let GENERIC_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -161,7 +161,7 @@ public let GENERIC_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -203,7 +203,7 @@ public let GENERIC_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "LayoutSpecifier",
@@ -220,29 +220,29 @@ public let GENERIC_NODES: [Node] = [
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")]),
+        kind: .token(choices: [.token(.leftParen)]),
         isOptional: true
       ),
       Child(
         name: "Size",
-        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")]),
+        kind: .token(choices: [.token(.integerLiteral)]),
         nameForDiagnostics: "size",
         isOptional: true
       ),
       Child(
         name: "Comma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
       Child(
         name: "Alignment",
-        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")]),
+        kind: .token(choices: [.token(.integerLiteral)]),
         nameForDiagnostics: "alignment",
         isOptional: true
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")]),
+        kind: .token(choices: [.token(.rightParen)]),
         isOptional: true
       ),
     ]
@@ -257,7 +257,7 @@ public let GENERIC_NODES: [Node] = [
       Child(
         name: "LeftAngle",
         deprecatedName: "LeftAngleBracket",
-        kind: .token(choices: [.token(tokenKind: "LeftAngleToken")])
+        kind: .token(choices: [.token(.leftAngle)])
       ),
       Child(
         name: "PrimaryAssociatedTypes",
@@ -267,7 +267,7 @@ public let GENERIC_NODES: [Node] = [
       Child(
         name: "RightAngle",
         deprecatedName: "RightAngleBracket",
-        kind: .token(choices: [.token(tokenKind: "RightAngleToken")])
+        kind: .token(choices: [.token(.rightAngle)])
       ),
     ]
   ),
@@ -290,12 +290,12 @@ public let GENERIC_NODES: [Node] = [
     children: [
       Child(
         name: "Name",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "name"
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -316,7 +316,7 @@ public let GENERIC_NODES: [Node] = [
       Child(
         name: "Equal",
         deprecatedName: "EqualityToken",
-        kind: .token(choices: [.token(tokenKind: "BinaryOperatorToken"), .token(tokenKind: "PrefixOperatorToken"), .token(tokenKind: "PostfixOperatorToken")])
+        kind: .token(choices: [.token(.binaryOperator), .token(.prefixOperator), .token(.postfixOperator)])
       ),
       Child(
         name: "RightType",

--- a/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
@@ -18,12 +18,12 @@ struct GrammarGenerator {
     switch tokenChoice {
     case .keyword(text: let text):
       return "`'\(text)'`"
-    case .token(tokenKind: let tokenKind):
-      let token = SYNTAX_TOKEN_MAP[tokenKind]!
-      if let tokenText = token.text {
+    case .token(let token):
+      let tokenSpec = token.spec
+      if let tokenText = tokenSpec.text {
         return "`'\(tokenText)'`"
       } else {
-        return "`<\(token.varOrCaseName)>`"
+        return "`<\(tokenSpec.varOrCaseName)>`"
       }
     }
   }

--- a/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
@@ -31,7 +31,7 @@ public let PATTERN_NODES: [Node] = [
     children: [
       Child(
         name: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .keyword(text: "self"), .keyword(text: "init")])
+        kind: .token(choices: [.token(.identifier), .keyword(text: "self"), .keyword(text: "init")])
       )
     ]
   ),
@@ -74,14 +74,14 @@ public let PATTERN_NODES: [Node] = [
       Child(
         name: "Label",
         deprecatedName: "LabelName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "label",
         isOptional: true
       ),
       Child(
         name: "Colon",
         deprecatedName: "LabelColon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         isOptional: true
       ),
       Child(
@@ -90,7 +90,7 @@ public let PATTERN_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -107,7 +107,7 @@ public let PATTERN_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Elements",
@@ -115,7 +115,7 @@ public let PATTERN_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -128,7 +128,7 @@ public let PATTERN_NODES: [Node] = [
     children: [
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Type",
@@ -166,7 +166,7 @@ public let PATTERN_NODES: [Node] = [
     children: [
       Child(
         name: "Wildcard",
-        kind: .token(choices: [.token(tokenKind: "WildcardToken")])
+        kind: .token(choices: [.token(.wildcard)])
       ),
       Child(
         name: "TypeAnnotation",

--- a/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
@@ -19,11 +19,11 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "AvailabilityKeyword",
-        kind: .token(choices: [.token(tokenKind: "PoundAvailableToken"), .token(tokenKind: "PoundUnavailableToken")])
+        kind: .token(choices: [.token(.poundAvailable), .token(.poundUnavailable)])
       ),
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "AvailabilityArguments",
@@ -32,7 +32,7 @@ public let STMT_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),
@@ -49,7 +49,7 @@ public let STMT_NODES: [Node] = [
       ),
       Child(
         name: "Label",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "label",
         isOptional: true
       ),
@@ -125,7 +125,7 @@ public let STMT_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -175,7 +175,7 @@ public let STMT_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -193,7 +193,7 @@ public let STMT_NODES: [Node] = [
       ),
       Child(
         name: "Label",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "label",
         isOptional: true
       ),
@@ -392,13 +392,13 @@ public let STMT_NODES: [Node] = [
       Child(
         name: "Label",
         deprecatedName: "LabelName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         nameForDiagnostics: "label name"
       ),
       Child(
         name: "Colon",
         deprecatedName: "LabelColon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Statement",
@@ -572,7 +572,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Elements",
@@ -581,7 +581,7 @@ public let STMT_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
@@ -66,58 +66,159 @@ public struct TokenSpec {
   }
 }
 
-public let SYNTAX_TOKENS: [TokenSpec] = [
-  .punctuator(name: "arrow", text: "->"),
-  .punctuator(name: "atSign", text: "@"),
-  .punctuator(name: "backslash", text: "\\"),
-  .punctuator(name: "backtick", text: "`"),
-  .other(name: "binaryOperator", nameForDiagnostics: "binary operator"),
-  .punctuator(name: "colon", text: ":"),
-  .punctuator(name: "comma", text: ","),
-  .other(name: "dollarIdentifier", nameForDiagnostics: "dollar identifier"),
-  .punctuator(name: "ellipsis", text: "..."),
-  .other(name: "endOfFile", nameForDiagnostics: "end of file", text: ""),
-  .punctuator(name: "equal", text: "="),
-  .punctuator(name: "exclamationMark", text: "!"),
-  .other(name: "floatLiteral", nameForDiagnostics: "float literal"),
-  .other(name: "identifier", nameForDiagnostics: "identifier"),
-  .punctuator(name: "infixQuestionMark", text: "?"),
-  .other(name: "integerLiteral", nameForDiagnostics: "integer literal"),
-  TokenSpec(name: "keyword", nameForDiagnostics: "keyword", text: nil, kind: .keyword),
-  .punctuator(name: "leftAngle", text: "<"),
-  .punctuator(name: "leftBrace", text: "{"),
-  .punctuator(name: "leftParen", text: "("),
-  .punctuator(name: "leftSquare", text: "["),
-  .punctuator(name: "multilineStringQuote", text: "\"\"\""),
-  .punctuator(name: "period", text: "."),
-  .other(name: "postfixOperator", nameForDiagnostics: "postfix operator"),
-  .punctuator(name: "postfixQuestionMark", text: "?"),
-  .punctuator(name: "pound", text: "#"),
-  .poundKeyword(name: "poundAvailable", text: "#available"),
-  .poundKeyword(name: "poundElse", text: "#else"),
-  .poundKeyword(name: "poundElseif", text: "#elseif"),
-  .poundKeyword(name: "poundEndif", text: "#endif"),
-  .poundKeyword(name: "poundIf", text: "#if"),
-  .poundKeyword(name: "poundSourceLocation", text: "#sourceLocation"),
-  .poundKeyword(name: "poundUnavailable", text: "#unavailable"),
-  .punctuator(name: "prefixAmpersand", text: "&"),
-  .other(name: "prefixOperator", nameForDiagnostics: "prefix operator"),
-  .other(name: "rawStringPoundDelimiter", nameForDiagnostics: "raw string delimiter"),
-  .other(name: "regexLiteralPattern", nameForDiagnostics: "regex pattern"),
-  .other(name: "regexPoundDelimiter", nameForDiagnostics: "extended delimiter"),
-  .punctuator(name: "regexSlash", text: "/"),
-  .punctuator(name: "rightAngle", text: ">"),
-  .punctuator(name: "rightBrace", text: "}"),
-  .punctuator(name: "rightParen", text: ")"),
-  .punctuator(name: "rightSquare", text: "]"),
-  .punctuator(name: "semicolon", text: ";"),
-  .punctuator(name: "singleQuote", text: "\'"),
-  .punctuator(name: "stringQuote", text: "\""),
-  .other(name: "stringSegment", nameForDiagnostics: "string segment"),
-  .other(name: "unknown", nameForDiagnostics: "token"),
-  .other(name: "wildcard", nameForDiagnostics: "wildcard", text: "_"),
-]
+public enum Token: CaseIterable {
+  // Please keep this list sorted alphabetically
 
-public let SYNTAX_TOKEN_MAP = Dictionary(
-  uniqueKeysWithValues: SYNTAX_TOKENS.map { ("\($0.varOrCaseName.description.withFirstCharacterUppercased)Token", $0) }
-)
+  case arrow
+  case atSign
+  case backslash
+  case backtick
+  case binaryOperator
+  case colon
+  case comma
+  case dollarIdentifier
+  case ellipsis
+  case endOfFile
+  case equal
+  case exclamationMark
+  case floatLiteral
+  case identifier
+  case infixQuestionMark
+  case integerLiteral
+  case keyword
+  case leftAngle
+  case leftBrace
+  case leftParen
+  case leftSquare
+  case multilineStringQuote
+  case period
+  case postfixOperator
+  case postfixQuestionMark
+  case pound
+  case poundAvailable
+  case poundElse
+  case poundElseif
+  case poundEndif
+  case poundIf
+  case poundSourceLocation
+  case poundUnavailable
+  case prefixAmpersand
+  case prefixOperator
+  case rawStringPoundDelimiter
+  case regexLiteralPattern
+  case regexPoundDelimiter
+  case regexSlash
+  case rightAngle
+  case rightBrace
+  case rightParen
+  case rightSquare
+  case semicolon
+  case singleQuote
+  case stringQuote
+  case stringSegment
+  case unknown
+  case wildcard
+
+  public var spec: TokenSpec {
+    switch self {
+    case .arrow:
+      return .punctuator(name: "arrow", text: "->")
+    case .atSign:
+      return .punctuator(name: "atSign", text: "@")
+    case .backslash:
+      return .punctuator(name: "backslash", text: "\\")
+    case .backtick:
+      return .punctuator(name: "backtick", text: "`")
+    case .binaryOperator:
+      return .other(name: "binaryOperator", nameForDiagnostics: "binary operator")
+    case .colon:
+      return .punctuator(name: "colon", text: ":")
+    case .comma:
+      return .punctuator(name: "comma", text: ",")
+    case .dollarIdentifier:
+      return .other(name: "dollarIdentifier", nameForDiagnostics: "dollar identifier")
+    case .ellipsis:
+      return .punctuator(name: "ellipsis", text: "...")
+    case .endOfFile:
+      return .other(name: "endOfFile", nameForDiagnostics: "end of file", text: "")
+    case .equal:
+      return .punctuator(name: "equal", text: "=")
+    case .exclamationMark:
+      return .punctuator(name: "exclamationMark", text: "!")
+    case .floatLiteral:
+      return .other(name: "floatLiteral", nameForDiagnostics: "float literal")
+    case .identifier:
+      return .other(name: "identifier", nameForDiagnostics: "identifier")
+    case .infixQuestionMark:
+      return .punctuator(name: "infixQuestionMark", text: "?")
+    case .integerLiteral:
+      return .other(name: "integerLiteral", nameForDiagnostics: "integer literal")
+    case .keyword:
+      return TokenSpec(name: "keyword", nameForDiagnostics: "keyword", text: nil, kind: .keyword)
+    case .leftAngle:
+      return .punctuator(name: "leftAngle", text: "<")
+    case .leftBrace:
+      return .punctuator(name: "leftBrace", text: "{")
+    case .leftParen:
+      return .punctuator(name: "leftParen", text: "(")
+    case .leftSquare:
+      return .punctuator(name: "leftSquare", text: "[")
+    case .multilineStringQuote:
+      return .punctuator(name: "multilineStringQuote", text: "\"\"\"")
+    case .period:
+      return .punctuator(name: "period", text: ".")
+    case .postfixOperator:
+      return .other(name: "postfixOperator", nameForDiagnostics: "postfix operator")
+    case .postfixQuestionMark:
+      return .punctuator(name: "postfixQuestionMark", text: "?")
+    case .pound:
+      return .punctuator(name: "pound", text: "#")
+    case .poundAvailable:
+      return .poundKeyword(name: "poundAvailable", text: "#available")
+    case .poundElse:
+      return .poundKeyword(name: "poundElse", text: "#else")
+    case .poundElseif:
+      return .poundKeyword(name: "poundElseif", text: "#elseif")
+    case .poundEndif:
+      return .poundKeyword(name: "poundEndif", text: "#endif")
+    case .poundIf:
+      return .poundKeyword(name: "poundIf", text: "#if")
+    case .poundSourceLocation:
+      return .poundKeyword(name: "poundSourceLocation", text: "#sourceLocation")
+    case .poundUnavailable:
+      return .poundKeyword(name: "poundUnavailable", text: "#unavailable")
+    case .prefixAmpersand:
+      return .punctuator(name: "prefixAmpersand", text: "&")
+    case .prefixOperator:
+      return .other(name: "prefixOperator", nameForDiagnostics: "prefix operator")
+    case .rawStringPoundDelimiter:
+      return .other(name: "rawStringPoundDelimiter", nameForDiagnostics: "raw string delimiter")
+    case .regexLiteralPattern:
+      return .other(name: "regexLiteralPattern", nameForDiagnostics: "regex pattern")
+    case .regexPoundDelimiter:
+      return .other(name: "regexPoundDelimiter", nameForDiagnostics: "extended delimiter")
+    case .regexSlash:
+      return .punctuator(name: "regexSlash", text: "/")
+    case .rightAngle:
+      return .punctuator(name: "rightAngle", text: ">")
+    case .rightBrace:
+      return .punctuator(name: "rightBrace", text: "}")
+    case .rightParen:
+      return .punctuator(name: "rightParen", text: ")")
+    case .rightSquare:
+      return .punctuator(name: "rightSquare", text: "]")
+    case .semicolon:
+      return .punctuator(name: "semicolon", text: ";")
+    case .singleQuote:
+      return .punctuator(name: "singleQuote", text: "\'")
+    case .stringQuote:
+      return .punctuator(name: "stringQuote", text: "\"")
+    case .stringSegment:
+      return .other(name: "stringSegment", nameForDiagnostics: "string segment")
+    case .unknown:
+      return .other(name: "unknown", nameForDiagnostics: "token")
+    case .wildcard:
+      return .other(name: "wildcard", nameForDiagnostics: "wildcard", text: "_")
+    }
+  }
+}

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -30,8 +30,8 @@ public let TRAITS: [Trait] = [
   Trait(
     traitName: "Braced",
     children: [
-      Child(name: "LeftBrace", kind: .token(choices: [.token(tokenKind: "LeftBraceToken")])),
-      Child(name: "RightBrace", kind: .token(choices: [.token(tokenKind: "RightBraceToken")])),
+      Child(name: "LeftBrace", kind: .token(choices: [.token(.leftBrace)])),
+      Child(name: "RightBrace", kind: .token(choices: [.token(.rightBrace)])),
     ]
   ),
   Trait(
@@ -62,12 +62,12 @@ public let TRAITS: [Trait] = [
   Trait(
     traitName: "FreestandingMacroExpansion",
     children: [
-      Child(name: "PoundToken", kind: .token(choices: [.token(tokenKind: "PoundToken")])),
-      Child(name: "Macro", kind: .token(choices: [.token(tokenKind: "IdentifierToken")])),
+      Child(name: "PoundToken", kind: .token(choices: [.token(.pound)])),
+      Child(name: "Macro", kind: .token(choices: [.token(.identifier)])),
       Child(name: "GenericArgumentClause", kind: .node(kind: .genericArgumentClause), isOptional: true),
-      Child(name: "LeftParen", kind: .token(choices: [.token(tokenKind: "LeftParenToken")]), isOptional: true),
+      Child(name: "LeftParen", kind: .token(choices: [.token(.leftParen)]), isOptional: true),
       Child(name: "ArgumentList", kind: .node(kind: .labeledExprList)),
-      Child(name: "RightParen", kind: .token(choices: [.token(tokenKind: "RightParenToken")]), isOptional: true),
+      Child(name: "RightParen", kind: .token(choices: [.token(.rightParen)]), isOptional: true),
       Child(name: "TrailingClosure", kind: .node(kind: .closureExpr), isOptional: true),
       Child(name: "AdditionalTrailingClosures", kind: .node(kind: .multipleTrailingClosureElementList), isOptional: true),
     ]
@@ -75,7 +75,7 @@ public let TRAITS: [Trait] = [
   Trait(
     traitName: "NamedDecl",
     children: [
-      Child(name: "Name", kind: .token(choices: [.token(tokenKind: "IdentifierToken")]))
+      Child(name: "Name", kind: .token(choices: [.token(.identifier)]))
     ]
   ),
   Trait(
@@ -88,7 +88,7 @@ public let TRAITS: [Trait] = [
     children: [
       Child(
         name: "Placeholder",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        kind: .token(choices: [.token(.identifier)]),
         documentation: """
           A placeholder, i.e. `<#placeholder#>`, that can be inserted into the source code to represent the missing node.
           """
@@ -98,8 +98,8 @@ public let TRAITS: [Trait] = [
   Trait(
     traitName: "Parenthesized",
     children: [
-      Child(name: "LeftParen", kind: .token(choices: [.token(tokenKind: "LeftParenToken")])),
-      Child(name: "RightParen", kind: .token(choices: [.token(tokenKind: "RightParenToken")])),
+      Child(name: "LeftParen", kind: .token(choices: [.token(.leftParen)])),
+      Child(name: "RightParen", kind: .token(choices: [.token(.rightParen)])),
     ]
   ),
   Trait(
@@ -152,7 +152,7 @@ public let TRAITS: [Trait] = [
   Trait(
     traitName: "WithTrailingComma",
     children: [
-      Child(name: "TrailingComma", kind: .token(choices: [.token(tokenKind: "CommaToken")]), isOptional: true)
+      Child(name: "TrailingComma", kind: .token(choices: [.token(.comma)]), isOptional: true)
     ]
   ),
 ]

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -20,7 +20,7 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "LeftSquare",
         deprecatedName: "LeftSquareBracket",
-        kind: .token(choices: [.token(tokenKind: "LeftSquareToken")])
+        kind: .token(choices: [.token(.leftSquare)])
       ),
       Child(
         name: "Element",
@@ -30,7 +30,7 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "RightSquare",
         deprecatedName: "RightSquareBracket",
-        kind: .token(choices: [.token(tokenKind: "RightSquareToken")])
+        kind: .token(choices: [.token(.rightSquare)])
       ),
     ]
   ),
@@ -149,7 +149,7 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "LeftSquare",
         deprecatedName: "LeftSquareBracket",
-        kind: .token(choices: [.token(tokenKind: "LeftSquareToken")])
+        kind: .token(choices: [.token(.leftSquare)])
       ),
       Child(
         name: "Key",
@@ -159,7 +159,7 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")])
+        kind: .token(choices: [.token(.colon)])
       ),
       Child(
         name: "Value",
@@ -170,7 +170,7 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "RightSquare",
         deprecatedName: "RightSquareBracket",
-        kind: .token(choices: [.token(tokenKind: "RightSquareToken")])
+        kind: .token(choices: [.token(.rightSquare)])
       ),
     ]
   ),
@@ -188,7 +188,7 @@ public let TYPE_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Parameters",
@@ -197,7 +197,7 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
       Child(
         name: "EffectSpecifiers",
@@ -221,7 +221,7 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "LeftAngle",
         deprecatedName: "LeftAngleBracket",
-        kind: .token(choices: [.token(tokenKind: "LeftAngleToken")])
+        kind: .token(choices: [.token(.leftAngle)])
       ),
       Child(
         name: "Arguments",
@@ -230,7 +230,7 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "RightAngle",
         deprecatedName: "RightAngleBracket",
-        kind: .token(choices: [.token(tokenKind: "RightAngleToken")])
+        kind: .token(choices: [.token(.rightAngle)])
       ),
     ]
   ),
@@ -261,7 +261,7 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -279,7 +279,7 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "ExclamationMark",
-        kind: .token(choices: [.token(tokenKind: "ExclamationMarkToken")])
+        kind: .token(choices: [.token(.exclamationMark)])
       ),
     ]
   ),
@@ -297,11 +297,11 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "Period",
-        kind: .token(choices: [.token(tokenKind: "PeriodToken")])
+        kind: .token(choices: [.token(.period)])
       ),
       Child(
         name: "Name",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .keyword(text: "self"), .keyword(text: "Self")]),
+        kind: .token(choices: [.token(.identifier), .keyword(text: "self"), .keyword(text: "Self")]),
         nameForDiagnostics: "name"
       ),
       Child(
@@ -325,7 +325,7 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "Period",
-        kind: .token(choices: [.token(tokenKind: "PeriodToken")])
+        kind: .token(choices: [.token(.period)])
       ),
       Child(
         name: "MetatypeSpecifier",
@@ -367,7 +367,7 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "QuestionMark",
-        kind: .token(choices: [.token(tokenKind: "PostfixQuestionMarkToken")])
+        kind: .token(choices: [.token(.postfixQuestionMark)])
       ),
     ]
   ),
@@ -380,7 +380,7 @@ public let TYPE_NODES: [Node] = [
     children: [
       Child(
         name: "WithoutTilde",
-        kind: .token(choices: [.token(tokenKind: "PrefixOperatorToken")])
+        kind: .token(choices: [.token(.prefixOperator)])
       ),
       Child(
         name: "Type",
@@ -435,11 +435,11 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "Name",
         kind: .token(choices: [
-          .token(tokenKind: "IdentifierToken"),
+          .token(.identifier),
           .keyword(text: "self"),
           .keyword(text: "Self"),
           .keyword(text: "Any"),
-          .token(tokenKind: "WildcardToken"),
+          .token(.wildcard),
         ])
       ),
       Child(
@@ -476,19 +476,19 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "FirstName",
         deprecatedName: "Name",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)]),
         nameForDiagnostics: "name",
         isOptional: true
       ),
       Child(
         name: "SecondName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(.identifier), .token(.wildcard)]),
         nameForDiagnostics: "internal name",
         isOptional: true
       ),
       Child(
         name: "Colon",
-        kind: .token(choices: [.token(tokenKind: "ColonToken")]),
+        kind: .token(choices: [.token(.colon)]),
         isOptional: true
       ),
       Child(
@@ -497,12 +497,12 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "Ellipsis",
-        kind: .token(choices: [.token(tokenKind: "EllipsisToken")]),
+        kind: .token(choices: [.token(.ellipsis)]),
         isOptional: true
       ),
       Child(
         name: "TrailingComma",
-        kind: .token(choices: [.token(tokenKind: "CommaToken")]),
+        kind: .token(choices: [.token(.comma)]),
         isOptional: true
       ),
     ]
@@ -519,7 +519,7 @@ public let TYPE_NODES: [Node] = [
     children: [
       Child(
         name: "LeftParen",
-        kind: .token(choices: [.token(tokenKind: "LeftParenToken")])
+        kind: .token(choices: [.token(.leftParen)])
       ),
       Child(
         name: "Elements",
@@ -527,7 +527,7 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "RightParen",
-        kind: .token(choices: [.token(tokenKind: "RightParenToken")])
+        kind: .token(choices: [.token(.rightParen)])
       ),
     ]
   ),

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -40,8 +40,8 @@ public struct SyntaxBuildableType: Hashable {
   /// The token if this is a token.
   public var token: TokenSpec? {
     switch kind {
-    case .token(let tokenKind):
-      return SYNTAX_TOKEN_MAP[tokenKind]
+    case .token(let token):
+      return token.spec
     default:
       return nil
     }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserTokenSpecSetFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserTokenSpecSetFile.swift
@@ -33,9 +33,8 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
               case .keyword(let keywordText):
                 let keyword = KEYWORDS.first(where: { $0.name == keywordText })!
                 DeclSyntax("case \(raw: keyword.escapedName)")
-              case .token(let tokenText):
-                let token = SYNTAX_TOKEN_MAP[tokenText]!
-                DeclSyntax("case \(token.varOrCaseName)")
+              case .token(let token):
+                DeclSyntax("case \(token.spec.varOrCaseName)")
               }
             }
 
@@ -46,10 +45,10 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                   case .keyword(let keywordText):
                     let keyword = KEYWORDS.first(where: { $0.name == keywordText })!
                     SwitchCaseSyntax("case TokenSpec(.\(raw: keyword.escapedName)): self = .\(raw: keyword.escapedName)")
-                  case .token(let tokenText):
-                    let token = SYNTAX_TOKEN_MAP[tokenText]!
+                  case .token(let token):
+                    let caseName = token.spec.varOrCaseName
                     SwitchCaseSyntax(
-                      "case TokenSpec(.\(token.varOrCaseName)): self = .\(token.varOrCaseName)"
+                      "case TokenSpec(.\(caseName)): self = .\(caseName)"
                     )
                   }
                 }
@@ -66,10 +65,10 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                     SwitchCaseSyntax(
                       "case .\(raw: keyword.escapedName): return .keyword(.\(raw: keyword.escapedName))"
                     )
-                  case .token(let tokenText):
-                    let token = SYNTAX_TOKEN_MAP[tokenText]!
+                  case .token(let token):
+                    let caseName = token.spec.varOrCaseName
                     SwitchCaseSyntax(
-                      "case .\(token.varOrCaseName): return .\(token.varOrCaseName)"
+                      "case .\(caseName): return .\(caseName)"
                     )
                   }
                 }
@@ -93,15 +92,15 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                     SwitchCaseSyntax(
                       "case .\(raw: keyword.escapedName): return .keyword(.\(raw: keyword.escapedName))"
                     )
-                  case .token(let tokenText):
-                    let token = SYNTAX_TOKEN_MAP[tokenText]!
-                    if token.text != nil {
+                  case .token(let token):
+                    let caseName = token.spec.varOrCaseName
+                    if token.spec.text != nil {
                       SwitchCaseSyntax(
-                        "case .\(raw: token.varOrCaseName): return .\(raw: token.varOrCaseName)Token()"
+                        "case .\(caseName): return .\(caseName)Token()"
                       )
                     } else {
                       SwitchCaseSyntax(
-                        #"case .\#(raw: token.varOrCaseName): return .\#(raw: token.varOrCaseName)("")"#
+                        #"case .\#(caseName): return .\#(caseName)("")"#
                       )
                     }
                   }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TokenSpecStaticMembersFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TokenSpecStaticMembersFile.swift
@@ -19,8 +19,8 @@ let tokenSpecStaticMembersFile = SourceFileSyntax(leadingTrivia: copyrightHeader
   DeclSyntax("@_spi(RawSyntax) import SwiftSyntax")
 
   try! ExtensionDeclSyntax("extension TokenSpec") {
-    for token in SYNTAX_TOKENS where token.kind != .keyword {
-      DeclSyntax("static var \(token.varOrCaseName): TokenSpec { return TokenSpec(.\(token.varOrCaseName)) }")
+    for tokenSpec in Token.allCases.map(\.spec) where tokenSpec.kind != .keyword {
+      DeclSyntax("static var \(tokenSpec.varOrCaseName): TokenSpec { return TokenSpec(.\(tokenSpec.varOrCaseName)) }")
     }
 
     DeclSyntax("static func keyword(_ keyword: Keyword) -> TokenSpec { return TokenSpec(keyword) }")

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
@@ -21,9 +21,9 @@ let tokenNameForDiagnosticFile = SourceFileSyntax(leadingTrivia: copyrightHeader
   try! ExtensionDeclSyntax("extension TokenKind") {
     try! VariableDeclSyntax("var nameForDiagnostics: String") {
       try! SwitchExprSyntax("switch self") {
-        for token in SYNTAX_TOKENS where token.kind != .keyword {
-          SwitchCaseSyntax("case .\(token.varOrCaseName):") {
-            StmtSyntax("return \(literal: token.nameForDiagnostics)")
+        for tokenSpec in Token.allCases.map(\.spec) where tokenSpec.kind != .keyword {
+          SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
+            StmtSyntax("return \(literal: tokenSpec.nameForDiagnostics)")
           }
         }
         SwitchCaseSyntax("case .keyword(let keyword):") {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
@@ -215,8 +215,8 @@ let rawSyntaxValidationFile = try! SourceFileSyntax(leadingTrivia: copyrightHead
                               switch choice {
                               case .keyword(text: let text):
                                 ArrayElementSyntax(expression: ExprSyntax(#".keyword("\#(raw: text)")"#))
-                              case .token(tokenKind: let tokenKind):
-                                ArrayElementSyntax(expression: ExprSyntax(".tokenKind(.\(SYNTAX_TOKEN_MAP[tokenKind]!.varOrCaseName))"))
+                              case .token(let token):
+                                ArrayElementSyntax(expression: ExprSyntax(".tokenKind(.\(token.spec.varOrCaseName))"))
                               }
                             }
                           }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -22,15 +22,15 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     public enum TokenKind: Hashable
     """
   ) {
-    for token in SYNTAX_TOKENS {
+    for tokenSpec in Token.allCases.map(\.spec) {
       // Tokens that don't have a set text have an associated value that
       // contains their text.
-      if token.kind == .keyword {
-        DeclSyntax("case \(token.varOrCaseName)(Keyword)")
-      } else if token.text == nil {
-        DeclSyntax("case \(token.varOrCaseName)(String)")
+      if tokenSpec.kind == .keyword {
+        DeclSyntax("case \(tokenSpec.varOrCaseName)(Keyword)")
+      } else if tokenSpec.text == nil {
+        DeclSyntax("case \(tokenSpec.varOrCaseName)(String)")
       } else {
-        DeclSyntax("case \(token.varOrCaseName)")
+        DeclSyntax("case \(tokenSpec.varOrCaseName)")
       }
     }
 
@@ -42,17 +42,17 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try SwitchExprSyntax("switch self") {
-        for token in SYNTAX_TOKENS {
-          if token.kind == .keyword {
-            SwitchCaseSyntax("case .\(token.varOrCaseName)(let assoc):") {
+        for tokenSpec in Token.allCases.map(\.spec) {
+          if tokenSpec.kind == .keyword {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName)(let assoc):") {
               StmtSyntax("return String(syntaxText: assoc.defaultText)")
             }
-          } else if let text = token.text {
-            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
+          } else if let text = tokenSpec.text {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
               StmtSyntax("return #\"\(raw: text)\"#")
             }
           } else {
-            SwitchCaseSyntax("case .\(token.varOrCaseName)(let text):") {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName)(let text):") {
               StmtSyntax("return text")
             }
           }
@@ -68,13 +68,13 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try SwitchExprSyntax("switch self") {
-        for token in SYNTAX_TOKENS {
-          if token.kind == .keyword {
-            SwitchCaseSyntax("case .\(token.varOrCaseName)(let assoc):") {
+        for tokenSpec in Token.allCases.map(\.spec) {
+          if tokenSpec.kind == .keyword {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName)(let assoc):") {
               StmtSyntax("return assoc.defaultText")
             }
-          } else if let text = token.text {
-            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
+          } else if let text = tokenSpec.text {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
               StmtSyntax("return #\"\(raw: text)\"#")
             }
           }
@@ -97,9 +97,9 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try SwitchExprSyntax("switch self") {
-        for token in SYNTAX_TOKENS {
-          SwitchCaseSyntax("case .\(token.varOrCaseName):") {
-            StmtSyntax("return \(raw: token.kind == .punctuation)")
+        for tokenSpec in Token.allCases.map(\.spec) {
+          SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
+            StmtSyntax("return \(raw: tokenSpec.kind == .punctuation)")
           }
         }
       }
@@ -109,13 +109,13 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! ExtensionDeclSyntax("extension TokenKind: Equatable") {
     try FunctionDeclSyntax("public static func ==(lhs: TokenKind, rhs: TokenKind) -> Bool") {
       try SwitchExprSyntax("switch (lhs, rhs)") {
-        for token in SYNTAX_TOKENS {
-          if token.text != nil {
-            SwitchCaseSyntax("case (.\(token.varOrCaseName), .\(token.varOrCaseName)):") {
+        for tokenSpec in Token.allCases.map(\.spec) {
+          if tokenSpec.text != nil {
+            SwitchCaseSyntax("case (.\(tokenSpec.varOrCaseName), .\(tokenSpec.varOrCaseName)):") {
               StmtSyntax("return true")
             }
           } else {
-            SwitchCaseSyntax("case (.\(token.varOrCaseName)(let lhsText), .\(token.varOrCaseName)(let rhsText)):") {
+            SwitchCaseSyntax("case (.\(tokenSpec.varOrCaseName)(let lhsText), .\(tokenSpec.varOrCaseName)(let rhsText)):") {
               StmtSyntax("return lhsText == rhsText")
             }
           }
@@ -139,8 +139,8 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     public enum RawTokenKind: UInt8, Equatable, Hashable
     """
   ) {
-    for token in SYNTAX_TOKENS {
-      DeclSyntax("case \(token.varOrCaseName)")
+    for tokenSpec in Token.allCases.map(\.spec) {
+      DeclSyntax("case \(tokenSpec.varOrCaseName)")
     }
 
     try VariableDeclSyntax(
@@ -150,9 +150,9 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch self") {
-        for token in SYNTAX_TOKENS {
-          if let text = token.text {
-            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
+        for tokenSpec in Token.allCases.map(\.spec) {
+          if let text = tokenSpec.text {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
               StmtSyntax("return #\"\(raw: text)\"#")
             }
           }
@@ -175,9 +175,9 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch self") {
-        for token in SYNTAX_TOKENS {
-          SwitchCaseSyntax("case .\(token.varOrCaseName):") {
-            StmtSyntax("return \(raw: token.kind == .punctuation)")
+        for tokenSpec in Token.allCases.map(\.spec) {
+          SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
+            StmtSyntax("return \(raw: tokenSpec.kind == .punctuation)")
           }
         }
       }
@@ -193,9 +193,9 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch rawKind") {
-        for token in SYNTAX_TOKENS {
-          if token.kind == .keyword {
-            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
+        for tokenSpec in Token.allCases.map(\.spec) {
+          if tokenSpec.kind == .keyword {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
               DeclSyntax("var text = text")
               StmtSyntax(
                 """
@@ -205,14 +205,14 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                 """
               )
             }
-          } else if token.text != nil {
-            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
+          } else if tokenSpec.text != nil {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
               ExprSyntax("precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)")
-              StmtSyntax("return .\(token.varOrCaseName)")
+              StmtSyntax("return .\(tokenSpec.varOrCaseName)")
             }
           } else {
-            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
-              StmtSyntax("return .\(token.varOrCaseName)(text)")
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
+              StmtSyntax("return .\(tokenSpec.varOrCaseName)(text)")
             }
           }
         }
@@ -228,18 +228,18 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch self") {
-        for token in SYNTAX_TOKENS {
-          if token.kind == .keyword {
-            SwitchCaseSyntax("case .\(token.varOrCaseName)(let keyword):") {
-              StmtSyntax("return (.\(token.varOrCaseName), String(syntaxText: keyword.defaultText))")
+        for tokenSpec in Token.allCases.map(\.spec) {
+          if tokenSpec.kind == .keyword {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName)(let keyword):") {
+              StmtSyntax("return (.\(tokenSpec.varOrCaseName), String(syntaxText: keyword.defaultText))")
             }
-          } else if token.text != nil {
-            SwitchCaseSyntax("case .\(token.varOrCaseName):") {
-              StmtSyntax("return (.\(token.varOrCaseName), nil)")
+          } else if tokenSpec.text != nil {
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName):") {
+              StmtSyntax("return (.\(tokenSpec.varOrCaseName), nil)")
             }
           } else {
-            SwitchCaseSyntax("case .\(token.varOrCaseName)(let str):") {
-              StmtSyntax("return (.\(token.varOrCaseName), str)")
+            SwitchCaseSyntax("case .\(tokenSpec.varOrCaseName)(let str):") {
+              StmtSyntax("return (.\(tokenSpec.varOrCaseName), str)")
             }
           }
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
@@ -17,17 +17,17 @@ import Utils
 
 let tokensFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! ExtensionDeclSyntax("extension TokenSyntax") {
-    for token in SYNTAX_TOKENS {
-      if let text = token.text {
+    for tokenSpec in Token.allCases.map(\.spec) {
+      if let text = tokenSpec.text {
         DeclSyntax(
           """
-          public static func \(token.varOrCaseName)Token(
+          public static func \(tokenSpec.varOrCaseName)Token(
             leadingTrivia: Trivia = [],
             trailingTrivia: Trivia = [],
             presence: SourcePresence = .present
           ) -> TokenSyntax {
             return TokenSyntax(
-              .\(token.varOrCaseName),
+              .\(tokenSpec.varOrCaseName),
               leadingTrivia: leadingTrivia,
               trailingTrivia: trailingTrivia,
               presence: presence
@@ -35,17 +35,17 @@ let tokensFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           }
           """
         )
-      } else if token.kind == .keyword {
+      } else if tokenSpec.kind == .keyword {
         DeclSyntax(
           """
-          public static func \(token.varOrCaseName)(
+          public static func \(tokenSpec.varOrCaseName)(
             _ value: Keyword,
             leadingTrivia: Trivia = [],
             trailingTrivia: Trivia = [],
             presence: SourcePresence = .present
           ) -> TokenSyntax {
             return TokenSyntax(
-              .\(token.varOrCaseName)(value),
+              .\(tokenSpec.varOrCaseName)(value),
               leadingTrivia: leadingTrivia,
               trailingTrivia: trailingTrivia,
               presence: presence
@@ -56,14 +56,14 @@ let tokensFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       } else {
         DeclSyntax(
           """
-          public static func \(token.varOrCaseName)(
+          public static func \(tokenSpec.varOrCaseName)(
             _ text: String,
             leadingTrivia: Trivia = [],
             trailingTrivia: Trivia = [],
             presence: SourcePresence = .present
           ) -> TokenSyntax {
             return TokenSyntax(
-              .\(token.varOrCaseName)(text),
+              .\(tokenSpec.varOrCaseName)(text),
               leadingTrivia: leadingTrivia,
               trailingTrivia: trailingTrivia,
               presence: presence

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -91,7 +91,7 @@ fileprivate extension Child {
     guard childIndex + 2 < node.children.count else {
       return false
     }
-    if case .token(choices: [.token(tokenKind: "ColonToken")], _, _) = node.children[childIndex + 2].kind {
+    if case .token(choices: [.token(.colon)], _, _) = node.children[childIndex + 2].kind {
       return true
     } else {
       return false
@@ -178,16 +178,16 @@ class ValidateSyntaxNodes: XCTestCase {
         }
       }
 
-    case .token(tokenKind: "IdentifierToken"), .token(tokenKind: "IntegerLiteralToken"), .token(tokenKind: "FloatLiteralToken"):
+    case .token(.identifier), .token(.integerLiteral), .token(.floatLiteral):
       // We allow arbitrary naming of identifiers and literals
       break
-    case .token(tokenKind: "CommaToken"):
+    case .token(.comma):
       if child.name != "TrailingComma" && child.name != "Comma" {
         return "child '\(child.name)' has a comma keyword as its only token choice and should thus be named 'Comma' or 'TrailingComma'"
       }
-    case .token(tokenKind: let tokenKind):
+    case .token(let token):
       let expectedChildName =
-        tokenKind
+        token.spec.varOrCaseName.text.withFirstCharacterUppercased
         .dropSuffix("Token")
         .dropPrefix("Prefix")
         .dropPrefix("Infix")


### PR DESCRIPTION
The CodeGeneration module was previously referring to tokens using string-based references like `IdentifierToken`, which is not idiomatic Swift. To make the code more concise and in line with Swift's best practices, this commit introduces a `Token` enum in the `TokenSpec.swift` file. 
Now, instead of string-based references, the new `Token` enum contains all the possible token kinds. It also includes a computed property that returns the corresponding `TokenSpec` for a given token, allowing for more concise and idiomatic references. 
The code has been refactored to replace all string-based token references with members of the newly introduced `Token` enum. Associated tests have also been updated to reflect these changes.

Resolves #1978 