### PR TITLE
Prune example projects that don’t use swift-syntax 508.0.0

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -16,28 +16,14 @@ Furthermore, SwiftSyntax uses [`SwiftSyntaxBuilder`](../Sources/SwiftSyntaxBuild
 
 [**Muter**](https://github.com/muter-mutation-testing/muter): Automated mutation testing for Swift.
 
-[**Pecker**](https://github.com/woshiccm/Pecker): A tool to detect unused code.
-
 [**Periphery**](https://github.com/peripheryapp/periphery): A tool to detect unused code.
 
-[**Piranha**](https://github.com/uber/piranha): A tool for refactoring code related to feature flags.
-
 [**Sitrep**](https://github.com/twostraws/Sitrep): A source code analyzer for Swift projects.
-
-[**STAR**](https://github.com/thumbtack/star): A tool to find how often specified Swift type(s) are used in a project.
 
 [**Swift AST Explorer**](https://swift-ast-explorer.com/): A Swift AST visualizer.
 
 [**Swift Stress Tester**](https://github.com/apple/swift-stress-tester): A test driver for `sourcekitd` and Swift evolution.
 
-[**Swift Variable Injector**](https://github.com/LucianoPAlmeida/variable-injector): A tool to replace string literals with the values of environment variables.
-
 [**swift-format**](https://github.com/apple/swift-format): Formatting technology for Swift source code.
 
 [**SwiftLint**](https://github.com/realm/SwiftLint): A tool to enforce Swift style and conventions.
-
-[**SwiftPack**](https://github.com/omochi/SwiftPack): A tool for automatically embedding Swift library source.
-
-[**SwiftRewriter**](https://github.com/inamiy/SwiftRewriter): A Swift code formatter.
-
-[**SwiftSemantics**](https://github.com/SwiftDocOrg/SwiftSemantics): Parses Swift code into its constituent declarations.


### PR DESCRIPTION
These projects haven’t been updated to the latest swift-syntax version and thus aren’t good examples anymore. Remove them.