### PR TITLE
Change `substructure` parameter of `assertParse` to `some SyntaxProtocol`

### DIFF
--- a/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
+++ b/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
@@ -72,9 +72,9 @@ public func assertIncrementalParse(
   )
 
   // Substructure
-  let subtreeMatcher = SubtreeMatcher(Syntax(incrementallyParsedNewTree), markers: [:])
+  let subtreeMatcher = SubtreeMatcher(incrementallyParsedNewTree, markers: [:])
   do {
-    try subtreeMatcher.assertSameStructure(Syntax(newTree), includeTrivia: true, file: file, line: line)
+    try subtreeMatcher.assertSameStructure(newTree, includeTrivia: true, file: file, line: line)
   } catch {
     XCTFail("Matching for a subtree failed with error: \(error)", file: file, line: line)
   }

--- a/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
+++ b/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
@@ -88,15 +88,15 @@ public struct SubtreeMatcher {
     self.actualTree = try parse(text)
   }
 
-  public init(_ actualTree: Syntax, markers: [String: Int]) {
+  public init(_ actualTree: some SyntaxProtocol, markers: [String: Int]) {
     self.markers = markers.isEmpty ? ["DEFAULT": 0] : markers
-    self.actualTree = actualTree
+    self.actualTree = Syntax(actualTree)
   }
 
   /// Same as `Syntax.findFirstDifference(baseline:includeTrivia:)`, but
   /// matches against the first subtree from parsing `markedText` that is after
   /// `afterMarker` with the root matching the root type of `baseline`.
-  public func findFirstDifference(afterMarker: String? = nil, baseline: Syntax, includeTrivia: Bool = false) throws -> TreeDifference? {
+  public func findFirstDifference(afterMarker: String? = nil, baseline: some SyntaxProtocol, includeTrivia: Bool = false) throws -> TreeDifference? {
     let afterMarker = afterMarker ?? markers.first!.key
     guard let subtreeStart = markers[afterMarker] else {
       throw SubtreeError.invalidMarker(name: afterMarker)
@@ -113,7 +113,7 @@ public struct SubtreeMatcher {
   /// `init(markedText:)` has the same structure as `expected`.
   public func assertSameStructure(
     afterMarker: String? = nil,
-    _ expected: Syntax,
+    _ expected: some SyntaxProtocol,
     includeTrivia: Bool = false,
     additionalInfo: String? = nil,
     file: StaticString = #filePath,

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -90,9 +90,9 @@ extension OperatorTable {
     XCTAssertFalse(parenthesizedSyntax.containsExprSequence)
 
     // Make sure the two have the same structure.
-    let subtreeMatcher = SubtreeMatcher(Syntax(foldedSyntax), markers: [:])
+    let subtreeMatcher = SubtreeMatcher(foldedSyntax, markers: [:])
     do {
-      try subtreeMatcher.assertSameStructure(Syntax(parenthesizedSyntax))
+      try subtreeMatcher.assertSameStructure(parenthesizedSyntax)
     } catch {
       XCTFail("Matching for a subtree failed with error: \(error)")
     }

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -531,7 +531,7 @@ public struct AssertParseOptions: OptionSet {
 /// parsing the resulting `String` as a ``SourceFileSyntax``.
 func assertParse(
   _ markedSource: String,
-  substructure expectedSubstructure: Syntax? = nil,
+  substructure expectedSubstructure: (some SyntaxProtocol)? = Optional<Syntax>.none,
   substructureAfterMarker: String = "START",
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   applyFixIts: [String]? = nil,
@@ -609,7 +609,7 @@ fileprivate func assertRoundTrip<S: SyntaxProtocol>(
 func assertParse<S: SyntaxProtocol>(
   _ markedSource: String,
   _ parse: (inout Parser) -> S,
-  substructure expectedSubstructure: Syntax? = nil,
+  substructure expectedSubstructure: (some SyntaxProtocol)? = Optional<Syntax>.none,
   substructureAfterMarker: String = "START",
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   applyFixIts: [String]? = nil,
@@ -648,11 +648,11 @@ func assertParse<S: SyntaxProtocol>(
 
   // Substructure
   if let expectedSubstructure {
-    let subtreeMatcher = SubtreeMatcher(Syntax(tree), markers: markerLocations)
+    let subtreeMatcher = SubtreeMatcher(tree, markers: markerLocations)
     do {
       try subtreeMatcher.assertSameStructure(
         afterMarker: substructureAfterMarker,
-        Syntax(expectedSubstructure),
+        expectedSubstructure,
         includeTrivia: options.contains(.substructureCheckTrivia),
         file: file,
         line: line
@@ -760,9 +760,9 @@ func assertBasicFormat<S: SyntaxProtocol>(
   let formattedReparsed = Syntax(parse(&formattedParser))
 
   do {
-    let subtreeMatcher = SubtreeMatcher(Syntax(formattedReparsed), markers: [:])
+    let subtreeMatcher = SubtreeMatcher(formattedReparsed, markers: [:])
     try subtreeMatcher.assertSameStructure(
-      Syntax(sourceTree),
+      sourceTree,
       includeTrivia: false,
       additionalInfo: """
         Removing trivia, formatting using BasicFormat and re-parsing did not produce the same syntax tree.

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -149,7 +149,7 @@ final class AttributeTests: XCTestCase {
       @1️⃣rethrows
       protocol P { }
       """,
-      substructure: Syntax(TokenSyntax.identifier("rethrows")),
+      substructure: TokenSyntax.identifier("rethrows"),
       substructureAfterMarker: "1️⃣"
     )
   }
@@ -327,7 +327,7 @@ final class AttributeTests: XCTestCase {
       assertParse(
         "@_implements(1️⃣\(baseType), f())",
         AttributeSyntax.parse,
-        substructure: Syntax(TypeSyntax.parse(from: &parser)),
+        substructure: TypeSyntax.parse(from: &parser),
         substructureAfterMarker: "1️⃣",
         line: line
       )

--- a/Tests/SwiftParserTest/AvailabilityTests.swift
+++ b/Tests/SwiftParserTest/AvailabilityTests.swift
@@ -106,10 +106,8 @@ final class AvailabilityTests: XCTestCase {
       @available(OSX 10)
       func test() {}
       """,
-      substructure: Syntax(
-        VersionTupleSyntax(
-          major: .integerLiteral("10")
-        )
+      substructure: VersionTupleSyntax(
+        major: .integerLiteral("10")
       )
     )
 
@@ -118,11 +116,9 @@ final class AvailabilityTests: XCTestCase {
       @available(OSX 10.0)
       func test() {}
       """,
-      substructure: Syntax(
-        VersionTupleSyntax(
-          major: .integerLiteral("10"),
-          components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])
-        )
+      substructure: VersionTupleSyntax(
+        major: .integerLiteral("10"),
+        components: VersionComponentListSyntax([VersionComponentSyntax(number: .integerLiteral("0"))])
       )
     )
 
@@ -131,14 +127,12 @@ final class AvailabilityTests: XCTestCase {
       @available(OSX 10.0.1)
       func test() {}
       """,
-      substructure: Syntax(
-        VersionTupleSyntax(
-          major: .integerLiteral("10"),
-          components: VersionComponentListSyntax([
-            VersionComponentSyntax(number: .integerLiteral("0")),
-            VersionComponentSyntax(number: .integerLiteral("1")),
-          ])
-        )
+      substructure: VersionTupleSyntax(
+        major: .integerLiteral("10"),
+        components: VersionComponentListSyntax([
+          VersionComponentSyntax(number: .integerLiteral("0")),
+          VersionComponentSyntax(number: .integerLiteral("1")),
+        ])
       )
     )
 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -84,13 +84,11 @@ final class DeclarationTests: XCTestCase {
       """
       func name(_ default: Int) {}
       """,
-      substructure: Syntax(
-        FunctionParameterSyntax(
-          firstName: .wildcardToken(),
-          secondName: .identifier("default"),
-          colon: .colonToken(),
-          type: IdentifierTypeSyntax(name: .identifier("Int"))
-        )
+      substructure: FunctionParameterSyntax(
+        firstName: .wildcardToken(),
+        secondName: .identifier("default"),
+        colon: .colonToken(),
+        type: IdentifierTypeSyntax(name: .identifier("Int"))
       )
     )
   }
@@ -807,16 +805,14 @@ final class DeclarationTests: XCTestCase {
         func withParameters() {}
       }
       """,
-      substructure: Syntax(
-        FunctionDeclSyntax(
-          funcKeyword: .keyword(.func),
-          name: .identifier("withoutParameters"),
-          signature: FunctionSignatureSyntax(
-            parameterClause: FunctionParameterClauseSyntax(
-              leftParen: .leftParenToken(presence: .missing),
-              parameters: FunctionParameterListSyntax([]),
-              rightParen: .rightParenToken(presence: .missing)
-            )
+      substructure: FunctionDeclSyntax(
+        funcKeyword: .keyword(.func),
+        name: .identifier("withoutParameters"),
+        signature: FunctionSignatureSyntax(
+          parameterClause: FunctionParameterClauseSyntax(
+            leftParen: .leftParenToken(presence: .missing),
+            parameters: FunctionParameterListSyntax([]),
+            rightParen: .rightParenToken(presence: .missing)
           )
         )
       ),
@@ -1009,20 +1005,18 @@ final class DeclarationTests: XCTestCase {
         var prop : Int { get 1️⃣bogus rethrows set }
       }
       """,
-      substructure: Syntax(
-        AccessorBlockSyntax(
-          accessors: .accessors(
-            AccessorDeclListSyntax([
-              AccessorDeclSyntax(
-                accessorSpecifier: .keyword(.get)
-              )
-            ])
-          ),
-          UnexpectedNodesSyntax([
-            TokenSyntax.identifier("bogus"), TokenSyntax.keyword(.rethrows),
-            TokenSyntax.identifier("set"),
+      substructure: AccessorBlockSyntax(
+        accessors: .accessors(
+          AccessorDeclListSyntax([
+            AccessorDeclSyntax(
+              accessorSpecifier: .keyword(.get)
+            )
           ])
-        )
+        ),
+        UnexpectedNodesSyntax([
+          TokenSyntax.identifier("bogus"), TokenSyntax.keyword(.rethrows),
+          TokenSyntax.identifier("set"),
+        ])
       ),
       diagnostics: [
         DiagnosticSpec(message: "unexpected code 'bogus rethrows set' in variable")
@@ -1107,14 +1101,12 @@ final class DeclarationTests: XCTestCase {
   func testRecoverOneExtraLabel() {
     assertParse(
       "func test(first second 1️⃣third: Int)",
-      substructure: Syntax(
-        FunctionParameterSyntax(
-          firstName: .identifier("first"),
-          secondName: .identifier("second"),
-          UnexpectedNodesSyntax([TokenSyntax.identifier("third")]),
-          colon: .colonToken(),
-          type: IdentifierTypeSyntax(name: .identifier("Int"))
-        )
+      substructure: FunctionParameterSyntax(
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        UnexpectedNodesSyntax([TokenSyntax.identifier("third")]),
+        colon: .colonToken(),
+        type: IdentifierTypeSyntax(name: .identifier("Int"))
       ),
       diagnostics: [
         DiagnosticSpec(message: "unexpected code 'third' in parameter")
@@ -1125,14 +1117,12 @@ final class DeclarationTests: XCTestCase {
   func testRecoverTwoExtraLabels() {
     assertParse(
       "func test(first second 1️⃣third fourth: Int)",
-      substructure: Syntax(
-        FunctionParameterSyntax(
-          firstName: .identifier("first"),
-          secondName: .identifier("second"),
-          UnexpectedNodesSyntax([TokenSyntax.identifier("third"), TokenSyntax.identifier("fourth")]),
-          colon: .colonToken(),
-          type: IdentifierTypeSyntax(name: .identifier("Int"))
-        )
+      substructure: FunctionParameterSyntax(
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        UnexpectedNodesSyntax([TokenSyntax.identifier("third"), TokenSyntax.identifier("fourth")]),
+        colon: .colonToken(),
+        type: IdentifierTypeSyntax(name: .identifier("Int"))
       ),
       diagnostics: [
         DiagnosticSpec(message: "unexpected code 'third fourth' in parameter")
@@ -1143,13 +1133,11 @@ final class DeclarationTests: XCTestCase {
   func testDontRecoverFromDeclKeyword() {
     assertParse(
       "func fooℹ️(first second 1️⃣third 2️⃣struct3️⃣: Int4️⃣) {}",
-      substructure: Syntax(
-        FunctionParameterSyntax(
-          firstName: .identifier("first"),
-          secondName: .identifier("second"),
-          colon: .colonToken(presence: .missing),
-          type: IdentifierTypeSyntax(name: .identifier("third"))
-        )
+      substructure: FunctionParameterSyntax(
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        colon: .colonToken(presence: .missing),
+        type: IdentifierTypeSyntax(name: .identifier("third"))
       ),
       diagnostics: [
         DiagnosticSpec(
@@ -1182,19 +1170,17 @@ final class DeclarationTests: XCTestCase {
   func testRecoverFromParens() {
     assertParse(
       "func test(first second 1️⃣[third fourth]: Int)",
-      substructure: Syntax(
-        FunctionParameterSyntax(
-          firstName: .identifier("first"),
-          secondName: .identifier("second"),
-          UnexpectedNodesSyntax([
-            TokenSyntax.leftSquareToken(),
-            TokenSyntax.identifier("third"),
-            TokenSyntax.identifier("fourth"),
-            TokenSyntax.rightSquareToken(),
-          ]),
-          colon: .colonToken(),
-          type: IdentifierTypeSyntax(name: .identifier("Int"))
-        )
+      substructure: FunctionParameterSyntax(
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        UnexpectedNodesSyntax([
+          TokenSyntax.leftSquareToken(),
+          TokenSyntax.identifier("third"),
+          TokenSyntax.identifier("fourth"),
+          TokenSyntax.rightSquareToken(),
+        ]),
+        colon: .colonToken(),
+        type: IdentifierTypeSyntax(name: .identifier("Int"))
       ),
       diagnostics: [
         DiagnosticSpec(message: "unexpected code '[third fourth]' in parameter")
@@ -1205,16 +1191,14 @@ final class DeclarationTests: XCTestCase {
   func testDontRecoverFromUnbalancedParens() {
     assertParse(
       "func foo(first second 1️⃣[third 2️⃣fourth: Int) {}",
-      substructure: Syntax(
-        FunctionParameterSyntax(
-          firstName: .identifier("first"),
-          secondName: .identifier("second"),
-          colon: .colonToken(presence: .missing),
-          type: ArrayTypeSyntax(
-            leftSquare: .leftSquareToken(),
-            element: IdentifierTypeSyntax(name: .identifier("third")),
-            rightSquare: .rightSquareToken(presence: .missing)
-          )
+      substructure: FunctionParameterSyntax(
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        colon: .colonToken(presence: .missing),
+        type: ArrayTypeSyntax(
+          leftSquare: .leftSquareToken(),
+          element: IdentifierTypeSyntax(name: .identifier("third")),
+          rightSquare: .rightSquareToken(presence: .missing)
         )
       ),
       diagnostics: [
@@ -1246,13 +1230,11 @@ final class DeclarationTests: XCTestCase {
       func fooℹ️(first second 1️⃣third2️⃣
       3️⃣: Int) {}
       """,
-      substructure: Syntax(
-        FunctionParameterSyntax(
-          firstName: .identifier("first"),
-          secondName: .identifier("second"),
-          colon: .colonToken(presence: .missing),
-          type: IdentifierTypeSyntax(name: .identifier("third"))
-        )
+      substructure: FunctionParameterSyntax(
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        colon: .colonToken(presence: .missing),
+        type: IdentifierTypeSyntax(name: .identifier("third"))
       ),
       diagnostics: [
         DiagnosticSpec(
@@ -1603,12 +1585,10 @@ final class DeclarationTests: XCTestCase {
       """
       #expand
       """,
-      substructure: Syntax(
-        SourceFileSyntax(
-          CodeBlockItemListSyntax {
-            MacroExpansionDeclSyntax(macroName: "expand") {}
-          }
-        )
+      substructure: SourceFileSyntax(
+        CodeBlockItemListSyntax {
+          MacroExpansionDeclSyntax(macroName: "expand") {}
+        }
       )
     )
   }
@@ -1620,12 +1600,10 @@ final class DeclarationTests: XCTestCase {
         #case
       }
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          pound: .poundToken(),
-          macroName: .identifier("case"),
-          arguments: LabeledExprListSyntax([])
-        )
+      substructure: MacroExpansionDeclSyntax(
+        pound: .poundToken(),
+        macroName: .identifier("case"),
+        arguments: LabeledExprListSyntax([])
       )
     )
   }
@@ -1635,12 +1613,10 @@ final class DeclarationTests: XCTestCase {
       """
       @attribute #topLevelWithAttr
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attribute")))],
-          macroName: "topLevelWithAttr",
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attribute")))],
+        macroName: "topLevelWithAttr",
+        arguments: []
       )
     )
 
@@ -1648,12 +1624,10 @@ final class DeclarationTests: XCTestCase {
       """
       public #topLevelWithModifier
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          modifiers: [DeclModifierSyntax(name: .keyword(.public))],
-          macroName: "topLevelWithModifier",
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+        macroName: "topLevelWithModifier",
+        arguments: []
       )
     )
 
@@ -1661,11 +1635,9 @@ final class DeclarationTests: XCTestCase {
       """
       #topLevelBare
       """,
-      substructure: Syntax(
-        MacroExpansionExprSyntax(
-          macroName: "topLevelBare",
-          arguments: []
-        )
+      substructure: MacroExpansionExprSyntax(
+        macroName: "topLevelBare",
+        arguments: []
       )
     )
 
@@ -1675,12 +1647,10 @@ final class DeclarationTests: XCTestCase {
         @attribute #memberWithAttr
       }
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attribute")))],
-          macroName: "memberWithAttr",
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attribute")))],
+        macroName: "memberWithAttr",
+        arguments: []
       )
     )
 
@@ -1690,12 +1660,10 @@ final class DeclarationTests: XCTestCase {
         public #memberWithModifier
       }
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          modifiers: [DeclModifierSyntax(name: .keyword(.public))],
-          macroName: "memberWithModifier",
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+        macroName: "memberWithModifier",
+        arguments: []
       )
     )
 
@@ -1705,11 +1673,9 @@ final class DeclarationTests: XCTestCase {
         #memberBare
       }
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          macroName: "memberBare",
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        macroName: "memberBare",
+        arguments: []
       )
     )
 
@@ -1719,12 +1685,10 @@ final class DeclarationTests: XCTestCase {
         @attribute #bodyWithAttr
       }
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attribute")))],
-          macroName: "bodyWithAttr",
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attribute")))],
+        macroName: "bodyWithAttr",
+        arguments: []
       )
     )
 
@@ -1734,12 +1698,10 @@ final class DeclarationTests: XCTestCase {
         public #bodyWithModifier
       }
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          modifiers: [DeclModifierSyntax(name: .keyword(.public))],
-          macroName: "bodyWithModifier",
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+        macroName: "bodyWithModifier",
+        arguments: []
 
       )
     )
@@ -1750,11 +1712,9 @@ final class DeclarationTests: XCTestCase {
         #bodyBare
       }
       """,
-      substructure: Syntax(
-        MacroExpansionExprSyntax(
-          macroName: "bodyBare",
-          arguments: []
-        )
+      substructure: MacroExpansionExprSyntax(
+        macroName: "bodyBare",
+        arguments: []
       )
     )
 
@@ -1767,16 +1727,14 @@ final class DeclarationTests: XCTestCase {
         #declMacro
       }
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          attributes: [
-            .attribute(AttributeSyntax(attributeName: TypeSyntax("attrib1"))),
-            .attribute(AttributeSyntax(attributeName: TypeSyntax("attrib2"))),
-          ],
-          modifiers: [DeclModifierSyntax(name: .keyword(.public))],
-          macroName: "declMacro",
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        attributes: [
+          .attribute(AttributeSyntax(attributeName: TypeSyntax("attrib1"))),
+          .attribute(AttributeSyntax(attributeName: TypeSyntax("attrib2"))),
+        ],
+        modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+        macroName: "declMacro",
+        arguments: []
       )
     )
 
@@ -1786,13 +1744,11 @@ final class DeclarationTests: XCTestCase {
         @attrib #class
       }
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attrib")))],
-          pound: .poundToken(),
-          macroName: .identifier("class"),
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("attrib")))],
+        pound: .poundToken(),
+        macroName: .identifier("class"),
+        arguments: []
       )
     )
 
@@ -1802,12 +1758,10 @@ final class DeclarationTests: XCTestCase {
         #struct
       }
       """,
-      substructure: Syntax(
-        MacroExpansionDeclSyntax(
-          pound: .poundToken(),
-          macroName: .identifier("struct"),
-          arguments: []
-        )
+      substructure: MacroExpansionDeclSyntax(
+        pound: .poundToken(),
+        macroName: .identifier("struct"),
+        arguments: []
       )
     )
   }
@@ -2016,51 +1970,50 @@ final class DeclarationTests: XCTestCase {
       class B {
       }
       """,
-      substructure: Syntax(
-        CodeBlockItemListSyntax([
-          CodeBlockItemSyntax(
-            item: .init(
-              ClassDeclSyntax(
-                classKeyword: .keyword(.class),
-                name: .identifier("A"),
-                memberBlock: MemberBlockSyntax(
-                  leftBrace: .leftBraceToken(),
-                  members: MemberBlockItemListSyntax([
-                    MemberBlockItemSyntax(
-                      decl: DeclSyntax(
-                        FunctionDeclSyntax(
-                          funcKeyword: .keyword(.func, presence: .missing),
-                          name: .binaryOperator("^"),
-                          signature: FunctionSignatureSyntax(
-                            parameterClause: FunctionParameterClauseSyntax(
-                              leftParen: .leftParenToken(presence: .missing),
-                              parameters: FunctionParameterListSyntax([]),
-                              rightParen: .rightParenToken(presence: .missing)
-                            )
+      substructure: CodeBlockItemListSyntax([
+        CodeBlockItemSyntax(
+          item: .init(
+            ClassDeclSyntax(
+              classKeyword: .keyword(.class),
+              name: .identifier("A"),
+              memberBlock: MemberBlockSyntax(
+                leftBrace: .leftBraceToken(),
+                members: MemberBlockItemListSyntax([
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      FunctionDeclSyntax(
+                        funcKeyword: .keyword(.func, presence: .missing),
+                        name: .binaryOperator("^"),
+                        signature: FunctionSignatureSyntax(
+                          parameterClause: FunctionParameterClauseSyntax(
+                            leftParen: .leftParenToken(presence: .missing),
+                            parameters: FunctionParameterListSyntax([]),
+                            rightParen: .rightParenToken(presence: .missing)
                           )
                         )
                       )
                     )
-                  ]),
-                  rightBrace: .rightBraceToken()
-                )
+                  )
+                ]),
+                rightBrace: .rightBraceToken()
               )
             )
-          ),
-          CodeBlockItemSyntax(
-            item: .init(
-              ClassDeclSyntax(
-                classKeyword: .keyword(.class),
-                name: .identifier("B"),
-                memberBlock: MemberBlockSyntax(
-                  leftBrace: .leftBraceToken(),
-                  members: MemberBlockItemListSyntax([]),
-                  rightBrace: .rightBraceToken()
-                )
+          )
+        ),
+        CodeBlockItemSyntax(
+          item: .init(
+            ClassDeclSyntax(
+              classKeyword: .keyword(.class),
+              name: .identifier("B"),
+              memberBlock: MemberBlockSyntax(
+                leftBrace: .leftBraceToken(),
+                members: MemberBlockItemListSyntax([]),
+                rightBrace: .rightBraceToken()
               )
             )
-          ),
-        ])
+          )
+        ),
+      ]
       ),
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'func' in function", fixIts: ["insert 'func'"]),
@@ -2159,9 +2112,7 @@ final class DeclarationTests: XCTestCase {
         1️⃣<#code#>
       }
       """,
-      substructure: Syntax(
-        MemberBlockItemSyntax(decl: EditorPlaceholderDeclSyntax(placeholder: .identifier("<#code#>")))
-      ),
+      substructure: MemberBlockItemSyntax(decl: EditorPlaceholderDeclSyntax(placeholder: .identifier("<#code#>"))),
       diagnostics: [
         DiagnosticSpec(message: "editor placeholder in source file")
       ]
@@ -2201,17 +2152,15 @@ final class DeclarationTests: XCTestCase {
         var foo = 2
       }
       """,
-      substructure: Syntax(
-        FunctionCallExprSyntax(
-          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("open")),
-          leftParen: .leftParenToken(),
-          arguments: LabeledExprListSyntax([
-            LabeledExprSyntax(
-              expression: DeclReferenceExprSyntax(baseName: .identifier("set"))
-            )
-          ]),
-          rightParen: .rightParenToken()
-        )
+      substructure: FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("open")),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+          LabeledExprSyntax(
+            expression: DeclReferenceExprSyntax(baseName: .identifier("set"))
+          )
+        ]),
+        rightParen: .rightParenToken()
       )
     )
   }
@@ -2226,21 +2175,19 @@ final class DeclarationTests: XCTestCase {
         var foo = 2
       }
       """,
-      substructure: Syntax(
-        VariableDeclSyntax(
-          modifiers: DeclModifierListSyntax([
-            DeclModifierSyntax(name: .keyword(.open))
-          ]),
-          bindingSpecifier: .keyword(.var),
-          bindings: PatternBindingListSyntax([
-            PatternBindingSyntax(
-              pattern: IdentifierPatternSyntax(identifier: .identifier("foo")),
-              initializer: InitializerClauseSyntax(
-                value: IntegerLiteralExprSyntax(literal: .integerLiteral("2"))
-              )
+      substructure: VariableDeclSyntax(
+        modifiers: DeclModifierListSyntax([
+          DeclModifierSyntax(name: .keyword(.open))
+        ]),
+        bindingSpecifier: .keyword(.var),
+        bindings: PatternBindingListSyntax([
+          PatternBindingSyntax(
+            pattern: IdentifierPatternSyntax(identifier: .identifier("foo")),
+            initializer: InitializerClauseSyntax(
+              value: IntegerLiteralExprSyntax(literal: .integerLiteral("2"))
             )
-          ])
-        )
+          )
+        ])
       )
     )
   }
@@ -2252,7 +2199,7 @@ final class DeclarationTests: XCTestCase {
         open var foo = 2
       }
       """,
-      substructure: Syntax(DeclModifierSyntax(name: .keyword(.open)))
+      substructure: DeclModifierSyntax(name: .keyword(.open))
     )
   }
 
@@ -2335,12 +2282,10 @@ final class DeclarationTests: XCTestCase {
       """
       struct Hello: ~Copyable {}
       """,
-      substructure: Syntax(
-        InheritedTypeSyntax(
-          type: SuppressedTypeSyntax(
-            withoutTilde: .prefixOperator("~"),
-            type: TypeSyntax(stringLiteral: "Copyable")
-          )
+      substructure: InheritedTypeSyntax(
+        type: SuppressedTypeSyntax(
+          withoutTilde: .prefixOperator("~"),
+          type: TypeSyntax(stringLiteral: "Copyable")
         )
       )
     )
@@ -2349,26 +2294,23 @@ final class DeclarationTests: XCTestCase {
       """
       enum Whatever: Int, ~ Hashable, Equatable {}
       """,
-      substructure:
-        Syntax(
-          InheritanceClauseSyntax(
-            colon: .colonToken(),
-            inheritedTypes: InheritedTypeListSyntax([
-              InheritedTypeSyntax(
-                type: TypeSyntax(stringLiteral: "Int"),
-                trailingComma: .commaToken()
-              ),
-              InheritedTypeSyntax(
-                type: SuppressedTypeSyntax(
-                  withoutTilde: .prefixOperator("~"),
-                  type: TypeSyntax(stringLiteral: "Hashable")
-                ),
-                trailingComma: .commaToken()
-              ),
-              InheritedTypeSyntax(type: TypeSyntax(stringLiteral: "Equatable")),
-            ])
-          )
-        )
+      substructure: InheritanceClauseSyntax(
+        colon: .colonToken(),
+        inheritedTypes: InheritedTypeListSyntax([
+          InheritedTypeSyntax(
+            type: TypeSyntax(stringLiteral: "Int"),
+            trailingComma: .commaToken()
+          ),
+          InheritedTypeSyntax(
+            type: SuppressedTypeSyntax(
+              withoutTilde: .prefixOperator("~"),
+              type: TypeSyntax(stringLiteral: "Hashable")
+            ),
+            trailingComma: .commaToken()
+          ),
+          InheritedTypeSyntax(type: TypeSyntax(stringLiteral: "Equatable")),
+        ])
+      )
     )
 
     assertParse(
@@ -2396,16 +2338,13 @@ final class DeclarationTests: XCTestCase {
       """
       typealias T = ~(Int) -> Bool
       """,
-      substructure:
-        Syntax(
-          SuppressedTypeSyntax(
-            withoutTilde: .prefixOperator("~"),
-            type: FunctionTypeSyntax(
-              parameters: [TupleTypeElementSyntax(type: TypeSyntax("Int"))],
-              returnClause: ReturnClauseSyntax(type: TypeSyntax("Bool"))
-            )
-          )
+      substructure: SuppressedTypeSyntax(
+        withoutTilde: .prefixOperator("~"),
+        type: FunctionTypeSyntax(
+          parameters: [TupleTypeElementSyntax(type: TypeSyntax("Int"))],
+          returnClause: ReturnClauseSyntax(type: TypeSyntax("Bool"))
         )
+      )
     )
   }
 
@@ -2515,27 +2454,25 @@ final class DeclarationTests: XCTestCase {
         }
       }
       """,
-      substructure: Syntax(
-        InitializerDeclSyntax(
-          initKeyword: .keyword(.`init`),
-          signature: FunctionSignatureSyntax(
-            parameterClause: FunctionParameterClauseSyntax(
-              leftParen: .leftParenToken(),
-              parameters: FunctionParameterListSyntax([
-                FunctionParameterSyntax(
-                  firstName: .identifier("initialValue"),
-                  colon: .colonToken(presence: .missing),
-                  type: TypeSyntax(MissingTypeSyntax(placeholder: .identifier("<#type#>", presence: .missing)))
-                )
-              ]),
-              rightParen: .rightParenToken(trailingTrivia: .space)
-            )
-          ),
-          body: CodeBlockSyntax(
-            leftBrace: .leftBraceToken(),
-            statements: CodeBlockItemListSyntax([]),
-            rightBrace: .rightBraceToken()
+      substructure: InitializerDeclSyntax(
+        initKeyword: .keyword(.`init`),
+        signature: FunctionSignatureSyntax(
+          parameterClause: FunctionParameterClauseSyntax(
+            leftParen: .leftParenToken(),
+            parameters: FunctionParameterListSyntax([
+              FunctionParameterSyntax(
+                firstName: .identifier("initialValue"),
+                colon: .colonToken(presence: .missing),
+                type: TypeSyntax(MissingTypeSyntax(placeholder: .identifier("<#type#>", presence: .missing)))
+              )
+            ]),
+            rightParen: .rightParenToken(trailingTrivia: .space)
           )
+        ),
+        body: CodeBlockSyntax(
+          leftBrace: .leftBraceToken(),
+          statements: CodeBlockItemListSyntax([]),
+          rightBrace: .rightBraceToken()
         )
       ),
       diagnostics: [

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -113,35 +113,33 @@ final class ExpressionTests: XCTestCase {
       #"""
       \.?.foo
       """#,
-      substructure: Syntax(
-        CodeBlockItemListSyntax([
-          CodeBlockItemSyntax(
-            item: .init(
-              KeyPathExprSyntax(
-                backslash: .backslashToken(),
-                components: KeyPathComponentListSyntax([
-                  KeyPathComponentSyntax(
-                    period: .periodToken(),
-                    component: .init(
-                      KeyPathOptionalComponentSyntax(
-                        questionOrExclamationMark: .postfixQuestionMarkToken()
-                      )
+      substructure: CodeBlockItemListSyntax([
+        CodeBlockItemSyntax(
+          item: .init(
+            KeyPathExprSyntax(
+              backslash: .backslashToken(),
+              components: KeyPathComponentListSyntax([
+                KeyPathComponentSyntax(
+                  period: .periodToken(),
+                  component: .init(
+                    KeyPathOptionalComponentSyntax(
+                      questionOrExclamationMark: .postfixQuestionMarkToken()
                     )
-                  ),
-                  KeyPathComponentSyntax(
-                    period: .periodToken(),
-                    component: .init(
-                      KeyPathPropertyComponentSyntax(
-                        declName: DeclReferenceExprSyntax(baseName: .identifier("foo"))
-                      )
+                  )
+                ),
+                KeyPathComponentSyntax(
+                  period: .periodToken(),
+                  component: .init(
+                    KeyPathPropertyComponentSyntax(
+                      declName: DeclReferenceExprSyntax(baseName: .identifier("foo"))
                     )
-                  ),
-                ])
-              )
+                  )
+                ),
+              ])
             )
           )
-        ])
-      )
+        )
+      ])
     )
 
     assertParse(
@@ -274,20 +272,18 @@ final class ExpressionTests: XCTestCase {
       assertParse(
         "\\\(rootType).y",
         ExprSyntax.parse,
-        substructure: Syntax(
-          KeyPathExprSyntax(
-            root: TypeSyntax.parse(from: &parser),
-            components: KeyPathComponentListSyntax([
-              KeyPathComponentSyntax(
-                period: .periodToken(),
-                component: .init(
-                  KeyPathPropertyComponentSyntax(
-                    declName: DeclReferenceExprSyntax(baseName: .identifier("y"))
-                  )
+        substructure: KeyPathExprSyntax(
+          root: TypeSyntax.parse(from: &parser),
+          components: KeyPathComponentListSyntax([
+            KeyPathComponentSyntax(
+              period: .periodToken(),
+              component: .init(
+                KeyPathPropertyComponentSyntax(
+                  declName: DeclReferenceExprSyntax(baseName: .identifier("y"))
                 )
               )
-            ])
-          )
+            )
+          ])
         ),
         line: line
       )
@@ -389,31 +385,29 @@ final class ExpressionTests: XCTestCase {
         1️⃣#line : Calendar(identifier: .buddhist),
       ]
       """,
-      substructure: Syntax(
-        DictionaryElementSyntax.init(
-          key: MacroExpansionExprSyntax(
-            pound: .poundToken(),
-            macroName: .identifier("line"),
-            arguments: LabeledExprListSyntax([])
-          ),
-          colon: .colonToken(),
-          value: FunctionCallExprSyntax(
-            calledExpression: DeclReferenceExprSyntax(baseName: .identifier("Calendar")),
-            leftParen: .leftParenToken(),
-            arguments: LabeledExprListSyntax([
-              LabeledExprSyntax(
-                label: .identifier("identifier"),
-                colon: .colonToken(),
-                expression: MemberAccessExprSyntax(
-                  period: .periodToken(),
-                  name: .identifier("buddhist")
-                )
+      substructure: DictionaryElementSyntax.init(
+        key: MacroExpansionExprSyntax(
+          pound: .poundToken(),
+          macroName: .identifier("line"),
+          arguments: LabeledExprListSyntax([])
+        ),
+        colon: .colonToken(),
+        value: FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("Calendar")),
+          leftParen: .leftParenToken(),
+          arguments: LabeledExprListSyntax([
+            LabeledExprSyntax(
+              label: .identifier("identifier"),
+              colon: .colonToken(),
+              expression: MemberAccessExprSyntax(
+                period: .periodToken(),
+                name: .identifier("buddhist")
               )
-            ]),
-            rightParen: .rightParenToken()
-          ),
-          trailingComma: .commaToken()
-        )
+            )
+          ]),
+          rightParen: .rightParenToken()
+        ),
+        trailingComma: .commaToken()
       ),
       substructureAfterMarker: "1️⃣"
     )
@@ -814,7 +808,7 @@ final class ExpressionTests: XCTestCase {
       ##"""
       "1️⃣\#(1)"
       """##,
-      substructure: Syntax(StringSegmentSyntax(content: .stringSegment(##"\#(1)"##))),
+      substructure: StringSegmentSyntax(content: .stringSegment(##"\#(1)"##)),
       diagnostics: [
         DiagnosticSpec(message: "invalid escape sequence in literal")
       ]
@@ -1029,7 +1023,7 @@ final class ExpressionTests: XCTestCase {
     assertParse(
       "Foo 1️⃣async ->2️⃣",
       { ExprSyntax.parse(from: &$0) },
-      substructure: Syntax(TokenSyntax.keyword(.async)),
+      substructure: TokenSyntax.keyword(.async),
       substructureAfterMarker: "1️⃣",
       diagnostics: [
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression", fixIts: ["insert expression"])
@@ -1112,7 +1106,7 @@ final class ExpressionTests: XCTestCase {
   func testOperatorReference() {
     assertParse(
       "reduce(0, 1️⃣+)",
-      substructure: Syntax(TokenSyntax.binaryOperator("+")),
+      substructure: TokenSyntax.binaryOperator("+"),
       substructureAfterMarker: "1️⃣"
     )
   }
@@ -1156,12 +1150,10 @@ final class ExpressionTests: XCTestCase {
   func testMacroExpansionExpressionWithKeywordName() {
     assertParse(
       "#case",
-      substructure: Syntax(
-        MacroExpansionExprSyntax(
-          pound: .poundToken(),
-          macroName: .identifier("case"),
-          arguments: LabeledExprListSyntax([])
-        )
+      substructure: MacroExpansionExprSyntax(
+        pound: .poundToken(),
+        macroName: .identifier("case"),
+        arguments: LabeledExprListSyntax([])
       )
     )
   }
@@ -1208,14 +1200,12 @@ final class ExpressionTests: XCTestCase {
       ℹ️"This is unterminated1️⃣
       x
       """,
-      substructure: Syntax(
-        StringLiteralExprSyntax(
-          openingQuote: .stringQuoteToken(),
-          segments: StringLiteralSegmentListSyntax([
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("This is unterminated")))
-          ]),
-          closingQuote: .stringQuoteToken(presence: .missing)
-        )
+      substructure: StringLiteralExprSyntax(
+        openingQuote: .stringQuoteToken(),
+        segments: StringLiteralSegmentListSyntax([
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("This is unterminated")))
+        ]),
+        closingQuote: .stringQuoteToken(presence: .missing)
       ),
       diagnostics: [
         DiagnosticSpec(
@@ -1239,15 +1229,14 @@ final class ExpressionTests: XCTestCase {
         line 2
         """
       """#,
-      substructure: Syntax(
-        StringLiteralExprSyntax(
-          openingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2), trailingTrivia: .newline),
-          segments: StringLiteralSegmentListSyntax([
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("line 1\n", leadingTrivia: .spaces(2)))),
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("line 2", leadingTrivia: .spaces(2), trailingTrivia: .newline))),
-          ]),
-          closingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2))
-        )
+      substructure: StringLiteralExprSyntax(
+        openingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2), trailingTrivia: .newline),
+        segments: StringLiteralSegmentListSyntax([
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("line 1\n", leadingTrivia: .spaces(2)))),
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("line 2", leadingTrivia: .spaces(2), trailingTrivia: .newline))),
+        ]),
+        closingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2))
+
       ),
       options: [.substructureCheckTrivia]
     )
@@ -1259,17 +1248,16 @@ final class ExpressionTests: XCTestCase {
         line 2
         """
       """#,
-      substructure: Syntax(
-        StringLiteralExprSyntax(
-          openingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2), trailingTrivia: .newline),
-          segments: StringLiteralSegmentListSyntax([
-            .stringSegment(
-              StringSegmentSyntax(content: .stringSegment("line 1 ", leadingTrivia: .spaces(2), trailingTrivia: [.backslashes(1), .newlines(1)]))
-            ),
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("line 2", leadingTrivia: .spaces(2), trailingTrivia: .newline))),
-          ]),
-          closingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2))
-        )
+      substructure: StringLiteralExprSyntax(
+        openingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2), trailingTrivia: .newline),
+        segments: StringLiteralSegmentListSyntax([
+          .stringSegment(
+            StringSegmentSyntax(content: .stringSegment("line 1 ", leadingTrivia: .spaces(2), trailingTrivia: [.backslashes(1), .newlines(1)]))
+          ),
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("line 2", leadingTrivia: .spaces(2), trailingTrivia: .newline))),
+        ]),
+        closingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2))
+
       ),
       options: [.substructureCheckTrivia]
     )
@@ -1281,20 +1269,19 @@ final class ExpressionTests: XCTestCase {
         line 2 1️⃣\
         """
       """#,
-      substructure: Syntax(
-        StringLiteralExprSyntax(
-          openingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2), trailingTrivia: .newline),
-          segments: StringLiteralSegmentListSyntax([
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("line 1\n", leadingTrivia: .spaces(2)))),
-            .stringSegment(
-              StringSegmentSyntax(
-                UnexpectedNodesSyntax([Syntax(TokenSyntax.stringSegment("  line 2 ", trailingTrivia: [.backslashes(1), .newlines(1)]))]),
-                content: .stringSegment("line 2 ", leadingTrivia: .spaces(2), trailingTrivia: .newline, presence: .missing)
-              )
-            ),
-          ]),
-          closingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2))
-        )
+      substructure: StringLiteralExprSyntax(
+        openingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2), trailingTrivia: .newline),
+        segments: StringLiteralSegmentListSyntax([
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("line 1\n", leadingTrivia: .spaces(2)))),
+          .stringSegment(
+            StringSegmentSyntax(
+              UnexpectedNodesSyntax([Syntax(TokenSyntax.stringSegment("  line 2 ", trailingTrivia: [.backslashes(1), .newlines(1)]))]),
+              content: .stringSegment("line 2 ", leadingTrivia: .spaces(2), trailingTrivia: .newline, presence: .missing)
+            )
+          ),
+        ]),
+        closingQuote: .multilineStringQuoteToken(leadingTrivia: .spaces(2))
+
       ),
       diagnostics: [
         DiagnosticSpec(message: "escaped newline at the last line of a multi-line string literal is not allowed", fixIts: ["remove ''"])
@@ -1329,18 +1316,17 @@ final class ExpressionTests: XCTestCase {
         line 2
         """
       """#,
-      substructure: Syntax(
-        StringLiteralExprSyntax(
-          openingPounds: nil,
-          openingQuote: .multilineStringQuoteToken(leadingTrivia: [.spaces(2)], trailingTrivia: .newline),
-          segments: StringLiteralSegmentListSyntax([
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("line 1\n", leadingTrivia: [.spaces(2)]))),
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("\n"))),
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("line 2", leadingTrivia: [.spaces(2)], trailingTrivia: .newline))),
-          ]),
-          closingQuote: .multilineStringQuoteToken(leadingTrivia: [.spaces(2)]),
-          closingPounds: nil
-        )
+      substructure: StringLiteralExprSyntax(
+        openingPounds: nil,
+        openingQuote: .multilineStringQuoteToken(leadingTrivia: [.spaces(2)], trailingTrivia: .newline),
+        segments: StringLiteralSegmentListSyntax([
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("line 1\n", leadingTrivia: [.spaces(2)]))),
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("\n"))),
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("line 2", leadingTrivia: [.spaces(2)], trailingTrivia: .newline))),
+        ]),
+        closingQuote: .multilineStringQuoteToken(leadingTrivia: [.spaces(2)]),
+        closingPounds: nil
+
       ),
       options: [.substructureCheckTrivia]
     )
@@ -1352,17 +1338,16 @@ final class ExpressionTests: XCTestCase {
 
         """
       """#,
-      substructure: Syntax(
-        StringLiteralExprSyntax(
-          openingPounds: nil,
-          openingQuote: .multilineStringQuoteToken(leadingTrivia: [.spaces(2)], trailingTrivia: .newline),
-          segments: StringLiteralSegmentListSyntax([
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("line 1\n", leadingTrivia: [.spaces(2)]))),
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("", trailingTrivia: .newline))),
-          ]),
-          closingQuote: .multilineStringQuoteToken(leadingTrivia: [.spaces(2)]),
-          closingPounds: nil
-        )
+      substructure: StringLiteralExprSyntax(
+        openingPounds: nil,
+        openingQuote: .multilineStringQuoteToken(leadingTrivia: [.spaces(2)], trailingTrivia: .newline),
+        segments: StringLiteralSegmentListSyntax([
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("line 1\n", leadingTrivia: [.spaces(2)]))),
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("", trailingTrivia: .newline))),
+        ]),
+        closingQuote: .multilineStringQuoteToken(leadingTrivia: [.spaces(2)]),
+        closingPounds: nil
+
       ),
       options: [.substructureCheckTrivia]
     )
@@ -1581,18 +1566,17 @@ final class StatementExpressionTests: XCTestCase {
         if .random() { 0 } else { 1 } as Int
       }
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: ExprListSyntax([
-            ifZeroElseOne(),
-            ExprSyntax(
-              UnresolvedAsExprSyntax()
-            ),
-            ExprSyntax(
-              TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
-            ),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: ExprListSyntax([
+          ifZeroElseOne(),
+          ExprSyntax(
+            UnresolvedAsExprSyntax()
+          ),
+          ExprSyntax(
+            TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
+          ),
+        ])
+
       )
     )
   }
@@ -1601,18 +1585,16 @@ final class StatementExpressionTests: XCTestCase {
       """
       switch Bool.random() { case true: 0 case false: 1 } as Int
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: ExprListSyntax([
-            switchRandomZeroOne(),
-            ExprSyntax(
-              UnresolvedAsExprSyntax()
-            ),
-            ExprSyntax(
-              TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
-            ),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: ExprListSyntax([
+          switchRandomZeroOne(),
+          ExprSyntax(
+            UnresolvedAsExprSyntax()
+          ),
+          ExprSyntax(
+            TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
+          ),
+        ])
       )
     )
   }
@@ -1623,9 +1605,7 @@ final class StatementExpressionTests: XCTestCase {
         return if .random() { 0 } else { 1 }
       }
       """,
-      substructure: Syntax(
-        ReturnStmtSyntax(expression: ifZeroElseOne())
-      )
+      substructure: ReturnStmtSyntax(expression: ifZeroElseOne())
     )
   }
   func testSwitchExprInReturn() {
@@ -1635,9 +1615,7 @@ final class StatementExpressionTests: XCTestCase {
         return switch Bool.random() { case true: 0 case false: 1 }
       }
       """,
-      substructure: Syntax(
-        ReturnStmtSyntax(expression: switchRandomZeroOne())
-      )
+      substructure: ReturnStmtSyntax(expression: switchRandomZeroOne())
     )
   }
   func testTryIf1() {
@@ -1647,9 +1625,7 @@ final class StatementExpressionTests: XCTestCase {
         try if .random() { 0 } else { 1 }
       }
       """,
-      substructure: Syntax(
-        TryExprSyntax(expression: ifZeroElseOne())
-      )
+      substructure: TryExprSyntax(expression: ifZeroElseOne())
     )
   }
   func testTryIf2() {
@@ -1659,9 +1635,7 @@ final class StatementExpressionTests: XCTestCase {
         return try if .random() { 0 } else { 1 }
       }
       """,
-      substructure: Syntax(
-        ReturnStmtSyntax(expression: TryExprSyntax(expression: ifZeroElseOne()))
-      )
+      substructure: ReturnStmtSyntax(expression: TryExprSyntax(expression: ifZeroElseOne()))
     )
   }
   func testTryIf3() {
@@ -1672,9 +1646,7 @@ final class StatementExpressionTests: XCTestCase {
         return x
       }
       """,
-      substructure: Syntax(
-        TryExprSyntax(expression: ifZeroElseOne())
-      )
+      substructure: TryExprSyntax(expression: ifZeroElseOne())
     )
   }
   func testAwaitIf1() {
@@ -1684,9 +1656,7 @@ final class StatementExpressionTests: XCTestCase {
         await if .random() { 0 } else { 1 }
       }
       """,
-      substructure: Syntax(
-        AwaitExprSyntax(expression: ifZeroElseOne())
-      )
+      substructure: AwaitExprSyntax(expression: ifZeroElseOne())
     )
   }
   func testAwaitIf2() {
@@ -1696,9 +1666,7 @@ final class StatementExpressionTests: XCTestCase {
         return await if .random() { 0 } else { 1 }
       }
       """,
-      substructure: Syntax(
-        ReturnStmtSyntax(expression: AwaitExprSyntax(expression: ifZeroElseOne()))
-      )
+      substructure: ReturnStmtSyntax(expression: AwaitExprSyntax(expression: ifZeroElseOne()))
     )
   }
   func testAwaitIf3() {
@@ -1709,9 +1677,7 @@ final class StatementExpressionTests: XCTestCase {
         return x
       }
       """,
-      substructure: Syntax(
-        AwaitExprSyntax(expression: ifZeroElseOne())
-      )
+      substructure: AwaitExprSyntax(expression: ifZeroElseOne())
     )
   }
   func testTrySwitch1() {
@@ -1719,9 +1685,7 @@ final class StatementExpressionTests: XCTestCase {
       """
       try switch Bool.random() { case true: 0 case false: 1 }
       """,
-      substructure: Syntax(
-        TryExprSyntax(expression: switchRandomZeroOne())
-      )
+      substructure: TryExprSyntax(expression: switchRandomZeroOne())
     )
   }
   func testTrySwitch2() {
@@ -1731,9 +1695,7 @@ final class StatementExpressionTests: XCTestCase {
         return try switch Bool.random() { case true: 0 case false: 1 }
       }
       """,
-      substructure: Syntax(
-        ReturnStmtSyntax(expression: TryExprSyntax(expression: switchRandomZeroOne()))
-      )
+      substructure: ReturnStmtSyntax(expression: TryExprSyntax(expression: switchRandomZeroOne()))
     )
   }
   func testTrySwitch3() {
@@ -1744,9 +1706,7 @@ final class StatementExpressionTests: XCTestCase {
         return x
       }
       """,
-      substructure: Syntax(
-        TryExprSyntax(expression: switchRandomZeroOne())
-      )
+      substructure: TryExprSyntax(expression: switchRandomZeroOne())
     )
   }
   func testAwaitSwitch1() {
@@ -1754,9 +1714,7 @@ final class StatementExpressionTests: XCTestCase {
       """
       await switch Bool.random() { case true: 0 case false: 1 }
       """,
-      substructure: Syntax(
-        AwaitExprSyntax(expression: switchRandomZeroOne())
-      )
+      substructure: AwaitExprSyntax(expression: switchRandomZeroOne())
     )
   }
   func testAwaitSwitch2() {
@@ -1766,9 +1724,7 @@ final class StatementExpressionTests: XCTestCase {
         return await switch Bool.random() { case true: 0 case false: 1 }
       }
       """,
-      substructure: Syntax(
-        ReturnStmtSyntax(expression: AwaitExprSyntax(expression: switchRandomZeroOne()))
-      )
+      substructure: ReturnStmtSyntax(expression: AwaitExprSyntax(expression: switchRandomZeroOne()))
     )
   }
   func testAwaitSwitch3() {
@@ -1779,9 +1735,7 @@ final class StatementExpressionTests: XCTestCase {
         return x
       }
       """,
-      substructure: Syntax(
-        AwaitExprSyntax(expression: switchRandomZeroOne())
-      )
+      substructure: AwaitExprSyntax(expression: switchRandomZeroOne())
     )
   }
   func testIfExprMultipleCoerce() {
@@ -1817,18 +1771,16 @@ final class StatementExpressionTests: XCTestCase {
       """
       if .random() { 0 } else { 1 } as? Int
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: ExprListSyntax([
-            ifZeroElseOne(),
-            ExprSyntax(
-              UnresolvedAsExprSyntax(questionOrExclamationMark: .postfixQuestionMarkToken())
-            ),
-            ExprSyntax(
-              TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
-            ),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: ExprListSyntax([
+          ifZeroElseOne(),
+          ExprSyntax(
+            UnresolvedAsExprSyntax(questionOrExclamationMark: .postfixQuestionMarkToken())
+          ),
+          ExprSyntax(
+            TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
+          ),
+        ])
       )
     )
   }
@@ -1838,18 +1790,16 @@ final class StatementExpressionTests: XCTestCase {
       """
       if .random() { 0 } else { 1 } as! Int
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: ExprListSyntax([
-            ifZeroElseOne(),
-            ExprSyntax(
-              UnresolvedAsExprSyntax(questionOrExclamationMark: .exclamationMarkToken())
-            ),
-            ExprSyntax(
-              TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
-            ),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: ExprListSyntax([
+          ifZeroElseOne(),
+          ExprSyntax(
+            UnresolvedAsExprSyntax(questionOrExclamationMark: .exclamationMarkToken())
+          ),
+          ExprSyntax(
+            TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
+          ),
+        ])
       )
     )
   }
@@ -1886,18 +1836,16 @@ final class StatementExpressionTests: XCTestCase {
       """
       switch Bool.random() { case true: 0 case false: 1 } as? Int
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: ExprListSyntax([
-            switchRandomZeroOne(),
-            ExprSyntax(
-              UnresolvedAsExprSyntax(questionOrExclamationMark: .postfixQuestionMarkToken())
-            ),
-            ExprSyntax(
-              TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
-            ),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: ExprListSyntax([
+          switchRandomZeroOne(),
+          ExprSyntax(
+            UnresolvedAsExprSyntax(questionOrExclamationMark: .postfixQuestionMarkToken())
+          ),
+          ExprSyntax(
+            TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
+          ),
+        ])
       )
     )
   }
@@ -1907,18 +1855,16 @@ final class StatementExpressionTests: XCTestCase {
       """
       switch Bool.random() { case true: 0 case false: 1 } as! Int
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: ExprListSyntax([
-            switchRandomZeroOne(),
-            ExprSyntax(
-              UnresolvedAsExprSyntax(questionOrExclamationMark: .exclamationMarkToken())
-            ),
-            ExprSyntax(
-              TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
-            ),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: ExprListSyntax([
+          switchRandomZeroOne(),
+          ExprSyntax(
+            UnresolvedAsExprSyntax(questionOrExclamationMark: .exclamationMarkToken())
+          ),
+          ExprSyntax(
+            TypeExprSyntax(type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Int"))))
+          ),
+        ])
       )
     )
   }
@@ -2598,13 +2544,11 @@ final class StatementExpressionTests: XCTestCase {
       }
       }
       """,
-      substructure: Syntax(
-        FunctionCallExprSyntax(
-          calledExpression: DeclReferenceExprSyntax(baseName: .keyword(.init("init")!)),
-          leftParen: .leftParenToken(),
-          arguments: LabeledExprListSyntax([]),
-          rightParen: .rightParenToken()
-        )
+      substructure: FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .keyword(.init("init")!)),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([]),
+        rightParen: .rightParenToken()
       )
     )
   }

--- a/Tests/SwiftParserTest/ExpressionTypeTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTypeTests.swift
@@ -75,7 +75,7 @@ final class ExpressionTypeTests: XCTestCase {
       assertParse(
         "G<\(type)>.self",
         ExprSyntax.parse,
-        substructure: Syntax(IdentifierTypeSyntax(name: .identifier("X"))),
+        substructure: IdentifierTypeSyntax(name: .identifier("X")),
         substructureAfterMarker: "1️⃣",
         line: line
       )
@@ -85,7 +85,7 @@ final class ExpressionTypeTests: XCTestCase {
     assertParse(
       "G<1️⃣()>.self",
       ExprSyntax.parse,
-      substructure: Syntax(TupleTypeSyntax(elements: .init([]))),
+      substructure: TupleTypeSyntax(elements: .init([])),
       substructureAfterMarker: "1️⃣"
     )
 
@@ -93,7 +93,7 @@ final class ExpressionTypeTests: XCTestCase {
     assertParse(
       "G<1️⃣Any>.self",
       ExprSyntax.parse,
-      substructure: Syntax(IdentifierTypeSyntax(name: .keyword(.Any))),
+      substructure: IdentifierTypeSyntax(name: .keyword(.Any)),
       substructureAfterMarker: "1️⃣"
     )
 
@@ -101,7 +101,7 @@ final class ExpressionTypeTests: XCTestCase {
     assertParse(
       "G<1️⃣Self>.self",
       ExprSyntax.parse,
-      substructure: Syntax(IdentifierTypeSyntax(name: .keyword(.Self))),
+      substructure: IdentifierTypeSyntax(name: .keyword(.Self)),
       substructureAfterMarker: "1️⃣"
     )
   }

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -51,15 +51,13 @@ public class EntryTests: XCTestCase {
     assertParse(
       "1️⃣operator 2️⃣test 3️⃣{} other tokens",
       { DeclSyntax.parse(from: &$0) },
-      substructure: Syntax(
-        UnexpectedNodesSyntax([
-          TokenSyntax.leftBraceToken(),
-          PrecedenceGroupAttributeListSyntax([]),
-          TokenSyntax.rightBraceToken(),
-          TokenSyntax.identifier("other"),
-          TokenSyntax.identifier("tokens"),
-        ])
-      ),
+      substructure: UnexpectedNodesSyntax([
+        TokenSyntax.leftBraceToken(),
+        PrecedenceGroupAttributeListSyntax([]),
+        TokenSyntax.rightBraceToken(),
+        TokenSyntax.identifier("other"),
+        TokenSyntax.identifier("tokens"),
+      ]),
       substructureAfterMarker: "3️⃣",
       diagnostics: [
         DiagnosticSpec(

--- a/Tests/SwiftParserTest/RegexLiteralTests.swift
+++ b/Tests/SwiftParserTest/RegexLiteralTests.swift
@@ -985,19 +985,17 @@ final class RegexLiteralTests: XCTestCase {
       """
       foo(a: /, /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            label: "a",
-            colon: .colonToken(),
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
-          ),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(
+          label: "a",
+          colon: .colonToken(),
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
+        ),
+      ])
     )
   }
 
@@ -1007,21 +1005,19 @@ final class RegexLiteralTests: XCTestCase {
       """
       foo(a, /, /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: "a"),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
-          ),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: "a"),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
+        ),
+      ])
     )
   }
 
@@ -1031,21 +1027,19 @@ final class RegexLiteralTests: XCTestCase {
       """
       foo(a, ^/, /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: "a"),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
-          ),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: "a"),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
+        ),
+      ])
     )
   }
 
@@ -1055,19 +1049,17 @@ final class RegexLiteralTests: XCTestCase {
       """
       foo(a: ^/, /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            label: "a",
-            colon: .colonToken(),
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
-          ),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(
+          label: "a",
+          colon: .colonToken(),
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
+        ),
+      ])
     )
   }
 
@@ -1077,17 +1069,15 @@ final class RegexLiteralTests: XCTestCase {
       """
       foo(^/, /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
-          ),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
+        ),
+      ])
     )
   }
 
@@ -1097,17 +1087,15 @@ final class RegexLiteralTests: XCTestCase {
       """
       (^/, /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
-          ),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
+        ),
+      ])
     )
   }
 
@@ -1117,17 +1105,15 @@ final class RegexLiteralTests: XCTestCase {
       """
       (/, /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
-          ),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
+        ),
+      ])
     )
   }
 
@@ -1137,17 +1123,15 @@ final class RegexLiteralTests: XCTestCase {
       """
       x[/, /]
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
-          ),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
+        ),
+      ])
     )
   }
 
@@ -1157,17 +1141,15 @@ final class RegexLiteralTests: XCTestCase {
       """
       x[^/, /]
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
-            trailingComma: .commaToken()
-          ),
-          .init(
-            expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
-          ),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("^/")),
+          trailingComma: .commaToken()
+        ),
+        .init(
+          expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))
+        ),
+      ])
     )
   }
 
@@ -1190,7 +1172,7 @@ final class RegexLiteralTests: XCTestCase {
       """
       [/,/]
       """,
-      substructure: Syntax(RegexLiteralExprSyntax(regex: .regexLiteralPattern(",")))
+      substructure: RegexLiteralExprSyntax(regex: .regexLiteralPattern(","))
     )
   }
 
@@ -1261,7 +1243,7 @@ final class RegexLiteralTests: XCTestCase {
       """
       let x = true?/abc/1️⃣:/def/
       """,
-      substructure: Syntax(BinaryOperatorExprSyntax(operator: .binaryOperator("/"))),
+      substructure: BinaryOperatorExprSyntax(operator: .binaryOperator("/")),
       diagnostics: [
         DiagnosticSpec(message: "extraneous code ':/def/' at top level")
       ]
@@ -1273,14 +1255,12 @@ final class RegexLiteralTests: XCTestCase {
       """
       let x = true ?/abc/ : /def/
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: .init([
-            BooleanLiteralExprSyntax(booleanLiteral: true),
-            UnresolvedTernaryExprSyntax(thenExpression: RegexLiteralExprSyntax(regex: .regexLiteralPattern("abc"))),
-            RegexLiteralExprSyntax(regex: .regexLiteralPattern("def")),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: .init([
+          BooleanLiteralExprSyntax(booleanLiteral: true),
+          UnresolvedTernaryExprSyntax(thenExpression: RegexLiteralExprSyntax(regex: .regexLiteralPattern("abc"))),
+          RegexLiteralExprSyntax(regex: .regexLiteralPattern("def")),
+        ])
       )
     )
   }
@@ -1290,11 +1270,9 @@ final class RegexLiteralTests: XCTestCase {
       """
       let x = &/abc/
       """,
-      substructure: Syntax(
-        InOutExprSyntax(
-          expression: RegexLiteralExprSyntax(
-            regex: .regexLiteralPattern("abc")
-          )
+      substructure: InOutExprSyntax(
+        expression: RegexLiteralExprSyntax(
+          regex: .regexLiteralPattern("abc")
         )
       )
     )

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -20,24 +20,22 @@ final class StatementTests: XCTestCase {
       """
       if let baz {}
       """,
-      substructure: Syntax(
-        IfExprSyntax(
-          ifKeyword: .keyword(.if),
-          conditions: ConditionElementListSyntax([
-            ConditionElementSyntax(
-              condition: .init(
-                OptionalBindingConditionSyntax(
-                  bindingSpecifier: .keyword(.let),
-                  pattern: IdentifierPatternSyntax(identifier: .identifier("baz"))
-                )
+      substructure: IfExprSyntax(
+        ifKeyword: .keyword(.if),
+        conditions: ConditionElementListSyntax([
+          ConditionElementSyntax(
+            condition: .init(
+              OptionalBindingConditionSyntax(
+                bindingSpecifier: .keyword(.let),
+                pattern: IdentifierPatternSyntax(identifier: .identifier("baz"))
               )
             )
-          ]),
-          body: .init(
-            leftBrace: .leftBraceToken(),
-            statements: .init([]),
-            rightBrace: .rightBraceToken()
           )
+        ]),
+        body: .init(
+          leftBrace: .leftBraceToken(),
+          statements: .init([]),
+          rightBrace: .rightBraceToken()
         )
       )
     )
@@ -46,25 +44,23 @@ final class StatementTests: XCTestCase {
       """
       if let self = self {}
       """,
-      substructure: Syntax(
-        IfExprSyntax(
-          ifKeyword: .keyword(.if),
-          conditions: ConditionElementListSyntax([
-            ConditionElementSyntax(
-              condition: .init(
-                OptionalBindingConditionSyntax(
-                  bindingSpecifier: .keyword(.let),
-                  pattern: IdentifierPatternSyntax(identifier: .keyword(.self)),
-                  initializer: InitializerClauseSyntax(equal: .equalToken(), value: DeclReferenceExprSyntax(baseName: .keyword(.self)))
-                )
+      substructure: IfExprSyntax(
+        ifKeyword: .keyword(.if),
+        conditions: ConditionElementListSyntax([
+          ConditionElementSyntax(
+            condition: .init(
+              OptionalBindingConditionSyntax(
+                bindingSpecifier: .keyword(.let),
+                pattern: IdentifierPatternSyntax(identifier: .keyword(.self)),
+                initializer: InitializerClauseSyntax(equal: .equalToken(), value: DeclReferenceExprSyntax(baseName: .keyword(.self)))
               )
             )
-          ]),
-          body: .init(
-            leftBrace: .leftBraceToken(),
-            statements: .init([]),
-            rightBrace: .rightBraceToken()
           )
+        ]),
+        body: .init(
+          leftBrace: .leftBraceToken(),
+          statements: .init([]),
+          rightBrace: .rightBraceToken()
         )
       )
     )
@@ -147,11 +143,9 @@ final class StatementTests: XCTestCase {
     assertParse(
       "{ 1️⃣return 0 }",
       { ExprSyntax.parse(from: &$0) },
-      substructure: Syntax(
-        ReturnStmtSyntax(
-          returnKeyword: .keyword(.return),
-          expression: IntegerLiteralExprSyntax(literal: .integerLiteral("0"))
-        )
+      substructure: ReturnStmtSyntax(
+        returnKeyword: .keyword(.return),
+        expression: IntegerLiteralExprSyntax(literal: .integerLiteral("0"))
       ),
       substructureAfterMarker: "1️⃣"
     )
@@ -351,10 +345,8 @@ final class StatementTests: XCTestCase {
   func testIdentifierPattern() {
     assertParse(
       "switch x { case let .y(z): break }",
-      substructure: Syntax(
-        IdentifierPatternSyntax(
-          identifier: .identifier("z")
-        )
+      substructure: IdentifierPatternSyntax(
+        identifier: .identifier("z")
       )
     )
   }
@@ -364,23 +356,21 @@ final class StatementTests: XCTestCase {
       """
       graphQLMap["clientMutationId"] as? 1️⃣Swift.Optional<String?> ?? Swift.Optional<String?>.none
       """,
-      substructure: Syntax(
-        MemberTypeSyntax(
-          baseType: IdentifierTypeSyntax(name: .identifier("Swift")),
-          period: .periodToken(),
-          name: .identifier("Optional"),
-          genericArgumentClause: GenericArgumentClauseSyntax(
-            leftAngle: .leftAngleToken(),
-            arguments: GenericArgumentListSyntax([
-              GenericArgumentSyntax(
-                argument: OptionalTypeSyntax(
-                  wrappedType: IdentifierTypeSyntax(name: .identifier("String")),
-                  questionMark: .postfixQuestionMarkToken()
-                )
+      substructure: MemberTypeSyntax(
+        baseType: IdentifierTypeSyntax(name: .identifier("Swift")),
+        period: .periodToken(),
+        name: .identifier("Optional"),
+        genericArgumentClause: GenericArgumentClauseSyntax(
+          leftAngle: .leftAngleToken(),
+          arguments: GenericArgumentListSyntax([
+            GenericArgumentSyntax(
+              argument: OptionalTypeSyntax(
+                wrappedType: IdentifierTypeSyntax(name: .identifier("String")),
+                questionMark: .postfixQuestionMarkToken()
               )
-            ]),
-            rightAngle: .rightAngleToken()
-          )
+            )
+          ]),
+          rightAngle: .rightAngleToken()
         )
       ),
       substructureAfterMarker: "1️⃣"
@@ -390,18 +380,16 @@ final class StatementTests: XCTestCase {
       """
       if case 1️⃣Optional<Any>.none = object["anyCol"] { }
       """,
-      substructure: Syntax(
-        GenericSpecializationExprSyntax(
-          expression: DeclReferenceExprSyntax(baseName: .identifier("Optional")),
-          genericArgumentClause: GenericArgumentClauseSyntax(
-            leftAngle: .leftAngleToken(),
-            arguments: GenericArgumentListSyntax([
-              GenericArgumentSyntax(
-                argument: IdentifierTypeSyntax(name: .keyword(.Any))
-              )
-            ]),
-            rightAngle: .rightAngleToken()
-          )
+      substructure: GenericSpecializationExprSyntax(
+        expression: DeclReferenceExprSyntax(baseName: .identifier("Optional")),
+        genericArgumentClause: GenericArgumentClauseSyntax(
+          leftAngle: .leftAngleToken(),
+          arguments: GenericArgumentListSyntax([
+            GenericArgumentSyntax(
+              argument: IdentifierTypeSyntax(name: .keyword(.Any))
+            )
+          ]),
+          rightAngle: .rightAngleToken()
         )
       ),
       substructureAfterMarker: "1️⃣"
@@ -414,7 +402,7 @@ final class StatementTests: XCTestCase {
       1️⃣yield
       print("huh")
       """,
-      substructure: Syntax(DeclReferenceExprSyntax(baseName: .identifier("yield"))),
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("yield")),
       substructureAfterMarker: "1️⃣"
     )
   }
@@ -429,14 +417,12 @@ final class StatementTests: XCTestCase {
         }
       }
       """,
-      substructure: Syntax(
-        YieldStmtSyntax(
-          yieldKeyword: .keyword(.yield),
-          yieldedExpressions: .init(
-            InOutExprSyntax(
-              ampersand: .prefixAmpersandToken(),
-              expression: DeclReferenceExprSyntax(baseName: .identifier("x"))
-            )
+      substructure: YieldStmtSyntax(
+        yieldKeyword: .keyword(.yield),
+        yieldedExpressions: .init(
+          InOutExprSyntax(
+            ampersand: .prefixAmpersandToken(),
+            expression: DeclReferenceExprSyntax(baseName: .identifier("x"))
           )
         )
       ),
@@ -463,28 +449,26 @@ final class StatementTests: XCTestCase {
         }
       }
       """,
-      substructure: Syntax(
-        YieldStmtSyntax(
-          yieldKeyword: .keyword(.yield),
-          yieldedExpressions: .init(
-            InOutExprSyntax(
-              ampersand: .prefixAmpersandToken(),
-              expression: SubscriptCallExprSyntax(
-                calledExpression: DeclReferenceExprSyntax(baseName: .identifier("native")),
-                leftSquare: .leftSquareToken(),
-                arguments: LabeledExprListSyntax([
-                  LabeledExprSyntax(
-                    expression: DeclReferenceExprSyntax(baseName: .identifier("key")),
-                    trailingComma: .commaToken()
-                  ),
-                  LabeledExprSyntax(
-                    label: .identifier("isUnique"),
-                    colon: .colonToken(),
-                    expression: BooleanLiteralExprSyntax(literal: .keyword(.true))
-                  ),
-                ]),
-                rightSquare: .rightSquareToken()
-              )
+      substructure: YieldStmtSyntax(
+        yieldKeyword: .keyword(.yield),
+        yieldedExpressions: .init(
+          InOutExprSyntax(
+            ampersand: .prefixAmpersandToken(),
+            expression: SubscriptCallExprSyntax(
+              calledExpression: DeclReferenceExprSyntax(baseName: .identifier("native")),
+              leftSquare: .leftSquareToken(),
+              arguments: LabeledExprListSyntax([
+                LabeledExprSyntax(
+                  expression: DeclReferenceExprSyntax(baseName: .identifier("key")),
+                  trailingComma: .commaToken()
+                ),
+                LabeledExprSyntax(
+                  label: .identifier("isUnique"),
+                  colon: .colonToken(),
+                  expression: BooleanLiteralExprSyntax(literal: .keyword(.true))
+                ),
+              ]),
+              rightSquare: .rightSquareToken()
             )
           )
         )
@@ -501,13 +485,11 @@ final class StatementTests: XCTestCase {
         }
       }
       """,
-      substructure: Syntax(
-        FunctionCallExprSyntax(
-          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("yield")),
-          leftParen: .leftParenToken(),
-          arguments: LabeledExprListSyntax([]),
-          rightParen: .rightParenToken()
-        )
+      substructure: FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("yield")),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([]),
+        rightParen: .rightParenToken()
       ),
       substructureAfterMarker: "1️⃣"
     )
@@ -520,13 +502,11 @@ final class StatementTests: XCTestCase {
         }
       }
       """,
-      substructure: Syntax(
-        FunctionCallExprSyntax(
-          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("yield")),
-          leftParen: .leftParenToken(),
-          arguments: LabeledExprListSyntax([]),
-          rightParen: .rightParenToken()
-        )
+      substructure: FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("yield")),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([]),
+        rightParen: .rightParenToken()
       ),
       substructureAfterMarker: "1️⃣"
     )
@@ -535,21 +515,19 @@ final class StatementTests: XCTestCase {
       """
       yield([])
       """,
-      substructure: Syntax(
-        FunctionCallExprSyntax(
-          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("yield")),
-          leftParen: .leftParenToken(),
-          arguments: LabeledExprListSyntax([
-            LabeledExprSyntax(
-              expression: ArrayExprSyntax(
-                leftSquare: .leftSquareToken(),
-                elements: ArrayElementListSyntax([]),
-                rightSquare: .rightSquareToken()
-              )
+      substructure: FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("yield")),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+          LabeledExprSyntax(
+            expression: ArrayExprSyntax(
+              leftSquare: .leftSquareToken(),
+              elements: ArrayElementListSyntax([]),
+              rightSquare: .rightSquareToken()
             )
-          ]),
-          rightParen: .rightParenToken()
-        )
+          )
+        ]),
+        rightParen: .rightParenToken()
       )
     )
 
@@ -559,14 +537,12 @@ final class StatementTests: XCTestCase {
         1️⃣yield & 5
       }
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: ExprListSyntax([
-            DeclReferenceExprSyntax(baseName: .identifier("yield")),
-            BinaryOperatorExprSyntax(operator: .binaryOperator("&")),
-            IntegerLiteralExprSyntax(5),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: ExprListSyntax([
+          DeclReferenceExprSyntax(baseName: .identifier("yield")),
+          BinaryOperatorExprSyntax(operator: .binaryOperator("&")),
+          IntegerLiteralExprSyntax(5),
+        ])
       ),
       substructureAfterMarker: "1️⃣"
     )
@@ -577,14 +553,12 @@ final class StatementTests: XCTestCase {
         1️⃣yield&5
       }
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: ExprListSyntax([
-            DeclReferenceExprSyntax(baseName: .identifier("yield")),
-            BinaryOperatorExprSyntax(operator: .binaryOperator("&")),
-            IntegerLiteralExprSyntax(5),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: ExprListSyntax([
+          DeclReferenceExprSyntax(baseName: .identifier("yield")),
+          BinaryOperatorExprSyntax(operator: .binaryOperator("&")),
+          IntegerLiteralExprSyntax(5),
+        ])
       ),
       substructureAfterMarker: "1️⃣"
     )
@@ -596,11 +570,9 @@ final class StatementTests: XCTestCase {
       """
       _forget self
       """,
-      substructure: Syntax(
-        DiscardStmtSyntax(
-          discardKeyword: .keyword(._forget),
-          expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
-        )
+      substructure: DiscardStmtSyntax(
+        discardKeyword: .keyword(._forget),
+        expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
       )
     )
 
@@ -608,11 +580,9 @@ final class StatementTests: XCTestCase {
       """
       discard self
       """,
-      substructure: Syntax(
-        DiscardStmtSyntax(
-          discardKeyword: .keyword(.discard),
-          expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
-        )
+      substructure: DiscardStmtSyntax(
+        discardKeyword: .keyword(.discard),
+        expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
       )
     )
 
@@ -620,11 +590,9 @@ final class StatementTests: XCTestCase {
       """
       discard Self
       """,
-      substructure: Syntax(
-        DiscardStmtSyntax(
-          discardKeyword: .keyword(.discard),
-          expression: DeclReferenceExprSyntax(baseName: .keyword(.Self))
-        )
+      substructure: DiscardStmtSyntax(
+        discardKeyword: .keyword(.discard),
+        expression: DeclReferenceExprSyntax(baseName: .keyword(.Self))
       )
     )
 
@@ -632,11 +600,9 @@ final class StatementTests: XCTestCase {
       """
       discard SarahMarshall
       """,
-      substructure: Syntax(
-        DiscardStmtSyntax(
-          discardKeyword: .keyword(.discard),
-          expression: DeclReferenceExprSyntax(baseName: .identifier("SarahMarshall"))
-        )
+      substructure: DiscardStmtSyntax(
+        discardKeyword: .keyword(.discard),
+        expression: DeclReferenceExprSyntax(baseName: .identifier("SarahMarshall"))
       )
     )
 
@@ -662,19 +628,17 @@ final class StatementTests: XCTestCase {
         discard(self)
       }
       """,
-      substructure: Syntax(
-        FunctionCallExprSyntax(
-          callee: DeclReferenceExprSyntax(
-            baseName: .identifier("discard")
-          ),
-          argumentList: {
-            LabeledExprListSyntax([
-              LabeledExprSyntax(
-                expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
-              )
-            ])
-          }
-        )
+      substructure: FunctionCallExprSyntax(
+        callee: DeclReferenceExprSyntax(
+          baseName: .identifier("discard")
+        ),
+        argumentList: {
+          LabeledExprListSyntax([
+            LabeledExprSyntax(
+              expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
+            )
+          ])
+        }
       )
     )
   }
@@ -688,23 +652,21 @@ final class StatementTests: XCTestCase {
       """
       data[position, default: 0]
       """,
-      substructure: Syntax(
-        SubscriptCallExprSyntax(
-          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("data")),
-          leftSquare: .leftSquareToken(),
-          arguments: LabeledExprListSyntax([
-            LabeledExprSyntax(
-              expression: DeclReferenceExprSyntax(baseName: .identifier("position")),
-              trailingComma: .commaToken()
-            ),
-            LabeledExprSyntax(
-              label: .identifier("default"),
-              colon: .colonToken(),
-              expression: IntegerLiteralExprSyntax(0)
-            ),
-          ]),
-          rightSquare: .rightSquareToken()
-        )
+      substructure: SubscriptCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("data")),
+        leftSquare: .leftSquareToken(),
+        arguments: LabeledExprListSyntax([
+          LabeledExprSyntax(
+            expression: DeclReferenceExprSyntax(baseName: .identifier("position")),
+            trailingComma: .commaToken()
+          ),
+          LabeledExprSyntax(
+            label: .identifier("default"),
+            colon: .colonToken(),
+            expression: IntegerLiteralExprSyntax(0)
+          ),
+        ]),
+        rightSquare: .rightSquareToken()
       )
     )
   }

--- a/Tests/SwiftParserTest/TypeCompositionTests.swift
+++ b/Tests/SwiftParserTest/TypeCompositionTests.swift
@@ -52,14 +52,12 @@ final class TypeCompositionTests: XCTestCase {
       assertParse(
         "\(component) & \(component) & \(component)",
         TypeSyntax.parse,
-        substructure: Syntax(
-          CompositionTypeSyntax(
-            elements: .init([
-              CompositionTypeElementSyntax(type: componentSyntax, ampersand: .binaryOperator("&")),
-              CompositionTypeElementSyntax(type: componentSyntax, ampersand: .binaryOperator("&")),
-              CompositionTypeElementSyntax(type: componentSyntax),
-            ])
-          )
+        substructure: CompositionTypeSyntax(
+          elements: .init([
+            CompositionTypeElementSyntax(type: componentSyntax, ampersand: .binaryOperator("&")),
+            CompositionTypeElementSyntax(type: componentSyntax, ampersand: .binaryOperator("&")),
+            CompositionTypeElementSyntax(type: componentSyntax),
+          ])
         ),
         line: line
       )

--- a/Tests/SwiftParserTest/TypeMemberTests.swift
+++ b/Tests/SwiftParserTest/TypeMemberTests.swift
@@ -19,13 +19,11 @@ final class TypeMemberTests: XCTestCase {
     assertParse(
       "MyType.class",
       TypeSyntax.parse,
-      substructure: Syntax(
-        MemberTypeSyntax(
-          baseType: IdentifierTypeSyntax(
-            name: .identifier("MyType")
-          ),
-          name: .identifier("class")
-        )
+      substructure: MemberTypeSyntax(
+        baseType: IdentifierTypeSyntax(
+          name: .identifier("MyType")
+        ),
+        name: .identifier("class")
       )
     )
   }
@@ -34,13 +32,11 @@ final class TypeMemberTests: XCTestCase {
     assertParse(
       "MyType.1️⃣",
       TypeSyntax.parse,
-      substructure: Syntax(
-        MemberTypeSyntax(
-          baseType: IdentifierTypeSyntax(
-            name: .identifier("MyType")
-          ),
-          name: .identifier("", presence: .missing)
-        )
+      substructure: MemberTypeSyntax(
+        baseType: IdentifierTypeSyntax(
+          name: .identifier("MyType")
+        ),
+        name: .identifier("", presence: .missing)
       ),
       diagnostics: [
         DiagnosticSpec(message: "expected name in member type", fixIts: ["insert name"])
@@ -141,21 +137,19 @@ final class TypeMemberTests: XCTestCase {
       assertParse(
         "\(baseType).Z",
         TypeSyntax.parse,
-        substructure: Syntax(expectedSyntax),
+        substructure: expectedSyntax,
         line: line
       )
 
       assertParse(
         "\(baseType).Z<W>",
         TypeSyntax.parse,
-        substructure: Syntax(
-          expectedSyntax.with(
-            \.genericArgumentClause,
-            GenericArgumentClauseSyntax(
-              arguments: .init([
-                GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: .identifier("W")))
-              ])
-            )
+        substructure: expectedSyntax.with(
+          \.genericArgumentClause,
+          GenericArgumentClauseSyntax(
+            arguments: .init([
+              GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: .identifier("W")))
+            ])
           )
         ),
         line: line

--- a/Tests/SwiftParserTest/TypeMetatypeTests.swift
+++ b/Tests/SwiftParserTest/TypeMetatypeTests.swift
@@ -56,11 +56,9 @@ final class TypeMetatypeTests: XCTestCase {
         assertParse(
           "\(baseType).\(metaKind)",
           TypeSyntax.parse,
-          substructure: Syntax(
-            MetatypeTypeSyntax(
-              baseType: baseTypeSyntax,
-              metatypeSpecifier: .keyword(metaKind)
-            )
+          substructure: MetatypeTypeSyntax(
+            baseType: baseTypeSyntax,
+            metatypeSpecifier: .keyword(metaKind)
           ),
           line: line
         )

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -21,14 +21,12 @@ final class VariadicGenericsTests: XCTestCase {
         return (1️⃣repeat each t)
       }
       """,
-      substructure: Syntax(
-        PackExpansionExprSyntax(
-          repeatKeyword: .keyword(.repeat),
-          repetitionPattern: PackElementExprSyntax(
-            eachKeyword: .keyword(.each),
-            pack: DeclReferenceExprSyntax(
-              baseName: .identifier("t")
-            )
+      substructure: PackExpansionExprSyntax(
+        repeatKeyword: .keyword(.repeat),
+        repetitionPattern: PackElementExprSyntax(
+          eachKeyword: .keyword(.each),
+          pack: DeclReferenceExprSyntax(
+            baseName: .identifier("t")
           )
         )
       ),
@@ -160,7 +158,7 @@ final class VariadicGenericsTests: XCTestCase {
       1️⃣each(x)
       }
       """,
-      substructure: Syntax(callExpr),
+      substructure: callExpr,
       substructureAfterMarker: "1️⃣"
     )
 
@@ -170,7 +168,7 @@ final class VariadicGenericsTests: XCTestCase {
       1️⃣each (x)
       }
       """,
-      substructure: Syntax(callExpr),
+      substructure: callExpr,
       substructureAfterMarker: "1️⃣"
     )
 
@@ -180,12 +178,10 @@ final class VariadicGenericsTests: XCTestCase {
       1️⃣each x
       }
       """,
-      substructure: Syntax(
-        PackElementExprSyntax(
-          eachKeyword: .keyword(.each),
-          pack: DeclReferenceExprSyntax(
-            baseName: .identifier("x")
-          )
+      substructure: PackElementExprSyntax(
+        eachKeyword: .keyword(.each),
+        pack: DeclReferenceExprSyntax(
+          baseName: .identifier("x")
         )
       ),
       substructureAfterMarker: "1️⃣"
@@ -199,27 +195,25 @@ final class VariadicGenericsTests: XCTestCase {
         1️⃣repeat (each t).member()
       }
       """,
-      substructure: Syntax(
-        PackExpansionExprSyntax(
-          repeatKeyword: .keyword(.repeat),
-          repetitionPattern: FunctionCallExprSyntax(
-            callee: MemberAccessExprSyntax(
-              base: ExprSyntax(
-                TupleExprSyntax(
-                  elements: .init([
-                    LabeledExprSyntax(
-                      expression: PackElementExprSyntax(
-                        eachKeyword: .keyword(.each),
-                        pack: DeclReferenceExprSyntax(
-                          baseName: .identifier("t")
-                        )
+      substructure: PackExpansionExprSyntax(
+        repeatKeyword: .keyword(.repeat),
+        repetitionPattern: FunctionCallExprSyntax(
+          callee: MemberAccessExprSyntax(
+            base: ExprSyntax(
+              TupleExprSyntax(
+                elements: .init([
+                  LabeledExprSyntax(
+                    expression: PackElementExprSyntax(
+                      eachKeyword: .keyword(.each),
+                      pack: DeclReferenceExprSyntax(
+                        baseName: .identifier("t")
                       )
                     )
-                  ])
-                )
-              ),
-              name: "member"
-            )
+                  )
+                ])
+              )
+            ),
+            name: "member"
           )
         )
       ),
@@ -232,19 +226,17 @@ final class VariadicGenericsTests: XCTestCase {
         1️⃣repeat each t.member
       }
       """,
-      substructure: Syntax(
-        PackExpansionExprSyntax(
-          repeatKeyword: .keyword(.repeat),
-          repetitionPattern: PackElementExprSyntax(
-            eachKeyword: .keyword(.each),
-            pack: MemberAccessExprSyntax(
-              base: ExprSyntax(
-                DeclReferenceExprSyntax(
-                  baseName: .identifier("t")
-                )
-              ),
-              name: "member"
-            )
+      substructure: PackExpansionExprSyntax(
+        repeatKeyword: .keyword(.repeat),
+        repetitionPattern: PackElementExprSyntax(
+          eachKeyword: .keyword(.each),
+          pack: MemberAccessExprSyntax(
+            base: ExprSyntax(
+              DeclReferenceExprSyntax(
+                baseName: .identifier("t")
+              )
+            ),
+            name: "member"
           )
         )
       ),
@@ -257,41 +249,39 @@ final class VariadicGenericsTests: XCTestCase {
         1️⃣repeat x + each t + 10
       }
       """,
-      substructure: Syntax(
-        PackExpansionExprSyntax(
-          repeatKeyword: .keyword(.repeat),
-          repetitionPattern: SequenceExprSyntax(
-            elements: .init([
-              ExprSyntax(
-                DeclReferenceExprSyntax(
-                  baseName: .identifier("x")
+      substructure: PackExpansionExprSyntax(
+        repeatKeyword: .keyword(.repeat),
+        repetitionPattern: SequenceExprSyntax(
+          elements: .init([
+            ExprSyntax(
+              DeclReferenceExprSyntax(
+                baseName: .identifier("x")
+              )
+            ),
+            ExprSyntax(
+              BinaryOperatorExprSyntax(
+                operator: .binaryOperator("+")
+              )
+            ),
+            ExprSyntax(
+              PackElementExprSyntax(
+                eachKeyword: .keyword(.each),
+                pack: DeclReferenceExprSyntax(
+                  baseName: .identifier("t")
                 )
-              ),
-              ExprSyntax(
-                BinaryOperatorExprSyntax(
-                  operator: .binaryOperator("+")
-                )
-              ),
-              ExprSyntax(
-                PackElementExprSyntax(
-                  eachKeyword: .keyword(.each),
-                  pack: DeclReferenceExprSyntax(
-                    baseName: .identifier("t")
-                  )
-                )
-              ),
-              ExprSyntax(
-                BinaryOperatorExprSyntax(
-                  operator: .binaryOperator("+")
-                )
-              ),
-              ExprSyntax(
-                IntegerLiteralExprSyntax(
-                  integerLiteral: 10
-                )
-              ),
-            ])
-          )
+              )
+            ),
+            ExprSyntax(
+              BinaryOperatorExprSyntax(
+                operator: .binaryOperator("+")
+              )
+            ),
+            ExprSyntax(
+              IntegerLiteralExprSyntax(
+                integerLiteral: 10
+              )
+            ),
+          ])
         )
       ),
       substructureAfterMarker: "1️⃣"

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -283,27 +283,25 @@ final class ErrorsTests: XCTestCase {
         let _: () 1️⃣throws
       }
       """,
-      substructure: Syntax(
-        CodeBlockSyntax(
-          statements: CodeBlockItemListSyntax([
-            CodeBlockItemSyntax(
-              item: .decl(
-                DeclSyntax(
-                  VariableDeclSyntax(
-                    bindingSpecifier: .keyword(.let),
-                    bindings: PatternBindingListSyntax([
-                      PatternBindingSyntax(
-                        pattern: WildcardPatternSyntax(),
-                        typeAnnotation: TypeAnnotationSyntax(type: TupleTypeSyntax(elements: TupleTypeElementListSyntax([])))
-                      )
-                    ])
-                  )
+      substructure: CodeBlockSyntax(
+        statements: CodeBlockItemListSyntax([
+          CodeBlockItemSyntax(
+            item: .decl(
+              DeclSyntax(
+                VariableDeclSyntax(
+                  bindingSpecifier: .keyword(.let),
+                  bindings: PatternBindingListSyntax([
+                    PatternBindingSyntax(
+                      pattern: WildcardPatternSyntax(),
+                      typeAnnotation: TypeAnnotationSyntax(type: TupleTypeSyntax(elements: TupleTypeElementListSyntax([])))
+                    )
+                  ])
                 )
               )
             )
-          ]),
-          UnexpectedNodesSyntax([TokenSyntax.keyword(.throws)])
-        )
+          )
+        ]),
+        UnexpectedNodesSyntax([TokenSyntax.keyword(.throws)])
       ),
       diagnostics: [
         DiagnosticSpec(message: "unexpected 'throws' keyword in function")

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
@@ -266,7 +266,7 @@ final class ForwardSlashRegexTests: XCTestCase {
           .blah
       }
       """,
-      substructure: Syntax(BinaryOperatorExprSyntax(operator: .binaryOperator("/?")))
+      substructure: BinaryOperatorExprSyntax(operator: .binaryOperator("/?"))
     )
   }
 
@@ -361,20 +361,18 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = /x/??/x/
       """,
-      substructure: Syntax(
-        SequenceExprSyntax(
-          elements: .init([
-            DiscardAssignmentExprSyntax(),
-            AssignmentExprSyntax(),
-            OptionalChainingExprSyntax(
-              expression: OptionalChainingExprSyntax(
-                expression: RegexLiteralExprSyntax(regex: .regexLiteralPattern("x"))
-              )
-            ),
-            BinaryOperatorExprSyntax(operator: .binaryOperator("/")),
-            PostfixOperatorExprSyntax(expression: DeclReferenceExprSyntax(baseName: "x"), operator: .postfixOperator("/")),
-          ])
-        )
+      substructure: SequenceExprSyntax(
+        elements: .init([
+          DiscardAssignmentExprSyntax(),
+          AssignmentExprSyntax(),
+          OptionalChainingExprSyntax(
+            expression: OptionalChainingExprSyntax(
+              expression: RegexLiteralExprSyntax(regex: .regexLiteralPattern("x"))
+            )
+          ),
+          BinaryOperatorExprSyntax(operator: .binaryOperator("/")),
+          PostfixOperatorExprSyntax(expression: DeclReferenceExprSyntax(baseName: "x"), operator: .postfixOperator("/")),
+        ])
       )
     )
   }
@@ -393,7 +391,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = /x/.../y/
       """,
-      substructure: Syntax(BinaryOperatorExprSyntax(operator: .binaryOperator(".../")))
+      substructure: BinaryOperatorExprSyntax(operator: .binaryOperator(".../"))
     )
   }
 
@@ -519,11 +517,9 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       bar(&/x/)
       """,
-      substructure: Syntax(
-        InOutExprSyntax(
-          expression: RegexLiteralExprSyntax(
-            regex: .regexLiteralPattern("x")
-          )
+      substructure: InOutExprSyntax(
+        expression: RegexLiteralExprSyntax(
+          regex: .regexLiteralPattern("x")
         )
       )
     )
@@ -627,16 +623,14 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = [/abc/:/abc/]
       """,
-      substructure: Syntax(
-        DictionaryExprSyntax(
-          content: .elements(
-            .init([
-              .init(
-                key: RegexLiteralExprSyntax(regex: .regexLiteralPattern("abc")),
-                value: RegexLiteralExprSyntax(regex: .regexLiteralPattern("abc"))
-              )
-            ])
-          )
+      substructure: DictionaryExprSyntax(
+        content: .elements(
+          .init([
+            .init(
+              key: RegexLiteralExprSyntax(regex: .regexLiteralPattern("abc")),
+              value: RegexLiteralExprSyntax(regex: .regexLiteralPattern("abc"))
+            )
+          ])
         )
       )
     )
@@ -740,7 +734,7 @@ final class ForwardSlashRegexTests: XCTestCase {
         2
       }
       """,
-      substructure: Syntax(BinaryOperatorExprSyntax(operator: .binaryOperator("/")))
+      substructure: BinaryOperatorExprSyntax(operator: .binaryOperator("/"))
     )
   }
 
@@ -763,7 +757,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       _ = 2
       / 1 / .bitWidth
       """,
-      substructure: Syntax(BinaryOperatorExprSyntax(operator: .binaryOperator("/")))
+      substructure: BinaryOperatorExprSyntax(operator: .binaryOperator("/"))
     )
   }
 
@@ -774,7 +768,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       _ = 2
       /1/ .bitWidth
       """,
-      substructure: Syntax(RegexLiteralExprSyntax(regex: .regexLiteralPattern("1")))
+      substructure: RegexLiteralExprSyntax(regex: .regexLiteralPattern("1"))
     )
   }
 
@@ -786,7 +780,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       / 1 /
         .bitWidth
       """,
-      substructure: Syntax(BinaryOperatorExprSyntax(operator: .binaryOperator("/")))
+      substructure: BinaryOperatorExprSyntax(operator: .binaryOperator("/"))
     )
   }
 
@@ -798,7 +792,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       /1 /
         .bitWidth
       """,
-      substructure: Syntax(BinaryOperatorExprSyntax(operator: .binaryOperator("/")))
+      substructure: BinaryOperatorExprSyntax(operator: .binaryOperator("/"))
     )
   }
 
@@ -808,13 +802,11 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = !!/1/ .bitWidth
       """,
-      substructure: Syntax(
-        PrefixOperatorExprSyntax(
-          operator: .prefixOperator("!!"),
-          expression: MemberAccessExprSyntax(
-            base: RegexLiteralExprSyntax(regex: .regexLiteralPattern("1")),
-            name: "bitWidth"
-          )
+      substructure: PrefixOperatorExprSyntax(
+        operator: .prefixOperator("!!"),
+        expression: MemberAccessExprSyntax(
+          base: RegexLiteralExprSyntax(regex: .regexLiteralPattern("1")),
+          name: "bitWidth"
         )
       )
     )
@@ -826,7 +818,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = !!/1 / .bitWidth
       """,
-      substructure: Syntax(BinaryOperatorExprSyntax(operator: .binaryOperator("/")))
+      substructure: BinaryOperatorExprSyntax(operator: .binaryOperator("/"))
     )
   }
 
@@ -836,7 +828,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       let z =
       /y/
       """,
-      substructure: Syntax(RegexLiteralExprSyntax(regex: .regexLiteralPattern("y")))
+      substructure: RegexLiteralExprSyntax(regex: .regexLiteralPattern("y"))
     )
   }
 
@@ -1058,7 +1050,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = /x// comment
       """,
-      substructure: Syntax(PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: DeclReferenceExprSyntax(baseName: "x")))
+      substructure: PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: DeclReferenceExprSyntax(baseName: "x"))
     )
   }
 
@@ -1067,7 +1059,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = /x // comment
       """,
-      substructure: Syntax(PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: DeclReferenceExprSyntax(baseName: "x")))
+      substructure: PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: DeclReferenceExprSyntax(baseName: "x"))
     )
   }
 
@@ -1076,7 +1068,7 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       _ = /x/*comment*/
       """,
-      substructure: Syntax(PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: DeclReferenceExprSyntax(baseName: "x")))
+      substructure: PrefixOperatorExprSyntax(operator: .prefixOperator("/"), expression: DeclReferenceExprSyntax(baseName: "x"))
     )
   }
 
@@ -1086,18 +1078,16 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       baz(/, /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")), trailingComma: .commaToken()),
-          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")), trailingComma: .commaToken()),
+        .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
+      ])
     )
     assertParse(
       """
       baz(/,/)
       """,
-      substructure: Syntax(RegexLiteralExprSyntax(regex: .regexLiteralPattern(",")))
+      substructure: RegexLiteralExprSyntax(regex: .regexLiteralPattern(","))
     )
   }
 
@@ -1106,19 +1096,17 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       baz((/), /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            expression: TupleExprSyntax(
-              elements: .init([
-                .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")))
-              ])
-            ),
-            trailingComma: .commaToken()
+      substructure: LabeledExprListSyntax([
+        .init(
+          expression: TupleExprSyntax(
+            elements: .init([
+              .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/")))
+            ])
           ),
-          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
-        ])
-      )
+          trailingComma: .commaToken()
+        ),
+        .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
+      ])
     )
   }
 
@@ -1127,18 +1115,16 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       baz(/^, /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/^")), trailingComma: .commaToken()),
-          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
-        ])
-      )
+      substructure: LabeledExprListSyntax([
+        .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/^")), trailingComma: .commaToken()),
+        .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
+      ])
     )
     assertParse(
       """
       baz(/^,/)
       """,
-      substructure: Syntax(RegexLiteralExprSyntax(regex: .regexLiteralPattern("^,")))
+      substructure: RegexLiteralExprSyntax(regex: .regexLiteralPattern("^,"))
     )
   }
 
@@ -1147,19 +1133,17 @@ final class ForwardSlashRegexTests: XCTestCase {
       """
       baz((/^), /)
       """,
-      substructure: Syntax(
-        LabeledExprListSyntax([
-          .init(
-            expression: TupleExprSyntax(
-              elements: .init([
-                .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/^")))
-              ])
-            ),
-            trailingComma: .commaToken()
+      substructure: LabeledExprListSyntax([
+        .init(
+          expression: TupleExprSyntax(
+            elements: .init([
+              .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/^")))
+            ])
           ),
-          .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
-        ])
-      )
+          trailingComma: .commaToken()
+        ),
+        .init(expression: DeclReferenceExprSyntax(baseName: .binaryOperator("/"))),
+      ])
     )
   }
 

--- a/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
+++ b/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
@@ -90,17 +90,15 @@ final class GenericDisambiguationTests: XCTestCase {
       """
       (a < b, c > (d))
       """,
-      substructure: Syntax(
-        GenericArgumentListSyntax([
-          GenericArgumentSyntax(
-            argument: IdentifierTypeSyntax(name: .identifier("b")),
-            trailingComma: .commaToken()
-          ),
-          GenericArgumentSyntax(
-            argument: IdentifierTypeSyntax(name: .identifier("c"))
-          ),
-        ])
-      )
+      substructure: GenericArgumentListSyntax([
+        GenericArgumentSyntax(
+          argument: IdentifierTypeSyntax(name: .identifier("b")),
+          trailingComma: .commaToken()
+        ),
+        GenericArgumentSyntax(
+          argument: IdentifierTypeSyntax(name: .identifier("c"))
+        ),
+      ])
     )
   }
 
@@ -110,17 +108,15 @@ final class GenericDisambiguationTests: XCTestCase {
       """
       (a<b, c>(d))
       """,
-      substructure: Syntax(
-        GenericArgumentListSyntax([
-          GenericArgumentSyntax(
-            argument: IdentifierTypeSyntax(name: .identifier("b")),
-            trailingComma: .commaToken()
-          ),
-          GenericArgumentSyntax(
-            argument: IdentifierTypeSyntax(name: .identifier("c"))
-          ),
-        ])
-      )
+      substructure: GenericArgumentListSyntax([
+        GenericArgumentSyntax(
+          argument: IdentifierTypeSyntax(name: .identifier("b")),
+          trailingComma: .commaToken()
+        ),
+        GenericArgumentSyntax(
+          argument: IdentifierTypeSyntax(name: .identifier("c"))
+        ),
+      ])
     )
   }
 

--- a/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
@@ -25,32 +25,30 @@ final class HashbangLibraryTests: XCTestCase {
       #!/usr/bin/swift
       class Foo {}
       """,
-      substructure: Syntax(
-        SourceFileSyntax(
-          statements: CodeBlockItemListSyntax([
-            CodeBlockItemSyntax(
-              item: .decl(
-                DeclSyntax(
-                  ClassDeclSyntax(
-                    classKeyword: .keyword(
-                      .class,
-                      leadingTrivia: [
-                        .shebang("#!/usr/bin/swift"),
-                        .newlines(1),
-                      ],
-                      trailingTrivia: .space
-                    ),
-                    name: .identifier("Foo", trailingTrivia: .space),
-                    memberBlock: MemberBlockSyntax(
-                      members: MemberBlockItemListSyntax([])
-                    )
+      substructure: SourceFileSyntax(
+        statements: CodeBlockItemListSyntax([
+          CodeBlockItemSyntax(
+            item: .decl(
+              DeclSyntax(
+                ClassDeclSyntax(
+                  classKeyword: .keyword(
+                    .class,
+                    leadingTrivia: [
+                      .shebang("#!/usr/bin/swift"),
+                      .newlines(1),
+                    ],
+                    trailingTrivia: .space
+                  ),
+                  name: .identifier("Foo", trailingTrivia: .space),
+                  memberBlock: MemberBlockSyntax(
+                    members: MemberBlockItemListSyntax([])
                   )
                 )
               )
             )
-          ]),
-          endOfFileToken: .endOfFileToken()
-        )
+          )
+        ]),
+        endOfFileToken: .endOfFileToken()
       ),
       options: [.substructureCheckTrivia]
     )

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -653,20 +653,18 @@ final class IfconfigExprTests: XCTestCase {
       #if compiler(<10.0) || hasGreeble(blah)
       #endif
       """,
-      substructure: Syntax(
-        FunctionCallExprSyntax(
-          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("compiler")),
-          leftParen: .leftParenToken(),
-          arguments: LabeledExprListSyntax([
-            LabeledExprSyntax(
-              expression: PrefixOperatorExprSyntax(
-                operator: .prefixOperator("<"),
-                expression: FloatLiteralExprSyntax(literal: .floatLiteral("10.0"))
-              )
+      substructure: FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("compiler")),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+          LabeledExprSyntax(
+            expression: PrefixOperatorExprSyntax(
+              operator: .prefixOperator("<"),
+              expression: FloatLiteralExprSyntax(literal: .floatLiteral("10.0"))
             )
-          ]),
-          rightParen: .rightParenToken(trailingTrivia: .space)
-        )
+          )
+        ]),
+        rightParen: .rightParenToken(trailingTrivia: .space)
       )
     )
   }
@@ -707,21 +705,19 @@ final class IfconfigExprTests: XCTestCase {
       #if hasFeature(17)
       #endif
       """,
-      substructure: Syntax(
-        IfConfigClauseSyntax(
-          poundKeyword: .poundIfToken(),
-          condition: FunctionCallExprSyntax(
-            calledExpression: DeclReferenceExprSyntax(baseName: .identifier("hasFeature")),
-            leftParen: .leftParenToken(),
-            arguments: LabeledExprListSyntax([
-              LabeledExprSyntax(
-                expression: IntegerLiteralExprSyntax(literal: .integerLiteral("17"))
-              )
-            ]),
-            rightParen: .rightParenToken()
-          ),
-          elements: .init(CodeBlockItemListSyntax([]))
-        )
+      substructure: IfConfigClauseSyntax(
+        poundKeyword: .poundIfToken(),
+        condition: FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("hasFeature")),
+          leftParen: .leftParenToken(),
+          arguments: LabeledExprListSyntax([
+            LabeledExprSyntax(
+              expression: IntegerLiteralExprSyntax(literal: .integerLiteral("17"))
+            )
+          ]),
+          rightParen: .rightParenToken()
+        ),
+        elements: .init(CodeBlockItemListSyntax([]))
       )
     )
   }

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -435,7 +435,7 @@ final class InitDeinitTests: XCTestCase {
         final func foo()
       }
       """,
-      substructure: Syntax(DeinitializerDeclSyntax())
+      substructure: DeinitializerDeclSyntax()
     )
   }
 

--- a/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
@@ -18,7 +18,7 @@ import SwiftSyntax
 
 func assertParseWithAllNewlineEndings(
   _ markedSource: String,
-  substructure expectedSubstructure: Syntax? = nil,
+  substructure expectedSubstructure: (some SyntaxProtocol)? = Optional<Syntax>.none,
   substructureAfterMarker: String = "START",
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   applyFixIts: [String]? = nil,
@@ -812,7 +812,7 @@ final class MultilineErrorsTests: XCTestCase {
         """
         abc
       """##,
-      substructure: Syntax(DeclReferenceExprSyntax(baseName: .identifier("abc"))),
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("abc")),
       diagnostics: [
         DiagnosticSpec(
           locationMarker: "3️⃣",

--- a/Tests/SwiftParserTest/translated/MultilineStringTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineStringTests.swift
@@ -495,19 +495,17 @@ final class MultilineStringTests: XCTestCase {
       Gamma
       """#
       """##,
-      substructure: Syntax(
-        StringLiteralExprSyntax(
-          openingPounds: .rawStringPoundDelimiter("#"),
-          openingQuote: .multilineStringQuoteToken(trailingTrivia: .newline),
-          segments: StringLiteralSegmentListSyntax([
-            .stringSegment(
-              StringSegmentSyntax(content: .stringSegment("Three ", trailingTrivia: [.backslashes(1), .pounds(1), .newlines(1)]))
-            ),
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("Gamma", trailingTrivia: .newline))),
-          ]),
-          closingQuote: .multilineStringQuoteToken(),
-          closingPounds: .rawStringPoundDelimiter("#")
-        )
+      substructure: StringLiteralExprSyntax(
+        openingPounds: .rawStringPoundDelimiter("#"),
+        openingQuote: .multilineStringQuoteToken(trailingTrivia: .newline),
+        segments: StringLiteralSegmentListSyntax([
+          .stringSegment(
+            StringSegmentSyntax(content: .stringSegment("Three ", trailingTrivia: [.backslashes(1), .pounds(1), .newlines(1)]))
+          ),
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("Gamma", trailingTrivia: .newline))),
+        ]),
+        closingQuote: .multilineStringQuoteToken(),
+        closingPounds: .rawStringPoundDelimiter("#")
       ),
       options: .substructureCheckTrivia
     )
@@ -524,19 +522,17 @@ final class MultilineStringTests: XCTestCase {
       Gamma \#
       """#
       """##,
-      substructure: Syntax(
-        StringLiteralExprSyntax(
-          openingPounds: .rawStringPoundDelimiter("#"),
-          openingQuote: .multilineStringQuoteToken(trailingTrivia: .newline),
-          segments: StringLiteralSegmentListSyntax([
-            .stringSegment(
-              StringSegmentSyntax(content: .stringSegment("Three ", trailingTrivia: [.backslashes(1), .pounds(1), .newlines(1)]))
-            ),
-            .stringSegment(StringSegmentSyntax(content: .stringSegment("Gamma ", trailingTrivia: [.backslashes(1), .pounds(1), .newlines(1)]))),
-          ]),
-          closingQuote: .multilineStringQuoteToken(),
-          closingPounds: .rawStringPoundDelimiter("#")
-        )
+      substructure: StringLiteralExprSyntax(
+        openingPounds: .rawStringPoundDelimiter("#"),
+        openingQuote: .multilineStringQuoteToken(trailingTrivia: .newline),
+        segments: StringLiteralSegmentListSyntax([
+          .stringSegment(
+            StringSegmentSyntax(content: .stringSegment("Three ", trailingTrivia: [.backslashes(1), .pounds(1), .newlines(1)]))
+          ),
+          .stringSegment(StringSegmentSyntax(content: .stringSegment("Gamma ", trailingTrivia: [.backslashes(1), .pounds(1), .newlines(1)]))),
+        ]),
+        closingQuote: .multilineStringQuoteToken(),
+        closingPounds: .rawStringPoundDelimiter("#")
       ),
       options: .substructureCheckTrivia
     )

--- a/Tests/SwiftParserTest/translated/OptionalTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalTests.swift
@@ -43,11 +43,9 @@ final class OptionalTests: XCTestCase {
       """
       var c = a?
       """,
-      substructure: Syntax(
-        OptionalChainingExprSyntax(
-          expression: DeclReferenceExprSyntax(baseName: .identifier("a")),
-          questionMark: .postfixQuestionMarkToken()
-        )
+      substructure: OptionalChainingExprSyntax(
+        expression: DeclReferenceExprSyntax(baseName: .identifier("a")),
+        questionMark: .postfixQuestionMarkToken()
       )
     )
   }

--- a/Tests/SwiftParserTest/translated/SuperTests.swift
+++ b/Tests/SwiftParserTest/translated/SuperTests.swift
@@ -136,17 +136,15 @@ final class SuperTests: XCTestCase {
         }
       }
       """#,
-      substructure: Syntax(
-        FunctionCallExprSyntax(
-          calledExpression: SuperExprSyntax(superKeyword: .keyword(.super)),
-          leftParen: .leftParenToken(),
-          arguments: LabeledExprListSyntax([
-            LabeledExprSyntax(
-              expression: IntegerLiteralExprSyntax(literal: .integerLiteral("0"))
-            )
-          ]),
-          rightParen: .rightParenToken()
-        )
+      substructure: FunctionCallExprSyntax(
+        calledExpression: SuperExprSyntax(superKeyword: .keyword(.super)),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+          LabeledExprSyntax(
+            expression: IntegerLiteralExprSyntax(literal: .integerLiteral("0"))
+          )
+        ]),
+        rightParen: .rightParenToken()
       )
     )
   }
@@ -161,16 +159,14 @@ final class SuperTests: XCTestCase {
         }
       }
       """#,
-      substructure: Syntax(
-        ArrayExprSyntax(
-          leftSquare: .leftSquareToken(),
-          elements: ArrayElementListSyntax([
-            ArrayElementSyntax(
-              expression: IntegerLiteralExprSyntax(literal: .integerLiteral("1"))
-            )
-          ]),
-          rightSquare: .rightSquareToken()
-        )
+      substructure: ArrayExprSyntax(
+        leftSquare: .leftSquareToken(),
+        elements: ArrayElementListSyntax([
+          ArrayElementSyntax(
+            expression: IntegerLiteralExprSyntax(literal: .integerLiteral("1"))
+          )
+        ]),
+        rightSquare: .rightSquareToken()
       )
     )
   }

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -178,19 +178,17 @@ final class TrailingClosuresTests: XCTestCase {
       """
       fn {} g: 1️⃣<#T##() -> Void#>
       """,
-      substructure: Syntax(
-        MultipleTrailingClosureElementSyntax(
-          label: .identifier("g"),
-          colon: .colonToken(trailingTrivia: .space),
-          closure: ClosureExprSyntax(
-            leftBrace: .leftBraceToken(presence: .missing),
-            statements: CodeBlockItemListSyntax([
-              CodeBlockItemSyntax(
-                item: .init(EditorPlaceholderExprSyntax(placeholder: .identifier("<#T##() -> Void#>")))
-              )
-            ]),
-            rightBrace: .rightBraceToken(presence: .missing)
-          )
+      substructure: MultipleTrailingClosureElementSyntax(
+        label: .identifier("g"),
+        colon: .colonToken(trailingTrivia: .space),
+        closure: ClosureExprSyntax(
+          leftBrace: .leftBraceToken(presence: .missing),
+          statements: CodeBlockItemListSyntax([
+            CodeBlockItemSyntax(
+              item: .init(EditorPlaceholderExprSyntax(placeholder: .identifier("<#T##() -> Void#>")))
+            )
+          ]),
+          rightBrace: .rightBraceToken(presence: .missing)
         )
       ),
       diagnostics: [

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -44,9 +44,9 @@ fileprivate func assertSyntaxCollectionManipulation(
   }
 
   do {
-    let subtreeMatcher = SubtreeMatcher(Syntax(modifiedArray), markers: [:])
+    let subtreeMatcher = SubtreeMatcher(modifiedArray, markers: [:])
     try subtreeMatcher.assertSameStructure(
-      Syntax(expectedArray),
+      expectedArray,
       includeTrivia: true,
       file: file,
       line: line

--- a/Tests/SwiftSyntaxTestSupportTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxTestSupportTest/SyntaxComparisonTests.swift
@@ -41,7 +41,7 @@ public class SyntaxComparisonTests: XCTestCase {
   }
 
   public func testDifferentTokenKind() throws {
-    let expected = Syntax(makeFunc(name: .binaryOperator("f")))
+    let expected = makeFunc(name: .binaryOperator("f"))
 
     func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
       let diff = try XCTUnwrap(diff, file: file, line: line)
@@ -58,7 +58,7 @@ public class SyntaxComparisonTests: XCTestCase {
   }
 
   public func testDifferentTokenText() throws {
-    let expected = Syntax(makeFunc(name: .identifier("f")))
+    let expected = makeFunc(name: .identifier("f"))
     func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
       let diff = try XCTUnwrap(diff, file: file, line: line)
       XCTAssertEqual(diff.reason, .token)
@@ -74,7 +74,7 @@ public class SyntaxComparisonTests: XCTestCase {
   }
 
   public func testDifferentTrivia() throws {
-    let expected = Syntax(makeFunc(name: .identifier("f"), indent: 2))
+    let expected = makeFunc(name: .identifier("f"), indent: 2)
     func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
       let diff = try XCTUnwrap(diff, file: file, line: line)
       XCTAssertEqual(diff.reason, .trivia)
@@ -92,14 +92,12 @@ public class SyntaxComparisonTests: XCTestCase {
   }
 
   public func testDifferentPresence() throws {
-    let expected = Syntax(
-      makeFunc(
-        name: .identifier("f"),
-        body: CodeBlockSyntax(
-          leftBrace: .leftBraceToken(presence: .missing),
-          statements: CodeBlockItemListSyntax([]),
-          rightBrace: .rightBraceToken(presence: .missing)
-        )
+    let expected = makeFunc(
+      name: .identifier("f"),
+      body: CodeBlockSyntax(
+        leftBrace: .leftBraceToken(presence: .missing),
+        statements: CodeBlockItemListSyntax([]),
+        rightBrace: .rightBraceToken(presence: .missing)
       )
     )
     func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
@@ -131,7 +129,7 @@ public class SyntaxComparisonTests: XCTestCase {
   }
 
   public func testAdditionalNode() throws {
-    let expected = Syntax(makeFunc(name: .identifier("f")))
+    let expected = makeFunc(name: .identifier("f"))
     func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
       let diff = try XCTUnwrap(diff, file: file, line: line)
       XCTAssertEqual(diff.reason, .additionalNode)


### PR DESCRIPTION
This eliminates a bunch of upcasts to `Syntax` in the tests.