### PR TITLE
Regenerate sources and fix a warning in CodeGeneration

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/LayoutNode+Extensions.swift
@@ -16,7 +16,7 @@ import SyntaxSupport
 import Utils
 
 extension LayoutNode {
-  func generateInitializerDeclHeader(useDeprecatedChildName: Bool = false) -> PartialSyntaxNodeString {
+  func generateInitializerDeclHeader(useDeprecatedChildName: Bool = false) -> SyntaxNodeString {
     if children.isEmpty {
       return "public init()"
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -5731,9 +5731,10 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable 
     self._syntaxNode = node._syntaxNode
   }
   
-  /// Creates a ``SimpleStringLiteralExprSyntax`` node from the given ``SyntaxData``. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
+  /// Creates a ``SimpleStringLiteralExprSyntax`` node from the given ``SyntaxData``. 
+  ///
+  ///  - Warning: This assumes that the `SyntaxData` is of the correct kind.
+  ///    If it is not, the behaviour is undefined.
   internal init(_ data: SyntaxData) {
     precondition(data.raw.kind == .simpleStringLiteralExpr)
     self._syntaxNode = Syntax(data)
@@ -5830,6 +5831,7 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable 
   
   /// Adds the provided `element` to the node's `segments`
   /// collection.
+  ///
   /// - param element: The new `Segment` to add to the node's
   ///                  `segments` collection.
   /// - returns: A copy of the receiver with the provided `Segment`


### PR DESCRIPTION
There was a race that caused the generated sources to be out-of-date.