### PR TITLE
Add some documentation for nodes that have unintuitive behavior on first sight

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -16,6 +16,20 @@ public let ATTRIBUTE_NODES: [Node] = [
     kind: .attributeList,
     base: .syntaxCollection,
     nameForDiagnostics: "attributes",
+    documentation: """
+      A list of attributes that can be attached to a declaration.
+
+      An element in this collection can either be an attribute itself or an ``IfConfigDeclSyntax``
+      that contains attributes. This is because attributes can be added conditional on compilcation
+      conditions, for example.
+
+      ```swift
+      #if !DISABLE_DEPRECATIONS
+      @available(*, deprecated)
+      #endif
+      func myFunction() {}
+      ```
+      """,
     elementChoices: [.attribute, .ifConfigDecl]
   ),
 

--- a/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
@@ -125,6 +125,13 @@ public let AVAILABILITY_NODES: [Node] = [
         name: "Version",
         kind: .node(kind: .versionTuple),
         nameForDiagnostics: "version",
+        documentation: """
+          The version of this platform.
+
+          This parameter is optional because a custom platform alias can be specified using the `-define-availability` 
+          argument to the Swift compiler. For example, when passing `-define-availability "_iOS8Aligned:macOS 10.10, iOS 8.0"`
+          to the Swift compiler, then `@available(_iOS8Aligned, *)` is interpreted as `@available(macOS 10.10, iOS 8.0, *)`.
+          """,
         isOptional: true
       ),
     ]

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/BuildableCollectionNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/BuildableCollectionNodesFile.swift
@@ -22,14 +22,8 @@ let buildableCollectionNodesFile = SourceFileSyntax(leadingTrivia: copyrightHead
   for node in SYNTAX_NODES.compactMap(\.collectionNode) {
     let elementType = node.collectionElementType
 
-    let docComment =
-      node.documentation.isEmpty
-      ? [.docLineComment("/// `\(node.kind.syntaxType)` represents a collection of `\(elementType.syntaxBaseName)`")]
-      : node.documentation
-    // Generate collection node struct
     try! ExtensionDeclSyntax(
       """
-      \(docComment)
       extension \(raw: node.type.syntaxBaseName): ExpressibleByArrayLiteral
       """
     ) {

--- a/Sources/SwiftSyntax/Documentation.docc/Glossary.md
+++ b/Sources/SwiftSyntax/Documentation.docc/Glossary.md
@@ -13,6 +13,8 @@ To avoid ongoing repetition of common long terms, SwiftSyntax uses a couple of a
 
 **Expr** Abbreviation for *Expression*
 
+**IfConfig** Abbrevation for *If Configuration*`. Refers to `#if` clauses in the source code.
+
 **Layout Node** A layout node can have an arbitrary number of children and provides structure to the syntax tree. All ``Syntax`` nodes that aren’t ``TokenSyntax`` are layout nodes. For example a ``StructDeclSyntax`` consists of, among others, of the `struct` keyword, the name and the `memberBlock`. The latter is again a layout node that contains multiple children. Layout nodes never represent any source code in the syntax tree by themselves. All source code within the syntax tree is represented by *tokens*.
 
 **Node** A *layout node* or *token*

--- a/Sources/SwiftSyntax/Documentation.docc/Glossary.md
+++ b/Sources/SwiftSyntax/Documentation.docc/Glossary.md
@@ -13,7 +13,7 @@ To avoid ongoing repetition of common long terms, SwiftSyntax uses a couple of a
 
 **Expr** Abbreviation for *Expression*
 
-**IfConfig** Abbrevation for *If Configuration*`. Refers to `#if` clauses in the source code.
+**IfConfig** Abbrevation for *If Configuration*. Refers to `#if` clauses in the source code.
 
 **Layout Node** A layout node can have an arbitrary number of children and provides structure to the syntax tree. All ``Syntax`` nodes that aren’t ``TokenSyntax`` are layout nodes. For example a ``StructDeclSyntax`` consists of, among others, of the `struct` keyword, the name and the `memberBlock`. The latter is again a layout node that contains multiple children. Layout nodes never represent any source code in the syntax tree by themselves. All source code within the syntax tree is represented by *tokens*.
 

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -56,6 +56,19 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   public static let syntaxKind = SyntaxKind.arrayElementList
 }
 
+/// A list of attributes that can be attached to a declaration.
+/// 
+/// An element in this collection can either be an attribute itself or an ``IfConfigDeclSyntax``
+/// that contains attributes. This is because attributes can be added conditional on compilcation
+/// conditions, for example.
+/// 
+/// ```swift
+/// #if !DISABLE_DEPRECATIONS
+/// @available(*, deprecated)
+/// #endif
+/// func myFunction() {}
+/// ```
+///
 /// ### Children
 /// 
 /// (``AttributeSyntax`` | ``IfConfigDeclSyntax``) `*`

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -14481,6 +14481,7 @@ public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable {
   /// - Parameters:
   ///   - leadingTrivia: Trivia to be prepended to the leading trivia of the node’s first token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   ///   - platform: The name of the OS on which the availability should be restricted or 'swift' if the availability should be restricted based on a Swift version.
+  ///   - version: The version of this platform.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
       leadingTrivia: Trivia? = nil,
@@ -14549,6 +14550,11 @@ public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The version of this platform.
+  /// 
+  /// This parameter is optional because a custom platform alias can be specified using the `-define-availability` 
+  /// argument to the Swift compiler. For example, when passing `-define-availability "_iOS8Aligned:macOS 10.10, iOS 8.0"`
+  /// to the Swift compiler, then `@available(_iOS8Aligned, *)` is interpreted as `@available(macOS 10.10, iOS 8.0, *)`.
   public var version: VersionTupleSyntax? {
     get {
       return data.child(at: 3, parent: Syntax(self)).map(VersionTupleSyntax.init)

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
@@ -14,165 +14,132 @@
 
 import SwiftSyntax
 
-/// `AccessorDeclListSyntax` represents a collection of `AccessorDeclSyntax`
 extension AccessorDeclListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `ArrayElementListSyntax` represents a collection of `ArrayElementSyntax`
 extension ArrayElementListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// A list of attributes that can be attached to a declaration.
-/// 
-/// An element in this collection can either be an attribute itself or an ``IfConfigDeclSyntax``
-/// that contains attributes. This is because attributes can be added conditional on compilcation
-/// conditions, for example.
-/// 
-/// ```swift
-/// #if !DISABLE_DEPRECATIONS
-/// @available(*, deprecated)
-/// #endif
-/// func myFunction() {}
-/// ```
 extension AttributeListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `AvailabilityArgumentListSyntax` represents a collection of `AvailabilityArgumentSyntax`
 extension AvailabilityArgumentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `CatchClauseListSyntax` represents a collection of `CatchClauseSyntax`
 extension CatchClauseListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `CatchItemListSyntax` represents a collection of `CatchItemSyntax`
 extension CatchItemListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `ClosureCaptureListSyntax` represents a collection of `ClosureCaptureSyntax`
 extension ClosureCaptureListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `ClosureParameterListSyntax` represents a collection of `ClosureParameterSyntax`
 extension ClosureParameterListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `ClosureShorthandParameterListSyntax` represents a collection of `ClosureShorthandParameterSyntax`
 extension ClosureShorthandParameterListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `CodeBlockItemListSyntax` represents a collection of `CodeBlockItemSyntax`
 extension CodeBlockItemListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `CompositionTypeElementListSyntax` represents a collection of `CompositionTypeElementSyntax`
 extension CompositionTypeElementListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `ConditionElementListSyntax` represents a collection of `ConditionElementSyntax`
 extension ConditionElementListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `DeclModifierListSyntax` represents a collection of `DeclModifierSyntax`
 extension DeclModifierListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `DeclNameArgumentListSyntax` represents a collection of `DeclNameArgumentSyntax`
 extension DeclNameArgumentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `DesignatedTypeListSyntax` represents a collection of `DesignatedTypeSyntax`
 extension DesignatedTypeListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `DictionaryElementListSyntax` represents a collection of `DictionaryElementSyntax`
 extension DictionaryElementListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `DifferentiabilityArgumentListSyntax` represents a collection of `DifferentiabilityArgumentSyntax`
 extension DifferentiabilityArgumentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// The arguments of the '@_documentation' attribute
 extension DocumentationAttributeArgumentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// The arguments of the '@_effects' attribute. These will be parsed during the SIL stage.
 extension EffectsAttributeArgumentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// A collection of 0 or more `EnumCaseElement`s.
 extension EnumCaseElementListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `EnumCaseParameterListSyntax` represents a collection of `EnumCaseParameterSyntax`
 extension EnumCaseParameterListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// A list of expressions connected by operators. This list is contained by a ``SequenceExprSyntax``.
 extension ExprListSyntax: ExpressibleByArrayLiteral {
   public init(_ elements: [ExprSyntaxProtocol]) {
     self = ExprListSyntax(elements.map {
@@ -185,168 +152,144 @@ extension ExprListSyntax: ExpressibleByArrayLiteral {
   }
 }
 
-/// `FunctionParameterListSyntax` represents a collection of `FunctionParameterSyntax`
 extension FunctionParameterListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `GenericArgumentListSyntax` represents a collection of `GenericArgumentSyntax`
 extension GenericArgumentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `GenericParameterListSyntax` represents a collection of `GenericParameterSyntax`
 extension GenericParameterListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `GenericRequirementListSyntax` represents a collection of `GenericRequirementSyntax`
 extension GenericRequirementListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `IfConfigClauseListSyntax` represents a collection of `IfConfigClauseSyntax`
 extension IfConfigClauseListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `ImportPathComponentListSyntax` represents a collection of `ImportPathComponentSyntax`
 extension ImportPathComponentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `InheritedTypeListSyntax` represents a collection of `InheritedTypeSyntax`
 extension InheritedTypeListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `KeyPathComponentListSyntax` represents a collection of `KeyPathComponentSyntax`
 extension KeyPathComponentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `LabeledExprListSyntax` represents a collection of `LabeledExprSyntax`
 extension LabeledExprListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `MemberBlockItemListSyntax` represents a collection of `MemberBlockItemSyntax`
 extension MemberBlockItemListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `MultipleTrailingClosureElementListSyntax` represents a collection of `MultipleTrailingClosureElementSyntax`
 extension MultipleTrailingClosureElementListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `ObjCSelectorPieceListSyntax` represents a collection of `ObjCSelectorPieceSyntax`
 extension ObjCSelectorPieceListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `PatternBindingListSyntax` represents a collection of `PatternBindingSyntax`
 extension PatternBindingListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `PlatformVersionItemListSyntax` represents a collection of `PlatformVersionItemSyntax`
 extension PlatformVersionItemListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `PrecedenceGroupAttributeListSyntax` represents a collection of `Syntax`
 extension PrecedenceGroupAttributeListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `PrecedenceGroupNameListSyntax` represents a collection of `PrecedenceGroupNameSyntax`
 extension PrecedenceGroupNameListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `PrimaryAssociatedTypeListSyntax` represents a collection of `PrimaryAssociatedTypeSyntax`
 extension PrimaryAssociatedTypeListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// A collection of arguments for the `@_specialize` attribute
 extension SpecializeAttributeArgumentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `StringLiteralSegmentListSyntax` represents a collection of `Syntax`
 extension StringLiteralSegmentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `SwitchCaseItemListSyntax` represents a collection of `SwitchCaseItemSyntax`
 extension SwitchCaseItemListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `SwitchCaseListSyntax` represents a collection of `Syntax`
 extension SwitchCaseListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `TuplePatternElementListSyntax` represents a collection of `TuplePatternElementSyntax`
 extension TuplePatternElementListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `TupleTypeElementListSyntax` represents a collection of `TupleTypeElementSyntax`
 extension TupleTypeElementListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// A collection of syntax nodes that occurred in the source code but could not be used to form a valid syntax tree.
 extension UnexpectedNodesSyntax: ExpressibleByArrayLiteral {
   public init(_ elements: [SyntaxProtocol]) {
     self = UnexpectedNodesSyntax(elements.map {
@@ -359,14 +302,12 @@ extension UnexpectedNodesSyntax: ExpressibleByArrayLiteral {
   }
 }
 
-/// `VersionComponentListSyntax` represents a collection of `VersionComponentSyntax`
 extension VersionComponentListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }
 }
 
-/// `YieldedExpressionListSyntax` represents a collection of `YieldedExpressionSyntax`
 extension YieldedExpressionListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
@@ -28,7 +28,18 @@ extension ArrayElementListSyntax: ExpressibleByArrayLiteral {
   }
 }
 
-/// `AttributeListSyntax` represents a collection of `Syntax`
+/// A list of attributes that can be attached to a declaration.
+/// 
+/// An element in this collection can either be an attribute itself or an ``IfConfigDeclSyntax``
+/// that contains attributes. This is because attributes can be added conditional on compilcation
+/// conditions, for example.
+/// 
+/// ```swift
+/// #if !DISABLE_DEPRECATIONS
+/// @available(*, deprecated)
+/// #endif
+/// func myFunction() {}
+/// ```
 extension AttributeListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)


### PR DESCRIPTION
Just adds a little documentation for nodes that we know have confused users of SwiftSyntax.

While at it: Don’t generate doc comments for extensions in `BuildableCollectionNodesFile.swift`. These doc comments served absolutely no purpose.