### PR TITLE
Add a `?` in the `Children` section for optional collections

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
@@ -37,7 +37,7 @@ struct GrammarGenerator {
       let choicesDescriptions = choices.map { grammar(for: $0) }
       return "(\(choicesDescriptions.joined(separator: " | ")))\(optionality)"
     case .collection(kind: let kind, _, _, _):
-      return "``\(kind.syntaxType)``"
+      return "``\(kind.syntaxType)``\(optionality)"
     case .token(let choices, _, _):
       if choices.count == 1 {
         return "\(grammar(for: choices.first!))\(optionality)"


### PR DESCRIPTION
Potentially, this is why I didn’t think about the fact that syntax collections can be optional. 
 
It’s basically a no-op change now that we don’t have optional collections anymore but we should still fix the bug.