### PR TITLE
remove SwiftSyntax support for `_forget`, the old spelling of `discard`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -155,7 +155,6 @@ public let KEYWORDS: [KeywordSpec] = [
   KeywordSpec("fileprivate", isLexerClassified: true, requiresTrailingSpace: true),
   KeywordSpec("final"),
   KeywordSpec("for", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("_forget"),  // NOTE: support for deprecated _forget
   KeywordSpec("discard"),
   KeywordSpec("forward"),
   KeywordSpec("func", isLexerClassified: true, requiresTrailingSpace: true),

--- a/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
@@ -339,10 +339,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "DiscardKeyword",
-        kind: .token(choices: [
-          .keyword(text: "_forget"),  // NOTE: support for deprecated _forget
-          .keyword(text: "discard"),
-        ])
+        kind: .token(choices: [.keyword(text: "discard")])
       ),
       Child(
         name: "Expression",

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -382,11 +382,6 @@ class ValidateSyntaxNodes: XCTestCase {
       expectedFailures: [
         // MARK: Only one non-deprecated keyword
         ValidationFailure(
-          node: .discardStmt,
-          message: "child 'discardKeyword' only has keywords as its token choices and should thus end with 'Specifier'"
-            // DiscardKeyword can be 'discard' or '_forget' and '_forget' is deprecated
-        ),
-        ValidationFailure(
           node: .consumeExpr,
           message: "child 'consumeKeyword' only has keywords as its token choices and should thus end with 'Specifier'"
             // ConsumeKeyword can be 'consume' or '_move' and '_move' is deprecated

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -93,7 +93,7 @@ extension Parser {
       return label(self.parseContinueStatement(continueHandle: handle), with: optLabel)
     case (.fallthrough, let handle)?:
       return label(self.parseFallThroughStatement(fallthroughHandle: handle), with: optLabel)
-    case (._forget, let handle)?, (.discard, let handle)?:  // NOTE: support for deprecated _forget
+    case (.discard, let handle)?:
       return label(self.parseDiscardStatement(discardHandle: handle), with: optLabel)
     case (.return, let handle)?:
       return label(self.parseReturnStatement(returnHandle: handle), with: optLabel)
@@ -859,7 +859,7 @@ extension Parser.Lookahead {
         // yield statement of some singular expression.
         return !self.peek().isAtStartOfLine
       }
-    case ._forget?, .discard?:  // NOTE: support for deprecated _forget
+    case .discard?:
       let next = peek()
       // The thing to be discarded must be on the same line as `discard`.
       if next.isAtStartOfLine {

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -53,7 +53,6 @@ enum AccessorModifier: TokenSpecSet {
 }
 
 enum CanBeStatementStart: TokenSpecSet {
-  case _forget  // NOTE: support for deprecated _forget
   case `break`
   case `continue`
   case `defer`
@@ -72,7 +71,6 @@ enum CanBeStatementStart: TokenSpecSet {
 
   init?(lexeme: Lexer.Lexeme) {
     switch PrepareForKeywordMatch(lexeme) {
-    case TokenSpec(._forget): self = ._forget
     case TokenSpec(.break): self = .break
     case TokenSpec(.continue): self = .continue
     case TokenSpec(.defer): self = .defer
@@ -94,7 +92,6 @@ enum CanBeStatementStart: TokenSpecSet {
 
   var spec: TokenSpec {
     switch self {
-    case ._forget: return TokenSpec(._forget, recoveryPrecedence: .stmtKeyword)
     case .break: return .keyword(.break)
     case .continue: return .keyword(.continue)
     case .defer: return .keyword(.defer)

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -1165,47 +1165,6 @@ extension DifferentiableAttributeArgumentsSyntax {
   }
 }
 
-extension DiscardStmtSyntax {
-  @_spi(Diagnostics)
-  public enum DiscardKeywordOptions: TokenSpecSet {
-    case _forget
-    case discard
-    
-    init?(lexeme: Lexer.Lexeme) {
-      switch PrepareForKeywordMatch(lexeme) {
-      case TokenSpec(._forget):
-        self = ._forget
-      case TokenSpec(.discard):
-        self = .discard
-      default:
-        return nil
-      }
-    }
-    
-    var spec: TokenSpec {
-      switch self {
-      case ._forget:
-        return .keyword(._forget)
-      case .discard:
-        return .keyword(.discard)
-      }
-    }
-    
-    /// Returns a token that satisfies the `TokenSpec` of this case.
-    ///
-    /// If the token kind of this spec has variable text, e.g. for an identifier, this returns a token with empty text.
-    @_spi(Diagnostics)
-    public var tokenSyntax: TokenSyntax {
-      switch self {
-      case ._forget:
-        return .keyword(._forget)
-      case .discard:
-        return .keyword(.discard)
-      }
-    }
-  }
-}
-
 extension DocumentationAttributeArgumentSyntax {
   @_spi(Diagnostics)
   public enum LabelOptions: TokenSpecSet {

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -116,7 +116,6 @@ public enum Keyword: UInt8, Hashable {
   case `fileprivate`
   case final
   case `for`
-  case _forget
   case discard
   case forward
   case `func`
@@ -434,8 +433,6 @@ public enum Keyword: UInt8, Hashable {
         self = .`default`
       case "dynamic":
         self = .dynamic
-      case "_forget":
-        self = ._forget
       case "discard":
         self = .discard
       case "forward":
@@ -865,7 +862,6 @@ public enum Keyword: UInt8, Hashable {
       "fileprivate", 
       "final", 
       "for", 
-      "_forget", 
       "discard", 
       "forward", 
       "func", 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -983,7 +983,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .discardStmt:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.keyword("_forget"), .keyword("discard")]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.keyword("discard")]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawExprSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -385,7 +385,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
 /// ### Children
 /// 
-///  - `discardKeyword`: (`'_forget'` | `'discard'`)
+///  - `discardKeyword`: `'discard'`
 ///  - `expression`: ``ExprSyntax``
 public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
@@ -412,7 +412,7 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeDiscardKeyword: UnexpectedNodesSyntax? = nil,
-      discardKeyword: TokenSyntax,
+      discardKeyword: TokenSyntax = .keyword(.discard),
       _ unexpectedBetweenDiscardKeywordAndExpression: UnexpectedNodesSyntax? = nil,
       expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -561,17 +561,6 @@ final class StatementTests: ParserTestCase {
   }
 
   func testDiscard() {
-    // ensure the old spelling '_forget' can be parsed for now.
-    assertParse(
-      """
-      _forget self
-      """,
-      substructure: DiscardStmtSyntax(
-        discardKeyword: .keyword(._forget),
-        expression: DeclReferenceExprSyntax(baseName: .keyword(.`self`))
-      )
-    )
-
     assertParse(
       """
       discard self


### PR DESCRIPTION
resolves rdar://112549258

paired with https://github.com/apple/swift/pull/67902