### PR TITLE
Ensure that the `deprecatedName` starts with an uppercase letter

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Child.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Child.swift
@@ -185,9 +185,8 @@ public class Child {
     documentation: String? = nil,
     isOptional: Bool = false
   ) {
-    if let firstCharInName = name.first {
-      precondition(firstCharInName.isUppercase == true, "The first letter of a child’s name should be uppercase")
-    }
+    precondition(name.first?.isUppercase ?? true, "The first letter of a child’s name should be uppercase")
+    precondition(deprecatedName?.first?.isUppercase ?? true, "The first letter of a child’s name should be uppercase")
     self.name = name
     self.deprecatedName = deprecatedName
     self.kind = kind

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -192,7 +192,7 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "Parameters",
-        deprecatedName: "arguments",
+        deprecatedName: "Arguments",
         kind: .collection(kind: .tupleTypeElementList, collectionElementName: "Parameter", deprecatedCollectionElementName: "Argument")
       ),
       Child(

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -3361,7 +3361,7 @@ extension FunctionSignatureSyntax {
 
 extension FunctionTypeSyntax {
   @available(*, deprecated, renamed: "unexpectedBetweenLeftParenAndParameters")
-  public var unexpectedBetweenLeftParenAndarguments: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? {
     get {
       return unexpectedBetweenLeftParenAndParameters
     }
@@ -3386,7 +3386,7 @@ extension FunctionTypeSyntax {
   }
   
   @available(*, deprecated, renamed: "unexpectedBetweenParametersAndRightParen")
-  public var unexpectedBetweenargumentsAndRightParen: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? {
     get {
       return unexpectedBetweenParametersAndRightParen
     }
@@ -3431,9 +3431,9 @@ extension FunctionTypeSyntax {
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
       leftParen: TokenSyntax = .leftParenToken(),
-      _ unexpectedBetweenLeftParenAndarguments: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil,
       arguments: TupleTypeElementListSyntax,
-      _ unexpectedBetweenargumentsAndRightParen: UnexpectedNodesSyntax? = nil,
+      _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil,
       rightParen: TokenSyntax = .rightParenToken(),
       _ unexpectedBetweenRightParenAndEffectSpecifiers: UnexpectedNodesSyntax? = nil,
       effectSpecifiers: TypeEffectSpecifiersSyntax? = nil,
@@ -3447,9 +3447,9 @@ extension FunctionTypeSyntax {
         leadingTrivia: leadingTrivia, 
         unexpectedBeforeLeftParen, 
         leftParen: leftParen, 
-        unexpectedBetweenLeftParenAndarguments, 
+        unexpectedBetweenLeftParenAndArguments, 
         parameters: arguments, 
-        unexpectedBetweenargumentsAndRightParen, 
+        unexpectedBetweenArgumentsAndRightParen, 
         rightParen: rightParen, 
         unexpectedBetweenRightParenAndEffectSpecifiers, 
         effectSpecifiers: effectSpecifiers, 


### PR DESCRIPTION
Add the same verification that we have for child names. It uncovered one issue.