### PR TITLE
Introduce ExperimentalFeatures

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -10,8 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftSyntax
+
 public struct KeywordSpec {
   public var name: String
+
+  /// If `true`, this is for an experimental language feature, and any public
+  /// API generated should be SPI.
+  public var isExperimental: Bool
+
   public var isLexerClassified: Bool
   public var requiresLeadingSpace: Bool
   public var requiresTrailingSpace: Bool
@@ -24,10 +31,18 @@ public struct KeywordSpec {
     }
   }
 
+  /// Retrieve the attributes that should be printed on any API for the
+  /// generated keyword.
+  public var apiAttributes: AttributeListSyntax {
+    guard isExperimental else { return "" }
+    return AttributeListSyntax("@_spi(ExperimentalLanguageFeatures)").with(\.trailingTrivia, .newline)
+  }
+
   /// `isLexerClassified` determines whether the token kind is switched from being an identifier to a keyword in the lexer.
   /// This is true for keywords that used to be considered non-contextual.
-  init(_ name: String, isLexerClassified: Bool = false, requiresLeadingSpace: Bool = false, requiresTrailingSpace: Bool = false) {
+  init(_ name: String, isExperimental: Bool = false, isLexerClassified: Bool = false, requiresLeadingSpace: Bool = false, requiresTrailingSpace: Bool = false) {
     self.name = name
+    self.isExperimental = isExperimental
     self.isLexerClassified = isLexerClassified
     self.requiresLeadingSpace = requiresLeadingSpace
     self.requiresTrailingSpace = requiresTrailingSpace

--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -40,6 +40,10 @@ public class Node {
   /// The kind of node’s supertype. This kind must have `isBase == true`
   public let base: SyntaxNodeKind
 
+  /// If `true`, this is for an experimental language feature, and any public
+  /// API generated should be SPI.
+  public let isExperimental: Bool
+
   /// When the node name is printed for diagnostics, this name is used.
   /// If `nil`, `nameForDiagnostics` will print the parent node’s name.
   public let nameForDiagnostics: String?
@@ -85,10 +89,25 @@ public class Node {
     }
   }
 
+  /// Retrieve the attributes that should be printed on any API for the
+  /// generated node. If `forRaw` is true, this is for the raw syntax node.
+  public func apiAttributes(forRaw: Bool = false) -> AttributeListSyntax {
+    let attrList = AttributeListSyntax {
+      if isExperimental {
+        "@_spi(ExperimentalLanguageFeatures)"
+      }
+      if forRaw {
+        "@_spi(RawSyntax)"
+      }
+    }
+    return attrList.with(\.trailingTrivia, attrList.isEmpty ? [] : .newline)
+  }
+
   /// Construct the specification for a layout syntax node.
   init(
     kind: SyntaxNodeKind,
     base: SyntaxNodeKind,
+    isExperimental: Bool = false,
     nameForDiagnostics: String?,
     documentation: String? = nil,
     parserFunction: String? = nil,
@@ -100,6 +119,7 @@ public class Node {
 
     self.kind = kind
     self.base = base
+    self.isExperimental = isExperimental
     self.nameForDiagnostics = nameForDiagnostics
     self.documentation = docCommentTrivia(from: documentation)
     self.parserFunction = parserFunction
@@ -204,6 +224,7 @@ public class Node {
   init(
     kind: SyntaxNodeKind,
     base: SyntaxNodeKind,
+    isExperimental: Bool = false,
     nameForDiagnostics: String?,
     documentation: String? = nil,
     parserFunction: String? = nil,
@@ -212,6 +233,7 @@ public class Node {
     self.kind = kind
     precondition(base == .syntaxCollection)
     self.base = base
+    self.isExperimental = isExperimental
     self.nameForDiagnostics = nameForDiagnostics
     self.documentation = docCommentTrivia(from: documentation)
     self.parserFunction = parserFunction

--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
@@ -22,20 +22,34 @@ public struct TokenSpec {
   }
 
   public let varOrCaseName: TokenSyntax
+
+  /// If `true`, this is for an experimental language feature, and any public
+  /// API generated should be SPI.
+  public let isExperimental: Bool
+
   public let nameForDiagnostics: String
   public let text: String?
   public let kind: Kind
 
   fileprivate init(
     name: String,
+    isExperimental: Bool = false,
     nameForDiagnostics: String,
     text: String? = nil,
     kind: Kind
   ) {
     self.varOrCaseName = .identifier(name)
+    self.isExperimental = isExperimental
     self.nameForDiagnostics = nameForDiagnostics
     self.text = text
     self.kind = kind
+  }
+
+  /// Retrieve the attributes that should be printed on any API for the
+  /// generated token.
+  public var apiAttributes: AttributeListSyntax {
+    guard isExperimental else { return "" }
+    return AttributeListSyntax("@_spi(ExperimentalLanguageFeatures)").with(\.trailingTrivia, .newline)
   }
 
   static func punctuator(name: String, text: String) -> TokenSpec {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/SyntaxKindNameForDiagnosticsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparserdiagnostics/SyntaxKindNameForDiagnosticsFile.swift
@@ -16,7 +16,7 @@ import SyntaxSupport
 import Utils
 
 let syntaxKindNameForDiagnosticFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
-  DeclSyntax("import SwiftSyntax")
+  DeclSyntax("@_spi(ExperimentalLanguageFeatures) import SwiftSyntax")
 
   try! ExtensionDeclSyntax("extension SyntaxKind") {
     try VariableDeclSyntax("var nameForDiagnostics: String?") {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
@@ -28,7 +28,12 @@ let keywordFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     """
   ) {
     for (index, keyword) in KEYWORDS.enumerated() {
-      DeclSyntax("case \(raw: keyword.escapedName)")
+      DeclSyntax(
+        """
+        \(keyword.apiAttributes)\
+        case \(raw: keyword.escapedName)
+        """
+      )
     }
 
     try! InitializerDeclSyntax("@_spi(RawSyntax) public init?(_ text: SyntaxText)") {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -42,7 +42,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   for node in SYNTAX_NODES where node.kind.isBase {
     DeclSyntax(
       """
-      @_spi(RawSyntax)
+      \(node.apiAttributes(forRaw: true))\
       public protocol \(node.kind.rawType)NodeProtocol: \(raw: node.base.rawProtocolType) {}
       """
     )
@@ -51,7 +51,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   for node in SYNTAX_NODES {
     try! StructDeclSyntax(
       """
-      @_spi(RawSyntax)
+      \(node.apiAttributes(forRaw: true))\
       public struct \(node.kind.rawType): \(node.kind.isBase ? node.kind.rawProtocolType : node.base.rawProtocolType)
       """
     ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SwiftSyntaxDoccIndex.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SwiftSyntaxDoccIndex.swift
@@ -37,7 +37,7 @@ let nodesSections: String = {
 
   for (baseKind, heading) in nodeKinds {
     let baseTypes = ["\(baseKind.syntaxType)", "\(baseKind.syntaxType)Protocol", "Missing\(baseKind.syntaxType)"]
-    let leafTypes = SYNTAX_NODES.filter({ $0.base == baseKind && !$0.kind.isMissing }).map(\.kind.syntaxType.description)
+    let leafTypes = SYNTAX_NODES.filter({ $0.base == baseKind && !$0.kind.isMissing && !$0.isExperimental }).map(\.kind.syntaxType.description)
     addSection(heading: heading, types: baseTypes + leafTypes)
   }
 
@@ -48,7 +48,7 @@ let nodesSections: String = {
       "SyntaxChildrenIndex",
     ]
       + SYNTAX_NODES.flatMap({ (node: Node) -> [String] in
-        guard let node = node.collectionNode else {
+        guard let node = node.collectionNode, !node.isExperimental else {
           return []
         }
         return [node.kind.syntaxType.description]
@@ -59,9 +59,12 @@ let nodesSections: String = {
       })
   )
 
-  addSection(heading: "Attributes", types: ATTRIBUTE_NODES.map(\.kind.syntaxType.description).sorted())
+  addSection(heading: "Attributes", types: ATTRIBUTE_NODES.filter({ !$0.isExperimental }).map(\.kind.syntaxType.description).sorted())
 
-  addSection(heading: "Miscellaneous Syntax", types: SYNTAX_NODES.map(\.kind.syntaxType.description).filter({ !handledSyntaxTypes.contains($0) }))
+  addSection(
+    heading: "Miscellaneous Syntax",
+    types: SYNTAX_NODES.filter({ !$0.isExperimental }).map(\.kind.syntaxType.description).filter({ !handledSyntaxTypes.contains($0) })
+  )
 
   addSection(heading: "Traits", types: TRAITS.map { "\($0.protocolName)" })
 

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxAnyVisitorFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxAnyVisitorFile.swift
@@ -79,6 +79,7 @@ let syntaxAnyVisitorFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     for node in SYNTAX_NODES where !node.kind.isBase {
       DeclSyntax(
         """
+        \(node.apiAttributes())\
         override open func visit(_ node: \(node.kind.syntaxType)) -> SyntaxVisitorContinueKind {
           return visitAny(node._syntaxNode)
         }
@@ -87,6 +88,7 @@ let syntaxAnyVisitorFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
       DeclSyntax(
         """
+        \(node.apiAttributes())\
         override open func visitPost(_ node: \(node.kind.syntaxType)) {
           visitAnyPost(node._syntaxNode)
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -26,6 +26,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// Extension point to add common methods to all ``\(node.kind.syntaxType)`` nodes.
       ///
       ///  - Warning: Do not conform to this protocol yourself.
+      \(node.apiAttributes())\
       public protocol \(node.kind.protocolType): \(raw: node.base.protocolType) {}
       """
     )
@@ -59,6 +60,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     try! StructDeclSyntax(
       """
       \(node.documentation)
+      \(node.apiAttributes())\
       public struct \(node.kind.syntaxType): \(node.kind.protocolType), SyntaxHashable
       """
     ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -33,6 +33,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     try! StructDeclSyntax(
       """
       \(documentation)
+      \(node.node.apiAttributes())\
       public struct \(node.kind.syntaxType): SyntaxCollection, SyntaxHashable
       """
     ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxEnumFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxEnumFile.swift
@@ -24,7 +24,12 @@ let syntaxEnumFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   ) {
     DeclSyntax("case token(TokenSyntax)")
     for node in NON_BASE_SYNTAX_NODES {
-      DeclSyntax("case \(node.varOrCaseName)(\(node.kind.syntaxType))")
+      DeclSyntax(
+        """
+        \(node.apiAttributes())\
+        case \(node.varOrCaseName)(\(node.kind.syntaxType))
+        """
+      )
     }
   }
 

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxKindFile.swift
@@ -24,7 +24,12 @@ let syntaxKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   ) {
     DeclSyntax("case token")
     for node in NON_BASE_SYNTAX_NODES {
-      DeclSyntax("case \(node.varOrCaseName)")
+      DeclSyntax(
+        """
+        \(node.apiAttributes())\
+        case \(node.varOrCaseName)
+        """
+      )
     }
 
     try VariableDeclSyntax("public var isSyntaxCollection: Bool") {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -40,6 +40,7 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
         // MARK: - \(raw: node.kind.syntaxType)
 
         \(documentation)
+        \(node.node.apiAttributes())\
         public struct \(raw: node.kind.syntaxType): \(raw: node.baseType.syntaxBaseName)Protocol, SyntaxHashable
         """
       ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -125,6 +125,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           /// Visit a ``\(node.kind.syntaxType)``.
           ///   - Parameter node: the node that is being visited
           ///   - Returns: the rewritten node
+          \(node.apiAttributes())\
           open func visit(_ node: \(node.kind.syntaxType)) -> \(node.kind.syntaxType) {
             return Syntax(visitChildren(node)).cast(\(node.kind.syntaxType).self)
           }
@@ -136,6 +137,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           /// Visit a ``\(node.kind.syntaxType)``.
           ///   - Parameter node: the node that is being visited
           ///   - Returns: the rewritten node
+          \(node.apiAttributes())\
           open func visit(_ node: \(node.kind.syntaxType)) -> \(raw: node.baseType.syntaxBaseName) {
             return \(raw: node.baseType.syntaxBaseName)(visitChildren(node))
           }
@@ -144,12 +146,14 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       }
     }
 
-    for baseKind in SyntaxNodeKind.allCases where baseKind.isBase && baseKind != .syntax && baseKind != .syntaxCollection {
+    for baseNode in SYNTAX_NODES where baseNode.kind.isBase && baseNode.kind != .syntax && baseNode.kind != .syntaxCollection {
+      let baseKind = baseNode.kind
       DeclSyntax(
         """
         /// Visit any \(raw: baseKind.syntaxType) node.
         ///   - Parameter node: the node that is being visited
         ///   - Returns: the rewritten node
+        \(baseNode.apiAttributes())\
         public func visit(_ node: \(raw: baseKind.syntaxType)) -> \(raw: baseKind.syntaxType) {
           return visit(node.data).cast(\(raw: baseKind.syntaxType).self)
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTransformFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTransformFile.swift
@@ -28,7 +28,9 @@ let syntaxTransformFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax("func visit(_ token: TokenSyntax) -> ResultType")
 
-    for node in SYNTAX_NODES where !node.kind.isBase {
+    // Don't bother including experimental nodes here since we want to remove
+    // SyntaxTransformVisitor anyway.
+    for node in SYNTAX_NODES where !node.kind.isBase && !node.isExperimental {
       DeclSyntax(
         """
         /// Visiting ``\(node.kind.syntaxType)`` specifically.
@@ -55,6 +57,7 @@ let syntaxTransformFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         /// Visiting ``\(node.kind.syntaxType)`` specifically.
         ///   - Parameter node: the node we are visiting.
         ///   - Returns: nil by default.
+        \(node.apiAttributes())\
         public func visit(_ node: \(node.kind.syntaxType)) -> ResultType {
           visitAny(Syntax(node))
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTransformFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTransformFile.swift
@@ -16,7 +16,12 @@ import SyntaxSupport
 import Utils
 
 let syntaxTransformFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
-  try! ProtocolDeclSyntax("public protocol SyntaxTransformVisitor") {
+  try! ProtocolDeclSyntax(
+    """
+    @_spi(SyntaxTransformVisitor)
+    public protocol SyntaxTransformVisitor
+    """
+  ) {
     DeclSyntax("associatedtype ResultType = Void")
 
     DeclSyntax("func visitAny(_ node: Syntax) -> ResultType")

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxVisitorFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxVisitorFile.swift
@@ -56,6 +56,7 @@ let syntaxVisitorFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         /// Visiting ``\(node.kind.syntaxType)`` specifically.
         ///   - Parameter node: the node we are visiting.
         ///   - Returns: how should we continue visiting.
+        \(node.apiAttributes())\
         open func visit(_ node: \(node.kind.syntaxType)) -> SyntaxVisitorContinueKind {
           return .visitChildren
         }
@@ -66,6 +67,7 @@ let syntaxVisitorFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         """
         /// The function called after visiting ``\(node.kind.syntaxType)`` and its descendants.
         ///   - node: the node we just finished visiting.
+        \(node.apiAttributes())\
         open func visitPost(_ node: \(node.kind.syntaxType)) {}
         """
       )

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -26,11 +26,26 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       // Tokens that don't have a set text have an associated value that
       // contains their text.
       if tokenSpec.kind == .keyword {
-        DeclSyntax("case \(tokenSpec.varOrCaseName)(Keyword)")
+        DeclSyntax(
+          """
+          \(tokenSpec.apiAttributes)\
+          case \(tokenSpec.varOrCaseName)(Keyword)
+          """
+        )
       } else if tokenSpec.text == nil {
-        DeclSyntax("case \(tokenSpec.varOrCaseName)(String)")
+        DeclSyntax(
+          """
+          \(tokenSpec.apiAttributes)\
+          case \(tokenSpec.varOrCaseName)(String)
+          """
+        )
       } else {
-        DeclSyntax("case \(tokenSpec.varOrCaseName)")
+        DeclSyntax(
+          """
+          \(tokenSpec.apiAttributes)\
+          case \(tokenSpec.varOrCaseName)
+          """
+        )
       }
     }
 
@@ -140,7 +155,12 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     """
   ) {
     for tokenSpec in Token.allCases.map(\.spec) {
-      DeclSyntax("case \(tokenSpec.varOrCaseName)")
+      DeclSyntax(
+        """
+        \(tokenSpec.apiAttributes)\
+        case \(tokenSpec.varOrCaseName)
+        """
+      )
     }
 
     try VariableDeclSyntax(

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
@@ -26,6 +26,7 @@ let resultBuildersFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     try! StructDeclSyntax(
       """
       @resultBuilder
+      \(node.node.apiAttributes())\
       public struct \(type.resultBuilderType)
       """
     ) {

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -13,6 +13,7 @@ add_swift_host_library(SwiftParser
   CollectionNodes+Parsable.swift
   Declarations.swift
   Directives.swift
+  ExperimentalFeatures.swift
   Expressions.swift
   IncrementalParseTransition.swift
   Lookahead.swift

--- a/Sources/SwiftParser/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/ExperimentalFeatures.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Parser {
+  @_spi(ExperimentalLanguageFeatures)
+  public struct ExperimentalFeatures: OptionSet {
+    public let rawValue: UInt
+    public init(rawValue: UInt) {
+      self.rawValue = rawValue
+    }
+  }
+}

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -27,22 +27,36 @@ extension Parser {
     /// i.e. how far it looked ahead.
     var tokensConsumed: Int = 0
 
+    /// The experimental features that have been enabled in the underlying
+    /// parser.
+    let experimentalFeatures: ExperimentalFeatures
+
     private init(
       lexemes: Lexer.LexemeSequence,
-      currentToken: Lexer.Lexeme
+      currentToken: Lexer.Lexeme,
+      experimentalFeatures: ExperimentalFeatures
     ) {
       self.lexemes = lexemes
       self.currentToken = currentToken
+      self.experimentalFeatures = experimentalFeatures
     }
 
     fileprivate init(cloning other: Parser) {
-      self.init(lexemes: other.lexemes, currentToken: other.currentToken)
+      self.init(
+        lexemes: other.lexemes,
+        currentToken: other.currentToken,
+        experimentalFeatures: other.experimentalFeatures
+      )
     }
 
     /// Initiates a lookahead session from the current point in this
     /// lookahead session.
     func lookahead() -> Lookahead {
-      return Lookahead(lexemes: self.lexemes, currentToken: self.currentToken)
+      return Lookahead(
+        lexemes: self.lexemes,
+        currentToken: self.currentToken,
+        experimentalFeatures: self.experimentalFeatures
+      )
     }
   }
 

--- a/Sources/SwiftParser/ParseSourceFile.swift
+++ b/Sources/SwiftParser/ParseSourceFile.swift
@@ -22,6 +22,16 @@ extension Parser {
     return SourceFileSyntax.parse(from: &parser)
   }
 
+  /// A compiler interface that allows the enabling of experimental features.
+  @_spi(ExperimentalLanguageFeatures)
+  public static func parse(
+    source: UnsafeBufferPointer<UInt8>,
+    experimentalFeatures: ExperimentalFeatures
+  ) -> SourceFileSyntax {
+    var parser = Parser(source, experimentalFeatures: experimentalFeatures)
+    return SourceFileSyntax.parse(from: &parser)
+  }
+
   /// Parse the source code in the given buffer as Swift source file. See
   /// `Parser.init` for more details.
   public static func parse(

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 extension TokenConsumer {
   /// Returns `true` if the current token represents the start of a statement

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 /// Describes how distinctive a token is for parser recovery. When expecting a
 /// token, tokens with a lower token precedence may be skipped and considered

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 /// A set of `TokenSpecs`. We expect to consume one of the sets specs in the
 /// parser.

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -12,7 +12,7 @@
 
 import SwiftDiagnostics
 @_spi(Diagnostics) import SwiftParser
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 fileprivate func getTokens(between first: TokenSyntax, and second: TokenSyntax) -> [TokenSyntax] {
   var first = first

--- a/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 extension SyntaxKind {
   var nameForDiagnostics: String? {

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SyntaxTransformVisitor)
 public protocol SyntaxTransformVisitor {
   associatedtype ResultType = Void
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -5731,9 +5731,10 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable 
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SimpleStringLiteralExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SimpleStringLiteralExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .simpleStringLiteralExpr)
     self._syntaxNode = Syntax(data)
@@ -5830,6 +5831,7 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable 
   
   /// Adds the provided `element` to the node's `segments`
   /// collection.
+  ///
   /// - param element: The new `Segment` to add to the node's
   ///                  `segments` collection.
   /// - returns: A copy of the receiver with the provided `Segment`

--- a/Tests/SwiftParserTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftParserTest/AbsolutePositionTests.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 import SwiftParser
 import _SwiftSyntaxTestSupport
 
-public class AbsolutePositionTests: XCTestCase {
+public class AbsolutePositionTests: ParserTestCase {
   public func testTokenAt() {
     let source =
       """

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -14,7 +14,7 @@
 @_spi(RawSyntax) import SwiftParser
 import XCTest
 
-final class AttributeTests: XCTestCase {
+final class AttributeTests: ParserTestCase {
   func testMissingArgumentToAttribute() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/AvailabilityTests.swift
+++ b/Tests/SwiftParserTest/AvailabilityTests.swift
@@ -14,7 +14,7 @@
 @_spi(RawSyntax) import SwiftParser
 import XCTest
 
-final class AvailabilityTests: XCTestCase {
+final class AvailabilityTests: ParserTestCase {
   func testAvailableMember() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -16,7 +16,7 @@ import SwiftSyntaxBuilder
 import SwiftBasicFormat
 import XCTest
 
-final class DeclarationTests: XCTestCase {
+final class DeclarationTests: ParserTestCase {
   func testImports() {
     assertParse("import Foundation")
 

--- a/Tests/SwiftParserTest/DirectiveTests.swift
+++ b/Tests/SwiftParserTest/DirectiveTests.swift
@@ -14,7 +14,7 @@
 @_spi(RawSyntax) import SwiftParser
 import XCTest
 
-final class DirectiveTests: XCTestCase {
+final class DirectiveTests: ParserTestCase {
   func testSwitchIfConfig() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -14,7 +14,7 @@
 @_spi(RawSyntax) import SwiftParser
 import XCTest
 
-final class ExpressionTests: XCTestCase {
+final class ExpressionTests: ParserTestCase {
   func testTernary() {
     assertParse(
       "let a =1️⃣",
@@ -1474,7 +1474,7 @@ final class ExpressionTests: XCTestCase {
   }
 }
 
-final class MemberExprTests: XCTestCase {
+final class MemberExprTests: ParserTestCase {
   func testMissing() {
     let cases: [UInt: String] = [
       #line: "",
@@ -1494,7 +1494,7 @@ final class MemberExprTests: XCTestCase {
   }
 }
 
-final class StatementExpressionTests: XCTestCase {
+final class StatementExpressionTests: ParserTestCase {
   private func ifZeroElseOne() -> ExprSyntax {
     .init(
       IfExprSyntax(

--- a/Tests/SwiftParserTest/ExpressionTypeTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTypeTests.swift
@@ -13,7 +13,7 @@
 import SwiftSyntax
 import XCTest
 
-final class ExpressionTypeTests: XCTestCase {
+final class ExpressionTypeTests: ParserTestCase {
   func testTypeExpression() {
     assertParse("_ = (any Sequence<Int>).self")
   }

--- a/Tests/SwiftParserTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftParserTest/IncrementalParsingTests.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 import SwiftParser
 import _SwiftSyntaxTestSupport
 
-public class IncrementalParsingTests: XCTestCase {
+public class IncrementalParsingTests: ParserTestCase {
 
   public func testBrokenMemberFunction() {
     assertIncrementalParse(

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -60,7 +60,7 @@ fileprivate func assertRawBytesLexeme(
   XCTAssertEqual(lexeme.diagnostic, error, file: file, line: line)
 }
 
-public class LexerTests: XCTestCase {
+public class LexerTests: ParserTestCase {
   func testIdentifiers() {
     assertLexemes(
       "Hello World",

--- a/Tests/SwiftParserTest/LinkageTests.swift
+++ b/Tests/SwiftParserTest/LinkageTests.swift
@@ -14,7 +14,7 @@
 import Darwin
 import XCTest
 
-final class LinkageTest: XCTestCase {
+final class LinkageTest: ParserTestCase {
   // Assert that SwiftSyntax and SwiftParser do not introduce more link-time
   // dependencies than are strictly necessary. We want to minimize our link-time
   // dependencies. If this set changes - in particular, if it grows - consult

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 import SwiftParser
 import XCTest
 
-public class EntryTests: XCTestCase {
+public class EntryTests: ParserTestCase {
   func testTopLevelStringParse() throws {
     let source = "func test() {}"
     let tree = Parser.parse(source: source)

--- a/Tests/SwiftParserTest/ParserTestCase.swift
+++ b/Tests/SwiftParserTest/ParserTestCase.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,20 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This test file has been translated from swift/test/Parse/hashbang_main.swift
-
 import XCTest
+import SwiftSyntax
 
-final class HashbangMainTests: ParserTestCase {
-  func testHashbangMain1() {
-    assertParse(
-      """
-      #!/usr/bin/swift
-      let x = 42
-      x + x
-      // Check that we skip the hashbang at the beginning of the file.
-      """
-    )
-  }
+@_spi(ExperimentalLanguageFeatures) import SwiftParser
 
+/// The base class for all parser test cases.
+public class ParserTestCase: XCTestCase {
+  /// The default set of experimental features to test with.
+  var experimentalFeatures: Parser.ExperimentalFeatures { [] }
 }

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -17,7 +17,7 @@ import SwiftSyntax
 import SwiftParser
 import SwiftParserDiagnostics
 
-public class ParserTests: XCTestCase {
+public class ParserTests: ParserTestCase {
   /// Run a single parse test.
   func runParseTest(fileURL: URL, checkDiagnostics: Bool) throws {
     let fileContents = try Data(contentsOf: fileURL)

--- a/Tests/SwiftParserTest/PatternTests.swift
+++ b/Tests/SwiftParserTest/PatternTests.swift
@@ -14,7 +14,7 @@
 @_spi(RawSyntax) import SwiftParser
 import XCTest
 
-final class PatternTests: XCTestCase {
+final class PatternTests: ParserTestCase {
   private var genericArgEnumPattern: Syntax {
     // let E<Int>.e(y)
     Syntax(

--- a/Tests/SwiftParserTest/RegexLiteralTests.swift
+++ b/Tests/SwiftParserTest/RegexLiteralTests.swift
@@ -14,7 +14,7 @@
 @_spi(RawSyntax) import SwiftParser
 import XCTest
 
-final class RegexLiteralTests: XCTestCase {
+final class RegexLiteralTests: ParserTestCase {
   func testForwardSlash1() {
     assertParse(
       #"""

--- a/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
+++ b/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
@@ -46,7 +46,7 @@ func verifySequentialToConcurrentTranslation(
   )
 }
 
-final class TranslateSequentialToConcurrentEditsTests: XCTestCase {
+final class TranslateSequentialToConcurrentEditsTests: ParserTestCase {
   func testEmpty() {
     verifySequentialToConcurrentTranslation([], [])
   }

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -14,7 +14,7 @@
 @_spi(RawSyntax) import SwiftParser
 import XCTest
 
-final class StatementTests: XCTestCase {
+final class StatementTests: ParserTestCase {
   func testIf() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/StringLiteralRepresentedLiteralValueTests.swift
+++ b/Tests/SwiftParserTest/StringLiteralRepresentedLiteralValueTests.swift
@@ -19,7 +19,7 @@ import SwiftSyntaxBuilder
 ///
 /// Most tests are expressed by a single function call that compares the
 /// run-time String value against the parsed node's `representedLiteralValue`.
-public class StringLiteralRepresentedLiteralValueTests: XCTestCase {
+public class StringLiteralRepresentedLiteralValueTests: ParserTestCase {
 
   func testIntro() {
     test(

--- a/Tests/SwiftParserTest/SyntaxTransformVisitorTest.swift
+++ b/Tests/SwiftParserTest/SyntaxTransformVisitorTest.swift
@@ -14,7 +14,7 @@ import XCTest
 import SwiftParser
 @_spi(SyntaxTransformVisitor) import SwiftSyntax
 
-final class SyntaxTransformVisitorTest: XCTestCase {
+final class SyntaxTransformVisitorTest: ParserTestCase {
   public func testFunctionCounter() {
     struct FuncCounter: SyntaxTransformVisitor {
       public func visitAny(_ node: Syntax) -> Int {

--- a/Tests/SwiftParserTest/SyntaxTransformVisitorTest.swift
+++ b/Tests/SwiftParserTest/SyntaxTransformVisitorTest.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 import SwiftParser
-import SwiftSyntax
+@_spi(SyntaxTransformVisitor) import SwiftSyntax
 
 final class SyntaxTransformVisitorTest: XCTestCase {
   public func testFunctionCounter() {

--- a/Tests/SwiftParserTest/TriviaParserTests.swift
+++ b/Tests/SwiftParserTest/TriviaParserTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) @_spi(Testing) import SwiftParser
 
-final class TriviaParserTests: XCTestCase {
+final class TriviaParserTests: ParserTestCase {
 
   func testTriviaParsing() {
 

--- a/Tests/SwiftParserTest/TypeCompositionTests.swift
+++ b/Tests/SwiftParserTest/TypeCompositionTests.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 import SwiftParser
 import XCTest
 
-final class TypeCompositionTests: XCTestCase {
+final class TypeCompositionTests: ParserTestCase {
   func testComponents() {
     let cases: [UInt: String] = [
       // Identifiers and member types

--- a/Tests/SwiftParserTest/TypeMemberTests.swift
+++ b/Tests/SwiftParserTest/TypeMemberTests.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 import SwiftParser
 import XCTest
 
-final class TypeMemberTests: XCTestCase {
+final class TypeMemberTests: ParserTestCase {
   func testKeyword() {
     assertParse(
       "MyType.class",

--- a/Tests/SwiftParserTest/TypeMetatypeTests.swift
+++ b/Tests/SwiftParserTest/TypeMetatypeTests.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 import SwiftParser
 import XCTest
 
-final class TypeMetatypeTests: XCTestCase {
+final class TypeMetatypeTests: ParserTestCase {
   func testBaseType() {
     let cases: [UInt: String] = [
       // Identifiers and member types

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -14,7 +14,7 @@
 @_spi(RawSyntax) import SwiftParser
 import XCTest
 
-final class TypeTests: XCTestCase {
+final class TypeTests: ParserTestCase {
   func testMissingColonInType() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -13,7 +13,7 @@
 import SwiftSyntax
 import XCTest
 
-final class VariadicGenericsTests: XCTestCase {
+final class VariadicGenericsTests: ParserTestCase {
   func testSimpleForwarding() {
     assertParse(
       """
@@ -297,7 +297,7 @@ final class VariadicGenericsTests: XCTestCase {
   }
 }
 
-final class TypeParameterPackTests: XCTestCase {
+final class TypeParameterPackTests: ParserTestCase {
   func testParameterPacks1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ActorTests.swift
+++ b/Tests/SwiftParserTest/translated/ActorTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ActorTests: XCTestCase {
+final class ActorTests: ParserTestCase {
   func testActor1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/AlwaysEmitConformanceMetadataAttrTests.swift
+++ b/Tests/SwiftParserTest/translated/AlwaysEmitConformanceMetadataAttrTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class AlwaysEmitConformanceMetadataAttrTests: XCTestCase {
+final class AlwaysEmitConformanceMetadataAttrTests: ParserTestCase {
   func testAlwaysEmitConformanceMetadataAttr() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/AsyncSyntaxTests.swift
+++ b/Tests/SwiftParserTest/translated/AsyncSyntaxTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class AsyncSyntaxTests: XCTestCase {
+final class AsyncSyntaxTests: ParserTestCase {
   func testAsyncSyntax1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/AsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/AsyncTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class AsyncTests: XCTestCase {
+final class AsyncTests: ParserTestCase {
   func testAsync1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class AvailabilityQueryTests: XCTestCase {
+final class AvailabilityQueryTests: ParserTestCase {
   func testAvailabilityQuery1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class AvailabilityQueryUnavailabilityTests: XCTestCase {
+final class AvailabilityQueryUnavailabilityTests: ParserTestCase {
   func testAvailabilityQueryUnavailability1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/BorrowExprTests.swift
+++ b/Tests/SwiftParserTest/translated/BorrowExprTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class BorrowExprTests: XCTestCase {
+final class BorrowExprTests: ParserTestCase {
   func testBorrowExpr1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/BraceRecoveryEofTests.swift
+++ b/Tests/SwiftParserTest/translated/BraceRecoveryEofTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class BraceRecoveryEofTests: XCTestCase {
+final class BraceRecoveryEofTests: ParserTestCase {
   func testBraceRecoveryEof1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/BuiltinBridgeObjectTests.swift
+++ b/Tests/SwiftParserTest/translated/BuiltinBridgeObjectTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class BuiltinBridgeObjectTests: XCTestCase {
+final class BuiltinBridgeObjectTests: ParserTestCase {
   func testBuiltinBridgeObject1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/BuiltinWordTests.swift
+++ b/Tests/SwiftParserTest/translated/BuiltinWordTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class BuiltinWordTests: XCTestCase {
+final class BuiltinWordTests: ParserTestCase {
   func testBuiltinWord1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
+++ b/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ConflictMarkersTests: XCTestCase {
+final class ConflictMarkersTests: ParserTestCase {
   func testConflictMarkers1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
+++ b/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ConsecutiveStatementsTests: XCTestCase {
+final class ConsecutiveStatementsTests: ParserTestCase {
   func testSimple1() {
     assertParse(
       "let x = 21️⃣ let y = 3",

--- a/Tests/SwiftParserTest/translated/CopyExprTests.swift
+++ b/Tests/SwiftParserTest/translated/CopyExprTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class CopyExprTests: XCTestCase {
+final class CopyExprTests: ParserTestCase {
   func testGlobal() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/DebuggerTests.swift
+++ b/Tests/SwiftParserTest/translated/DebuggerTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class DebuggerTests: XCTestCase {
+final class DebuggerTests: ParserTestCase {
   func testDebugger1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/DelayedExtensionTests.swift
+++ b/Tests/SwiftParserTest/translated/DelayedExtensionTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class DelayedExtensionTests: XCTestCase {
+final class DelayedExtensionTests: ParserTestCase {
   func testDelayedExtension1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
+++ b/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 // TODO: The generic where clause next to generic parameters is only valid in language mode 4. We should disallow them in language mode 5.
 
-final class DeprecatedWhereTests: XCTestCase {
+final class DeprecatedWhereTests: ParserTestCase {
   func testDeprecatedWhere1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/DiagnoseAvailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseAvailabilityTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class DiagnoseAvailabilityTests: XCTestCase {
+final class DiagnoseAvailabilityTests: ParserTestCase {
   func testDiagnoseAvailability1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/DiagnoseAvailabilityWindowsTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseAvailabilityWindowsTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class DiagnoseAvailabilityWindowsTests: XCTestCase {
+final class DiagnoseAvailabilityWindowsTests: ParserTestCase {
   func testDiagnoseAvailabilityWindows1() {
     assertParse(
       #"""

--- a/Tests/SwiftParserTest/translated/DiagnoseDynamicReplacementTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseDynamicReplacementTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class DiagnoseDynamicReplacementTests: XCTestCase {
+final class DiagnoseDynamicReplacementTests: ParserTestCase {
   func testDiagnoseDynamicReplacement1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 
 // https://github.com/apple/swift/issues/44070
-final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
+final class DiagnoseInitializerAsTypedPatternTests: ParserTestCase {
   func testDiagnoseInitializerAsTypedPattern3a() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class DiagnosticMissingFuncKeywordTests: XCTestCase {
+final class DiagnosticMissingFuncKeywordTests: ParserTestCase {
   func testDiagnosticMissingFuncKeyword2a() {
     // https://github.com/apple/swift/issues/52877
     assertParse(

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class DollarIdentifierTests: XCTestCase {
+final class DollarIdentifierTests: ParserTestCase {
   func testDollarIdentifier1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
+++ b/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class EffectfulPropertiesTests: XCTestCase {
+final class EffectfulPropertiesTests: ParserTestCase {
   func testEffectfulProperties1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/EnumElementPatternSwift4Tests.swift
+++ b/Tests/SwiftParserTest/translated/EnumElementPatternSwift4Tests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class EnumElementPatternSwift4Tests: XCTestCase {
+final class EnumElementPatternSwift4Tests: ParserTestCase {
   func testEnumElementPatternSwift41() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class EnumTests: XCTestCase {
+final class EnumTests: ParserTestCase {
   func testEnum1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 
 import XCTest
 
-final class ErrorsTests: XCTestCase {
+final class ErrorsTests: ParserTestCase {
   func testErrors1() {
     assertParse(
       #"""

--- a/Tests/SwiftParserTest/translated/EscapedIdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/EscapedIdentifiersTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class EscapedIdentifiersTests: XCTestCase {
+final class EscapedIdentifiersTests: ParserTestCase {
   func testEscapedIdentifiers1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ForeachAsyncTests: XCTestCase {
+final class ForeachAsyncTests: ParserTestCase {
   func testForeachAsync1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ForeachTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ForeachTests: XCTestCase {
+final class ForeachTests: ParserTestCase {
   func testForeach1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexSkippingAllowedTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexSkippingAllowedTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ForwardSlashRegexSkippingAllowedTests: XCTestCase {
+final class ForwardSlashRegexSkippingAllowedTests: ParserTestCase {
   func testForwardSlashRegexSkippingAllowed3() {
     // Ensures there is a parse error
     assertParse(

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexSkippingInvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexSkippingInvalidTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ForwardSlashRegexSkippingInvalidTests: XCTestCase {
+final class ForwardSlashRegexSkippingInvalidTests: ParserTestCase {
   func testForwardSlashRegexSkippingInvalid1() {
     // We don't consider this a regex literal when skipping as it has an initial
     // space.

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexSkippingTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexSkippingTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ForwardSlashRegexSkippingTests: XCTestCase {
+final class ForwardSlashRegexSkippingTests: ParserTestCase {
   func testForwardSlashRegexSkipping3() {
     assertParse(
       #"""

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
@@ -16,7 +16,7 @@
 @_spi(RawSyntax) import SwiftParser
 import XCTest
 
-final class ForwardSlashRegexTests: XCTestCase {
+final class ForwardSlashRegexTests: ParserTestCase {
   func testForwardSlashRegex1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
+++ b/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 
 import XCTest
 
-final class GenericDisambiguationTests: XCTestCase {
+final class GenericDisambiguationTests: ParserTestCase {
   func testGenericDisambiguation1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/GuardTests.swift
+++ b/Tests/SwiftParserTest/translated/GuardTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class GuardTests: XCTestCase {
+final class GuardTests: ParserTestCase {
   func testGuard1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/GuardTopLevelTests.swift
+++ b/Tests/SwiftParserTest/translated/GuardTopLevelTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class GuardTopLevelTests: XCTestCase {
+final class GuardTopLevelTests: ParserTestCase {
   func testGuardTopLevel1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 
 import XCTest
 
-final class HashbangLibraryTests: XCTestCase {
+final class HashbangLibraryTests: ParserTestCase {
   func testHashbangLibrary1() {
     // Check that we diagnose and skip the hashbang at the beginning of the file
     // when compiling in library mode.

--- a/Tests/SwiftParserTest/translated/IdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/IdentifiersTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class IdentifiersTests: XCTestCase {
+final class IdentifiersTests: ParserTestCase {
   func testIdentifiers1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 import SwiftSyntax
 
-final class IfconfigExprTests: XCTestCase {
+final class IfconfigExprTests: ParserTestCase {
   func testIfconfigExpr1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ImplicitGetterIncompleteTests.swift
+++ b/Tests/SwiftParserTest/translated/ImplicitGetterIncompleteTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ImplicitGetterIncompleteTests: XCTestCase {
+final class ImplicitGetterIncompleteTests: ParserTestCase {
   func testImplicitGetterIncomplete1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 
 import XCTest
 
-final class InitDeinitTests: XCTestCase {
+final class InitDeinitTests: ParserTestCase {
   func testInitDeinit1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class InvalidIfExprTests: XCTestCase {
+final class InvalidIfExprTests: ParserTestCase {
   func testInvalidIfExpr1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/InvalidStringInterpolationProtocolTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidStringInterpolationProtocolTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class InvalidStringInterpolationProtocolTests: XCTestCase {
+final class InvalidStringInterpolationProtocolTests: ParserTestCase {
   func testInvalidStringInterpolationProtocol1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class InvalidTests: XCTestCase {
+final class InvalidTests: ParserTestCase {
   func testInvalid1a() {
     // rdar://15946844
     assertParse(

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class MatchingPatternsTests: XCTestCase {
+final class MatchingPatternsTests: ParserTestCase {
   func testMatchingPatterns1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/MetatypeObjectConversionTests.swift
+++ b/Tests/SwiftParserTest/translated/MetatypeObjectConversionTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class MetatypeObjectConversionTests: XCTestCase {
+final class MetatypeObjectConversionTests: ParserTestCase {
   func testMetatypeObjectConversion1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/MoveExprTests.swift
+++ b/Tests/SwiftParserTest/translated/MoveExprTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class MoveExprTests: XCTestCase {
+final class MoveExprTests: ParserTestCase {
   func testMoveExpr1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
@@ -16,32 +16,34 @@ import XCTest
 
 import SwiftSyntax
 
-func assertParseWithAllNewlineEndings(
-  _ markedSource: String,
-  substructure expectedSubstructure: (some SyntaxProtocol)? = Optional<Syntax>.none,
-  substructureAfterMarker: String = "START",
-  diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
-  applyFixIts: [String]? = nil,
-  fixedSource expectedFixedSource: String? = nil,
-  file: StaticString = #file,
-  line: UInt = #line
-) {
-  for newline in ["\n", "\r", "\r\n"] {
-    assertParse(
-      markedSource.replacingOccurrences(of: "\n", with: newline),
-      substructure: expectedSubstructure,
-      substructureAfterMarker: substructureAfterMarker,
-      diagnostics: expectedDiagnostics,
-      applyFixIts: applyFixIts,
-      fixedSource: expectedFixedSource,
-      options: [.normalizeNewlinesInFixedSource],
-      file: file,
-      line: line
-    )
+extension ParserTestCase {
+  fileprivate func assertParseWithAllNewlineEndings(
+    _ markedSource: String,
+    substructure expectedSubstructure: (some SyntaxProtocol)? = Optional<Syntax>.none,
+    substructureAfterMarker: String = "START",
+    diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
+    applyFixIts: [String]? = nil,
+    fixedSource expectedFixedSource: String? = nil,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    for newline in ["\n", "\r", "\r\n"] {
+      assertParse(
+        markedSource.replacingOccurrences(of: "\n", with: newline),
+        substructure: expectedSubstructure,
+        substructureAfterMarker: substructureAfterMarker,
+        diagnostics: expectedDiagnostics,
+        applyFixIts: applyFixIts,
+        fixedSource: expectedFixedSource,
+        options: [.normalizeNewlinesInFixedSource],
+        file: file,
+        line: line
+      )
+    }
   }
 }
 
-final class MultilineErrorsTests: XCTestCase {
+final class MultilineErrorsTests: ParserTestCase {
   func testMultilineErrors1() {
     assertParseWithAllNewlineEndings(
       """

--- a/Tests/SwiftParserTest/translated/MultilinePoundDiagnosticArgRdar41154797Tests.swift
+++ b/Tests/SwiftParserTest/translated/MultilinePoundDiagnosticArgRdar41154797Tests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class MultilinePoundDiagnosticArgRdar41154797Tests: XCTestCase {
+final class MultilinePoundDiagnosticArgRdar41154797Tests: ParserTestCase {
   func testMultilinePoundDiagnosticArgRdar411547971() {
     assertParse(
       ##"""

--- a/Tests/SwiftParserTest/translated/MultilineStringTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineStringTests.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 
 import XCTest
 
-final class MultilineStringTests: XCTestCase {
+final class MultilineStringTests: ParserTestCase {
   func testMultilineString1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/NoimplicitcopyAttrTests.swift
+++ b/Tests/SwiftParserTest/translated/NoimplicitcopyAttrTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class NoimplicitcopyAttrTests: XCTestCase {
+final class NoimplicitcopyAttrTests: ParserTestCase {
   func testNoimplicitcopyAttr1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class NumberIdentifierErrorsTests: XCTestCase {
+final class NumberIdentifierErrorsTests: ParserTestCase {
   func testNumberIdentifierErrors1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ObjcEnumTests.swift
+++ b/Tests/SwiftParserTest/translated/ObjcEnumTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ObjcEnumTests: XCTestCase {
+final class ObjcEnumTests: ParserTestCase {
   func testObjcEnum1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
+++ b/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ObjectLiteralsTests: XCTestCase {
+final class ObjectLiteralsTests: ParserTestCase {
   func testObjectLiterals1a() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 // TODO: Designated operator types are only valid in langauge mode 4. We should disallow them in language mode 5.
 
-final class OperatorDeclDesignatedTypesTests: XCTestCase {
+final class OperatorDeclDesignatedTypesTests: ParserTestCase {
   func testOperatorDeclDesignatedTypes1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class OperatorDeclTests: XCTestCase {
+final class OperatorDeclTests: ParserTestCase {
   func testOperatorDecl1a() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/OperatorsTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorsTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class OperatorsTests: XCTestCase {
+final class OperatorsTests: ParserTestCase {
   func testOperators1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/OptionalChainLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalChainLvaluesTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class OptionalChainLvaluesTests: XCTestCase {
+final class OptionalChainLvaluesTests: ParserTestCase {
   func testOptionalChainLvalues1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/OptionalLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalLvaluesTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class OptionalLvaluesTests: XCTestCase {
+final class OptionalLvaluesTests: ParserTestCase {
   func testOptionalLvalues1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/OptionalTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalTests.swift
@@ -15,7 +15,7 @@
 import SwiftSyntax
 import XCTest
 
-final class OptionalTests: XCTestCase {
+final class OptionalTests: ParserTestCase {
   func testOptional1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/OriginalDefinedInAttrTests.swift
+++ b/Tests/SwiftParserTest/translated/OriginalDefinedInAttrTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class OriginalDefinedInAttrTests: XCTestCase {
+final class OriginalDefinedInAttrTests: ParserTestCase {
   func testOriginalDefinedInAttr1() {
     assertParse(
       #"""

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesScriptTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesScriptTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class PatternWithoutVariablesScriptTests: XCTestCase {
+final class PatternWithoutVariablesScriptTests: ParserTestCase {
   func testPatternWithoutVariablesScript1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class PatternWithoutVariablesTests: XCTestCase {
+final class PatternWithoutVariablesTests: ParserTestCase {
   func testPatternWithoutVariables1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/PlaygroundLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/PlaygroundLvaluesTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class PlaygroundLvaluesTests: XCTestCase {
+final class PlaygroundLvaluesTests: ParserTestCase {
   func testPlaygroundLvalues1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/PoundAssertTests.swift
+++ b/Tests/SwiftParserTest/translated/PoundAssertTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class PoundAssertTests: XCTestCase {
+final class PoundAssertTests: ParserTestCase {
   func testPoundAssert1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/PrefixSlashTests.swift
+++ b/Tests/SwiftParserTest/translated/PrefixSlashTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class PrefixSlashTests: XCTestCase {
+final class PrefixSlashTests: ParserTestCase {
   func testPrefixSlash2() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class RawStringErrorsTests: XCTestCase {
+final class RawStringErrorsTests: ParserTestCase {
   func testRawStringErrors1() {
     assertParse(
       ###"""

--- a/Tests/SwiftParserTest/translated/RawStringTests.swift
+++ b/Tests/SwiftParserTest/translated/RawStringTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class RawStringTests: XCTestCase {
+final class RawStringTests: ParserTestCase {
   func testRawString1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/RecoveryLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryLibraryTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class RecoveryLibraryTests: XCTestCase {
+final class RecoveryLibraryTests: ParserTestCase {
   func testRecoveryLibrary() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -2,7 +2,7 @@
 
 import XCTest
 
-final class RecoveryTests: XCTestCase {
+final class RecoveryTests: ParserTestCase {
   func testRecovery4() {
     assertParse(
       #"""

--- a/Tests/SwiftParserTest/translated/RegexParseEndOfBufferTests.swift
+++ b/Tests/SwiftParserTest/translated/RegexParseEndOfBufferTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class RegexParseEndOfBufferTests: XCTestCase {
+final class RegexParseEndOfBufferTests: ParserTestCase {
   func testRegexParseEndOfBuffer1() {
     assertParse(
       "var unterminated = #/(xy1️⃣",

--- a/Tests/SwiftParserTest/translated/RegexParseErrorTests.swift
+++ b/Tests/SwiftParserTest/translated/RegexParseErrorTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class RegexParseErrorTests: XCTestCase {
+final class RegexParseErrorTests: ParserTestCase {
   func testRegexParseError1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/RegexTests.swift
+++ b/Tests/SwiftParserTest/translated/RegexTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class RegexTests: XCTestCase {
+final class RegexTests: ParserTestCase {
   func testRegex1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ResultBuilderTests.swift
+++ b/Tests/SwiftParserTest/translated/ResultBuilderTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ResultBuilderTests: XCTestCase {
+final class ResultBuilderTests: ParserTestCase {
   func testResultBuilder1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
+++ b/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class SelfRebindingTests: XCTestCase {
+final class SelfRebindingTests: ParserTestCase {
   func testSelfRebinding1() {
     assertParse(
       #"""

--- a/Tests/SwiftParserTest/translated/SemicolonTests.swift
+++ b/Tests/SwiftParserTest/translated/SemicolonTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class SemicolonTests: XCTestCase {
+final class SemicolonTests: ParserTestCase {
   func testSemicolon1() {
     assertParse(
       #"""

--- a/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class StringLiteralEofTests: XCTestCase {
+final class StringLiteralEofTests: ParserTestCase {
   func testStringLiteralEof1() {
     assertParse(
       ##"""

--- a/Tests/SwiftParserTest/translated/SubscriptingTests.swift
+++ b/Tests/SwiftParserTest/translated/SubscriptingTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class SubscriptingTests: XCTestCase {
+final class SubscriptingTests: ParserTestCase {
   func testSubscripting1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/SuperTests.swift
+++ b/Tests/SwiftParserTest/translated/SuperTests.swift
@@ -15,7 +15,7 @@
 import SwiftSyntax
 import XCTest
 
-final class SuperTests: XCTestCase {
+final class SuperTests: ParserTestCase {
   func testSuper1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class SwitchIncompleteTests: XCTestCase {
+final class SwitchIncompleteTests: ParserTestCase {
   func testSwitchIncomplete1() {
     // <rdar://problem/15971438> Incomplete switch was parsing to an AST that
     // triggered an assertion failure.

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class SwitchTests: XCTestCase {
+final class SwitchTests: ParserTestCase {
   func testSwitch1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/ToplevelLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/ToplevelLibraryTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class ToplevelLibraryTests: XCTestCase {
+final class ToplevelLibraryTests: ParserTestCase {
   func testToplevelLibrary1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -15,7 +15,7 @@
 import SwiftSyntax
 import XCTest
 
-final class TrailingClosuresTests: XCTestCase {
+final class TrailingClosuresTests: ParserTestCase {
   func testTrailingClosures1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/TrailingSemiTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingSemiTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class TrailingSemiTests: XCTestCase {
+final class TrailingSemiTests: ParserTestCase {
   func testTrailingSemi1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/TryTests.swift
+++ b/Tests/SwiftParserTest/translated/TryTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class TryTests: XCTestCase {
+final class TryTests: ParserTestCase {
   func testTry1() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/TypeExprTests.swift
+++ b/Tests/SwiftParserTest/translated/TypeExprTests.swift
@@ -17,7 +17,7 @@ import SwiftSyntax
 
 // Types in expression contexts must be followed by a member access or
 // constructor call.
-final class TypeExprTests: XCTestCase {
+final class TypeExprTests: ParserTestCase {
   func testTypeExpr3() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/TypealiasTests.swift
+++ b/Tests/SwiftParserTest/translated/TypealiasTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class TypealiasTests: XCTestCase {
+final class TypealiasTests: ParserTestCase {
   func testTypealias2a() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
+++ b/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 
-final class UnclosedStringInterpolationTests: XCTestCase {
+final class UnclosedStringInterpolationTests: ParserTestCase {
   func testUnclosedStringInterpolation1() {
     assertParse(
       #"""


### PR DESCRIPTION
These allow the parser to optionally support new Swift features that haven't yet been enabled by default.