### PR TITLE
Add a version indicator macro to indicate the swift-syntax version a client is building against

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -146,7 +146,7 @@ let package = Package(
 
     .target(
       name: "SwiftSyntax",
-      dependencies: [],
+      dependencies: ["SwiftSyntax509"],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
     ),
@@ -154,6 +154,13 @@ let package = Package(
     .testTarget(
       name: "SwiftSyntaxTest",
       dependencies: ["_SwiftSyntaxTestSupport", "SwiftSyntax", "SwiftSyntaxBuilder"]
+    ),
+
+    // MARK: Verison marker modules
+
+    .target(
+      name: "SwiftSyntax509",
+      dependencies: []
     ),
 
     // MARK: SwiftSyntaxBuilder

--- a/Sources/SwiftSyntax509/Empty.swift
+++ b/Sources/SwiftSyntax509/Empty.swift
@@ -1,0 +1,3 @@
+// The SwiftSyntax509 module is intentionally empty.
+// It serves as an indicator which version of swift-syntax a package is building against.
+// See the 'Macro Versioning.md' document for more details.


### PR DESCRIPTION
All swift-syntax versions ≥ 509 will include a module `SwiftSyntax509` and all swift-syntax versions ≥ 510 will include both `SwiftSyntax509` and `SwiftSyntax510`. This way clients can check which version of swift-syntax they are building against using e.g.

```swift
#if canImport(SwiftSyntax510)
// code specific to swift-syntax version >= 510
#else
// code for swift-syntax < 510
#endif
```