### PR TITLE
Replace string-based keyword references with `Keyword` enum in CodeGeneration

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -179,7 +179,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "availabilityLabel",
         deprecatedName: "label",
-        kind: .token(choices: [.keyword(text: "availability")]),
+        kind: .token(choices: [.keyword(.availability)]),
         nameForDiagnostics: "label",
         documentation: "The label of the argument"
       ),
@@ -241,7 +241,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "beforeLabel",
-        kind: .token(choices: [.keyword(text: "before")]),
+        kind: .token(choices: [.keyword(.before)]),
         documentation: "The \"before\" label."
       ),
       Child(
@@ -277,7 +277,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       ),
       Child(
         name: "cTypeLabel",
-        kind: .token(choices: [.keyword(text: "cType")]),
+        kind: .token(choices: [.keyword(.cType)]),
         isOptional: true
       ),
       Child(
@@ -302,7 +302,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "witnessMethodLabel",
-        kind: .token(choices: [.keyword(text: "witness_method")])
+        kind: .token(choices: [.keyword(.witness_method)])
       ),
       Child(
         name: "colon",
@@ -330,7 +330,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "ofLabel",
-        kind: .token(choices: [.keyword(text: "of")]),
+        kind: .token(choices: [.keyword(.of)]),
         documentation: "The \"of\" label."
       ),
       Child(
@@ -352,7 +352,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "accessorSpecifier",
         deprecatedName: "accessorKind",
-        kind: .token(choices: [.keyword(text: "get"), .keyword(text: "set")]),
+        kind: .token(choices: [.keyword(.get), .keyword(.set)]),
         documentation: "The accessor name.",
         isOptional: true
       ),
@@ -392,7 +392,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "argument",
         deprecatedName: "parameter",
-        kind: .token(choices: [.token(.identifier), .token(.integerLiteral), .keyword(text: "self")])
+        kind: .token(choices: [.token(.identifier), .token(.integerLiteral), .keyword(.self)])
       ),
       Child(
         name: "trailingComma",
@@ -412,7 +412,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "wrtLabel",
-        kind: .token(choices: [.keyword(text: "wrt")]),
+        kind: .token(choices: [.keyword(.wrt)]),
         documentation: "The \"wrt\" label."
       ),
       Child(
@@ -478,7 +478,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "kindSpecifier",
         deprecatedName: "diffKind",
-        kind: .token(choices: [.keyword(text: "_forward"), .keyword(text: "reverse"), .keyword(text: "_linear")]),
+        kind: .token(choices: [.keyword(._forward), .keyword(.reverse), .keyword(._linear)]),
         isOptional: true
       ),
       Child(
@@ -521,7 +521,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "label",
-        kind: .token(choices: [.keyword(text: "visibility"), .keyword(text: "metadata")]),
+        kind: .token(choices: [.keyword(.visibility), .keyword(.metadata)]),
         nameForDiagnostics: "label"
       ),
       Child(
@@ -535,11 +535,11 @@ public let ATTRIBUTE_NODES: [Node] = [
             name: "token",
             kind: .token(choices: [
               .token(.identifier),
-              .keyword(text: "private"),
-              .keyword(text: "fileprivate"),
-              .keyword(text: "internal"),
-              .keyword(text: "public"),
-              .keyword(text: "open"),
+              .keyword(.private),
+              .keyword(.fileprivate),
+              .keyword(.internal),
+              .keyword(.public),
+              .keyword(.open),
             ])
           ),  // Keywords can be: public, internal, private, fileprivate, open
           Child(
@@ -573,7 +573,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "forLabel",
-        kind: .token(choices: [.keyword(text: "for")], requiresTrailingSpace: false)
+        kind: .token(choices: [.keyword(.for)], requiresTrailingSpace: false)
       ),
       Child(
         name: "colon",
@@ -662,13 +662,13 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "label",
         kind: .token(choices: [
-          .keyword(text: "target"),
-          .keyword(text: "availability"),
-          .keyword(text: "exported"),
-          .keyword(text: "kind"),
-          .keyword(text: "spi"),
-          .keyword(text: "spiModule"),
-          .keyword(text: "available"),
+          .keyword(.target),
+          .keyword(.availability),
+          .keyword(.exported),
+          .keyword(.kind),
+          .keyword(.spi),
+          .keyword(.spiModule),
+          .keyword(.available),
         ]),
         nameForDiagnostics: "label",
         documentation: "The label of the argument"
@@ -755,7 +755,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "moduleLabel",
-        kind: .token(choices: [.keyword(text: "module")])
+        kind: .token(choices: [.keyword(.module)])
       ),
       Child(
         name: "colon",
@@ -803,7 +803,7 @@ public let ATTRIBUTE_NODES: [Node] = [
       Child(
         name: "targetLabel",
         deprecatedName: "label",
-        kind: .token(choices: [.keyword(text: "target")]),
+        kind: .token(choices: [.keyword(.target)]),
         nameForDiagnostics: "label",
         documentation: "The label of the argument"
       ),
@@ -836,7 +836,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "messageLabel",
-        kind: .token(choices: [.keyword(text: "message")])
+        kind: .token(choices: [.keyword(.message)])
       ),
       Child(
         name: "colon",
@@ -857,7 +857,7 @@ public let ATTRIBUTE_NODES: [Node] = [
     children: [
       Child(
         name: "sourceFileLabel",
-        kind: .token(choices: [.keyword(text: "sourceFile")])
+        kind: .token(choices: [.keyword(.sourceFile)])
       ),
       Child(
         name: "colon",

--- a/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
@@ -66,11 +66,11 @@ public let AVAILABILITY_NODES: [Node] = [
       Child(
         name: "label",
         kind: .token(choices: [
-          .keyword(text: "message"),
-          .keyword(text: "renamed"),
-          .keyword(text: "introduced"),
-          .keyword(text: "obsoleted"),
-          .keyword(text: "deprecated"),
+          .keyword(.message),
+          .keyword(.renamed),
+          .keyword(.introduced),
+          .keyword(.obsoleted),
+          .keyword(.deprecated),
         ]),
         nameForDiagnostics: "label",
         documentation: "The label of the argument"

--- a/CodeGeneration/Sources/SyntaxSupport/Child.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Child.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 /// The kind of token a node can contain. Either a token of a specific kind or a
 /// keyword with the given text.
 public enum TokenChoice: Equatable {
-  case keyword(text: String)
+  case keyword(Keyword)
   case token(Token)
 
   public var isKeyword: Bool {

--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -91,12 +91,12 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "asyncSpecifier",
-        kind: .token(choices: [.keyword(text: "async")]),
+        kind: .token(choices: [.keyword(.async)]),
         isOptional: true
       ),
       Child(
         name: "throwsSpecifier",
-        kind: .token(choices: [.keyword(text: "throws")]),
+        kind: .token(choices: [.keyword(.throws)]),
         isOptional: true
       ),
     ]
@@ -113,12 +113,12 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "asyncSpecifier",
-        kind: .token(choices: [.keyword(text: "async"), .keyword(text: "reasync")]),
+        kind: .token(choices: [.keyword(.async), .keyword(.reasync)]),
         isOptional: true
       ),
       Child(
         name: "throwsSpecifier",
-        kind: .token(choices: [.keyword(text: "throws"), .keyword(text: "rethrows")]),
+        kind: .token(choices: [.keyword(.throws), .keyword(.rethrows)]),
         isOptional: true
       ),
     ]
@@ -133,7 +133,7 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "asyncSpecifier",
-        kind: .token(choices: [.keyword(text: "async")]),
+        kind: .token(choices: [.keyword(.async)]),
         isOptional: true
       )
     ]
@@ -316,12 +316,12 @@ public let COMMON_NODES: [Node] = [
     children: [
       Child(
         name: "asyncSpecifier",
-        kind: .token(choices: [.keyword(text: "async")]),
+        kind: .token(choices: [.keyword(.async)]),
         isOptional: true
       ),
       Child(
         name: "throwsSpecifier",
-        kind: .token(choices: [.keyword(text: "throws")]),
+        kind: .token(choices: [.keyword(.throws)]),
         isOptional: true
       ),
     ]

--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -97,19 +97,19 @@ public let DECL_NODES: [Node] = [
         name: "accessorSpecifier",
         deprecatedName: "accessorKind",
         kind: .token(choices: [
-          .keyword(text: "get"),
-          .keyword(text: "set"),
-          .keyword(text: "didSet"),
-          .keyword(text: "willSet"),
-          .keyword(text: "unsafeAddress"),
-          .keyword(text: "addressWithOwner"),
-          .keyword(text: "addressWithNativeOwner"),
-          .keyword(text: "unsafeMutableAddress"),
-          .keyword(text: "mutableAddressWithOwner"),
-          .keyword(text: "mutableAddressWithNativeOwner"),
-          .keyword(text: "_read"),
-          .keyword(text: "_modify"),
-          .keyword(text: "init"),
+          .keyword(.get),
+          .keyword(.set),
+          .keyword(.didSet),
+          .keyword(.willSet),
+          .keyword(.unsafeAddress),
+          .keyword(.addressWithOwner),
+          .keyword(.addressWithNativeOwner),
+          .keyword(.unsafeMutableAddress),
+          .keyword(.mutableAddressWithOwner),
+          .keyword(.mutableAddressWithNativeOwner),
+          .keyword(._read),
+          .keyword(._modify),
+          .keyword(.`init`),
         ])
       ),
       Child(
@@ -195,7 +195,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "actorKeyword",
-        kind: .token(choices: [.keyword(text: "actor")])
+        kind: .token(choices: [.keyword(.actor)])
       ),
       Child(
         name: "name",
@@ -285,7 +285,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "associatedtypeKeyword",
-        kind: .token(choices: [.keyword(text: "associatedtype")]),
+        kind: .token(choices: [.keyword(.associatedtype)]),
         documentation: "The `associatedtype` keyword for this declaration."
       ),
       Child(
@@ -375,7 +375,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "classKeyword",
-        kind: .token(choices: [.keyword(text: "class")]),
+        kind: .token(choices: [.keyword(.class)]),
         documentation: "The `class` keyword for this declaration."
       ),
       Child(
@@ -445,41 +445,41 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "name",
         kind: .token(choices: [
-          .keyword(text: "__consuming"),
-          .keyword(text: "__setter_access"),
-          .keyword(text: "_const"),
-          .keyword(text: "_local"),
-          .keyword(text: "actor"),
-          .keyword(text: "async"),
-          .keyword(text: "borrowing"),
-          .keyword(text: "class"),
-          .keyword(text: "consuming"),
-          .keyword(text: "convenience"),
-          .keyword(text: "distributed"),
-          .keyword(text: "dynamic"),
-          .keyword(text: "fileprivate"),
-          .keyword(text: "final"),
-          .keyword(text: "indirect"),
-          .keyword(text: "infix"),
-          .keyword(text: "internal"),
-          .keyword(text: "isolated"),
-          .keyword(text: "lazy"),
-          .keyword(text: "mutating"),
-          .keyword(text: "nonisolated"),
-          .keyword(text: "nonmutating"),
-          .keyword(text: "open"),
-          .keyword(text: "optional"),
-          .keyword(text: "override"),
-          .keyword(text: "package"),
-          .keyword(text: "postfix"),
-          .keyword(text: "prefix"),
-          .keyword(text: "private"),
-          .keyword(text: "public"),
-          .keyword(text: "reasync"),
-          .keyword(text: "required"),
-          .keyword(text: "static"),
-          .keyword(text: "unowned"),
-          .keyword(text: "weak"),
+          .keyword(.__consuming),
+          .keyword(.__setter_access),
+          .keyword(._const),
+          .keyword(._local),
+          .keyword(.actor),
+          .keyword(.async),
+          .keyword(.borrowing),
+          .keyword(.class),
+          .keyword(.consuming),
+          .keyword(.convenience),
+          .keyword(.distributed),
+          .keyword(.dynamic),
+          .keyword(.fileprivate),
+          .keyword(.final),
+          .keyword(.indirect),
+          .keyword(.infix),
+          .keyword(.internal),
+          .keyword(.isolated),
+          .keyword(.lazy),
+          .keyword(.mutating),
+          .keyword(.nonisolated),
+          .keyword(.nonmutating),
+          .keyword(.open),
+          .keyword(.optional),
+          .keyword(.override),
+          .keyword(.package),
+          .keyword(.postfix),
+          .keyword(.prefix),
+          .keyword(.private),
+          .keyword(.public),
+          .keyword(.reasync),
+          .keyword(.required),
+          .keyword(.static),
+          .keyword(.unowned),
+          .keyword(.weak),
         ])
       ),
       Child(
@@ -523,7 +523,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "deinitKeyword",
-        kind: .token(choices: [.keyword(text: "deinit")]),
+        kind: .token(choices: [.keyword(.deinit)]),
         documentation: "The deinit keyword."
       ),
       Child(
@@ -708,7 +708,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "caseKeyword",
-        kind: .token(choices: [.keyword(text: "case")]),
+        kind: .token(choices: [.keyword(.case)]),
         documentation: "The `case` keyword for this case."
       ),
       Child(
@@ -793,7 +793,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "enumKeyword",
-        kind: .token(choices: [.keyword(text: "enum")]),
+        kind: .token(choices: [.keyword(.enum)]),
         documentation: "The `enum` keyword for this declaration."
       ),
       Child(
@@ -861,7 +861,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "extensionKeyword",
-        kind: .token(choices: [.keyword(text: "extension")])
+        kind: .token(choices: [.keyword(.extension)])
       ),
       Child(
         name: "extendedType",
@@ -910,7 +910,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "funcKeyword",
-        kind: .token(choices: [.keyword(text: "func")])
+        kind: .token(choices: [.keyword(.func)])
       ),
       Child(
         name: "name",
@@ -1147,22 +1147,22 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "importKeyword",
         deprecatedName: "importTok",
-        kind: .token(choices: [.keyword(text: "import")]),
+        kind: .token(choices: [.keyword(.import)]),
         documentation: "The `import` keyword for this declaration."
       ),
       Child(
         name: "importKindSpecifier",
         deprecatedName: "importKind",
         kind: .token(choices: [
-          .keyword(text: "typealias"),
-          .keyword(text: "struct"),
-          .keyword(text: "class"),
-          .keyword(text: "enum"),
-          .keyword(text: "protocol"),
-          .keyword(text: "var"),
-          .keyword(text: "let"),
-          .keyword(text: "func"),
-          .keyword(text: "inout"),
+          .keyword(.typealias),
+          .keyword(.struct),
+          .keyword(.class),
+          .keyword(.enum),
+          .keyword(.protocol),
+          .keyword(.var),
+          .keyword(.let),
+          .keyword(.func),
+          .keyword(.inout),
         ]),
         documentation: """
           The kind of declaration being imported. 
@@ -1260,7 +1260,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "initKeyword",
-        kind: .token(choices: [.keyword(text: "init")]),
+        kind: .token(choices: [.keyword(.`init`)]),
         documentation: "The init keyword"
       ),
       Child(
@@ -1325,7 +1325,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "macroKeyword",
-        kind: .token(choices: [.keyword(text: "macro")])
+        kind: .token(choices: [.keyword(.macro)])
       ),
       Child(
         name: "name",
@@ -1518,13 +1518,13 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "fixitySpecifier",
         deprecatedName: "fixity",
-        kind: .token(choices: [.keyword(text: "prefix"), .keyword(text: "postfix"), .keyword(text: "infix")]),
+        kind: .token(choices: [.keyword(.prefix), .keyword(.postfix), .keyword(.infix)]),
         nameForDiagnostics: "fixity",
         documentation: "The fixity applied to the 'operator' declaration."
       ),
       Child(
         name: "operatorKeyword",
-        kind: .token(choices: [.keyword(text: "operator")])
+        kind: .token(choices: [.keyword(.operator)])
       ),
       Child(
         name: "name",
@@ -1670,7 +1670,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "fileLabel",
         deprecatedName: "fileArgLabel",
-        kind: .token(choices: [.keyword(text: "file")])
+        kind: .token(choices: [.keyword(.file)])
       ),
       Child(
         name: "fileColon",
@@ -1689,7 +1689,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "lineLabel",
         deprecatedName: "lineArgLabel",
-        kind: .token(choices: [.keyword(text: "line")])
+        kind: .token(choices: [.keyword(.line)])
       ),
       Child(
         name: "lineColon",
@@ -1745,7 +1745,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "assignmentLabel",
         deprecatedName: "assignmentKeyword",
-        kind: .token(choices: [.keyword(text: "assignment")])
+        kind: .token(choices: [.keyword(.assignment)])
       ),
       Child(
         name: "colon",
@@ -1754,7 +1754,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "value",
         deprecatedName: "flag",
-        kind: .token(choices: [.keyword(text: "true"), .keyword(text: "false")]),
+        kind: .token(choices: [.keyword(.true), .keyword(.false)]),
         documentation:
           "When true, an operator in the corresponding precedence group uses the same grouping rules during optional chaining as the assignment operators from the standard library. Otherwise, operators in the precedence group follows the same optional chaining rules as operators that don't perform assignment."
       ),
@@ -1772,7 +1772,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "associativityLabel",
         deprecatedName: "associativityKeyword",
-        kind: .token(choices: [.keyword(text: "associativity")])
+        kind: .token(choices: [.keyword(.associativity)])
       ),
       Child(
         name: "colon",
@@ -1780,7 +1780,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "value",
-        kind: .token(choices: [.keyword(text: "left"), .keyword(text: "right"), .keyword(text: "none")]),
+        kind: .token(choices: [.keyword(.left), .keyword(.right), .keyword(.none)]),
         documentation:
           "Operators that are `left`-associative group left-to-right. Operators that are `right`-associative group right-to-left. Operators that are specified with an associativity of `none` don't associate at all"
       ),
@@ -1824,7 +1824,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "precedencegroupKeyword",
-        kind: .token(choices: [.keyword(text: "precedencegroup")])
+        kind: .token(choices: [.keyword(.precedencegroup)])
       ),
       Child(
         name: "name",
@@ -1887,7 +1887,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "higherThanOrLowerThanLabel",
         deprecatedName: "higherThanOrLowerThan",
-        kind: .token(choices: [.keyword(text: "higherThan"), .keyword(text: "lowerThan")]),
+        kind: .token(choices: [.keyword(.higherThan), .keyword(.lowerThan)]),
         documentation: "The relation to specified other precedence groups."
       ),
       Child(
@@ -1939,7 +1939,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "protocolKeyword",
-        kind: .token(choices: [.keyword(text: "protocol")]),
+        kind: .token(choices: [.keyword(.protocol)]),
         documentation: "The `protocol` keyword for this declaration."
       ),
       Child(
@@ -2115,7 +2115,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "structKeyword",
-        kind: .token(choices: [.keyword(text: "struct")]),
+        kind: .token(choices: [.keyword(.struct)]),
         documentation: "The `struct` keyword for this declaration."
       ),
       Child(
@@ -2176,7 +2176,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "subscriptKeyword",
-        kind: .token(choices: [.keyword(text: "subscript")])
+        kind: .token(choices: [.keyword(.subscript)])
       ),
       Child(
         name: "genericParameterClause",
@@ -2274,7 +2274,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "typealiasKeyword",
-        kind: .token(choices: [.keyword(text: "typealias")])
+        kind: .token(choices: [.keyword(.typealias)])
       ),
       Child(
         name: "name",
@@ -2330,7 +2330,7 @@ public let DECL_NODES: [Node] = [
       Child(
         name: "bindingSpecifier",
         deprecatedName: "bindingKeyword",
-        kind: .token(choices: [.keyword(text: "let"), .keyword(text: "var"), .keyword(text: "inout")]),
+        kind: .token(choices: [.keyword(.let), .keyword(.var), .keyword(.inout)]),
         documentation: """
           The specifier that defines the type of the variables declared (`let` or `var`).
           """

--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -99,7 +99,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "asKeyword",
         deprecatedName: "asTok",
-        kind: .token(choices: [.keyword(text: "as")])
+        kind: .token(choices: [.keyword(.as)])
       ),
       Child(
         name: "questionOrExclamationMark",
@@ -137,7 +137,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "awaitKeyword",
-        kind: .token(choices: [.keyword(text: "await")])
+        kind: .token(choices: [.keyword(.await)])
       ),
       Child(
         name: "expression",
@@ -170,7 +170,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "literal",
         deprecatedName: "booleanLiteral",
-        kind: .token(choices: [.keyword(text: "true"), .keyword(text: "false")])
+        kind: .token(choices: [.keyword(.true), .keyword(.false)])
       )
     ]
   ),
@@ -183,7 +183,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "borrowKeyword",
-        kind: .token(choices: [.keyword(text: "_borrow")])
+        kind: .token(choices: [.keyword(._borrow)])
       ),
       Child(
         name: "expression",
@@ -200,7 +200,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "canImportKeyword",
-        kind: .token(choices: [.keyword(text: "canImport")])
+        kind: .token(choices: [.keyword(.canImport)])
       ),
       Child(
         name: "leftParen",
@@ -233,7 +233,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "label",
-        kind: .token(choices: [.keyword(text: "_version"), .keyword(text: "_underlyingVersion")])
+        kind: .token(choices: [.keyword(._version), .keyword(._underlyingVersion)])
       ),
       Child(
         name: "colon",
@@ -287,7 +287,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "specifier",
-        kind: .token(choices: [.keyword(text: "weak"), .keyword(text: "unowned")])
+        kind: .token(choices: [.keyword(.weak), .keyword(.unowned)])
       ),
       Child(
         name: "leftParen",
@@ -296,7 +296,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "detail",
-        kind: .token(choices: [.keyword(text: "safe"), .keyword(text: "unsafe")]),
+        kind: .token(choices: [.keyword(.safe), .keyword(.unsafe)]),
         isOptional: true
       ),
       Child(
@@ -561,7 +561,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "inKeyword",
         deprecatedName: "inTok",
-        kind: .token(choices: [.keyword(text: "in")])
+        kind: .token(choices: [.keyword(.in)])
       ),
     ]
   ),
@@ -841,9 +841,9 @@ public let EXPR_NODES: [Node] = [
         deprecatedName: "identifier",
         kind: .token(choices: [
           .token(.identifier),
-          .keyword(text: "self"),
-          .keyword(text: "Self"),
-          .keyword(text: "init"),
+          .keyword(.self),
+          .keyword(.Self),
+          .keyword(.`init`),
           .token(.dollarIdentifier),
           .token(.binaryOperator),
           .token(.integerLiteral),
@@ -873,7 +873,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "ifKeyword",
-        kind: .token(choices: [.keyword(text: "if")])
+        kind: .token(choices: [.keyword(.if)])
       ),
       Child(
         name: "conditions",
@@ -886,7 +886,7 @@ public let EXPR_NODES: [Node] = [
       ),
       Child(
         name: "elseKeyword",
-        kind: .token(choices: [.keyword(text: "else")]),
+        kind: .token(choices: [.keyword(.else)]),
         isOptional: true
       ),
       Child(
@@ -995,7 +995,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "isKeyword",
         deprecatedName: "isTok",
-        kind: .token(choices: [.keyword(text: "is")]),
+        kind: .token(choices: [.keyword(.is)]),
         documentation: "The `is` keyword for this expression."
       ),
       Child(
@@ -1215,7 +1215,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "consumeKeyword",
         deprecatedName: "moveKeyword",
-        kind: .token(choices: [.keyword(text: "_move"), .keyword(text: "consume")])
+        kind: .token(choices: [.keyword(._move), .keyword(.consume)])
       ),
       Child(
         name: "expression",
@@ -1231,7 +1231,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "copyKeyword",
-        kind: .token(choices: [.keyword(text: "copy")])
+        kind: .token(choices: [.keyword(.copy)])
       ),
       Child(
         name: "expression",
@@ -1277,7 +1277,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "nilKeyword",
-        kind: .token(choices: [.keyword(text: "nil")])
+        kind: .token(choices: [.keyword(.nil)])
       )
     ]
   ),
@@ -1307,7 +1307,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "eachKeyword",
-        kind: .token(choices: [.keyword(text: "each")])
+        kind: .token(choices: [.keyword(.each)])
       ),
       Child(
         name: "pack",
@@ -1325,7 +1325,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "repeatKeyword",
-        kind: .token(choices: [.keyword(text: "repeat")])
+        kind: .token(choices: [.keyword(.repeat)])
       ),
       Child(
         name: "repetitionPattern",
@@ -1593,7 +1593,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "superKeyword",
-        kind: .token(choices: [.keyword(text: "super")])
+        kind: .token(choices: [.keyword(.super)])
       )
     ]
   ),
@@ -1606,7 +1606,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "caseKeyword",
-        kind: .token(choices: [.keyword(text: "case")])
+        kind: .token(choices: [.keyword(.case)])
       ),
       Child(
         name: "caseItems",
@@ -1672,7 +1672,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "defaultKeyword",
-        kind: .token(choices: [.keyword(text: "default")])
+        kind: .token(choices: [.keyword(.default)])
       ),
       Child(
         name: "colon",
@@ -1696,7 +1696,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "switchKeyword",
-        kind: .token(choices: [.keyword(text: "switch")])
+        kind: .token(choices: [.keyword(.switch)])
       ),
       Child(
         name: "subject",
@@ -1768,7 +1768,7 @@ public let EXPR_NODES: [Node] = [
     children: [
       Child(
         name: "tryKeyword",
-        kind: .token(choices: [.keyword(text: "try")])
+        kind: .token(choices: [.keyword(.try)])
       ),
       Child(
         name: "questionOrExclamationMark",
@@ -1870,7 +1870,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "asKeyword",
         deprecatedName: "asTok",
-        kind: .token(choices: [.keyword(text: "as")])
+        kind: .token(choices: [.keyword(.as)])
       ),
       Child(
         name: "questionOrExclamationMark",
@@ -1891,7 +1891,7 @@ public let EXPR_NODES: [Node] = [
       Child(
         name: "isKeyword",
         deprecatedName: "isTok",
-        kind: .token(choices: [.keyword(text: "is")])
+        kind: .token(choices: [.keyword(.is)])
       )
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
@@ -95,7 +95,7 @@ public let GENERIC_NODES: [Node] = [
       Child(
         name: "eachKeyword",
         deprecatedName: "each",
-        kind: .token(choices: [.keyword(text: "each")]),
+        kind: .token(choices: [.keyword(.each)]),
         nameForDiagnostics: "parameter pack specifier",
         isOptional: true
       ),
@@ -175,7 +175,7 @@ public let GENERIC_NODES: [Node] = [
     children: [
       Child(
         name: "whereKeyword",
-        kind: .token(choices: [.keyword(text: "where")]),
+        kind: .token(choices: [.keyword(.where)]),
         documentation: "The `where` keyword in the clause."
       ),
       Child(
@@ -208,13 +208,13 @@ public let GENERIC_NODES: [Node] = [
         name: "layoutSpecifier",
         deprecatedName: "layoutConstraint",
         kind: .token(choices: [
-          .keyword(text: "_Trivial"),
-          .keyword(text: "_TrivialAtMost"),
-          .keyword(text: "_UnknownLayout"),
-          .keyword(text: "_RefCountedObject"),
-          .keyword(text: "_NativeRefCountedObject"),
-          .keyword(text: "_Class"),
-          .keyword(text: "_NativeClass"),
+          .keyword(._Trivial),
+          .keyword(._TrivialAtMost),
+          .keyword(._UnknownLayout),
+          .keyword(._RefCountedObject),
+          .keyword(._NativeRefCountedObject),
+          .keyword(._Class),
+          .keyword(._NativeClass),
         ])
       ),
       Child(

--- a/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GrammarGenerator.swift
@@ -16,8 +16,8 @@ import SwiftSyntax
 struct GrammarGenerator {
   private func grammar(for tokenChoice: TokenChoice) -> String {
     switch tokenChoice {
-    case .keyword(text: let text):
-      return "`'\(text)'`"
+    case .keyword(let keyword):
+      return "`'\(keyword.spec.name)'`"
     case .token(let token):
       let tokenSpec = token.spec
       if let tokenText = tokenSpec.text {

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -49,219 +49,632 @@ public struct KeywordSpec {
   }
 }
 
-public let KEYWORDS: [KeywordSpec] = [
-  // Please keep these sorted alphabetically
-
-  KeywordSpec("__consuming"),
-  KeywordSpec("__owned"),
-  KeywordSpec("__setter_access"),
-  KeywordSpec("__shared"),
-  KeywordSpec("_alignment"),
-  KeywordSpec("_backDeploy"),
-  KeywordSpec("_borrow"),
-  KeywordSpec("_cdecl"),
-  KeywordSpec("_Class"),
-  KeywordSpec("_compilerInitialized"),
-  KeywordSpec("_const"),
-  KeywordSpec("_documentation"),
-  KeywordSpec("_dynamicReplacement"),
-  KeywordSpec("_effects"),
-  KeywordSpec("_expose"),
-  KeywordSpec("_forward"),
-  KeywordSpec("_implements"),
-  KeywordSpec("_linear"),
-  KeywordSpec("_local"),
-  KeywordSpec("_modify"),
-  KeywordSpec("_move"),
-  KeywordSpec("_NativeClass"),
-  KeywordSpec("_NativeRefCountedObject"),
-  KeywordSpec("_noMetadata"),
-  KeywordSpec("_nonSendable"),
-  KeywordSpec("_objcImplementation"),
-  KeywordSpec("_objcRuntimeName"),
-  KeywordSpec("_opaqueReturnTypeOf"),
-  KeywordSpec("_optimize"),
-  KeywordSpec("_originallyDefinedIn"),
-  KeywordSpec("_PackageDescription"),
-  KeywordSpec("_private"),
-  KeywordSpec("_projectedValueProperty"),
-  KeywordSpec("_read"),
-  KeywordSpec("_RefCountedObject"),
-  KeywordSpec("_semantics"),
-  KeywordSpec("_specialize"),
-  KeywordSpec("_spi"),
-  KeywordSpec("_spi_available"),
-  KeywordSpec("_swift_native_objc_runtime_base"),
-  KeywordSpec("_Trivial"),
-  KeywordSpec("_TrivialAtMost"),
-  KeywordSpec("_typeEraser"),
-  KeywordSpec("_unavailableFromAsync"),
-  KeywordSpec("_underlyingVersion"),
-  KeywordSpec("_UnknownLayout"),
-  KeywordSpec("_version"),
-  KeywordSpec("accesses"),
-  KeywordSpec("actor"),
-  KeywordSpec("addressWithNativeOwner"),
-  KeywordSpec("addressWithOwner"),
-  KeywordSpec("any"),
-  KeywordSpec("Any", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("as", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("assignment"),
-  KeywordSpec("associatedtype", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("associativity"),
-  KeywordSpec("async", requiresTrailingSpace: true),
-  KeywordSpec("attached"),
-  KeywordSpec("autoclosure"),
-  KeywordSpec("availability"),
-  KeywordSpec("available"),
-  KeywordSpec("await", requiresTrailingSpace: true),
-  KeywordSpec("backDeployed"),
-  KeywordSpec("before"),
-  KeywordSpec("block"),
-  KeywordSpec("borrowing"),
-  KeywordSpec("break", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("canImport"),
-  KeywordSpec("case", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("catch", isLexerClassified: true, requiresLeadingSpace: true),
-  KeywordSpec("class", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("compiler"),
-  KeywordSpec("consume"),
-  KeywordSpec("copy"),
-  KeywordSpec("consuming"),
-  KeywordSpec("continue", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("convenience"),
-  KeywordSpec("convention"),
-  KeywordSpec("cType"),
-  KeywordSpec("default", isLexerClassified: true),
-  KeywordSpec("defer", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("deinit", isLexerClassified: true),
-  KeywordSpec("deprecated"),
-  KeywordSpec("derivative"),
-  KeywordSpec("didSet"),
-  KeywordSpec("differentiable"),
-  KeywordSpec("distributed"),
-  KeywordSpec("do", isLexerClassified: true),
-  KeywordSpec("dynamic"),
-  KeywordSpec("each"),
-  KeywordSpec("else", isLexerClassified: true, requiresLeadingSpace: true, requiresTrailingSpace: true),
-  KeywordSpec("enum", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("escaping"),
-  KeywordSpec("exclusivity"),
-  KeywordSpec("exported"),
-  KeywordSpec("extension", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("fallthrough", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("false", isLexerClassified: true),
-  KeywordSpec("file"),
-  KeywordSpec("fileprivate", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("final"),
-  KeywordSpec("for", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("discard"),
-  KeywordSpec("forward"),
-  KeywordSpec("func", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("get"),
-  KeywordSpec("guard", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("higherThan"),
-  KeywordSpec("if", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("import", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("in", isLexerClassified: true, requiresLeadingSpace: true, requiresTrailingSpace: true),
-  KeywordSpec("indirect"),
-  KeywordSpec("infix"),
-  KeywordSpec("init", isLexerClassified: true),
-  KeywordSpec("initializes"),
-  KeywordSpec("inline"),
-  KeywordSpec("inout", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("internal", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("introduced"),
-  KeywordSpec("is", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("isolated"),
-  KeywordSpec("kind"),
-  KeywordSpec("lazy"),
-  KeywordSpec("left"),
-  KeywordSpec("let", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("line"),
-  KeywordSpec("linear"),
-  KeywordSpec("lowerThan"),
-  KeywordSpec("macro"),
-  KeywordSpec("message"),
-  KeywordSpec("metadata"),
-  KeywordSpec("module"),
-  KeywordSpec("mutableAddressWithNativeOwner"),
-  KeywordSpec("mutableAddressWithOwner"),
-  KeywordSpec("mutating"),
-  KeywordSpec("nil", isLexerClassified: true),
-  KeywordSpec("noasync"),
-  KeywordSpec("noDerivative"),
-  KeywordSpec("noescape"),
-  KeywordSpec("none"),
-  KeywordSpec("nonisolated"),
-  KeywordSpec("nonmutating"),
-  KeywordSpec("objc"),
-  KeywordSpec("obsoleted"),
-  KeywordSpec("of"),
-  KeywordSpec("open"),
-  KeywordSpec("operator", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("optional"),
-  KeywordSpec("override"),
-  KeywordSpec("package"),
-  KeywordSpec("postfix"),
-  KeywordSpec("precedencegroup", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("prefix"),
-  KeywordSpec("private", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("Protocol"),
-  KeywordSpec("protocol", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("public", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("reasync"),
-  KeywordSpec("renamed"),
-  KeywordSpec("repeat", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("required"),
-  KeywordSpec("rethrows", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("return", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("reverse"),
-  KeywordSpec("right"),
-  KeywordSpec("safe"),
-  KeywordSpec("self", isLexerClassified: true),
-  KeywordSpec("Self", isLexerClassified: true),
-  KeywordSpec("Sendable"),
-  KeywordSpec("set"),
-  KeywordSpec("some"),
-  KeywordSpec("sourceFile"),
-  KeywordSpec("spi"),
-  KeywordSpec("spiModule"),
-  KeywordSpec("static", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("struct", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("subscript", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("super", isLexerClassified: true),
-  KeywordSpec("swift"),
-  KeywordSpec("switch", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("target"),
-  KeywordSpec("throw", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("throws", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("transpose"),
-  KeywordSpec("true", isLexerClassified: true),
-  KeywordSpec("try", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("Type"),
-  KeywordSpec("typealias", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("unavailable"),
-  KeywordSpec("unchecked"),
-  KeywordSpec("unowned"),
-  KeywordSpec("unsafe"),
-  KeywordSpec("unsafeAddress"),
-  KeywordSpec("unsafeMutableAddress"),
-  KeywordSpec("var", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("visibility"),
-  KeywordSpec("weak"),
-  KeywordSpec("where", isLexerClassified: true, requiresLeadingSpace: true, requiresTrailingSpace: true),
-  KeywordSpec("while", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("willSet"),
-  KeywordSpec("witness_method"),
-  KeywordSpec("wrt"),
-  KeywordSpec("yield"),
-]
-
 public func keywordsByLength() -> [(Int, [KeywordSpec])] {
   var result: [Int: [KeywordSpec]] = [:]
-  for keyword in KEYWORDS {
+  for keyword in Keyword.allCases.map(\.spec) {
     result[keyword.name.count, default: []].append(keyword)
   }
   return result.sorted(by: { $0.key < $1.key })
+}
+
+public enum Keyword: CaseIterable {
+  // Please keep these sorted alphabetically
+
+  case __consuming
+  case __owned
+  case __setter_access
+  case __shared
+  case _alignment
+  case _backDeploy
+  case _borrow
+  case _cdecl
+  case _Class
+  case _compilerInitialized
+  case _const
+  case _documentation
+  case _dynamicReplacement
+  case _effects
+  case _expose
+  case _forward
+  case _implements
+  case _linear
+  case _local
+  case _modify
+  case _move
+  case _NativeClass
+  case _NativeRefCountedObject
+  case _noMetadata
+  case _nonSendable
+  case _objcImplementation
+  case _objcRuntimeName
+  case _opaqueReturnTypeOf
+  case _optimize
+  case _originallyDefinedIn
+  case _PackageDescription
+  case _private
+  case _projectedValueProperty
+  case _read
+  case _RefCountedObject
+  case _semantics
+  case _specialize
+  case _spi
+  case _spi_available
+  case _swift_native_objc_runtime_base
+  case _Trivial
+  case _TrivialAtMost
+  case _typeEraser
+  case _unavailableFromAsync
+  case _underlyingVersion
+  case _UnknownLayout
+  case _version
+  case accesses
+  case actor
+  case addressWithNativeOwner
+  case addressWithOwner
+  case any
+  case `Any`
+  case `as`
+  case assignment
+  case `associatedtype`
+  case associativity
+  case async
+  case attached
+  case autoclosure
+  case availability
+  case available
+  case await
+  case backDeployed
+  case before
+  case block
+  case borrowing
+  case `break`
+  case canImport
+  case `case`
+  case `catch`
+  case `class`
+  case compiler
+  case consume
+  case copy
+  case consuming
+  case `continue`
+  case convenience
+  case convention
+  case cType
+  case `default`
+  case `defer`
+  case `deinit`
+  case deprecated
+  case derivative
+  case didSet
+  case differentiable
+  case distributed
+  case `do`
+  case dynamic
+  case each
+  case `else`
+  case `enum`
+  case escaping
+  case exclusivity
+  case exported
+  case `extension`
+  case `fallthrough`
+  case `false`
+  case file
+  case `fileprivate`
+  case final
+  case `for`
+  case discard
+  case forward
+  case `func`
+  case get
+  case `guard`
+  case higherThan
+  case `if`
+  case `import`
+  case `in`
+  case indirect
+  case infix
+  case `init`
+  case initializes
+  case inline
+  case `inout`
+  case `internal`
+  case introduced
+  case `is`
+  case isolated
+  case kind
+  case lazy
+  case left
+  case `let`
+  case line
+  case linear
+  case lowerThan
+  case macro
+  case message
+  case metadata
+  case module
+  case mutableAddressWithNativeOwner
+  case mutableAddressWithOwner
+  case mutating
+  case `nil`
+  case noasync
+  case noDerivative
+  case noescape
+  case none
+  case nonisolated
+  case nonmutating
+  case objc
+  case obsoleted
+  case of
+  case open
+  case `operator`
+  case optional
+  case override
+  case package
+  case postfix
+  case `precedencegroup`
+  case prefix
+  case `private`
+  case `Protocol`
+  case `protocol`
+  case `public`
+  case reasync
+  case renamed
+  case `repeat`
+  case required
+  case `rethrows`
+  case `return`
+  case reverse
+  case right
+  case safe
+  case `self`
+  case `Self`
+  case Sendable
+  case set
+  case some
+  case sourceFile
+  case spi
+  case spiModule
+  case `static`
+  case `struct`
+  case `subscript`
+  case `super`
+  case swift
+  case `switch`
+  case target
+  case `throw`
+  case `throws`
+  case transpose
+  case `true`
+  case `try`
+  case `Type`
+  case `typealias`
+  case unavailable
+  case unchecked
+  case unowned
+  case unsafe
+  case unsafeAddress
+  case unsafeMutableAddress
+  case `var`
+  case visibility
+  case weak
+  case `where`
+  case `while`
+  case willSet
+  case witness_method
+  case wrt
+  case yield
+
+  public var spec: KeywordSpec {
+    switch self {
+    case .__consuming:
+      return KeywordSpec("__consuming")
+    case .__owned:
+      return KeywordSpec("__owned")
+    case .__setter_access:
+      return KeywordSpec("__setter_access")
+    case .__shared:
+      return KeywordSpec("__shared")
+    case ._alignment:
+      return KeywordSpec("_alignment")
+    case ._backDeploy:
+      return KeywordSpec("_backDeploy")
+    case ._borrow:
+      return KeywordSpec("_borrow")
+    case ._cdecl:
+      return KeywordSpec("_cdecl")
+    case ._Class:
+      return KeywordSpec("_Class")
+    case ._compilerInitialized:
+      return KeywordSpec("_compilerInitialized")
+    case ._const:
+      return KeywordSpec("_const")
+    case ._documentation:
+      return KeywordSpec("_documentation")
+    case ._dynamicReplacement:
+      return KeywordSpec("_dynamicReplacement")
+    case ._effects:
+      return KeywordSpec("_effects")
+    case ._expose:
+      return KeywordSpec("_expose")
+    case ._forward:
+      return KeywordSpec("_forward")
+    case ._implements:
+      return KeywordSpec("_implements")
+    case ._linear:
+      return KeywordSpec("_linear")
+    case ._local:
+      return KeywordSpec("_local")
+    case ._modify:
+      return KeywordSpec("_modify")
+    case ._move:
+      return KeywordSpec("_move")
+    case ._NativeClass:
+      return KeywordSpec("_NativeClass")
+    case ._NativeRefCountedObject:
+      return KeywordSpec("_NativeRefCountedObject")
+    case ._noMetadata:
+      return KeywordSpec("_noMetadata")
+    case ._nonSendable:
+      return KeywordSpec("_nonSendable")
+    case ._objcImplementation:
+      return KeywordSpec("_objcImplementation")
+    case ._objcRuntimeName:
+      return KeywordSpec("_objcRuntimeName")
+    case ._opaqueReturnTypeOf:
+      return KeywordSpec("_opaqueReturnTypeOf")
+    case ._optimize:
+      return KeywordSpec("_optimize")
+    case ._originallyDefinedIn:
+      return KeywordSpec("_originallyDefinedIn")
+    case ._PackageDescription:
+      return KeywordSpec("_PackageDescription")
+    case ._private:
+      return KeywordSpec("_private")
+    case ._projectedValueProperty:
+      return KeywordSpec("_projectedValueProperty")
+    case ._read:
+      return KeywordSpec("_read")
+    case ._RefCountedObject:
+      return KeywordSpec("_RefCountedObject")
+    case ._semantics:
+      return KeywordSpec("_semantics")
+    case ._specialize:
+      return KeywordSpec("_specialize")
+    case ._spi:
+      return KeywordSpec("_spi")
+    case ._spi_available:
+      return KeywordSpec("_spi_available")
+    case ._swift_native_objc_runtime_base:
+      return KeywordSpec("_swift_native_objc_runtime_base")
+    case ._Trivial:
+      return KeywordSpec("_Trivial")
+    case ._TrivialAtMost:
+      return KeywordSpec("_TrivialAtMost")
+    case ._typeEraser:
+      return KeywordSpec("_typeEraser")
+    case ._unavailableFromAsync:
+      return KeywordSpec("_unavailableFromAsync")
+    case ._underlyingVersion:
+      return KeywordSpec("_underlyingVersion")
+    case ._UnknownLayout:
+      return KeywordSpec("_UnknownLayout")
+    case ._version:
+      return KeywordSpec("_version")
+    case .accesses:
+      return KeywordSpec("accesses")
+    case .actor:
+      return KeywordSpec("actor")
+    case .addressWithNativeOwner:
+      return KeywordSpec("addressWithNativeOwner")
+    case .addressWithOwner:
+      return KeywordSpec("addressWithOwner")
+    case .any:
+      return KeywordSpec("any")
+    case .Any:
+      return KeywordSpec("Any", isLexerClassified: true, requiresTrailingSpace: true)
+    case .as:
+      return KeywordSpec("as", isLexerClassified: true, requiresTrailingSpace: true)
+    case .assignment:
+      return KeywordSpec("assignment")
+    case .associatedtype:
+      return KeywordSpec("associatedtype", isLexerClassified: true, requiresTrailingSpace: true)
+    case .associativity:
+      return KeywordSpec("associativity")
+    case .async:
+      return KeywordSpec("async", requiresTrailingSpace: true)
+    case .attached:
+      return KeywordSpec("attached")
+    case .autoclosure:
+      return KeywordSpec("autoclosure")
+    case .availability:
+      return KeywordSpec("availability")
+    case .available:
+      return KeywordSpec("available")
+    case .await:
+      return KeywordSpec("await", requiresTrailingSpace: true)
+    case .backDeployed:
+      return KeywordSpec("backDeployed")
+    case .before:
+      return KeywordSpec("before")
+    case .block:
+      return KeywordSpec("block")
+    case .borrowing:
+      return KeywordSpec("borrowing")
+    case .break:
+      return KeywordSpec("break", isLexerClassified: true, requiresTrailingSpace: true)
+    case .canImport:
+      return KeywordSpec("canImport")
+    case .case:
+      return KeywordSpec("case", isLexerClassified: true, requiresTrailingSpace: true)
+    case .catch:
+      return KeywordSpec("catch", isLexerClassified: true, requiresLeadingSpace: true)
+    case .class:
+      return KeywordSpec("class", isLexerClassified: true, requiresTrailingSpace: true)
+    case .compiler:
+      return KeywordSpec("compiler")
+    case .consume:
+      return KeywordSpec("consume")
+    case .copy:
+      return KeywordSpec("copy")
+    case .consuming:
+      return KeywordSpec("consuming")
+    case .continue:
+      return KeywordSpec("continue", isLexerClassified: true, requiresTrailingSpace: true)
+    case .convenience:
+      return KeywordSpec("convenience")
+    case .convention:
+      return KeywordSpec("convention")
+    case .cType:
+      return KeywordSpec("cType")
+    case .default:
+      return KeywordSpec("default", isLexerClassified: true)
+    case .defer:
+      return KeywordSpec("defer", isLexerClassified: true, requiresTrailingSpace: true)
+    case .deinit:
+      return KeywordSpec("deinit", isLexerClassified: true)
+    case .deprecated:
+      return KeywordSpec("deprecated")
+    case .derivative:
+      return KeywordSpec("derivative")
+    case .didSet:
+      return KeywordSpec("didSet")
+    case .differentiable:
+      return KeywordSpec("differentiable")
+    case .distributed:
+      return KeywordSpec("distributed")
+    case .do:
+      return KeywordSpec("do", isLexerClassified: true)
+    case .dynamic:
+      return KeywordSpec("dynamic")
+    case .each:
+      return KeywordSpec("each")
+    case .else:
+      return KeywordSpec("else", isLexerClassified: true, requiresLeadingSpace: true, requiresTrailingSpace: true)
+    case .enum:
+      return KeywordSpec("enum", isLexerClassified: true, requiresTrailingSpace: true)
+    case .escaping:
+      return KeywordSpec("escaping")
+    case .exclusivity:
+      return KeywordSpec("exclusivity")
+    case .exported:
+      return KeywordSpec("exported")
+    case .extension:
+      return KeywordSpec("extension", isLexerClassified: true, requiresTrailingSpace: true)
+    case .fallthrough:
+      return KeywordSpec("fallthrough", isLexerClassified: true, requiresTrailingSpace: true)
+    case .false:
+      return KeywordSpec("false", isLexerClassified: true)
+    case .file:
+      return KeywordSpec("file")
+    case .fileprivate:
+      return KeywordSpec("fileprivate", isLexerClassified: true, requiresTrailingSpace: true)
+    case .final:
+      return KeywordSpec("final")
+    case .for:
+      return KeywordSpec("for", isLexerClassified: true, requiresTrailingSpace: true)
+    case .discard:
+      return KeywordSpec("discard")
+    case .forward:
+      return KeywordSpec("forward")
+    case .func:
+      return KeywordSpec("func", isLexerClassified: true, requiresTrailingSpace: true)
+    case .get:
+      return KeywordSpec("get")
+    case .guard:
+      return KeywordSpec("guard", isLexerClassified: true, requiresTrailingSpace: true)
+    case .higherThan:
+      return KeywordSpec("higherThan")
+    case .if:
+      return KeywordSpec("if", isLexerClassified: true, requiresTrailingSpace: true)
+    case .import:
+      return KeywordSpec("import", isLexerClassified: true, requiresTrailingSpace: true)
+    case .in:
+      return KeywordSpec("in", isLexerClassified: true, requiresLeadingSpace: true, requiresTrailingSpace: true)
+    case .indirect:
+      return KeywordSpec("indirect")
+    case .infix:
+      return KeywordSpec("infix")
+    case .`init`:
+      return KeywordSpec("init", isLexerClassified: true)
+    case .initializes:
+      return KeywordSpec("initializes")
+    case .inline:
+      return KeywordSpec("inline")
+    case .inout:
+      return KeywordSpec("inout", isLexerClassified: true, requiresTrailingSpace: true)
+    case .internal:
+      return KeywordSpec("internal", isLexerClassified: true, requiresTrailingSpace: true)
+    case .introduced:
+      return KeywordSpec("introduced")
+    case .is:
+      return KeywordSpec("is", isLexerClassified: true, requiresTrailingSpace: true)
+    case .isolated:
+      return KeywordSpec("isolated")
+    case .kind:
+      return KeywordSpec("kind")
+    case .lazy:
+      return KeywordSpec("lazy")
+    case .left:
+      return KeywordSpec("left")
+    case .let:
+      return KeywordSpec("let", isLexerClassified: true, requiresTrailingSpace: true)
+    case .line:
+      return KeywordSpec("line")
+    case .linear:
+      return KeywordSpec("linear")
+    case .lowerThan:
+      return KeywordSpec("lowerThan")
+    case .macro:
+      return KeywordSpec("macro")
+    case .message:
+      return KeywordSpec("message")
+    case .metadata:
+      return KeywordSpec("metadata")
+    case .module:
+      return KeywordSpec("module")
+    case .mutableAddressWithNativeOwner:
+      return KeywordSpec("mutableAddressWithNativeOwner")
+    case .mutableAddressWithOwner:
+      return KeywordSpec("mutableAddressWithOwner")
+    case .mutating:
+      return KeywordSpec("mutating")
+    case .nil:
+      return KeywordSpec("nil", isLexerClassified: true)
+    case .noasync:
+      return KeywordSpec("noasync")
+    case .noDerivative:
+      return KeywordSpec("noDerivative")
+    case .noescape:
+      return KeywordSpec("noescape")
+    case .none:
+      return KeywordSpec("none")
+    case .nonisolated:
+      return KeywordSpec("nonisolated")
+    case .nonmutating:
+      return KeywordSpec("nonmutating")
+    case .objc:
+      return KeywordSpec("objc")
+    case .obsoleted:
+      return KeywordSpec("obsoleted")
+    case .of:
+      return KeywordSpec("of")
+    case .open:
+      return KeywordSpec("open")
+    case .operator:
+      return KeywordSpec("operator", isLexerClassified: true, requiresTrailingSpace: true)
+    case .optional:
+      return KeywordSpec("optional")
+    case .override:
+      return KeywordSpec("override")
+    case .package:
+      return KeywordSpec("package")
+    case .postfix:
+      return KeywordSpec("postfix")
+    case .precedencegroup:
+      return KeywordSpec("precedencegroup", isLexerClassified: true, requiresTrailingSpace: true)
+    case .prefix:
+      return KeywordSpec("prefix")
+    case .private:
+      return KeywordSpec("private", isLexerClassified: true, requiresTrailingSpace: true)
+    case .Protocol:
+      return KeywordSpec("Protocol")
+    case .protocol:
+      return KeywordSpec("protocol", isLexerClassified: true, requiresTrailingSpace: true)
+    case .public:
+      return KeywordSpec("public", isLexerClassified: true, requiresTrailingSpace: true)
+    case .reasync:
+      return KeywordSpec("reasync")
+    case .renamed:
+      return KeywordSpec("renamed")
+    case .repeat:
+      return KeywordSpec("repeat", isLexerClassified: true, requiresTrailingSpace: true)
+    case .required:
+      return KeywordSpec("required")
+    case .rethrows:
+      return KeywordSpec("rethrows", isLexerClassified: true, requiresTrailingSpace: true)
+    case .return:
+      return KeywordSpec("return", isLexerClassified: true, requiresTrailingSpace: true)
+    case .reverse:
+      return KeywordSpec("reverse")
+    case .right:
+      return KeywordSpec("right")
+    case .safe:
+      return KeywordSpec("safe")
+    case .self:
+      return KeywordSpec("self", isLexerClassified: true)
+    case .Self:
+      return KeywordSpec("Self", isLexerClassified: true)
+    case .Sendable:
+      return KeywordSpec("Sendable")
+    case .set:
+      return KeywordSpec("set")
+    case .some:
+      return KeywordSpec("some")
+    case .sourceFile:
+      return KeywordSpec("sourceFile")
+    case .spi:
+      return KeywordSpec("spi")
+    case .spiModule:
+      return KeywordSpec("spiModule")
+    case .static:
+      return KeywordSpec("static", isLexerClassified: true, requiresTrailingSpace: true)
+    case .struct:
+      return KeywordSpec("struct", isLexerClassified: true, requiresTrailingSpace: true)
+    case .subscript:
+      return KeywordSpec("subscript", isLexerClassified: true, requiresTrailingSpace: true)
+    case .super:
+      return KeywordSpec("super", isLexerClassified: true)
+    case .swift:
+      return KeywordSpec("swift")
+    case .switch:
+      return KeywordSpec("switch", isLexerClassified: true, requiresTrailingSpace: true)
+    case .target:
+      return KeywordSpec("target")
+    case .throw:
+      return KeywordSpec("throw", isLexerClassified: true, requiresTrailingSpace: true)
+    case .throws:
+      return KeywordSpec("throws", isLexerClassified: true, requiresTrailingSpace: true)
+    case .transpose:
+      return KeywordSpec("transpose")
+    case .true:
+      return KeywordSpec("true", isLexerClassified: true)
+    case .try:
+      return KeywordSpec("try", isLexerClassified: true, requiresTrailingSpace: true)
+    case .Type:
+      return KeywordSpec("Type")
+    case .typealias:
+      return KeywordSpec("typealias", isLexerClassified: true, requiresTrailingSpace: true)
+    case .unavailable:
+      return KeywordSpec("unavailable")
+    case .unchecked:
+      return KeywordSpec("unchecked")
+    case .unowned:
+      return KeywordSpec("unowned")
+    case .unsafe:
+      return KeywordSpec("unsafe")
+    case .unsafeAddress:
+      return KeywordSpec("unsafeAddress")
+    case .unsafeMutableAddress:
+      return KeywordSpec("unsafeMutableAddress")
+    case .var:
+      return KeywordSpec("var", isLexerClassified: true, requiresTrailingSpace: true)
+    case .visibility:
+      return KeywordSpec("visibility")
+    case .weak:
+      return KeywordSpec("weak")
+    case .where:
+      return KeywordSpec("where", isLexerClassified: true, requiresLeadingSpace: true, requiresTrailingSpace: true)
+    case .while:
+      return KeywordSpec("while", isLexerClassified: true, requiresTrailingSpace: true)
+    case .willSet:
+      return KeywordSpec("willSet")
+    case .witness_method:
+      return KeywordSpec("witness_method")
+    case .wrt:
+      return KeywordSpec("wrt")
+    case .yield:
+      return KeywordSpec("yield")
+    }
+  }
 }

--- a/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
@@ -31,7 +31,7 @@ public let PATTERN_NODES: [Node] = [
     children: [
       Child(
         name: "identifier",
-        kind: .token(choices: [.token(.identifier), .keyword(text: "self"), .keyword(text: "init")])
+        kind: .token(choices: [.token(.identifier), .keyword(.self), .keyword(.`init`)])
       )
     ]
   ),
@@ -44,7 +44,7 @@ public let PATTERN_NODES: [Node] = [
     children: [
       Child(
         name: "isKeyword",
-        kind: .token(choices: [.keyword(text: "is")])
+        kind: .token(choices: [.keyword(.is)])
       ),
       Child(
         name: "type",
@@ -148,7 +148,7 @@ public let PATTERN_NODES: [Node] = [
       Child(
         name: "bindingSpecifier",
         deprecatedName: "bindingKeyword",
-        kind: .token(choices: [.keyword(text: "let"), .keyword(text: "var"), .keyword(text: "inout")])
+        kind: .token(choices: [.keyword(.let), .keyword(.var), .keyword(.inout)])
       ),
       Child(
         name: "pattern",

--- a/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
@@ -45,7 +45,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "breakKeyword",
-        kind: .token(choices: [.keyword(text: "break")], requiresTrailingSpace: false)
+        kind: .token(choices: [.keyword(.break)], requiresTrailingSpace: false)
       ),
       Child(
         name: "label",
@@ -82,7 +82,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "catchKeyword",
-        kind: .token(choices: [.keyword(text: "catch")])
+        kind: .token(choices: [.keyword(.catch)])
       ),
       Child(
         name: "catchItems",
@@ -188,7 +188,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "continueKeyword",
-        kind: .token(choices: [.keyword(text: "continue")])
+        kind: .token(choices: [.keyword(.continue)])
       ),
       Child(
         name: "label",
@@ -210,7 +210,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "deferKeyword",
-        kind: .token(choices: [.keyword(text: "defer")])
+        kind: .token(choices: [.keyword(.defer)])
       ),
       Child(
         name: "body",
@@ -230,7 +230,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "doKeyword",
-        kind: .token(choices: [.keyword(text: "do")])
+        kind: .token(choices: [.keyword(.do)])
       ),
       Child(
         name: "body",
@@ -265,7 +265,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "fallthroughKeyword",
-        kind: .token(choices: [.keyword(text: "fallthrough")])
+        kind: .token(choices: [.keyword(.fallthrough)])
       )
     ]
   ),
@@ -283,21 +283,21 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "forKeyword",
-        kind: .token(choices: [.keyword(text: "for")])
+        kind: .token(choices: [.keyword(.for)])
       ),
       Child(
         name: "tryKeyword",
-        kind: .token(choices: [.keyword(text: "try")]),
+        kind: .token(choices: [.keyword(.try)]),
         isOptional: true
       ),
       Child(
         name: "awaitKeyword",
-        kind: .token(choices: [.keyword(text: "await")]),
+        kind: .token(choices: [.keyword(.await)]),
         isOptional: true
       ),
       Child(
         name: "caseKeyword",
-        kind: .token(choices: [.keyword(text: "case")]),
+        kind: .token(choices: [.keyword(.case)]),
         isOptional: true
       ),
       Child(
@@ -311,7 +311,7 @@ public let STMT_NODES: [Node] = [
       ),
       Child(
         name: "inKeyword",
-        kind: .token(choices: [.keyword(text: "in")])
+        kind: .token(choices: [.keyword(.in)])
       ),
       Child(
         name: "sequence",
@@ -339,7 +339,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "discardKeyword",
-        kind: .token(choices: [.keyword(text: "discard")])
+        kind: .token(choices: [.keyword(.discard)])
       ),
       Child(
         name: "expression",
@@ -359,7 +359,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "guardKeyword",
-        kind: .token(choices: [.keyword(text: "guard")])
+        kind: .token(choices: [.keyword(.guard)])
       ),
       Child(
         name: "conditions",
@@ -368,7 +368,7 @@ public let STMT_NODES: [Node] = [
       ),
       Child(
         name: "elseKeyword",
-        kind: .token(choices: [.keyword(text: "else")])
+        kind: .token(choices: [.keyword(.else)])
       ),
       Child(
         name: "body",
@@ -409,7 +409,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "caseKeyword",
-        kind: .token(choices: [.keyword(text: "case")])
+        kind: .token(choices: [.keyword(.case)])
       ),
       Child(
         name: "pattern",
@@ -435,7 +435,7 @@ public let STMT_NODES: [Node] = [
       Child(
         name: "bindingSpecifier",
         deprecatedName: "bindingKeyword",
-        kind: .token(choices: [.keyword(text: "let"), .keyword(text: "var"), .keyword(text: "inout")])
+        kind: .token(choices: [.keyword(.let), .keyword(.var), .keyword(.inout)])
       ),
       Child(
         name: "pattern",
@@ -465,7 +465,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "repeatKeyword",
-        kind: .token(choices: [.keyword(text: "repeat")])
+        kind: .token(choices: [.keyword(.repeat)])
       ),
       Child(
         name: "body",
@@ -474,7 +474,7 @@ public let STMT_NODES: [Node] = [
       ),
       Child(
         name: "whileKeyword",
-        kind: .token(choices: [.keyword(text: "while")])
+        kind: .token(choices: [.keyword(.while)])
       ),
       Child(
         name: "condition",
@@ -492,7 +492,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "returnKeyword",
-        kind: .token(choices: [.keyword(text: "return")])
+        kind: .token(choices: [.keyword(.return)])
       ),
       Child(
         name: "expression",
@@ -510,7 +510,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "throwKeyword",
-        kind: .token(choices: [.keyword(text: "throw")])
+        kind: .token(choices: [.keyword(.throw)])
       ),
       Child(
         name: "expression",
@@ -526,7 +526,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "whereKeyword",
-        kind: .token(choices: [.keyword(text: "where")])
+        kind: .token(choices: [.keyword(.where)])
       ),
       Child(
         name: "condition",
@@ -547,7 +547,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "whileKeyword",
-        kind: .token(choices: [.keyword(text: "while")])
+        kind: .token(choices: [.keyword(.while)])
       ),
       Child(
         name: "conditions",
@@ -589,7 +589,7 @@ public let STMT_NODES: [Node] = [
     children: [
       Child(
         name: "yieldKeyword",
-        kind: .token(choices: [.keyword(text: "yield")])
+        kind: .token(choices: [.keyword(.yield)])
       ),
       Child(
         name: "yieldedExpressions",

--- a/CodeGeneration/Sources/SyntaxSupport/String+Extensions.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/String+Extensions.swift
@@ -14,7 +14,7 @@ public extension StringProtocol {
   var withFirstCharacterLowercased: String { prefix(1).lowercased() + dropFirst() }
   var withFirstCharacterUppercased: String { prefix(1).uppercased() + dropFirst() }
   var backtickedIfNeeded: String {
-    if KEYWORDS.contains(where: {
+    if Keyword.allCases.map(\.spec).contains(where: {
       $0.name == self && $0.isLexerClassified
     }) {
       return "`\(self)`"

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -53,9 +53,9 @@ public let TRAITS: [Trait] = [
     traitName: "EffectSpecifiers",
     children: [
       Child(name: "unexpectedBeforeAsyncSpecifier", kind: .node(kind: .unexpectedNodes), isOptional: true),
-      Child(name: "asyncSpecifier", kind: .token(choices: [.keyword(text: "async"), .keyword(text: "reasync")]), isOptional: true),
+      Child(name: "asyncSpecifier", kind: .token(choices: [.keyword(.async), .keyword(.reasync)]), isOptional: true),
       Child(name: "unexpectedBetweenAsyncSpecifierAndThrowsSpecifier", kind: .node(kind: .unexpectedNodes), isOptional: true),
-      Child(name: "throwsSpecifier", kind: .token(choices: [.keyword(text: "throws"), .keyword(text: "rethrows")]), isOptional: true),
+      Child(name: "throwsSpecifier", kind: .token(choices: [.keyword(.throws), .keyword(.rethrows)]), isOptional: true),
       Child(name: "unexpectedAfterThrowsSpecifier", kind: .node(kind: .unexpectedNodes), isOptional: true),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -48,13 +48,13 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "specifier",
         kind: .token(choices: [
-          .keyword(text: "inout"),
-          .keyword(text: "__shared"),
-          .keyword(text: "__owned"),
-          .keyword(text: "isolated"),
-          .keyword(text: "_const"),
-          .keyword(text: "borrowing"),
-          .keyword(text: "consuming"),
+          .keyword(.inout),
+          .keyword(.__shared),
+          .keyword(.__owned),
+          .keyword(.isolated),
+          .keyword(._const),
+          .keyword(.borrowing),
+          .keyword(.consuming),
         ]),
         isOptional: true
       ),
@@ -76,7 +76,7 @@ public let TYPE_NODES: [Node] = [
     children: [
       Child(
         name: "classKeyword",
-        kind: .token(choices: [.keyword(text: "class")])
+        kind: .token(choices: [.keyword(.class)])
       )
     ]
   ),
@@ -129,7 +129,7 @@ public let TYPE_NODES: [Node] = [
     children: [
       Child(
         name: "someOrAnySpecifier",
-        kind: .token(choices: [.keyword(text: "some"), .keyword(text: "any")])
+        kind: .token(choices: [.keyword(.some), .keyword(.any)])
       ),
       Child(
         name: "constraint",
@@ -300,7 +300,7 @@ public let TYPE_NODES: [Node] = [
       ),
       Child(
         name: "name",
-        kind: .token(choices: [.token(.identifier), .keyword(text: "self"), .keyword(text: "Self")]),
+        kind: .token(choices: [.token(.identifier), .keyword(.self), .keyword(.Self)]),
         nameForDiagnostics: "name"
       ),
       Child(
@@ -329,7 +329,7 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "metatypeSpecifier",
         deprecatedName: "typeOrProtocol",
-        kind: .token(choices: [.keyword(text: "Type"), .keyword(text: "Protocol")])
+        kind: .token(choices: [.keyword(.Type), .keyword(.Protocol)])
       ),
     ]
   ),
@@ -397,7 +397,7 @@ public let TYPE_NODES: [Node] = [
     children: [
       Child(
         name: "repeatKeyword",
-        kind: .token(choices: [.keyword(text: "repeat")])
+        kind: .token(choices: [.keyword(.repeat)])
       ),
       Child(
         name: "repetitionPattern",
@@ -415,7 +415,7 @@ public let TYPE_NODES: [Node] = [
     children: [
       Child(
         name: "eachKeyword",
-        kind: .token(choices: [.keyword(text: "each")])
+        kind: .token(choices: [.keyword(.each)])
       ),
       Child(
         name: "pack",
@@ -435,9 +435,9 @@ public let TYPE_NODES: [Node] = [
         name: "name",
         kind: .token(choices: [
           .token(.identifier),
-          .keyword(text: "self"),
-          .keyword(text: "Self"),
-          .keyword(text: "Any"),
+          .keyword(.self),
+          .keyword(.Self),
+          .keyword(.Any),
           .token(.wildcard),
         ])
       ),
@@ -469,7 +469,7 @@ public let TYPE_NODES: [Node] = [
       Child(
         name: "inoutKeyword",
         deprecatedName: "inOut",
-        kind: .token(choices: [.keyword(text: "inout")]),
+        kind: .token(choices: [.keyword(.inout)]),
         isOptional: true
       ),
       Child(

--- a/CodeGeneration/Sources/SyntaxSupport/Utils.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Utils.swift
@@ -68,7 +68,7 @@ public extension Collection {
 
 public extension TokenSyntax {
   var backtickedIfNeeded: TokenSyntax {
-    if KEYWORDS.contains(where: {
+    if Keyword.allCases.map(\.spec).contains(where: {
       $0.name == self.description && $0.isLexerClassified
     }) {
       return "`\(self)`"

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -75,12 +75,13 @@ public extension Child {
       return ExprSyntax(".\(token.varOrCaseName)Token()")
     }
     if case .token(let choices, _, _) = kind,
-      case .keyword(var text) = choices.only
+      case .keyword(let keyword) = choices.only
     {
-      if text == "init" {
-        text = "`init`"
+      var name = keyword.spec.name
+      if keyword == .`init` {
+        name = "`init`"
       }
-      return ExprSyntax(".\(token.varOrCaseName)(.\(raw: text))")
+      return ExprSyntax(".\(token.varOrCaseName)(.\(raw: name))")
     }
     return nil
   }
@@ -122,8 +123,8 @@ public extension Child {
         switch $0 {
         case .token(let token):
           return token.spec.text
-        case .keyword(text: let text):
-          return text
+        case .keyword(let keyword):
+          return keyword.spec.name
         }
       }
     } else {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/IsLexerClassifiedFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/IsLexerClassifiedFile.swift
@@ -31,9 +31,9 @@ let isLexerClassifiedFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       try! SwitchExprSyntax("switch self") {
-        for keyword in KEYWORDS {
-          if keyword.isLexerClassified {
-            SwitchCaseSyntax("case .\(raw: keyword.escapedName): return true")
+        for keyword in Keyword.allCases {
+          if keyword.spec.isLexerClassified {
+            SwitchCaseSyntax("case .\(raw: keyword.spec.escapedName): return true")
           }
         }
         SwitchCaseSyntax("default: return false")

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserTokenSpecSetFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserTokenSpecSetFile.swift
@@ -30,9 +30,8 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           ) {
             for choice in choices {
               switch choice {
-              case .keyword(let keywordText):
-                let keyword = KEYWORDS.first(where: { $0.name == keywordText })!
-                DeclSyntax("case \(raw: keyword.escapedName)")
+              case .keyword(let keyword):
+                DeclSyntax("case \(raw: keyword.spec.escapedName)")
               case .token(let token):
                 DeclSyntax("case \(token.spec.varOrCaseName)")
               }
@@ -42,14 +41,12 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
               try SwitchExprSyntax("switch PrepareForKeywordMatch(lexeme)") {
                 for choice in choices {
                   switch choice {
-                  case .keyword(let keywordText):
-                    let keyword = KEYWORDS.first(where: { $0.name == keywordText })!
-                    SwitchCaseSyntax("case TokenSpec(.\(raw: keyword.escapedName)): self = .\(raw: keyword.escapedName)")
+                  case .keyword(let keyword):
+                    let escapedName = keyword.spec.escapedName
+                    SwitchCaseSyntax("case TokenSpec(.\(raw: escapedName)): self = .\(raw: escapedName)")
                   case .token(let token):
                     let caseName = token.spec.varOrCaseName
-                    SwitchCaseSyntax(
-                      "case TokenSpec(.\(caseName)): self = .\(caseName)"
-                    )
+                    SwitchCaseSyntax("case TokenSpec(.\(caseName)): self = .\(caseName)")
                   }
                 }
                 SwitchCaseSyntax("default: return nil")
@@ -60,16 +57,12 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
               try SwitchExprSyntax("switch self") {
                 for choice in choices {
                   switch choice {
-                  case .keyword(let keywordText):
-                    let keyword = KEYWORDS.first(where: { $0.name == keywordText })!
-                    SwitchCaseSyntax(
-                      "case .\(raw: keyword.escapedName): return .keyword(.\(raw: keyword.escapedName))"
-                    )
+                  case .keyword(let keyword):
+                    let escapedName = keyword.spec.escapedName
+                    SwitchCaseSyntax("case .\(raw: escapedName): return .keyword(.\(raw: escapedName))")
                   case .token(let token):
                     let caseName = token.spec.varOrCaseName
-                    SwitchCaseSyntax(
-                      "case .\(caseName): return .\(caseName)"
-                    )
+                    SwitchCaseSyntax("case .\(caseName): return .\(caseName)")
                   }
                 }
               }
@@ -87,21 +80,15 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
               try SwitchExprSyntax("switch self") {
                 for choice in choices {
                   switch choice {
-                  case .keyword(let keywordText):
-                    let keyword = KEYWORDS.first(where: { $0.name == keywordText })!
-                    SwitchCaseSyntax(
-                      "case .\(raw: keyword.escapedName): return .keyword(.\(raw: keyword.escapedName))"
-                    )
+                  case .keyword(let keyword):
+                    let escapedName = keyword.spec.escapedName
+                    SwitchCaseSyntax("case .\(raw: escapedName): return .keyword(.\(raw: escapedName))")
                   case .token(let token):
                     let caseName = token.spec.varOrCaseName
                     if token.spec.text != nil {
-                      SwitchCaseSyntax(
-                        "case .\(caseName): return .\(caseName)Token()"
-                      )
+                      SwitchCaseSyntax("case .\(caseName): return .\(caseName)Token()")
                     } else {
-                      SwitchCaseSyntax(
-                        #"case .\#(caseName): return .\#(caseName)("")"#
-                      )
+                      SwitchCaseSyntax(#"case .\#(caseName): return .\#(caseName)("")"#)
                     }
                   }
                 }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
@@ -16,8 +16,8 @@ import SyntaxSupport
 import Utils
 
 let lookupTable = ArrayExprSyntax(leftSquare: .leftSquareToken(trailingTrivia: .newline)) {
-  for keyword in KEYWORDS {
-    ArrayElementSyntax(expression: ExprSyntax("\(literal: keyword.name)"), trailingComma: .commaToken())
+  for keyword in Keyword.allCases {
+    ArrayElementSyntax(expression: ExprSyntax("\(literal: keyword.spec.name)"), trailingComma: .commaToken())
   }
 }
 
@@ -27,11 +27,11 @@ let keywordFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     public enum Keyword: UInt8, Hashable
     """
   ) {
-    for (index, keyword) in KEYWORDS.enumerated() {
+    for keyword in Keyword.allCases {
       DeclSyntax(
         """
-        \(keyword.apiAttributes)\
-        case \(raw: keyword.escapedName)
+        \(keyword.spec.apiAttributes)\
+        case \(raw: keyword.spec.escapedName)
         """
       )
     }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
@@ -213,8 +213,8 @@ let rawSyntaxValidationFile = try! SourceFileSyntax(leadingTrivia: copyrightHead
                           let choices = ArrayExprSyntax {
                             for choice in choices {
                               switch choice {
-                              case .keyword(text: let text):
-                                ArrayElementSyntax(expression: ExprSyntax(#".keyword("\#(raw: text)")"#))
+                              case .keyword(let keyword):
+                                ArrayElementSyntax(expression: ExprSyntax(#".keyword("\#(raw: keyword.spec.name)")"#))
                               case .token(let token):
                                 ArrayElementSyntax(expression: ExprSyntax(".tokenKind(.\(token.spec.varOrCaseName))"))
                               }

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -166,15 +166,17 @@ class ValidateSyntaxNodes: XCTestCase {
       return nil
     }
     switch choice {
-    case .keyword(text: let keyword):
+    case .keyword(let keyword):
+      let keywordName = keyword.spec.name
+
       if child.isFollowedByColonToken(in: node) {
-        if child.varOrCaseName.description != "\(keyword)Label" {
+        if child.varOrCaseName.description != "\(keywordName)Label" {
           return
-            "child '\(child.varOrCaseName)' has a single keyword as its only token choice and is followed by a colon. It should thus be named '\(keyword)Label'"
+            "child '\(child.varOrCaseName)' has a single keyword as its only token choice and is followed by a colon. It should thus be named '\(keywordName)Label'"
         }
       } else {
-        if child.varOrCaseName.description != "\(keyword)Keyword" {
-          return "child '\(child.varOrCaseName)' has a single keyword as its only token choice and should thus be named '\(keyword)Keyword'"
+        if child.varOrCaseName.description != "\(keywordName)Keyword" {
+          return "child '\(child.varOrCaseName)' has a single keyword as its only token choice and should thus be named '\(keywordName)Keyword'"
         }
       }
 


### PR DESCRIPTION
Follow-up PR to #2006 
Resolves #2008 