### PR TITLE
Format doc comments so they render better in docc

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -242,7 +242,9 @@ public let DECL_NODES: [Node] = [
     base: .decl,
     nameForDiagnostics: "associatedtype declaration",
     documentation: """
-      An associated type declaration like the following.
+      An `associatedtype` declaration
+
+      An example of an associatedtype declaration is
 
       ```swift
       associatedtype Item
@@ -332,7 +334,9 @@ public let DECL_NODES: [Node] = [
     base: .decl,
     nameForDiagnostics: "class",
     documentation: """
-      A class declaration like the following.
+      A `class` declaration
+
+      An example of a class declaration is
 
       ```swift
       class SomeClass {
@@ -498,7 +502,9 @@ public let DECL_NODES: [Node] = [
     base: .decl,
     nameForDiagnostics: "deinitializer",
     documentation: """
-      A deinitializer declaration like the following.
+      A `deint` declaration
+
+      An example of a deinitializer is
 
       ```swift
       deinit {
@@ -1135,7 +1141,9 @@ public let DECL_NODES: [Node] = [
     base: .decl,
     nameForDiagnostics: "import",
     documentation: """
-      An import declaration like the following.
+      An `import` declaration
+
+      An example of an import declaration is
 
       ```swift
       import Foundation
@@ -1180,7 +1188,11 @@ public let DECL_NODES: [Node] = [
           .keyword(text: "func"),
           .keyword(text: "inout"),
         ]),
-        documentation: "The kind of declaration being imported. For example, a struct can be imported from a specific module.",
+        documentation: """
+          The kind of declaration being imported. 
+
+          A struct can be imported from a specific module.
+          """,
         isOptional: true
       ),
       Child(
@@ -1241,7 +1253,9 @@ public let DECL_NODES: [Node] = [
     base: .decl,
     nameForDiagnostics: "initializer",
     documentation: """
-      An initializer declaration like the following.
+      An `init` declaration
+
+      An example of an initializer is
 
       ```swift
       init(someParameter: Int) {
@@ -1900,7 +1914,9 @@ public let DECL_NODES: [Node] = [
     base: .decl,
     nameForDiagnostics: "protocol",
     documentation: """
-      A protocol declaration like the following.
+      A `protocol` declaration
+
+      An example of a protocol declaration is
 
       ```swift
       protocol Example {
@@ -2021,61 +2037,63 @@ public let DECL_NODES: [Node] = [
     base: .decl,
     nameForDiagnostics: "struct",
     documentation: """
-          A struct declaration like the following.
+      A `struct` declaration
 
-          ```swift
-          struct SomeStruct {
-            let someMember: String
-            var anotherMember: Int
+      An example of a struct declaration is
 
-            func foo() {
-              print(someMember)
-            }
+      ```swift
+      struct SomeStruct {
+        let someMember: String
+        var anotherMember: Int
 
-            mutating func bar() {
-              anotherMember = 42
-            }
-          }
-          ```
+        func foo() {
+          print(someMember)
+        }
 
-          A struct declaration may be declared without any members.
+        mutating func bar() {
+          anotherMember = 42
+        }
+      }
+      ```
 
-          ```swift
-          struct EmptyStruct {
+      A struct declaration may be declared without any members.
 
-          }
-          ```
+      ```swift
+      struct EmptyStruct {
 
-          A struct declaration may include a type inheritance clause listing
-          one or more protocols the struct conforms to.
+      }
+      ```
 
-          The example below uses Hashable and Equatable protocols whose members
-          are automatically synthesized by the compiler if the struct contains
-          stored members that are themselves `Hashable` and `Equatable`.
+      A struct declaration may include a type inheritance clause listing
+      one or more protocols the struct conforms to.
 
-          ```swift
-          struct AdvancedStruct: Hashable, Equatable {
-            let someMember: String
-            var anotherMember: Int
-          }
-          ```
+      The example below uses Hashable and Equatable protocols whose members
+      are automatically synthesized by the compiler if the struct contains
+      stored members that are themselves `Hashable` and `Equatable`.
 
-          A struct declaration may include a generic parameter clause as well
-          as a generic where clause.
+      ```swift
+      struct AdvancedStruct: Hashable, Equatable {
+        let someMember: String
+        var anotherMember: Int
+      }
+      ```
 
-          ```swift
-          struct Stack<Element> {
-            var items: [Element] = []
+      A struct declaration may include a generic parameter clause as well
+      as a generic where clause.
 
-            mutating func push(_ item: Element) {
-              items.append(item)
-            }
+      ```swift
+      struct Stack<Element> {
+        var items: [Element] = []
 
-            mutating func pop() -> Element {
-              return items.removeLast()
-            }
-         }
-         ```
+        mutating func push(_ item: Element) {
+          items.append(item)
+        }
+
+        mutating func pop() -> Element {
+          return items.removeLast()
+        }
+      }
+      ```
       """,
     traits: [
       "DeclGroup",

--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -981,7 +981,9 @@ public let EXPR_NODES: [Node] = [
     base: .expr,
     nameForDiagnostics: "'is'",
     documentation: """
-      An `is` expression like the following.
+      Checks if an expression is of a given type.
+
+      An example of an `is` expression is
 
       ```swift
       value is Double

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -21,9 +21,11 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       // MARK: - \(node.kind.syntaxType)
 
-      /// Protocol to which all ``\(node.kind.syntaxType)`` nodes conform. Extension point to add
-      /// common methods to all ``\(node.kind.syntaxType)`` nodes.
-      /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
+      /// Protocol to which all ``\(node.kind.syntaxType)`` nodes conform. 
+      ///
+      /// Extension point to add common methods to all ``\(node.kind.syntaxType)`` nodes.
+      ///
+      ///  - Warning: Do not conform to this protocol yourself.
       public protocol \(node.kind.protocolType): \(raw: node.base.protocolType) {}
       """
     )
@@ -33,7 +35,8 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         """
         /// Check whether the non-type erased version of this syntax node conforms to
         /// \(node.kind.protocolType).
-        /// Note that this will incur an existential conversion.
+        ///
+        ///  - Note:  This will incur an existential conversion.
         func isProtocol(_: \(node.kind.protocolType).Protocol) -> Bool {
           return self.asProtocol(\(node.kind.protocolType).self) != nil
         }
@@ -44,7 +47,8 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         """
         /// Return the non-type erased version of this syntax node if it conforms to
         /// \(node.kind.protocolType). Otherwise return nil.
-        /// Note that this will incur an existential conversion.
+        ///
+        ///  - Note:  This will incur an existential conversion.
         func asProtocol(_: \(node.kind.protocolType).Protocol) -> \(node.kind.protocolType)? {
           return self.asProtocol(SyntaxProtocol.self) as? \(node.kind.protocolType)
         }
@@ -131,9 +135,10 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
       try InitializerDeclSyntax(
         """
-        /// Creates a ``\(node.kind.syntaxType)`` node from the given ``SyntaxData``. This assumes
-        /// that the ``SyntaxData`` is of the correct kind. If it is not, the behaviour
-        /// is undefined.
+        /// Creates a ``\(node.kind.syntaxType)`` node from the given ``SyntaxData``.
+        ///
+        ///  - Warning: This assumes  that the ``SyntaxData`` is of the correct kind.
+        ///    If it is not, the behaviour is undefined.
         internal init(_ data: SyntaxData)
         """
       ) {
@@ -192,7 +197,8 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         """
         /// Syntax nodes always conform to `\(node.kind.protocolType)`. This API is just
         /// added for consistency.
-        /// Note that this will incur an existential conversion.
+        ///
+        ///  - Note:  This will incur an existential conversion.
         @available(*, deprecated, message: "Expression always evaluates to true")
         public func isProtocol(_: \(raw: node.kind.protocolType).Protocol) -> Bool {
           return true
@@ -203,7 +209,8 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Return the non-type erased version of this syntax node.
-        /// Note that this will incur an existential conversion.
+        ///
+        ///  - Note:  This will incur an existential conversion.
         public func asProtocol(_: \(node.kind.protocolType).Protocol) -> \(node.kind.protocolType) {
           return Syntax(self).asProtocol(\(node.kind.protocolType).self)!
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -66,9 +66,10 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
 
         DeclSyntax(
           """
-          /// Creates a ``\(node.kind.syntaxType)`` node from the given ``SyntaxData``. This assumes
-          /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-          /// is undefined.
+          /// Creates a ``\(node.kind.syntaxType)`` node from the given ``SyntaxData``. 
+          ///
+          ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+          ///    If it is not, the behaviour is undefined.
           internal init(_ data: SyntaxData) {
             precondition(data.raw.kind == .\(raw: node.varOrCaseName))
             self._syntaxNode = Syntax(data)
@@ -199,6 +200,7 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
               """
               /// Adds the provided `element` to the node's `\(child.varOrCaseName)`
               /// collection.
+              ///
               /// - param element: The new `\(raw: childElt)` to add to the node's
               ///                  `\(child.varOrCaseName)` collection.
               /// - returns: A copy of the receiver with the provided `\(raw: childElt)`

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -14,22 +14,26 @@
 
 // MARK: - DeclSyntax
 
-/// Protocol to which all ``DeclSyntax`` nodes conform. Extension point to add
-/// common methods to all ``DeclSyntax`` nodes.
-/// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
+/// Protocol to which all ``DeclSyntax`` nodes conform. 
+///
+/// Extension point to add common methods to all ``DeclSyntax`` nodes.
+///
+///  - Warning: Do not conform to this protocol yourself.
 public protocol DeclSyntaxProtocol: SyntaxProtocol {}
 
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// DeclSyntaxProtocol.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func isProtocol(_: DeclSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(DeclSyntaxProtocol.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// DeclSyntaxProtocol. Otherwise return nil.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func asProtocol(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? DeclSyntaxProtocol
   }
@@ -78,9 +82,10 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// Creates a ``DeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the ``SyntaxData`` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DeclSyntax`` node from the given ``SyntaxData``.
+  ///
+  ///  - Warning: This assumes  that the ``SyntaxData`` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     switch data.raw.kind {
     case .accessorDecl, .actorDecl, .associatedTypeDecl, .classDecl, .deinitializerDecl, .editorPlaceholderDecl, .enumCaseDecl, .enumDecl, .extensionDecl, .functionDecl, .ifConfigDecl, .importDecl, .initializerDecl, .macroDecl, .macroExpansionDecl, .missingDecl, .operatorDecl, .poundSourceLocation, .precedenceGroupDecl, .protocolDecl, .structDecl, .subscriptDecl, .typeAliasDecl, .variableDecl:
@@ -105,14 +110,16 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Syntax nodes always conform to `DeclSyntaxProtocol`. This API is just
   /// added for consistency.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
   public func isProtocol(_: DeclSyntaxProtocol.Protocol) -> Bool {
     return true
   }
   
   /// Return the non-type erased version of this syntax node.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   public func asProtocol(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol {
     return Syntax(self).asProtocol(DeclSyntaxProtocol.self)!
   }
@@ -149,22 +156,26 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ExprSyntax
 
-/// Protocol to which all ``ExprSyntax`` nodes conform. Extension point to add
-/// common methods to all ``ExprSyntax`` nodes.
-/// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
+/// Protocol to which all ``ExprSyntax`` nodes conform. 
+///
+/// Extension point to add common methods to all ``ExprSyntax`` nodes.
+///
+///  - Warning: Do not conform to this protocol yourself.
 public protocol ExprSyntaxProtocol: SyntaxProtocol {}
 
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// ExprSyntaxProtocol.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func isProtocol(_: ExprSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(ExprSyntaxProtocol.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// ExprSyntaxProtocol. Otherwise return nil.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func asProtocol(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? ExprSyntaxProtocol
   }
@@ -213,9 +224,10 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// Creates a ``ExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the ``SyntaxData`` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ExprSyntax`` node from the given ``SyntaxData``.
+  ///
+  ///  - Warning: This assumes  that the ``SyntaxData`` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     switch data.raw.kind {
     case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .canImportExpr, .canImportVersionInfo, .closureExpr, .consumeExpr, .copyExpr, .declReferenceExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forceUnwrapExpr, .functionCallExpr, .genericSpecializationExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .patternExpr, .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .stringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:
@@ -240,14 +252,16 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Syntax nodes always conform to `ExprSyntaxProtocol`. This API is just
   /// added for consistency.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
   public func isProtocol(_: ExprSyntaxProtocol.Protocol) -> Bool {
     return true
   }
   
   /// Return the non-type erased version of this syntax node.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   public func asProtocol(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol {
     return Syntax(self).asProtocol(ExprSyntaxProtocol.self)!
   }
@@ -311,22 +325,26 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - PatternSyntax
 
-/// Protocol to which all ``PatternSyntax`` nodes conform. Extension point to add
-/// common methods to all ``PatternSyntax`` nodes.
-/// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
+/// Protocol to which all ``PatternSyntax`` nodes conform. 
+///
+/// Extension point to add common methods to all ``PatternSyntax`` nodes.
+///
+///  - Warning: Do not conform to this protocol yourself.
 public protocol PatternSyntaxProtocol: SyntaxProtocol {}
 
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// PatternSyntaxProtocol.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func isProtocol(_: PatternSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(PatternSyntaxProtocol.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// PatternSyntaxProtocol. Otherwise return nil.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func asProtocol(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? PatternSyntaxProtocol
   }
@@ -375,9 +393,10 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// Creates a ``PatternSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the ``SyntaxData`` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PatternSyntax`` node from the given ``SyntaxData``.
+  ///
+  ///  - Warning: This assumes  that the ``SyntaxData`` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     switch data.raw.kind {
     case .expressionPattern, .identifierPattern, .isTypePattern, .missingPattern, .tuplePattern, .valueBindingPattern, .wildcardPattern:
@@ -402,14 +421,16 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   
   /// Syntax nodes always conform to `PatternSyntaxProtocol`. This API is just
   /// added for consistency.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
   public func isProtocol(_: PatternSyntaxProtocol.Protocol) -> Bool {
     return true
   }
   
   /// Return the non-type erased version of this syntax node.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   public func asProtocol(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol {
     return Syntax(self).asProtocol(PatternSyntaxProtocol.self)!
   }
@@ -429,22 +450,26 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
 // MARK: - StmtSyntax
 
-/// Protocol to which all ``StmtSyntax`` nodes conform. Extension point to add
-/// common methods to all ``StmtSyntax`` nodes.
-/// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
+/// Protocol to which all ``StmtSyntax`` nodes conform. 
+///
+/// Extension point to add common methods to all ``StmtSyntax`` nodes.
+///
+///  - Warning: Do not conform to this protocol yourself.
 public protocol StmtSyntaxProtocol: SyntaxProtocol {}
 
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// StmtSyntaxProtocol.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func isProtocol(_: StmtSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(StmtSyntaxProtocol.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// StmtSyntaxProtocol. Otherwise return nil.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func asProtocol(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? StmtSyntaxProtocol
   }
@@ -493,9 +518,10 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// Creates a ``StmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the ``SyntaxData`` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``StmtSyntax`` node from the given ``SyntaxData``.
+  ///
+  ///  - Warning: This assumes  that the ``SyntaxData`` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     switch data.raw.kind {
     case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallThroughStmt, .forStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
@@ -520,14 +546,16 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   /// Syntax nodes always conform to `StmtSyntaxProtocol`. This API is just
   /// added for consistency.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
   public func isProtocol(_: StmtSyntaxProtocol.Protocol) -> Bool {
     return true
   }
   
   /// Return the non-type erased version of this syntax node.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   public func asProtocol(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol {
     return Syntax(self).asProtocol(StmtSyntaxProtocol.self)!
   }
@@ -556,22 +584,26 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 // MARK: - TypeSyntax
 
-/// Protocol to which all ``TypeSyntax`` nodes conform. Extension point to add
-/// common methods to all ``TypeSyntax`` nodes.
-/// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
+/// Protocol to which all ``TypeSyntax`` nodes conform. 
+///
+/// Extension point to add common methods to all ``TypeSyntax`` nodes.
+///
+///  - Warning: Do not conform to this protocol yourself.
 public protocol TypeSyntaxProtocol: SyntaxProtocol {}
 
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// TypeSyntaxProtocol.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func isProtocol(_: TypeSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(TypeSyntaxProtocol.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// TypeSyntaxProtocol. Otherwise return nil.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   func asProtocol(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? TypeSyntaxProtocol
   }
@@ -620,9 +652,10 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// Creates a ``TypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the ``SyntaxData`` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TypeSyntax`` node from the given ``SyntaxData``.
+  ///
+  ///  - Warning: This assumes  that the ``SyntaxData`` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     switch data.raw.kind {
     case .arrayType, .attributedType, .classRestrictionType, .compositionType, .dictionaryType, .functionType, .identifierType, .implicitlyUnwrappedOptionalType, .memberType, .metatypeType, .missingType, .namedOpaqueReturnType, .optionalType, .packElementType, .packExpansionType, .someOrAnyType, .suppressedType, .tupleType:
@@ -647,14 +680,16 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   
   /// Syntax nodes always conform to `TypeSyntaxProtocol`. This API is just
   /// added for consistency.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
   public func isProtocol(_: TypeSyntaxProtocol.Protocol) -> Bool {
     return true
   }
   
   /// Return the non-type erased version of this syntax node.
-  /// Note that this will incur an existential conversion.
+  ///
+  ///  - Note:  This will incur an existential conversion.
   public func asProtocol(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol {
     return Syntax(self).asProtocol(TypeSyntaxProtocol.self)!
   }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -36,9 +36,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AccessorDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AccessorDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .accessorDecl)
     self._syntaxNode = Syntax(data)
@@ -130,6 +131,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -293,9 +295,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ActorDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ActorDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .actorDecl)
     self._syntaxNode = Syntax(data)
@@ -401,6 +404,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -444,6 +448,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -611,7 +616,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - AssociatedTypeDeclSyntax
 
-/// An associated type declaration like the following.
+/// An `associatedtype` declaration
+/// 
+/// An example of an associatedtype declaration is
 /// 
 /// ```swift
 /// associatedtype Item
@@ -654,9 +661,10 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AssociatedTypeDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AssociatedTypeDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .associatedTypeDecl)
     self._syntaxNode = Syntax(data)
@@ -762,6 +770,7 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -806,6 +815,7 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -956,7 +966,9 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ClassDeclSyntax
 
-/// A class declaration like the following.
+/// A `class` declaration
+/// 
+/// An example of a class declaration is
 /// 
 /// ```swift
 /// class SomeClass {
@@ -998,9 +1010,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClassDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClassDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .classDecl)
     self._syntaxNode = Syntax(data)
@@ -1113,6 +1126,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -1157,6 +1171,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -1328,7 +1343,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - DeinitializerDeclSyntax
 
-/// A deinitializer declaration like the following.
+/// A `deint` declaration
+/// 
+/// An example of a deinitializer is
 /// 
 /// ```swift
 /// deinit {
@@ -1352,9 +1369,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DeinitializerDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DeinitializerDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .deinitializerDecl)
     self._syntaxNode = Syntax(data)
@@ -1445,6 +1463,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -1489,6 +1508,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -1613,9 +1633,10 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``EditorPlaceholderDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``EditorPlaceholderDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .editorPlaceholderDecl)
     self._syntaxNode = Syntax(data)
@@ -1693,6 +1714,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -1737,6 +1759,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -1821,9 +1844,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``EnumCaseDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``EnumCaseDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .enumCaseDecl)
     self._syntaxNode = Syntax(data)
@@ -1908,6 +1932,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -1952,6 +1977,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -2015,6 +2041,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `elements`
   /// collection.
+  ///
   /// - param element: The new `Element` to add to the node's
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
@@ -2086,9 +2113,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``EnumDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``EnumDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .enumDecl)
     self._syntaxNode = Syntax(data)
@@ -2201,6 +2229,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -2245,6 +2274,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -2435,9 +2465,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ExtensionDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ExtensionDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .extensionDecl)
     self._syntaxNode = Syntax(data)
@@ -2536,6 +2567,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -2579,6 +2611,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -2745,9 +2778,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``FunctionDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``FunctionDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .functionDecl)
     self._syntaxNode = Syntax(data)
@@ -2853,6 +2887,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -2896,6 +2931,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -3083,9 +3119,10 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``IfConfigDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``IfConfigDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .ifConfigDecl)
     self._syntaxNode = Syntax(data)
@@ -3153,6 +3190,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `clauses`
   /// collection.
+  ///
   /// - param element: The new `Clause` to add to the node's
   ///                  `clauses` collection.
   /// - returns: A copy of the receiver with the provided `Clause`
@@ -3216,7 +3254,9 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ImportDeclSyntax
 
-/// An import declaration like the following.
+/// An `import` declaration
+/// 
+/// An example of an import declaration is
 /// 
 /// ```swift
 /// import Foundation
@@ -3239,9 +3279,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ImportDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ImportDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .importDecl)
     self._syntaxNode = Syntax(data)
@@ -3252,7 +3293,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///   - attributes: Attributes attached to the import declaration, for example `@testable`.
   ///   - modifiers: Modifiers attached to the import declaration. Currently, no modifiers are supported by Swift.
   ///   - importKeyword: The `import` keyword for this declaration.
-  ///   - importKindSpecifier: The kind of declaration being imported. For example, a struct can be imported from a specific module.
+  ///   - importKindSpecifier: The kind of declaration being imported. 
   ///   - path: The path to the module, submodule or symbol being imported.
   ///   - trailingTrivia: Trivia to be appended to the trailing trivia of the node’s last token. If the node is empty, there is no token to attach the trivia to and the parameter is ignored.
   public init(
@@ -3333,6 +3374,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -3377,6 +3419,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -3428,7 +3471,9 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// The kind of declaration being imported. For example, a struct can be imported from a specific module.
+  /// The kind of declaration being imported. 
+  /// 
+  /// A struct can be imported from a specific module.
   public var importKindSpecifier: TokenSyntax? {
     get {
       return data.child(at: 7, parent: Syntax(self)).map(TokenSyntax.init)
@@ -3459,6 +3504,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `path`
   /// collection.
+  ///
   /// - param element: The new `PathComponent` to add to the node's
   ///                  `path` collection.
   /// - returns: A copy of the receiver with the provided `PathComponent`
@@ -3510,7 +3556,9 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - InitializerDeclSyntax
 
-/// An initializer declaration like the following.
+/// An `init` declaration
+/// 
+/// An example of an initializer is
 /// 
 /// ```swift
 /// init(someParameter: Int) {
@@ -3539,9 +3587,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``InitializerDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``InitializerDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .initializerDecl)
     self._syntaxNode = Syntax(data)
@@ -3654,6 +3703,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -3698,6 +3748,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -3889,9 +3940,10 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MacroDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MacroDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .macroDecl)
     self._syntaxNode = Syntax(data)
@@ -3997,6 +4049,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -4040,6 +4093,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -4229,9 +4283,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MacroExpansionDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MacroExpansionDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .macroExpansionDecl)
     self._syntaxNode = Syntax(data)
@@ -4348,6 +4403,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -4391,6 +4447,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -4507,6 +4564,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `arguments`
   /// collection.
+  ///
   /// - param element: The new `Argument` to add to the node's
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
@@ -4586,6 +4644,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `additionalTrailingClosures`
   /// collection.
+  ///
   /// - param element: The new `AdditionalTrailingClosure` to add to the node's
   ///                  `additionalTrailingClosures` collection.
   /// - returns: A copy of the receiver with the provided `AdditionalTrailingClosure`
@@ -4664,9 +4723,10 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MissingDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MissingDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .missingDecl)
     self._syntaxNode = Syntax(data)
@@ -4744,6 +4804,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -4788,6 +4849,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -4874,9 +4936,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``OperatorDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``OperatorDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .operatorDecl)
     self._syntaxNode = Syntax(data)
@@ -5054,9 +5117,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PoundSourceLocationSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PoundSourceLocationSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .poundSourceLocation)
     self._syntaxNode = Syntax(data)
@@ -5235,9 +5299,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PrecedenceGroupDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PrecedenceGroupDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .precedenceGroupDecl)
     self._syntaxNode = Syntax(data)
@@ -5340,6 +5405,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -5384,6 +5450,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -5483,6 +5550,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `groupAttributes`
   /// collection.
+  ///
   /// - param element: The new `GroupAttribute` to add to the node's
   ///                  `groupAttributes` collection.
   /// - returns: A copy of the receiver with the provided `GroupAttribute`
@@ -5556,7 +5624,9 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ProtocolDeclSyntax
 
-/// A protocol declaration like the following.
+/// A `protocol` declaration
+/// 
+/// An example of a protocol declaration is
 /// 
 /// ```swift
 /// protocol Example {
@@ -5584,9 +5654,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ProtocolDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ProtocolDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .protocolDecl)
     self._syntaxNode = Syntax(data)
@@ -5699,6 +5770,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -5743,6 +5815,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -5914,61 +5987,63 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - StructDeclSyntax
 
-///     A struct declaration like the following.
+/// A `struct` declaration
 /// 
-///     ```swift
-///     struct SomeStruct {
-///       let someMember: String
-///       var anotherMember: Int
+/// An example of a struct declaration is
 /// 
-///       func foo() {
-///         print(someMember)
-///       }
+/// ```swift
+/// struct SomeStruct {
+///   let someMember: String
+///   var anotherMember: Int
 /// 
-///       mutating func bar() {
-///         anotherMember = 42
-///       }
-///     }
-///     ```
+///   func foo() {
+///     print(someMember)
+///   }
 /// 
-///     A struct declaration may be declared without any members.
+///   mutating func bar() {
+///     anotherMember = 42
+///   }
+/// }
+/// ```
 /// 
-///     ```swift
-///     struct EmptyStruct {
+/// A struct declaration may be declared without any members.
 /// 
-///     }
-///     ```
+/// ```swift
+/// struct EmptyStruct {
 /// 
-///     A struct declaration may include a type inheritance clause listing
-///     one or more protocols the struct conforms to.
+/// }
+/// ```
 /// 
-///     The example below uses Hashable and Equatable protocols whose members
-///     are automatically synthesized by the compiler if the struct contains
-///     stored members that are themselves `Hashable` and `Equatable`.
+/// A struct declaration may include a type inheritance clause listing
+/// one or more protocols the struct conforms to.
 /// 
-///     ```swift
-///     struct AdvancedStruct: Hashable, Equatable {
-///       let someMember: String
-///       var anotherMember: Int
-///     }
-///     ```
+/// The example below uses Hashable and Equatable protocols whose members
+/// are automatically synthesized by the compiler if the struct contains
+/// stored members that are themselves `Hashable` and `Equatable`.
 /// 
-///     A struct declaration may include a generic parameter clause as well
-///     as a generic where clause.
+/// ```swift
+/// struct AdvancedStruct: Hashable, Equatable {
+///   let someMember: String
+///   var anotherMember: Int
+/// }
+/// ```
 /// 
-///     ```swift
-///     struct Stack<Element> {
-///       var items: [Element] = []
+/// A struct declaration may include a generic parameter clause as well
+/// as a generic where clause.
 /// 
-///       mutating func push(_ item: Element) {
-///         items.append(item)
-///       }
+/// ```swift
+/// struct Stack<Element> {
+///   var items: [Element] = []
 /// 
-///       mutating func pop() -> Element {
-///         return items.removeLast()
-///       }
-///    }
-///    ```
+///   mutating func push(_ item: Element) {
+///     items.append(item)
+///   }
+/// 
+///   mutating func pop() -> Element {
+///     return items.removeLast()
+///   }
+/// }
+/// ```
 ///
 /// ### Children
 /// 
@@ -5990,9 +6065,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``StructDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``StructDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .structDecl)
     self._syntaxNode = Syntax(data)
@@ -6105,6 +6181,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -6149,6 +6226,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -6340,9 +6418,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SubscriptDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SubscriptDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .subscriptDecl)
     self._syntaxNode = Syntax(data)
@@ -6448,6 +6527,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -6491,6 +6571,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -6677,9 +6758,10 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TypeAliasDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TypeAliasDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .typeAliasDecl)
     self._syntaxNode = Syntax(data)
@@ -6779,6 +6861,7 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -6822,6 +6905,7 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -6985,9 +7069,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``VariableDeclSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``VariableDeclSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .variableDecl)
     self._syntaxNode = Syntax(data)
@@ -7067,6 +7152,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -7110,6 +7196,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -7171,6 +7258,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `bindings`
   /// collection.
+  ///
   /// - param element: The new `Binding` to add to the node's
   ///                  `bindings` collection.
   /// - returns: A copy of the receiver with the provided `Binding`

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -29,9 +29,10 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ArrayExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ArrayExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .arrayExpr)
     self._syntaxNode = Syntax(data)
@@ -123,6 +124,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `elements`
   /// collection.
+  ///
   /// - param element: The new `Element` to add to the node's
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
@@ -202,9 +204,10 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ArrowExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ArrowExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .arrowExpr)
     self._syntaxNode = Syntax(data)
@@ -326,9 +329,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AsExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AsExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .asExpr)
     self._syntaxNode = Syntax(data)
@@ -499,9 +503,10 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AssignmentExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AssignmentExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .assignmentExpr)
     self._syntaxNode = Syntax(data)
@@ -583,9 +588,10 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AwaitExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AwaitExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .awaitExpr)
     self._syntaxNode = Syntax(data)
@@ -704,9 +710,10 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``BinaryOperatorExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``BinaryOperatorExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .binaryOperatorExpr)
     self._syntaxNode = Syntax(data)
@@ -787,9 +794,10 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``BooleanLiteralExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``BooleanLiteralExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .booleanLiteralExpr)
     self._syntaxNode = Syntax(data)
@@ -871,9 +879,10 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``BorrowExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``BorrowExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .borrowExpr)
     self._syntaxNode = Syntax(data)
@@ -996,9 +1005,10 @@ public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``CanImportExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``CanImportExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .canImportExpr)
     self._syntaxNode = Syntax(data)
@@ -1202,9 +1212,10 @@ public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``CanImportVersionInfoSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``CanImportVersionInfoSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .canImportVersionInfo)
     self._syntaxNode = Syntax(data)
@@ -1386,9 +1397,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClosureExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClosureExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .closureExpr)
     self._syntaxNode = Syntax(data)
@@ -1504,6 +1516,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `statements`
   /// collection.
+  ///
   /// - param element: The new `Statement` to add to the node's
   ///                  `statements` collection.
   /// - returns: A copy of the receiver with the provided `Statement`
@@ -1585,9 +1598,10 @@ public struct ConsumeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ConsumeExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ConsumeExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .consumeExpr)
     self._syntaxNode = Syntax(data)
@@ -1707,9 +1721,10 @@ public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``CopyExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``CopyExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .copyExpr)
     self._syntaxNode = Syntax(data)
@@ -1838,9 +1853,10 @@ public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DeclReferenceExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DeclReferenceExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .declReferenceExpr)
     self._syntaxNode = Syntax(data)
@@ -2003,9 +2019,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DictionaryExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DictionaryExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .dictionaryExpr)
     self._syntaxNode = Syntax(data)
@@ -2150,9 +2167,10 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DiscardAssignmentExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DiscardAssignmentExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .discardAssignmentExpr)
     self._syntaxNode = Syntax(data)
@@ -2233,9 +2251,10 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``EditorPlaceholderExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``EditorPlaceholderExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .editorPlaceholderExpr)
     self._syntaxNode = Syntax(data)
@@ -2316,9 +2335,10 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``FloatLiteralExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``FloatLiteralExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .floatLiteralExpr)
     self._syntaxNode = Syntax(data)
@@ -2400,9 +2420,10 @@ public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ForceUnwrapExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ForceUnwrapExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .forceUnwrapExpr)
     self._syntaxNode = Syntax(data)
@@ -2526,9 +2547,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``FunctionCallExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``FunctionCallExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .functionCallExpr)
     self._syntaxNode = Syntax(data)
@@ -2656,6 +2678,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `arguments`
   /// collection.
+  ///
   /// - param element: The new `Argument` to add to the node's
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
@@ -2735,6 +2758,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `additionalTrailingClosures`
   /// collection.
+  ///
   /// - param element: The new `AdditionalTrailingClosure` to add to the node's
   ///                  `additionalTrailingClosures` collection.
   /// - returns: A copy of the receiver with the provided `AdditionalTrailingClosure`
@@ -2802,9 +2826,10 @@ public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashabl
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``GenericSpecializationExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``GenericSpecializationExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .genericSpecializationExpr)
     self._syntaxNode = Syntax(data)
@@ -2973,9 +2998,10 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``IfExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``IfExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .ifExpr)
     self._syntaxNode = Syntax(data)
@@ -3079,6 +3105,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `conditions`
   /// collection.
+  ///
   /// - param element: The new `Condition` to add to the node's
   ///                  `conditions` collection.
   /// - returns: A copy of the receiver with the provided `Condition`
@@ -3198,9 +3225,10 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``InOutExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``InOutExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .inOutExpr)
     self._syntaxNode = Syntax(data)
@@ -3321,9 +3349,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``InfixOperatorExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``InfixOperatorExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .infixOperatorExpr)
     self._syntaxNode = Syntax(data)
@@ -3468,9 +3497,10 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``IntegerLiteralExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``IntegerLiteralExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .integerLiteralExpr)
     self._syntaxNode = Syntax(data)
@@ -3538,7 +3568,9 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - IsExprSyntax
 
-/// An `is` expression like the following.
+/// Checks if an expression is of a given type.
+/// 
+/// An example of an `is` expression is
 /// 
 /// ```swift
 /// value is Double
@@ -3561,9 +3593,10 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``IsExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``IsExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .isExpr)
     self._syntaxNode = Syntax(data)
@@ -3716,9 +3749,10 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``KeyPathExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``KeyPathExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .keyPathExpr)
     self._syntaxNode = Syntax(data)
@@ -3828,6 +3862,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `components`
   /// collection.
+  ///
   /// - param element: The new `KeyPathComponent` to add to the node's
   ///                  `components` collection.
   /// - returns: A copy of the receiver with the provided `KeyPathComponent`
@@ -3895,9 +3930,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MacroExpansionExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MacroExpansionExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .macroExpansionExpr)
     self._syntaxNode = Syntax(data)
@@ -4075,6 +4111,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `arguments`
   /// collection.
+  ///
   /// - param element: The new `Argument` to add to the node's
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
@@ -4154,6 +4191,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `additionalTrailingClosures`
   /// collection.
+  ///
   /// - param element: The new `AdditionalTrailingClosure` to add to the node's
   ///                  `additionalTrailingClosures` collection.
   /// - returns: A copy of the receiver with the provided `AdditionalTrailingClosure`
@@ -4226,9 +4264,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MemberAccessExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MemberAccessExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .memberAccessExpr)
     self._syntaxNode = Syntax(data)
@@ -4375,9 +4414,10 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MissingExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MissingExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .missingExpr)
     self._syntaxNode = Syntax(data)
@@ -4462,9 +4502,10 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``NilLiteralExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``NilLiteralExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .nilLiteralExpr)
     self._syntaxNode = Syntax(data)
@@ -4546,9 +4587,10 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``OptionalChainingExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``OptionalChainingExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .optionalChainingExpr)
     self._syntaxNode = Syntax(data)
@@ -4668,9 +4710,10 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PackElementExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PackElementExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .packElementExpr)
     self._syntaxNode = Syntax(data)
@@ -4790,9 +4833,10 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PackExpansionExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PackExpansionExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .packExpansionExpr)
     self._syntaxNode = Syntax(data)
@@ -4911,9 +4955,10 @@ public struct PatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PatternExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PatternExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .patternExpr)
     self._syntaxNode = Syntax(data)
@@ -4995,9 +5040,10 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PostfixIfConfigExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PostfixIfConfigExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .postfixIfConfigExpr)
     self._syntaxNode = Syntax(data)
@@ -5117,9 +5163,10 @@ public struct PostfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PostfixOperatorExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PostfixOperatorExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .postfixOperatorExpr)
     self._syntaxNode = Syntax(data)
@@ -5239,9 +5286,10 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PrefixOperatorExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PrefixOperatorExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .prefixOperatorExpr)
     self._syntaxNode = Syntax(data)
@@ -5364,9 +5412,10 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``RegexLiteralExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``RegexLiteralExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .regexLiteralExpr)
     self._syntaxNode = Syntax(data)
@@ -5563,9 +5612,10 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SequenceExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SequenceExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .sequenceExpr)
     self._syntaxNode = Syntax(data)
@@ -5619,6 +5669,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `elements`
   /// collection.
+  ///
   /// - param element: The new `Element` to add to the node's
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
@@ -5688,9 +5739,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``StringLiteralExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``StringLiteralExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .stringLiteralExpr)
     self._syntaxNode = Syntax(data)
@@ -5812,6 +5864,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `segments`
   /// collection.
+  ///
   /// - param element: The new `Segment` to add to the node's
   ///                  `segments` collection.
   /// - returns: A copy of the receiver with the provided `Segment`
@@ -5917,9 +5970,10 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SubscriptCallExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SubscriptCallExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .subscriptCallExpr)
     self._syntaxNode = Syntax(data)
@@ -6047,6 +6101,7 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `arguments`
   /// collection.
+  ///
   /// - param element: The new `Argument` to add to the node's
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
@@ -6126,6 +6181,7 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `additionalTrailingClosures`
   /// collection.
+  ///
   /// - param element: The new `AdditionalTrailingClosure` to add to the node's
   ///                  `additionalTrailingClosures` collection.
   /// - returns: A copy of the receiver with the provided `AdditionalTrailingClosure`
@@ -6192,9 +6248,10 @@ public struct SuperExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SuperExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SuperExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .superExpr)
     self._syntaxNode = Syntax(data)
@@ -6279,9 +6336,10 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SwitchExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SwitchExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .switchExpr)
     self._syntaxNode = Syntax(data)
@@ -6421,6 +6479,7 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `cases`
   /// collection.
+  ///
   /// - param element: The new `Case` to add to the node's
   ///                  `cases` collection.
   /// - returns: A copy of the receiver with the provided `Case`
@@ -6507,9 +6566,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TernaryExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TernaryExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .ternaryExpr)
     self._syntaxNode = Syntax(data)
@@ -6708,9 +6768,10 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TryExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TryExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .tryExpr)
     self._syntaxNode = Syntax(data)
@@ -6857,9 +6918,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TupleExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TupleExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .tupleExpr)
     self._syntaxNode = Syntax(data)
@@ -6951,6 +7013,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `elements`
   /// collection.
+  ///
   /// - param element: The new `Element` to add to the node's
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
@@ -7029,9 +7092,10 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TypeExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TypeExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .typeExpr)
     self._syntaxNode = Syntax(data)
@@ -7113,9 +7177,10 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``UnresolvedAsExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``UnresolvedAsExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .unresolvedAsExpr)
     self._syntaxNode = Syntax(data)
@@ -7234,9 +7299,10 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``UnresolvedIsExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``UnresolvedIsExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .unresolvedIsExpr)
     self._syntaxNode = Syntax(data)
@@ -7319,9 +7385,10 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``UnresolvedTernaryExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``UnresolvedTernaryExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .unresolvedTernaryExpr)
     self._syntaxNode = Syntax(data)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -76,9 +76,10 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AccessorBlockSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AccessorBlockSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .accessorBlock)
     self._syntaxNode = Syntax(data)
@@ -228,9 +229,10 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AccessorEffectSpecifiersSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AccessorEffectSpecifiersSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .accessorEffectSpecifiers)
     self._syntaxNode = Syntax(data)
@@ -355,9 +357,10 @@ public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AccessorParametersSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AccessorParametersSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .accessorParameters)
     self._syntaxNode = Syntax(data)
@@ -507,9 +510,10 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ArrayElementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ArrayElementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .arrayElement)
     self._syntaxNode = Syntax(data)
@@ -900,9 +904,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AttributeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AttributeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .attribute)
     self._syntaxNode = Syntax(data)
@@ -1169,9 +1174,10 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AvailabilityArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AvailabilityArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .availabilityArgument)
     self._syntaxNode = Syntax(data)
@@ -1301,9 +1307,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AvailabilityConditionSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AvailabilityConditionSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .availabilityCondition)
     self._syntaxNode = Syntax(data)
@@ -1419,6 +1426,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `availabilityArguments`
   /// collection.
+  ///
   /// - param element: The new `AvailabilityArgument` to add to the node's
   ///                  `availabilityArguments` collection.
   /// - returns: A copy of the receiver with the provided `AvailabilityArgument`
@@ -1549,9 +1557,10 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AvailabilityLabeledArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AvailabilityLabeledArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .availabilityLabeledArgument)
     self._syntaxNode = Syntax(data)
@@ -1710,9 +1719,10 @@ public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashab
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``BackDeployedAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``BackDeployedAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .backDeployedAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -1828,6 +1838,7 @@ public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashab
   
   /// Adds the provided `element` to the node's `platforms`
   /// collection.
+  ///
   /// - param element: The new `Platform` to add to the node's
   ///                  `platforms` collection.
   /// - returns: A copy of the receiver with the provided `Platform`
@@ -1894,9 +1905,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``CatchClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``CatchClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .catchClause)
     self._syntaxNode = Syntax(data)
@@ -1988,6 +2000,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `catchItems`
   /// collection.
+  ///
   /// - param element: The new `CatchItem` to add to the node's
   ///                  `catchItems` collection.
   /// - returns: A copy of the receiver with the provided `CatchItem`
@@ -2072,9 +2085,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``CatchItemSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``CatchItemSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .catchItem)
     self._syntaxNode = Syntax(data)
@@ -2225,9 +2239,10 @@ public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClosureCaptureClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClosureCaptureClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .closureCaptureClause)
     self._syntaxNode = Syntax(data)
@@ -2319,6 +2334,7 @@ public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `items`
   /// collection.
+  ///
   /// - param element: The new `Item` to add to the node's
   ///                  `items` collection.
   /// - returns: A copy of the receiver with the provided `Item`
@@ -2404,9 +2420,10 @@ public struct ClosureCaptureSpecifierSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClosureCaptureSpecifierSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClosureCaptureSpecifierSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .closureCaptureSpecifier)
     self._syntaxNode = Syntax(data)
@@ -2585,9 +2602,10 @@ public struct ClosureCaptureSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClosureCaptureSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClosureCaptureSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .closureCapture)
     self._syntaxNode = Syntax(data)
@@ -2790,9 +2808,10 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClosureParameterClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClosureParameterClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .closureParameterClause)
     self._syntaxNode = Syntax(data)
@@ -2889,6 +2908,7 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `parameters`
   /// collection.
+  ///
   /// - param element: The new `Parameter` to add to the node's
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
@@ -2979,9 +2999,10 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClosureParameterSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClosureParameterSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .closureParameter)
     self._syntaxNode = Syntax(data)
@@ -3091,6 +3112,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -3134,6 +3156,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -3323,9 +3346,10 @@ public struct ClosureShorthandParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClosureShorthandParameterSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClosureShorthandParameterSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .closureShorthandParameter)
     self._syntaxNode = Syntax(data)
@@ -3495,9 +3519,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClosureSignatureSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClosureSignatureSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .closureSignature)
     self._syntaxNode = Syntax(data)
@@ -3589,6 +3614,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -3805,9 +3831,10 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``CodeBlockItemSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``CodeBlockItemSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .codeBlockItem)
     self._syntaxNode = Syntax(data)
@@ -3948,9 +3975,10 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``CodeBlockSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``CodeBlockSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .codeBlock)
     self._syntaxNode = Syntax(data)
@@ -4042,6 +4070,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `statements`
   /// collection.
+  ///
   /// - param element: The new `Statement` to add to the node's
   ///                  `statements` collection.
   /// - returns: A copy of the receiver with the provided `Statement`
@@ -4125,9 +4154,10 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``CompositionTypeElementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``CompositionTypeElementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .compositionTypeElement)
     self._syntaxNode = Syntax(data)
@@ -4320,9 +4350,10 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ConditionElementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ConditionElementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .conditionElement)
     self._syntaxNode = Syntax(data)
@@ -4447,9 +4478,10 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ConformanceRequirementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ConformanceRequirementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .conformanceRequirement)
     self._syntaxNode = Syntax(data)
@@ -4604,9 +4636,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ConventionAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ConventionAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .conventionAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -4813,9 +4846,10 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ConventionWitnessMethodAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ConventionWitnessMethodAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .conventionWitnessMethodAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -4966,9 +5000,10 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DeclModifierDetailSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DeclModifierDetailSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .declModifierDetail)
     self._syntaxNode = Syntax(data)
@@ -5119,9 +5154,10 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DeclModifierSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DeclModifierSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .declModifier)
     self._syntaxNode = Syntax(data)
@@ -5245,9 +5281,10 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DeclNameArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DeclNameArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .declNameArgument)
     self._syntaxNode = Syntax(data)
@@ -5372,9 +5409,10 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DeclNameArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DeclNameArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .declNameArguments)
     self._syntaxNode = Syntax(data)
@@ -5466,6 +5504,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `arguments`
   /// collection.
+  ///
   /// - param element: The new `Argument` to add to the node's
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
@@ -5548,9 +5587,10 @@ public struct DeinitializerEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashabl
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DeinitializerEffectSpecifiersSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DeinitializerEffectSpecifiersSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .deinitializerEffectSpecifiers)
     self._syntaxNode = Syntax(data)
@@ -5643,9 +5683,10 @@ public struct DerivativeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DerivativeAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DerivativeAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .derivativeAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -5909,9 +5950,10 @@ public struct DesignatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DesignatedTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DesignatedTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .designatedType)
     self._syntaxNode = Syntax(data)
@@ -6037,9 +6079,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DictionaryElementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DictionaryElementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .dictionaryElement)
     self._syntaxNode = Syntax(data)
@@ -6218,9 +6261,10 @@ public struct DifferentiabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DifferentiabilityArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DifferentiabilityArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .differentiabilityArgument)
     self._syntaxNode = Syntax(data)
@@ -6347,9 +6391,10 @@ public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DifferentiabilityArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DifferentiabilityArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .differentiabilityArguments)
     self._syntaxNode = Syntax(data)
@@ -6443,6 +6488,7 @@ public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `arguments`
   /// collection.
+  ///
   /// - param element: The new `Argument` to add to the node's
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
@@ -6572,9 +6618,10 @@ public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, Synt
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DifferentiabilityWithRespectToArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DifferentiabilityWithRespectToArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .differentiabilityWithRespectToArgument)
     self._syntaxNode = Syntax(data)
@@ -6733,9 +6780,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DifferentiableAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DifferentiableAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .differentiableAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -6987,9 +7035,10 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DocumentationAttributeArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DocumentationAttributeArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .documentationAttributeArgument)
     self._syntaxNode = Syntax(data)
@@ -7170,9 +7219,10 @@ public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DynamicReplacementAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DynamicReplacementAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .dynamicReplacementAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -7326,9 +7376,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``EnumCaseElementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``EnumCaseElementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .enumCaseElement)
     self._syntaxNode = Syntax(data)
@@ -7513,9 +7564,10 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``EnumCaseParameterClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``EnumCaseParameterClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .enumCaseParameterClause)
     self._syntaxNode = Syntax(data)
@@ -7612,6 +7664,7 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `parameters`
   /// collection.
+  ///
   /// - param element: The new `Parameter` to add to the node's
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
@@ -7701,9 +7754,10 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``EnumCaseParameterSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``EnumCaseParameterSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .enumCaseParameter)
     self._syntaxNode = Syntax(data)
@@ -7805,6 +7859,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -7993,9 +8048,10 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ExposeAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ExposeAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .exposeAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -8148,9 +8204,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ExpressionSegmentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ExpressionSegmentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .expressionSegment)
     self._syntaxNode = Syntax(data)
@@ -8290,6 +8347,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `expressions`
   /// collection.
+  ///
   /// - param element: The new `Expression` to add to the node's
   ///                  `expressions` collection.
   /// - returns: A copy of the receiver with the provided `Expression`
@@ -8377,9 +8435,10 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``FunctionEffectSpecifiersSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``FunctionEffectSpecifiersSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .functionEffectSpecifiers)
     self._syntaxNode = Syntax(data)
@@ -8505,9 +8564,10 @@ public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``FunctionParameterClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``FunctionParameterClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .functionParameterClause)
     self._syntaxNode = Syntax(data)
@@ -8599,6 +8659,7 @@ public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `parameters`
   /// collection.
+  ///
   /// - param element: The new `Parameter` to add to the node's
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
@@ -8689,9 +8750,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``FunctionParameterSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``FunctionParameterSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .functionParameter)
     self._syntaxNode = Syntax(data)
@@ -8801,6 +8863,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -8844,6 +8907,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `modifiers`
   /// collection.
+  ///
   /// - param element: The new `Modifier` to add to the node's
   ///                  `modifiers` collection.
   /// - returns: A copy of the receiver with the provided `Modifier`
@@ -9050,9 +9114,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``FunctionSignatureSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``FunctionSignatureSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .functionSignature)
     self._syntaxNode = Syntax(data)
@@ -9208,9 +9273,10 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``GenericArgumentClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``GenericArgumentClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .genericArgumentClause)
     self._syntaxNode = Syntax(data)
@@ -9302,6 +9368,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `arguments`
   /// collection.
+  ///
   /// - param element: The new `Argument` to add to the node's
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
@@ -9385,9 +9452,10 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``GenericArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``GenericArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .genericArgument)
     self._syntaxNode = Syntax(data)
@@ -9524,9 +9592,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``GenericParameterClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``GenericParameterClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .genericParameterClause)
     self._syntaxNode = Syntax(data)
@@ -9630,6 +9699,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `parameters`
   /// collection.
+  ///
   /// - param element: The new `Parameter` to add to the node's
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
@@ -9739,9 +9809,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``GenericParameterSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``GenericParameterSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .genericParameter)
     self._syntaxNode = Syntax(data)
@@ -9833,6 +9904,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -10047,9 +10119,10 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``GenericRequirementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``GenericRequirementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .genericRequirement)
     self._syntaxNode = Syntax(data)
@@ -10189,9 +10262,10 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``GenericWhereClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``GenericWhereClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .genericWhereClause)
     self._syntaxNode = Syntax(data)
@@ -10281,6 +10355,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `requirements`
   /// collection.
+  ///
   /// - param element: The new `Requirement` to add to the node's
   ///                  `requirements` collection.
   /// - returns: A copy of the receiver with the provided `Requirement`
@@ -10426,9 +10501,10 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``IfConfigClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``IfConfigClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .ifConfigClause)
     self._syntaxNode = Syntax(data)
@@ -10581,9 +10657,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ImplementsAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ImplementsAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .implementsAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -10739,9 +10816,10 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ImportPathComponentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ImportPathComponentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .importPathComponent)
     self._syntaxNode = Syntax(data)
@@ -10871,9 +10949,10 @@ public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``InheritanceClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``InheritanceClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .inheritanceClause)
     self._syntaxNode = Syntax(data)
@@ -10959,6 +11038,7 @@ public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `inheritedTypes`
   /// collection.
+  ///
   /// - param element: The new `InheritedType` to add to the node's
   ///                  `inheritedTypes` collection.
   /// - returns: A copy of the receiver with the provided `InheritedType`
@@ -11022,9 +11102,10 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``InheritedTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``InheritedTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .inheritedType)
     self._syntaxNode = Syntax(data)
@@ -11154,9 +11235,10 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``InitializerClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``InitializerClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .initializerClause)
     self._syntaxNode = Syntax(data)
@@ -11333,9 +11415,10 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``KeyPathComponentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``KeyPathComponentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .keyPathComponent)
     self._syntaxNode = Syntax(data)
@@ -11458,9 +11541,10 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``KeyPathOptionalComponentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``KeyPathOptionalComponentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .keyPathOptionalComponent)
     self._syntaxNode = Syntax(data)
@@ -11546,9 +11630,10 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``KeyPathPropertyComponentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``KeyPathPropertyComponentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .keyPathPropertyComponent)
     self._syntaxNode = Syntax(data)
@@ -11673,9 +11758,10 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``KeyPathSubscriptComponentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``KeyPathSubscriptComponentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .keyPathSubscriptComponent)
     self._syntaxNode = Syntax(data)
@@ -11767,6 +11853,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `arguments`
   /// collection.
+  ///
   /// - param element: The new `Argument` to add to the node's
   ///                  `arguments` collection.
   /// - returns: A copy of the receiver with the provided `Argument`
@@ -11852,9 +11939,10 @@ public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``LabeledExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``LabeledExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .labeledExpr)
     self._syntaxNode = Syntax(data)
@@ -12034,9 +12122,10 @@ public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``LabeledSpecializeArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``LabeledSpecializeArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .labeledSpecializeArgument)
     self._syntaxNode = Syntax(data)
@@ -12226,9 +12315,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``LayoutRequirementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``LayoutRequirementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .layoutRequirement)
     self._syntaxNode = Syntax(data)
@@ -12510,9 +12600,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MatchingPatternConditionSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MatchingPatternConditionSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .matchingPatternCondition)
     self._syntaxNode = Syntax(data)
@@ -12690,9 +12781,10 @@ public struct MemberBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MemberBlockItemSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MemberBlockItemSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .memberBlockItem)
     self._syntaxNode = Syntax(data)
@@ -12826,9 +12918,10 @@ public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MemberBlockSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MemberBlockSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .memberBlock)
     self._syntaxNode = Syntax(data)
@@ -12920,6 +13013,7 @@ public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `members`
   /// collection.
+  ///
   /// - param element: The new `Member` to add to the node's
   ///                  `members` collection.
   /// - returns: A copy of the receiver with the provided `Member`
@@ -13000,9 +13094,10 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MissingSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MissingSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .missing)
     self._syntaxNode = Syntax(data)
@@ -13093,9 +13188,10 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MultipleTrailingClosureElementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MultipleTrailingClosureElementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .multipleTrailingClosureElement)
     self._syntaxNode = Syntax(data)
@@ -13247,9 +13343,10 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ObjCSelectorPieceSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ObjCSelectorPieceSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .objCSelectorPiece)
     self._syntaxNode = Syntax(data)
@@ -13376,9 +13473,10 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``OpaqueReturnTypeOfAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``OpaqueReturnTypeOfAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .opaqueReturnTypeOfAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -13535,9 +13633,10 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``OperatorPrecedenceAndTypesSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``OperatorPrecedenceAndTypesSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .operatorPrecedenceAndTypes)
     self._syntaxNode = Syntax(data)
@@ -13651,6 +13750,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `designatedTypes`
   /// collection.
+  ///
   /// - param element: The new `DesignatedTypeElement` to add to the node's
   ///                  `designatedTypes` collection.
   /// - returns: A copy of the receiver with the provided `DesignatedTypeElement`
@@ -13718,9 +13818,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``OptionalBindingConditionSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``OptionalBindingConditionSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .optionalBindingCondition)
     self._syntaxNode = Syntax(data)
@@ -13901,9 +14002,10 @@ public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, Synta
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``OriginallyDefinedInAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``OriginallyDefinedInAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .originallyDefinedInAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -14061,6 +14163,7 @@ public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, Synta
   
   /// Adds the provided `element` to the node's `platforms`
   /// collection.
+  ///
   /// - param element: The new `Platform` to add to the node's
   ///                  `platforms` collection.
   /// - returns: A copy of the receiver with the provided `Platform`
@@ -14133,9 +14236,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PatternBindingSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PatternBindingSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .patternBinding)
     self._syntaxNode = Syntax(data)
@@ -14339,9 +14443,10 @@ public struct PlatformVersionItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PlatformVersionItemSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PlatformVersionItemSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .platformVersionItem)
     self._syntaxNode = Syntax(data)
@@ -14470,9 +14575,10 @@ public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PlatformVersionSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PlatformVersionSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .platformVersion)
     self._syntaxNode = Syntax(data)
@@ -14603,9 +14709,10 @@ public struct PoundSourceLocationArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PoundSourceLocationArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PoundSourceLocationArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .poundSourceLocationArguments)
     self._syntaxNode = Syntax(data)
@@ -14862,9 +14969,10 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PrecedenceGroupAssignmentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PrecedenceGroupAssignmentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .precedenceGroupAssignment)
     self._syntaxNode = Syntax(data)
@@ -15019,9 +15127,10 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PrecedenceGroupAssociativitySyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PrecedenceGroupAssociativitySyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .precedenceGroupAssociativity)
     self._syntaxNode = Syntax(data)
@@ -15173,9 +15282,10 @@ public struct PrecedenceGroupNameSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PrecedenceGroupNameSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PrecedenceGroupNameSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .precedenceGroupName)
     self._syntaxNode = Syntax(data)
@@ -15302,9 +15412,10 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PrecedenceGroupRelationSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PrecedenceGroupRelationSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .precedenceGroupRelation)
     self._syntaxNode = Syntax(data)
@@ -15418,6 +15529,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `precedenceGroups`
   /// collection.
+  ///
   /// - param element: The new `OtherName` to add to the node's
   ///                  `precedenceGroups` collection.
   /// - returns: A copy of the receiver with the provided `OtherName`
@@ -15484,9 +15596,10 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PrimaryAssociatedTypeClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PrimaryAssociatedTypeClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .primaryAssociatedTypeClause)
     self._syntaxNode = Syntax(data)
@@ -15578,6 +15691,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   
   /// Adds the provided `element` to the node's `primaryAssociatedTypes`
   /// collection.
+  ///
   /// - param element: The new `PrimaryAssociatedType` to add to the node's
   ///                  `primaryAssociatedTypes` collection.
   /// - returns: A copy of the receiver with the provided `PrimaryAssociatedType`
@@ -15661,9 +15775,10 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PrimaryAssociatedTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PrimaryAssociatedTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .primaryAssociatedType)
     self._syntaxNode = Syntax(data)
@@ -15790,9 +15905,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``QualifiedDeclNameSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``QualifiedDeclNameSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .qualifiedDeclName)
     self._syntaxNode = Syntax(data)
@@ -15949,9 +16065,10 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ReturnClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ReturnClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .returnClause)
     self._syntaxNode = Syntax(data)
@@ -16076,9 +16193,10 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SameTypeRequirementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SameTypeRequirementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .sameTypeRequirement)
     self._syntaxNode = Syntax(data)
@@ -16224,9 +16342,10 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SourceFileSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SourceFileSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .sourceFile)
     self._syntaxNode = Syntax(data)
@@ -16294,6 +16413,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `statements`
   /// collection.
+  ///
   /// - param element: The new `Statement` to add to the node's
   ///                  `statements` collection.
   /// - returns: A copy of the receiver with the provided `Statement`
@@ -16379,9 +16499,10 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SpecializeAvailabilityArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SpecializeAvailabilityArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .specializeAvailabilityArgument)
     self._syntaxNode = Syntax(data)
@@ -16501,6 +16622,7 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
   
   /// Adds the provided `element` to the node's `availabilityArguments`
   /// collection.
+  ///
   /// - param element: The new `AvailabilityArgument` to add to the node's
   ///                  `availabilityArguments` collection.
   /// - returns: A copy of the receiver with the provided `AvailabilityArgument`
@@ -16590,9 +16712,10 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SpecializeTargetFunctionArgumentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SpecializeTargetFunctionArgumentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .specializeTargetFunctionArgument)
     self._syntaxNode = Syntax(data)
@@ -16775,9 +16898,10 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``StringSegmentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``StringSegmentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .stringSegment)
     self._syntaxNode = Syntax(data)
@@ -16864,9 +16988,10 @@ public struct SwitchCaseItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SwitchCaseItemSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SwitchCaseItemSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .switchCaseItem)
     self._syntaxNode = Syntax(data)
@@ -17017,9 +17142,10 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SwitchCaseLabelSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SwitchCaseLabelSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .switchCaseLabel)
     self._syntaxNode = Syntax(data)
@@ -17111,6 +17237,7 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `caseItems`
   /// collection.
+  ///
   /// - param element: The new `CaseItem` to add to the node's
   ///                  `caseItems` collection.
   /// - returns: A copy of the receiver with the provided `CaseItem`
@@ -17237,9 +17364,10 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SwitchCaseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SwitchCaseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .switchCase)
     self._syntaxNode = Syntax(data)
@@ -17351,6 +17479,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `statements`
   /// collection.
+  ///
   /// - param element: The new `Statement` to add to the node's
   ///                  `statements` collection.
   /// - returns: A copy of the receiver with the provided `Statement`
@@ -17416,9 +17545,10 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SwitchDefaultLabelSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SwitchDefaultLabelSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .switchDefaultLabel)
     self._syntaxNode = Syntax(data)
@@ -17544,9 +17674,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TuplePatternElementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TuplePatternElementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .tuplePatternElement)
     self._syntaxNode = Syntax(data)
@@ -17727,9 +17858,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TupleTypeElementSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TupleTypeElementSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .tupleTypeElement)
     self._syntaxNode = Syntax(data)
@@ -17987,9 +18119,10 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TypeAnnotationSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TypeAnnotationSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .typeAnnotation)
     self._syntaxNode = Syntax(data)
@@ -18115,9 +18248,10 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TypeEffectSpecifiersSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TypeEffectSpecifiersSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .typeEffectSpecifiers)
     self._syntaxNode = Syntax(data)
@@ -18242,9 +18376,10 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TypeInitializerClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TypeInitializerClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .typeInitializerClause)
     self._syntaxNode = Syntax(data)
@@ -18371,9 +18506,10 @@ public struct UnavailableFromAsyncAttributeArgumentsSyntax: SyntaxProtocol, Synt
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``UnavailableFromAsyncAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``UnavailableFromAsyncAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .unavailableFromAsyncAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -18526,9 +18662,10 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``UnderscorePrivateAttributeArgumentsSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``UnderscorePrivateAttributeArgumentsSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .underscorePrivateAttributeArguments)
     self._syntaxNode = Syntax(data)
@@ -18680,9 +18817,10 @@ public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``VersionComponentSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``VersionComponentSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .versionComponent)
     self._syntaxNode = Syntax(data)
@@ -18814,9 +18952,10 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``VersionTupleSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``VersionTupleSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .versionTuple)
     self._syntaxNode = Syntax(data)
@@ -18906,6 +19045,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `components`
   /// collection.
+  ///
   /// - param element: The new `VersionComponent` to add to the node's
   ///                  `components` collection.
   /// - returns: A copy of the receiver with the provided `VersionComponent`
@@ -18971,9 +19111,10 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``WhereClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``WhereClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .whereClause)
     self._syntaxNode = Syntax(data)
@@ -19097,9 +19238,10 @@ public struct YieldedExpressionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``YieldedExpressionSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``YieldedExpressionSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .yieldedExpression)
     self._syntaxNode = Syntax(data)
@@ -19224,9 +19366,10 @@ public struct YieldedExpressionsClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``YieldedExpressionsClauseSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``YieldedExpressionsClauseSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .yieldedExpressionsClause)
     self._syntaxNode = Syntax(data)
@@ -19318,6 +19461,7 @@ public struct YieldedExpressionsClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `elements`
   /// collection.
+  ///
   /// - param element: The new `Element` to add to the node's
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -27,9 +27,10 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ExpressionPatternSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ExpressionPatternSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .expressionPattern)
     self._syntaxNode = Syntax(data)
@@ -110,9 +111,10 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``IdentifierPatternSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``IdentifierPatternSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .identifierPattern)
     self._syntaxNode = Syntax(data)
@@ -194,9 +196,10 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``IsTypePatternSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``IsTypePatternSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .isTypePattern)
     self._syntaxNode = Syntax(data)
@@ -317,9 +320,10 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MissingPatternSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MissingPatternSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .missingPattern)
     self._syntaxNode = Syntax(data)
@@ -406,9 +410,10 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TuplePatternSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TuplePatternSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .tuplePattern)
     self._syntaxNode = Syntax(data)
@@ -500,6 +505,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `elements`
   /// collection.
+  ///
   /// - param element: The new `Element` to add to the node's
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
@@ -579,9 +585,10 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ValueBindingPatternSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ValueBindingPatternSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .valueBindingPattern)
     self._syntaxNode = Syntax(data)
@@ -701,9 +708,10 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``WildcardPatternSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``WildcardPatternSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .wildcardPattern)
     self._syntaxNode = Syntax(data)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -28,9 +28,10 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``BreakStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``BreakStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .breakStmt)
     self._syntaxNode = Syntax(data)
@@ -150,9 +151,10 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ContinueStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ContinueStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .continueStmt)
     self._syntaxNode = Syntax(data)
@@ -272,9 +274,10 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DeferStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DeferStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .deferStmt)
     self._syntaxNode = Syntax(data)
@@ -394,9 +397,10 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DiscardStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DiscardStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .discardStmt)
     self._syntaxNode = Syntax(data)
@@ -517,9 +521,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DoStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DoStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .doStmt)
     self._syntaxNode = Syntax(data)
@@ -629,6 +634,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `catchClauses`
   /// collection.
+  ///
   /// - param element: The new `CatchClause` to add to the node's
   ///                  `catchClauses` collection.
   /// - returns: A copy of the receiver with the provided `CatchClause`
@@ -689,9 +695,10 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ExpressionStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ExpressionStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .expressionStmt)
     self._syntaxNode = Syntax(data)
@@ -772,9 +779,10 @@ public struct FallThroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``FallThroughStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``FallThroughStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .fallThroughStmt)
     self._syntaxNode = Syntax(data)
@@ -864,9 +872,10 @@ public struct ForStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ForStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ForStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .forStmt)
     self._syntaxNode = Syntax(data)
@@ -1196,9 +1205,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``GuardStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``GuardStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .guardStmt)
     self._syntaxNode = Syntax(data)
@@ -1296,6 +1306,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `conditions`
   /// collection.
+  ///
   /// - param element: The new `Condition` to add to the node's
   ///                  `conditions` collection.
   /// - returns: A copy of the receiver with the provided `Condition`
@@ -1396,9 +1407,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``LabeledStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``LabeledStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .labeledStmt)
     self._syntaxNode = Syntax(data)
@@ -1545,9 +1557,10 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MissingStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MissingStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .missingStmt)
     self._syntaxNode = Syntax(data)
@@ -1635,9 +1648,10 @@ public struct RepeatStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``RepeatStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``RepeatStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .repeatStmt)
     self._syntaxNode = Syntax(data)
@@ -1809,9 +1823,10 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ReturnStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ReturnStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .returnStmt)
     self._syntaxNode = Syntax(data)
@@ -1931,9 +1946,10 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ThrowStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ThrowStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .throwStmt)
     self._syntaxNode = Syntax(data)
@@ -2054,9 +2070,10 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``WhileStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``WhileStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .whileStmt)
     self._syntaxNode = Syntax(data)
@@ -2148,6 +2165,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `conditions`
   /// collection.
+  ///
   /// - param element: The new `Condition` to add to the node's
   ///                  `conditions` collection.
   /// - returns: A copy of the receiver with the provided `Condition`
@@ -2269,9 +2287,10 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``YieldStmtSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``YieldStmtSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .yieldStmt)
     self._syntaxNode = Syntax(data)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -29,9 +29,10 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ArrayTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ArrayTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .arrayType)
     self._syntaxNode = Syntax(data)
@@ -178,9 +179,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``AttributedTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``AttributedTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .attributedType)
     self._syntaxNode = Syntax(data)
@@ -272,6 +274,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `attributes`
   /// collection.
+  ///
   /// - param element: The new `Attribute` to add to the node's
   ///                  `attributes` collection.
   /// - returns: A copy of the receiver with the provided `Attribute`
@@ -350,9 +353,10 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ClassRestrictionTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ClassRestrictionTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .classRestrictionType)
     self._syntaxNode = Syntax(data)
@@ -433,9 +437,10 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``CompositionTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``CompositionTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .compositionType)
     self._syntaxNode = Syntax(data)
@@ -489,6 +494,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `elements`
   /// collection.
+  ///
   /// - param element: The new `Element` to add to the node's
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`
@@ -545,9 +551,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``DictionaryTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``DictionaryTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .dictionaryType)
     self._syntaxNode = Syntax(data)
@@ -748,9 +755,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``FunctionTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``FunctionTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .functionType)
     self._syntaxNode = Syntax(data)
@@ -854,6 +862,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `parameters`
   /// collection.
+  ///
   /// - param element: The new `Parameter` to add to the node's
   ///                  `parameters` collection.
   /// - returns: A copy of the receiver with the provided `Parameter`
@@ -973,9 +982,10 @@ public struct IdentifierTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``IdentifierTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``IdentifierTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .identifierType)
     self._syntaxNode = Syntax(data)
@@ -1095,9 +1105,10 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``ImplicitlyUnwrappedOptionalTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``ImplicitlyUnwrappedOptionalTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .implicitlyUnwrappedOptionalType)
     self._syntaxNode = Syntax(data)
@@ -1219,9 +1230,10 @@ public struct MemberTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MemberTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MemberTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .memberType)
     self._syntaxNode = Syntax(data)
@@ -1394,9 +1406,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MetatypeTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MetatypeTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .metatypeType)
     self._syntaxNode = Syntax(data)
@@ -1543,9 +1556,10 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``MissingTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``MissingTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .missingType)
     self._syntaxNode = Syntax(data)
@@ -1631,9 +1645,10 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``NamedOpaqueReturnTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``NamedOpaqueReturnTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .namedOpaqueReturnType)
     self._syntaxNode = Syntax(data)
@@ -1755,9 +1770,10 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``OptionalTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``OptionalTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .optionalType)
     self._syntaxNode = Syntax(data)
@@ -1877,9 +1893,10 @@ public struct PackElementTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PackElementTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PackElementTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .packElementType)
     self._syntaxNode = Syntax(data)
@@ -1999,9 +2016,10 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``PackExpansionTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``PackExpansionTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .packExpansionType)
     self._syntaxNode = Syntax(data)
@@ -2121,9 +2139,10 @@ public struct SomeOrAnyTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SomeOrAnyTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SomeOrAnyTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .someOrAnyType)
     self._syntaxNode = Syntax(data)
@@ -2243,9 +2262,10 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SuppressedTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SuppressedTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .suppressedType)
     self._syntaxNode = Syntax(data)
@@ -2366,9 +2386,10 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``TupleTypeSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``TupleTypeSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .tupleType)
     self._syntaxNode = Syntax(data)
@@ -2460,6 +2481,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   
   /// Adds the provided `element` to the node's `elements`
   /// collection.
+  ///
   /// - param element: The new `Element` to add to the node's
   ///                  `elements` collection.
   /// - returns: A copy of the receiver with the provided `Element`


### PR DESCRIPTION
Add a couple of line breaks to doc comments so they render more nicely in docc.

For example, `DO NOT CONFORM TO THIS PROTOCOL YOURSELF!` should not show up in the abstract of the base syntax nodes