### PR TITLE
Allow trivia to be added to `SyntaxStringInterpolation` without adding a `raw:` label

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -54,7 +54,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     try! StructDeclSyntax(
       """
-      \(raw: node.documentation)
+      \(node.documentation)
       public struct \(node.kind.syntaxType): \(node.kind.protocolType), SyntaxHashable
       """
     ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -32,7 +32,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     try! StructDeclSyntax(
       """
-      \(raw: documentation)
+      \(documentation)
       public struct \(node.kind.syntaxType): SyntaxCollection, SyntaxHashable
       """
     ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -39,7 +39,7 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
         """
         // MARK: - \(raw: node.kind.syntaxType)
 
-        \(raw: documentation)
+        \(documentation)
         public struct \(raw: node.kind.syntaxType): \(raw: node.baseType.syntaxBaseName)Protocol, SyntaxHashable
         """
       ) {
@@ -78,7 +78,7 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
 
         try! InitializerDeclSyntax(
           """
-          \(raw: node.generateInitializerDocComment())
+          \(node.generateInitializerDocComment())
           \(node.generateInitializerDeclHeader())
           """
         ) {
@@ -163,7 +163,7 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
 
           try! VariableDeclSyntax(
             """
-            \(raw: child.documentation)
+            \(child.documentation)
             public var \(child.varOrCaseName.backtickedIfNeeded): \(type)
             """
           ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -21,14 +21,14 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       // MARK: - \(trait.protocolName)
 
-      \(raw: trait.documentation)
+      \(trait.documentation)
       public protocol \(trait.protocolName): SyntaxProtocol
       """
     ) {
       for child in trait.children {
         DeclSyntax(
           """
-          \(raw: child.documentation)
+          \(child.documentation)
           var \(child.varOrCaseName): \(child.syntaxNodeKind.syntaxType)\(raw: child.isOptional ? "?" : "") { get set }
           """
         )

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/BuildableCollectionNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/BuildableCollectionNodesFile.swift
@@ -29,7 +29,7 @@ let buildableCollectionNodesFile = SourceFileSyntax(leadingTrivia: copyrightHead
     // Generate collection node struct
     try! ExtensionDeclSyntax(
       """
-      \(raw: docComment)
+      \(docComment)
       extension \(raw: node.type.syntaxBaseName): ExpressibleByArrayLiteral
       """
     ) {

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -104,6 +104,12 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
     self.appendInterpolation(buildable.formatted(using: format))
   }
 
+  public mutating func appendInterpolation(
+    _ trivia: Trivia
+  ) {
+    self.appendInterpolation(raw: trivia.description)
+  }
+
   /// Interpolates a literal or similar expression syntax equivalent to `value`.
   ///
   /// - SeeAlso: ``SwiftSyntax/ExprSyntax/init(literal:)``


### PR DESCRIPTION
`Trivia` is a first-class citizen in SwiftSyntax and you shouldn’t need to add `raw` in front of it to add it to `SyntaxStringInterpolation`.