### PR TITLE
Fix trivia transfer bugs for freestanding expression macros

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
@@ -85,6 +85,13 @@ extension Trivia {
     }
     return Trivia(pieces: resultPieces)
   }
+
+  /// Remove all indentation from the last line of this trivia
+  var removingIndentationOnLastLine: Trivia {
+    let lastNewlineIndex = pieces.lastIndex(where: \.isNewline) ?? pieces.startIndex
+
+    return Trivia(pieces: pieces[..<lastNewlineIndex]) + Trivia(pieces: pieces[lastNewlineIndex...]).removingIndentation
+  }
 }
 
 extension SyntaxProtocol {

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
@@ -701,6 +701,25 @@ final class MacroSystemTests: XCTestCase {
     )
   }
 
+  func testTriviaTransferOnExpressionMacro() {
+    assertMacroExpansion(
+      """
+      // Ignore me
+      \t
+      // Capture me
+      #stringify(x)
+      """,
+      expandedSource: """
+        // Ignore me
+        \t
+        // Capture me
+        (x, "x")
+        """,
+      macros: testMacros,
+      indentationWidth: indentationWidth
+    )
+  }
+
   func testCommentsOnExpressionMacro() {
     assertMacroExpansion(
       """
@@ -709,7 +728,7 @@ final class MacroSystemTests: XCTestCase {
       """,
       expandedSource: """
         let b = 
-        (x + y, "x + y")
+        /*leading */ (x + y, "x + y") /*trailing*/
         """,
       macros: testMacros,
       indentationWidth: indentationWidth
@@ -1441,10 +1460,11 @@ final class MacroSystemTests: XCTestCase {
       ) /* trailing comment */
       """,
       expandedSource: """
+        // some comment
         func foo() {
         }
         func bar() {
-        }
+        } /* trailing comment */
         """,
       macros: ["decls": DeclsFromStringsMacro.self],
       indentationWidth: indentationWidth
@@ -1464,10 +1484,11 @@ final class MacroSystemTests: XCTestCase {
       """,
       expandedSource: """
         struct Foo {
+          // some comment
           func foo() {
           }
           func bar() {
-          }
+          } /* trailing comment */
         }
         """,
       macros: ["decls": DeclsFromStringsMacro.self],


### PR DESCRIPTION
There were two bugs in the way we transferred trivia from the original macro expansion expression to the expanded expression.

1. We were attaching the stripped leading trivia to the end of the node
2. We weren’t resetting the `lineContainedComment` and `lineContainedNonWhitespaceNonComment` variables when seeing a newline in a comment-only line

rdar://113639097