### PR TITLE
Improve compatibility layer for `KeyPathPropertyComponentSyntax`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -1090,7 +1090,6 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "DeclName",
-        deprecatedName: "Identifier",
         kind: .node(kind: .declReferenceExpr)
       ),
       Child(

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -70,6 +70,28 @@ extension GenericRequirementSyntax {
 @available(*, deprecated, renamed: "NamedDeclSyntax")
 public typealias IdentifiedDeclSyntax = NamedDeclSyntax
 
+extension KeyPathPropertyComponentSyntax {
+  @available(*, deprecated, renamed: "declName.baseName")
+  public var identifier: TokenSyntax {
+    get {
+      return declName.baseName
+    }
+    set {
+      declName.baseName = newValue
+    }
+  }
+
+  @available(*, deprecated, renamed: "declName.argumentNames")
+  public var declNameArguments: DeclNameArgumentsSyntax? {
+    get {
+      return declName.argumentNames
+    }
+    set {
+      declName.argumentNames = newValue
+    }
+  }
+}
+
 extension NamedDeclSyntax {
   @available(*, deprecated, renamed: "name")
   public var identifier: TokenSyntax {

--- a/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift
@@ -4404,61 +4404,6 @@ extension IsExprSyntax {
   }
 }
 
-extension KeyPathPropertyComponentSyntax {
-  @available(*, deprecated, renamed: "unexpectedBeforeDeclName")
-  public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
-    get {
-      return unexpectedBeforeDeclName
-    }
-    set {
-      unexpectedBeforeDeclName = newValue
-    }
-  }
-  
-  @available(*, deprecated, renamed: "declName")
-  public var identifier: DeclReferenceExprSyntax {
-    get {
-      return declName
-    }
-    set {
-      declName = newValue
-    }
-  }
-  
-  @available(*, deprecated, renamed: "unexpectedBetweenDeclNameAndGenericArgumentClause")
-  public var unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? {
-    get {
-      return unexpectedBetweenDeclNameAndGenericArgumentClause
-    }
-    set {
-      unexpectedBetweenDeclNameAndGenericArgumentClause = newValue
-    }
-  }
-  
-  @available(*, deprecated, renamed: "KeyPathPropertyComponentSyntax(leadingTrivia:_:declName:_:genericArgumentClause:_:trailingTrivia:)")
-  @_disfavoredOverload
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
-      identifier: DeclReferenceExprSyntax,
-      _ unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-      genericArgumentClause: GenericArgumentClauseSyntax? = nil,
-      _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia, 
-        unexpectedBeforeIdentifier, 
-        declName: identifier, 
-        unexpectedBetweenIdentifierAndGenericArgumentClause, 
-        genericArgumentClause: genericArgumentClause, 
-        unexpectedAfterGenericArgumentClause, 
-        trailingTrivia: trailingTrivia
-      )
-  }
-}
-
 extension KeyPathSubscriptComponentSyntax {
   @available(*, deprecated, renamed: "unexpectedBeforeLeftSquare")
   public var unexpectedBeforeLeftBracket: UnexpectedNodesSyntax? {


### PR DESCRIPTION
The rename of `identifier` -> `declName` was not correct in `KeyPathPropertyComponentSyntax` because we also chagned its type from `TokenSyntax` to `DeclReferenceExprSyntax`.

Instead, provide two hand-written compatibility properties that transparently access the `DeclReferenceExprSyntax`.