### PR TITLE
Incorporate Doug’s macro examples in swift-syntax/Examples

### DIFF
--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -49,6 +49,22 @@ let package = Package(
       ],
       path: "Sources/MacroExamples/Implementation"
     ),
+    .testTarget(
+      name: "MacroExamplesImplementationTests",
+      dependencies: [
+        "MacroExamplesImplementation"
+      ],
+      path: "Tests/MacroExamples/Implementation"
+    ),
+  ]
+)
+
+// The following targets are added only if the OS is macOS. This is because Swift macros are currently
+// not available on other platforms. As a result, we're guarding these targets with `#if os(macOS)`
+// to ensure that they are only included in the package when building on a macOS system.
+#if os(macOS)
+package.targets.append(
+  contentsOf: [
     .target(
       name: "MacroExamplesInterface",
       dependencies: [
@@ -63,15 +79,9 @@ let package = Package(
       ],
       path: "Sources/MacroExamples/Playground"
     ),
-    .testTarget(
-      name: "MacroExamplesImplementationTests",
-      dependencies: [
-        "MacroExamplesImplementation"
-      ],
-      path: "Tests/MacroExamples/Implementation"
-    ),
   ]
 )
+#endif
 
 // This is a fake target that depends on all targets in the package.
 // We need to define it manually because the `Examples-Package` target doesn't exist for `swift build`.

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -1,6 +1,7 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
   name: "Examples",
@@ -37,6 +38,37 @@ let package = Package(
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftDiagnostics", package: "swift-syntax"),
       ]
+    ),
+    .macro(
+      name: "MacroExamplesImplementation",
+      dependencies: [
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+      ],
+      path: "Sources/MacroExamples/Implementation"
+    ),
+    .target(
+      name: "MacroExamplesInterface",
+      dependencies: [
+        "MacroExamplesImplementation"
+      ],
+      path: "Sources/MacroExamples/Interface"
+    ),
+    .executableTarget(
+      name: "MacroExamplesPlayground",
+      dependencies: [
+        "MacroExamplesInterface"
+      ],
+      path: "Sources/MacroExamples/Playground"
+    ),
+    .testTarget(
+      name: "MacroExamplesImplementationTests",
+      dependencies: [
+        "MacroExamplesImplementation"
+      ],
+      path: "Tests/MacroExamples/Implementation"
     ),
   ]
 )

--- a/Examples/Sources/MacroExamples/Implementation/AddAsyncMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/AddAsyncMacro.swift
@@ -1,0 +1,161 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+extension SyntaxCollection {
+  mutating func removeLast() {
+    self.remove(at: self.index(before: self.endIndex))
+  }
+}
+
+public struct AddAsyncMacro: PeerMacro {
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+
+    // Only on functions at the moment.
+    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+      throw CustomError.message("@addAsync only works on functions")
+    }
+
+    // This only makes sense for non async functions.
+    if funcDecl.signature.effectSpecifiers?.asyncSpecifier != nil {
+      throw CustomError.message(
+        "@addAsync requires an non async function"
+      )
+    }
+
+    // This only makes sense void functions
+    if funcDecl.signature.returnClause?.type.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description != "Void" {
+      throw CustomError.message(
+        "@addAsync requires an function that returns void"
+      )
+    }
+
+    // Requires a completion handler block as last parameter
+    guard let completionHandlerParameterAttribute = funcDecl.signature.parameterClause.parameters.last?.type.as(AttributedTypeSyntax.self),
+      let completionHandlerParameter = completionHandlerParameterAttribute.baseType.as(FunctionTypeSyntax.self)
+    else {
+      throw CustomError.message(
+        "@addAsync requires an function that has a completion handler as last parameter"
+      )
+    }
+
+    // Completion handler needs to return Void
+    if completionHandlerParameter.returnClause.type.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description != "Void" {
+      throw CustomError.message(
+        "@addAsync requires an function that has a completion handler that returns Void"
+      )
+    }
+
+    let returnType = completionHandlerParameter.parameters.first?.type
+
+    let isResultReturn = returnType?.children(viewMode: .all).first?.description == "Result"
+    let successReturnType = isResultReturn ? returnType!.as(IdentifierTypeSyntax.self)!.genericArgumentClause?.arguments.first!.argument : returnType
+
+    // Remove completionHandler and comma from the previous parameter
+    var newParameterList = funcDecl.signature.parameterClause.parameters
+    newParameterList.removeLast()
+    let newParameterListLastParameter = newParameterList.last!
+    newParameterList.removeLast()
+    newParameterList.append(newParameterListLastParameter.with(\.trailingTrivia, []).with(\.trailingComma, nil))
+
+    // Drop the @addAsync attribute from the new declaration.
+    let newAttributeList = AttributeListSyntax(
+      funcDecl.attributes?.filter {
+        guard case let .attribute(attribute) = $0,
+          let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
+          let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
+        else {
+          return true
+        }
+
+        return attributeType.name.text != nodeType.name.text
+      } ?? []
+    )
+
+    let callArguments: [String] = newParameterList.map { param in
+      let argName = param.secondName ?? param.firstName
+
+      let paramName = param.firstName
+      if paramName.text != "_" {
+        return "\(paramName.text): \(argName.text)"
+      }
+
+      return "\(argName.text)"
+    }
+
+    let switchBody: ExprSyntax =
+      """
+        switch returnValue {
+        case .success(let value):
+            continuation.resume(returning: value)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
+      """
+
+    let newBody: ExprSyntax =
+      """
+
+        \(isResultReturn ? "try await withCheckedThrowingContinuation { continuation in" : "await withCheckedContinuation { continuation in")
+          \(funcDecl.name)(\(raw: callArguments.joined(separator: ", "))) { \(returnType != nil ? "returnValue in" : "")
+        
+          \(isResultReturn ? switchBody : "continuation.resume(returning: \(returnType != nil ? "returnValue" : "()"))")
+            
+          }
+        }
+
+      """
+
+    let newFunc =
+      funcDecl
+      .with(
+        \.signature,
+        funcDecl.signature
+          .with(
+            \.effectSpecifiers,
+            FunctionEffectSpecifiersSyntax(leadingTrivia: .space, asyncSpecifier: "async", throwsSpecifier: isResultReturn ? " throws" : nil)  // add async
+          )
+          .with(
+            \.returnClause,
+            successReturnType != nil ? ReturnClauseSyntax(leadingTrivia: .space, type: successReturnType!.with(\.leadingTrivia, .space)) : nil
+          )  // add result type
+          .with(
+            \.parameterClause,
+            funcDecl.signature.parameterClause.with(\.parameters, newParameterList)  // drop completion handler
+              .with(\.trailingTrivia, [])
+          )
+      )
+      .with(
+        \.body,
+        CodeBlockSyntax(
+          leftBrace: .leftBraceToken(leadingTrivia: .space),
+          statements: CodeBlockItemListSyntax(
+            [CodeBlockItemSyntax(item: .expr(newBody))]
+          ),
+          rightBrace: .rightBraceToken(leadingTrivia: .newline)
+        )
+      )
+      .with(\.attributes, newAttributeList)
+      .with(\.leadingTrivia, .newlines(2))
+
+    return [DeclSyntax(newFunc)]
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/AddAsyncMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/AddAsyncMacro.swift
@@ -77,18 +77,16 @@ public struct AddAsyncMacro: PeerMacro {
     newParameterList.append(newParameterListLastParameter.with(\.trailingTrivia, []).with(\.trailingComma, nil))
 
     // Drop the @addAsync attribute from the new declaration.
-    let newAttributeList = AttributeListSyntax(
-      funcDecl.attributes?.filter {
-        guard case let .attribute(attribute) = $0,
-          let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
-          let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
-        else {
-          return true
-        }
+    let newAttributeList = funcDecl.attributes.filter {
+      guard case let .attribute(attribute) = $0,
+        let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
+        let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
+      else {
+        return true
+      }
 
-        return attributeType.name.text != nodeType.name.text
-      } ?? []
-    )
+      return attributeType.name.text != nodeType.name.text
+    }
 
     let callArguments: [String] = newParameterList.map { param in
       let argName = param.secondName ?? param.firstName
@@ -114,11 +112,11 @@ public struct AddAsyncMacro: PeerMacro {
     let newBody: ExprSyntax =
       """
 
-        \(isResultReturn ? "try await withCheckedThrowingContinuation { continuation in" : "await withCheckedContinuation { continuation in")
-          \(funcDecl.name)(\(raw: callArguments.joined(separator: ", "))) { \(returnType != nil ? "returnValue in" : "")
-        
-          \(isResultReturn ? switchBody : "continuation.resume(returning: \(returnType != nil ? "returnValue" : "()"))")
-            
+        \(raw: isResultReturn ? "try await withCheckedThrowingContinuation { continuation in" : "await withCheckedContinuation { continuation in")
+          \(raw: funcDecl.name)(\(raw: callArguments.joined(separator: ", "))) { \(raw: returnType != nil ? "returnValue in" : "")
+
+          \(raw: isResultReturn ? switchBody : "continuation.resume(returning: \(raw: returnType != nil ? "returnValue" : "()"))")
+
           }
         }
 
@@ -131,7 +129,11 @@ public struct AddAsyncMacro: PeerMacro {
         funcDecl.signature
           .with(
             \.effectSpecifiers,
-            FunctionEffectSpecifiersSyntax(leadingTrivia: .space, asyncSpecifier: "async", throwsSpecifier: isResultReturn ? " throws" : nil)  // add async
+            FunctionEffectSpecifiersSyntax(
+              leadingTrivia: .space,
+              asyncSpecifier: .keyword(.async),
+              throwsSpecifier: isResultReturn ? .keyword(.throws) : nil
+            )  // add async
           )
           .with(
             \.returnClause,

--- a/Examples/Sources/MacroExamples/Implementation/AddBlocker.swift
+++ b/Examples/Sources/MacroExamples/Implementation/AddBlocker.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntaxMacros
+import SwiftSyntax
+import SwiftOperators
+import SwiftDiagnostics
+
+/// Implementation of the `addBlocker` macro, which demonstrates how to
+/// produce detailed diagnostics from a macro implementation for an utterly
+/// silly task: warning about every "add" (binary +) in the argument, with a
+/// Fix-It that changes it to a "-".
+public struct AddBlocker: ExpressionMacro {
+  class AddVisitor: SyntaxRewriter {
+    var diagnostics: [Diagnostic] = []
+
+    override func visit(
+      _ node: InfixOperatorExprSyntax
+    ) -> ExprSyntax {
+      // Identify any infix operator + in the tree.
+      if let binOp = node.operator.as(BinaryOperatorExprSyntax.self) {
+        if binOp.operator.text == "+" {
+          // Form the warning
+          let messageID = MessageID(domain: "silly", id: "addblock")
+          diagnostics.append(
+            Diagnostic(
+              // Where the warning should go (on the "+").
+              node: Syntax(node.operator),
+              // The warning message and severity.
+              message: SimpleDiagnosticMessage(
+                message: "blocked an add; did you mean to subtract?",
+                diagnosticID: messageID,
+                severity: .warning
+              ),
+              // Highlight the left and right sides of the `+`.
+              highlights: [
+                Syntax(node.leftOperand),
+                Syntax(node.rightOperand),
+              ],
+              fixIts: [
+                // Fix-It to replace the '+' with a '-'.
+                FixIt(
+                  message: SimpleDiagnosticMessage(
+                    message: "use '-'",
+                    diagnosticID: messageID,
+                    severity: .error
+                  ),
+                  changes: [
+                    FixIt.Change.replace(
+                      oldNode: Syntax(binOp.operator),
+                      newNode: Syntax(
+                        TokenSyntax(
+                          .binaryOperator("-"),
+                          leadingTrivia: binOp.operator.leadingTrivia,
+                          trailingTrivia: binOp.operator.trailingTrivia,
+                          presence: .present
+                        )
+                      )
+                    )
+                  ]
+                )
+              ]
+            )
+          )
+
+          return ExprSyntax(
+            node.with(
+              \.operator,
+              ExprSyntax(
+                binOp.with(
+                  \.operator,
+                  binOp.operator.with(\.tokenKind, .binaryOperator("-"))
+                )
+              )
+            )
+          )
+        }
+      }
+
+      return ExprSyntax(node)
+    }
+  }
+
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    let visitor = AddVisitor()
+    let result = visitor.rewrite(Syntax(node))
+
+    for diag in visitor.diagnostics {
+      context.diagnose(diag)
+    }
+
+    return result.asProtocol(FreestandingMacroExpansionSyntax.self)!.argumentList.first!.expression
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/AddCompletionHandlerMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/AddCompletionHandlerMacro.swift
@@ -125,18 +125,16 @@ public struct AddCompletionHandlerMacro: PeerMacro {
       """
 
     // Drop the @addCompletionHandler attribute from the new declaration.
-    let newAttributeList = AttributeListSyntax(
-      funcDecl.attributes?.filter {
-        guard case let .attribute(attribute) = $0,
-          let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
-          let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
-        else {
-          return true
-        }
+    let newAttributeList = funcDecl.attributes.filter {
+      guard case let .attribute(attribute) = $0,
+        let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
+        let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
+      else {
+        return true
+      }
 
-        return attributeType.name.text != nodeType.name.text
-      } ?? []
-    )
+      return attributeType.name.text != nodeType.name.text
+    }
 
     let newFunc =
       funcDecl

--- a/Examples/Sources/MacroExamples/Implementation/AddCompletionHandlerMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/AddCompletionHandlerMacro.swift
@@ -1,0 +1,172 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct AddCompletionHandlerMacro: PeerMacro {
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+    // Only on functions at the moment. We could handle initializers as well
+    // with a bit of work.
+    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+      throw CustomError.message("@addCompletionHandler only works on functions")
+    }
+
+    // This only makes sense for async functions.
+    if funcDecl.signature.effectSpecifiers?.asyncSpecifier == nil {
+      let newEffects: FunctionEffectSpecifiersSyntax
+      if let existingEffects = funcDecl.signature.effectSpecifiers {
+        newEffects = existingEffects.with(\.asyncSpecifier, "async ")
+      } else {
+        newEffects = FunctionEffectSpecifiersSyntax(asyncSpecifier: "async ")
+      }
+
+      let newSignature = funcDecl.signature.with(\.effectSpecifiers, newEffects)
+      let messageID = MessageID(domain: "MacroExamples", id: "MissingAsync")
+
+      let diag = Diagnostic(
+        // Where the error should go (on the "+").
+        node: Syntax(funcDecl.funcKeyword),
+        // The warning message and severity.
+        message: SimpleDiagnosticMessage(
+          message: "can only add a completion-handler variant to an 'async' function",
+          diagnosticID: messageID,
+          severity: .error
+        ),
+        fixIts: [
+          // Fix-It to replace the '+' with a '-'.
+          FixIt(
+            message: SimpleDiagnosticMessage(
+              message: "add 'async'",
+              diagnosticID: messageID,
+              severity: .error
+            ),
+            changes: [
+              FixIt.Change.replace(
+                oldNode: Syntax(funcDecl.signature),
+                newNode: Syntax(newSignature)
+              )
+            ]
+          )
+        ]
+      )
+
+      context.diagnose(diag)
+      return []
+    }
+
+    // Form the completion handler parameter.
+    let resultType: TypeSyntax? = funcDecl.signature.returnClause?.type.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
+
+    let completionHandlerParam =
+      FunctionParameterSyntax(
+        firstName: .identifier("completionHandler"),
+        colon: .colonToken(trailingTrivia: .space),
+        type: "@escaping (\(resultType ?? "")) -> Void" as TypeSyntax
+      )
+
+    // Add the completion handler parameter to the parameter list.
+    let parameterList = funcDecl.signature.parameterClause.parameters
+    var newParameterList = parameterList
+    if let lastParam = parameterList.last {
+      // We need to add a trailing comma to the preceding list.
+      newParameterList.removeLast()
+      newParameterList += [
+        lastParam.with(
+          \.trailingComma,
+          .commaToken(trailingTrivia: .space)
+        ),
+        completionHandlerParam,
+      ]
+    } else {
+      newParameterList.append(completionHandlerParam)
+    }
+
+    let callArguments: [String] = parameterList.map { param in
+      let argName = param.secondName ?? param.firstName
+
+      let paramName = param.firstName
+      if paramName.text != "_" {
+        return "\(paramName.text): \(argName.text)"
+      }
+
+      return "\(argName.text)"
+    }
+
+    let call: ExprSyntax =
+      "\(funcDecl.name)(\(raw: callArguments.joined(separator: ", ")))"
+
+    // FIXME: We should make CodeBlockSyntax ExpressibleByStringInterpolation,
+    // so that the full body could go here.
+    let newBody: ExprSyntax =
+      """
+
+        Task {
+          completionHandler(await \(call))
+        }
+
+      """
+
+    // Drop the @addCompletionHandler attribute from the new declaration.
+    let newAttributeList = AttributeListSyntax(
+      funcDecl.attributes?.filter {
+        guard case let .attribute(attribute) = $0,
+          let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
+          let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
+        else {
+          return true
+        }
+
+        return attributeType.name.text != nodeType.name.text
+      } ?? []
+    )
+
+    let newFunc =
+      funcDecl
+      .with(
+        \.signature,
+        funcDecl.signature
+          .with(
+            \.effectSpecifiers,
+            funcDecl.signature.effectSpecifiers?.with(\.asyncSpecifier, nil)  // drop async
+          )
+          .with(\.returnClause, nil)  // drop result type
+          .with(
+            \.parameterClause,  // add completion handler parameter
+            funcDecl.signature.parameterClause.with(\.parameters, newParameterList)
+              .with(\.trailingTrivia, [])
+          )
+      )
+      .with(
+        \.body,
+        CodeBlockSyntax(
+          leftBrace: .leftBraceToken(leadingTrivia: .space),
+          statements: CodeBlockItemListSyntax(
+            [CodeBlockItemSyntax(item: .expr(newBody))]
+          ),
+          rightBrace: .rightBraceToken(leadingTrivia: .newline)
+        )
+      )
+      .with(\.attributes, newAttributeList)
+      .with(\.leadingTrivia, .newlines(2))
+
+    return [DeclSyntax(newFunc)]
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/CaseDetectionMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/CaseDetectionMacro.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+extension TokenSyntax {
+  fileprivate var initialUppercased: String {
+    let name = self.text
+    guard let initial = name.first else {
+      return name
+    }
+
+    return "\(initial.uppercased())\(name.dropFirst())"
+  }
+}
+
+public struct CaseDetectionMacro: MemberMacro {
+  public static func expansion<
+    Declaration: DeclGroupSyntax,
+    Context: MacroExpansionContext
+  >(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+    declaration.memberBlock.members
+      .compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }
+      .map { $0.elements.first!.name }
+      .map { ($0, $0.initialUppercased) }
+      .map { original, uppercased in
+        """
+        var is\(raw: uppercased): Bool {
+          if case .\(raw: original) = self {
+            return true
+          }
+
+          return false
+        }
+        """
+      }
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/CodableKey.swift
+++ b/Examples/Sources/MacroExamples/Implementation/CodableKey.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct CodableKey: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // Does nothing, used only to decorate members with data
+    return []
+  }
+
+}

--- a/Examples/Sources/MacroExamples/Implementation/CodableKey.swift
+++ b/Examples/Sources/MacroExamples/Implementation/CodableKey.swift
@@ -13,14 +13,13 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-public struct CodableKey: MemberMacro {
+public struct CodableKey: PeerMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    providingMembersOf declaration: some DeclGroupSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     // Does nothing, used only to decorate members with data
     return []
   }
-
 }

--- a/Examples/Sources/MacroExamples/Implementation/CustomCodable.swift
+++ b/Examples/Sources/MacroExamples/Implementation/CustomCodable.swift
@@ -32,7 +32,7 @@ public struct CustomCodable: MemberMacro {
       }
 
       // if it has a CodableKey macro on it
-      if let customKeyMacro = member.decl.as(VariableDeclSyntax.self)?.attributes?.first(where: { element in
+      if let customKeyMacro = member.decl.as(VariableDeclSyntax.self)?.attributes.first(where: { element in
         element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "CodableKey"
       }) {
 

--- a/Examples/Sources/MacroExamples/Implementation/CustomCodable.swift
+++ b/Examples/Sources/MacroExamples/Implementation/CustomCodable.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct CustomCodable: MemberMacro {
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+
+    let memberList = declaration.memberBlock.members
+
+    let cases = memberList.compactMap({ member -> String? in
+      // is a property
+      guard
+        let propertyName = member.decl.as(VariableDeclSyntax.self)?.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+      else {
+        return nil
+      }
+
+      // if it has a CodableKey macro on it
+      if let customKeyMacro = member.decl.as(VariableDeclSyntax.self)?.attributes?.first(where: { element in
+        element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description == "CodableKey"
+      }) {
+
+        // Uses the value in the Macro
+        let customKeyValue = customKeyMacro.as(AttributeSyntax.self)!.arguments!.as(LabeledExprListSyntax.self)!.first!.expression
+
+        return "case \(propertyName) = \(customKeyValue)"
+      } else {
+        return "case \(propertyName)"
+      }
+    })
+
+    let codingKeys: DeclSyntax = """
+
+        enum CodingKeys: String, CodingKey {
+          \(raw: cases.joined(separator: "\n"))
+        }
+
+      """
+
+    return [
+      codingKeys
+    ]
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/Diagnostics.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Diagnostics.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftDiagnostics
+
+struct SimpleDiagnosticMessage: DiagnosticMessage, Error {
+  let message: String
+  let diagnosticID: MessageID
+  let severity: DiagnosticSeverity
+}
+
+extension SimpleDiagnosticMessage: FixItMessage {
+  var fixItID: MessageID { diagnosticID }
+}
+
+enum CustomError: Error, CustomStringConvertible {
+  case message(String)
+
+  var description: String {
+    switch self {
+    case .message(let text):
+      return text
+    }
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/DictionaryIndirectionMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/DictionaryIndirectionMacro.swift
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct DictionaryStorageMacro {}
+
+extension DictionaryStorageMacro: AccessorMacro {
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: Declaration,
+    in context: Context
+  ) throws -> [AccessorDeclSyntax] {
+    guard let varDecl = declaration.as(VariableDeclSyntax.self),
+      let binding = varDecl.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      binding.accessorBlock == nil,
+      let type = binding.typeAnnotation?.type
+    else {
+      return []
+    }
+
+    // Ignore the "_storage" variable.
+    if identifier.text == "_storage" {
+      return []
+    }
+
+    guard let defaultValue = binding.initializer?.value else {
+      throw CustomError.message("stored property must have an initializer")
+    }
+
+    return [
+      """
+
+        get {
+          _storage[\(literal: identifier.text), default: \(defaultValue)] as! \(type)
+        }
+      """,
+      """
+
+        set {
+            _storage[\(literal: identifier.text)] = newValue
+        }
+      """,
+    ]
+  }
+}
+
+extension DictionaryStorageMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let storage: DeclSyntax = "var _storage: [String: Any] = [:]"
+    return [
+      storage.with(\.leadingTrivia, [.newlines(1), .spaces(2)])
+    ]
+  }
+}
+
+extension DictionaryStorageMacro: MemberAttributeMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    guard let property = member.as(VariableDeclSyntax.self),
+      property.isStoredProperty
+    else {
+      return []
+    }
+
+    return [
+      AttributeSyntax(
+        attributeName: IdentifierTypeSyntax(
+          name: .identifier("DictionaryStorage")
+        )
+      )
+      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
+    ]
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/DictionaryIndirectionMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/DictionaryIndirectionMacro.swift
@@ -15,7 +15,44 @@ import SwiftSyntaxMacros
 
 public struct DictionaryStorageMacro {}
 
-extension DictionaryStorageMacro: AccessorMacro {
+extension DictionaryStorageMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let storage: DeclSyntax = "var _storage: [String: Any] = [:]"
+    return [
+      storage.with(\.leadingTrivia, [.newlines(1), .spaces(2)])
+    ]
+  }
+}
+
+extension DictionaryStorageMacro: MemberAttributeMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    guard let property = member.as(VariableDeclSyntax.self),
+      property.isStoredProperty
+    else {
+      return []
+    }
+
+    return [
+      AttributeSyntax(
+        attributeName: IdentifierTypeSyntax(
+          name: .identifier("DictionaryStorageProperty")
+        )
+      )
+      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
+    ]
+  }
+}
+
+public struct DictionaryStoragePropertyMacro: AccessorMacro {
   public static func expansion<
     Context: MacroExpansionContext,
     Declaration: DeclSyntaxProtocol
@@ -55,43 +92,6 @@ extension DictionaryStorageMacro: AccessorMacro {
             _storage[\(literal: identifier.text)] = newValue
         }
       """,
-    ]
-  }
-}
-
-extension DictionaryStorageMacro: MemberMacro {
-  public static func expansion(
-    of node: AttributeSyntax,
-    providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
-  ) throws -> [DeclSyntax] {
-    let storage: DeclSyntax = "var _storage: [String: Any] = [:]"
-    return [
-      storage.with(\.leadingTrivia, [.newlines(1), .spaces(2)])
-    ]
-  }
-}
-
-extension DictionaryStorageMacro: MemberAttributeMacro {
-  public static func expansion(
-    of node: AttributeSyntax,
-    attachedTo declaration: some DeclGroupSyntax,
-    providingAttributesFor member: some DeclSyntaxProtocol,
-    in context: some MacroExpansionContext
-  ) throws -> [AttributeSyntax] {
-    guard let property = member.as(VariableDeclSyntax.self),
-      property.isStoredProperty
-    else {
-      return []
-    }
-
-    return [
-      AttributeSyntax(
-        attributeName: IdentifierTypeSyntax(
-          name: .identifier("DictionaryStorage")
-        )
-      )
-      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }

--- a/Examples/Sources/MacroExamples/Implementation/FontLiteralMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/FontLiteralMacro.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Implementation of the `#fontLiteral` macro, which is similar in spirit
+/// to the built-in expressions `#colorLiteral`, `#imageLiteral`, etc., but in
+/// a small macro.
+public struct FontLiteralMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    let argList = replaceFirstLabel(
+      of: macro.argumentList,
+      with: "fontLiteralName"
+    )
+    return ".init(\(argList))"
+  }
+}
+
+/// Replace the label of the first element in the tuple with the given
+/// new label.
+private func replaceFirstLabel(
+  of tuple: LabeledExprListSyntax,
+  with newLabel: String
+) -> LabeledExprListSyntax {
+  guard let firstElement = tuple.first else {
+    return tuple
+  }
+
+  var tuple = tuple
+  tuple[tuple.startIndex] = firstElement.with(\.label, .identifier(newLabel))
+  return tuple
+}

--- a/Examples/Sources/MacroExamples/Implementation/MetaEnumMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/MetaEnumMacro.swift
@@ -30,7 +30,7 @@ public struct MetaEnumMacro {
 
     parentTypeName = enumDecl.name.with(\.trailingTrivia, [])
 
-    access = enumDecl.modifiers?.first(where: \.isNeededAccessLevelModifier)
+    access = enumDecl.modifiers.first(where: \.isNeededAccessLevelModifier)
 
     childCases = enumDecl.caseElements.map { parentCase in
       parentCase.with(\.parameterClause, nil)

--- a/Examples/Sources/MacroExamples/Implementation/MetaEnumMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/MetaEnumMacro.swift
@@ -1,0 +1,152 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxBuilder
+
+public struct MetaEnumMacro {
+  let parentTypeName: TokenSyntax
+  let childCases: [EnumCaseElementSyntax]
+  let access: DeclModifierListSyntax.Element?
+  let parentParamName: TokenSyntax
+
+  init(node: AttributeSyntax, declaration: some DeclGroupSyntax, context: some MacroExpansionContext) throws {
+    guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+      throw DiagnosticsError(diagnostics: [
+        CaseMacroDiagnostic.notAnEnum(declaration).diagnose(at: Syntax(node))
+      ])
+    }
+
+    parentTypeName = enumDecl.name.with(\.trailingTrivia, [])
+
+    access = enumDecl.modifiers?.first(where: \.isNeededAccessLevelModifier)
+
+    childCases = enumDecl.caseElements.map { parentCase in
+      parentCase.with(\.parameterClause, nil)
+    }
+
+    parentParamName = context.makeUniqueName("parent")
+  }
+
+  func makeMetaEnum() -> DeclSyntax {
+    // FIXME: Why does this need to be a string to make trailing trivia work properly?
+    let caseDecls = childCases.map { childCase in
+      "    case \(childCase.name)"
+    }.joined(separator: "\n")
+
+    return """
+
+        \(access)enum Meta {
+      \(raw: caseDecls)
+      \(makeMetaInit())
+        }
+
+      """
+  }
+
+  func makeMetaInit() -> DeclSyntax {
+    // FIXME: Why does this need to be a string to make trailing trivia work properly?
+    let caseStatements = childCases.map { childCase in
+      """
+            case .\(childCase.name):
+              self = .\(childCase.name)
+      """
+    }.joined(separator: "\n")
+
+    return """
+
+          \(access)init(_ \(parentParamName): \(parentTypeName)) {
+            switch \(parentParamName) {
+      \(raw: caseStatements)
+            }
+          }
+      """
+  }
+}
+
+extension MetaEnumMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let macro = try MetaEnumMacro(node: node, declaration: declaration, context: context)
+
+    return [macro.makeMetaEnum()]
+  }
+}
+
+extension EnumDeclSyntax {
+  var caseElements: [EnumCaseElementSyntax] {
+    memberBlock.members.flatMap { member in
+      guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+        return Array<EnumCaseElementSyntax>()
+      }
+
+      return Array(caseDecl.elements)
+    }
+  }
+}
+
+enum CaseMacroDiagnostic {
+  case notAnEnum(DeclGroupSyntax)
+}
+
+extension CaseMacroDiagnostic: DiagnosticMessage {
+  var message: String {
+    switch self {
+    case .notAnEnum(let decl):
+      return "'@MetaEnum' can only be attached to an enum, not \(decl.descriptiveDeclKind(withArticle: true))"
+    }
+  }
+
+  var diagnosticID: MessageID {
+    switch self {
+    case .notAnEnum:
+      return MessageID(domain: "MetaEnumDiagnostic", id: "notAnEnum")
+    }
+  }
+
+  var severity: DiagnosticSeverity {
+    switch self {
+    case .notAnEnum:
+      return .error
+    }
+  }
+
+  func diagnose(at node: Syntax) -> Diagnostic {
+    Diagnostic(node: node, message: self)
+  }
+}
+
+extension DeclGroupSyntax {
+  func descriptiveDeclKind(withArticle article: Bool = false) -> String {
+    switch self {
+    case is ActorDeclSyntax:
+      return article ? "an actor" : "actor"
+    case is ClassDeclSyntax:
+      return article ? "a class" : "class"
+    case is ExtensionDeclSyntax:
+      return article ? "an extension" : "extension"
+    case is ProtocolDeclSyntax:
+      return article ? "a protocol" : "protocol"
+    case is StructDeclSyntax:
+      return article ? "a struct" : "struct"
+    case is EnumDeclSyntax:
+      return article ? "an enum" : "enum"
+    default:
+      fatalError("Unknown DeclGroupSyntax")
+    }
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/NewTypeMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/NewTypeMacro.swift
@@ -37,7 +37,7 @@ extension NewTypeMacro: MemberMacro {
         throw CustomError.message("@NewType can only be applied to a struct declarations.")
       }
 
-      let access = declaration.modifiers?.first(where: \.isNeededAccessLevelModifier)
+      let access = declaration.modifiers.first(where: \.isNeededAccessLevelModifier)
 
       return [
         "\(access)typealias RawValue = \(rawType)",

--- a/Examples/Sources/MacroExamples/Implementation/NewTypeMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/NewTypeMacro.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public enum NewTypeMacro {}
+
+extension NewTypeMacro: MemberMacro {
+  public static func expansion<Declaration, Context>(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] where Declaration: DeclGroupSyntax, Context: MacroExpansionContext {
+    do {
+      guard
+        case .argumentList(let arguments) = node.arguments,
+        arguments.count == 1,
+        let memberAccessExn = arguments.first?
+          .expression.as(MemberAccessExprSyntax.self),
+        let rawType = memberAccessExn.base?.as(DeclReferenceExprSyntax.self)
+      else {
+        throw CustomError.message(#"@NewType requires the raw type as an argument, in the form "RawType.self"."#)
+      }
+
+      guard let declaration = declaration.as(StructDeclSyntax.self) else {
+        throw CustomError.message("@NewType can only be applied to a struct declarations.")
+      }
+
+      let access = declaration.modifiers?.first(where: \.isNeededAccessLevelModifier)
+
+      return [
+        "\(access)typealias RawValue = \(rawType)",
+        "\(access)var rawValue: RawValue",
+        "\(access)init(_ rawValue: RawValue) { self.rawValue = rawValue }",
+      ]
+    } catch {
+      print("--------------- throwing \(error)")
+      throw error
+    }
+  }
+}
+
+extension DeclModifierSyntax {
+  var isNeededAccessLevelModifier: Bool {
+    switch self.name.tokenKind {
+    case .keyword(.public): return true
+    default: return false
+    }
+  }
+}
+
+extension SyntaxStringInterpolation {
+  // It would be nice for SwiftSyntaxBuilder to provide this out-of-the-box.
+  mutating func appendInterpolation<Node: SyntaxProtocol>(_ node: Node?) {
+    if let node {
+      appendInterpolation(node)
+    }
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/ObservableMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/ObservableMacro.swift
@@ -120,13 +120,15 @@ public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
 
 }
 
-extension ObservableMacro: ConformanceMacro {
-  public static func expansion<Declaration, Context>(
+extension ObservableMacro: ExtensionMacro {
+  public static func expansion(
     of node: AttributeSyntax,
-    providingConformancesOf declaration: Declaration,
-    in context: Context
-  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] where Declaration: DeclGroupSyntax, Context: MacroExpansionContext {
-    return [("Observable", nil)]
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    [try ExtensionDeclSyntax("extension \(type): Observable {}")]
   }
 }
 

--- a/Examples/Sources/MacroExamples/Implementation/ObservableMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/ObservableMacro.swift
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+private extension DeclSyntaxProtocol {
+  var isObservableStoredProperty: Bool {
+    if let property = self.as(VariableDeclSyntax.self),
+      let binding = property.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      identifier.text != "_registrar", identifier.text != "_storage",
+      binding.accessorBlock == nil
+    {
+      return true
+    }
+
+    return false
+  }
+}
+
+public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
+
+  // MARK: - MemberMacro
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let identified = declaration.asProtocol(NamedDeclSyntax.self) else {
+      return []
+    }
+
+    let parentName = identified.name
+
+    let registrar: DeclSyntax =
+      """
+      let _registrar = ObservationRegistrar<\(parentName)>()
+      """
+
+    let addObserver: DeclSyntax =
+      """
+      public nonisolated func addObserver(_ observer: some Observer<\(parentName)>) {
+        _registrar.addObserver(observer)
+      }
+      """
+
+    let removeObserver: DeclSyntax =
+      """
+      public nonisolated func removeObserver(_ observer: some Observer<\(parentName)>) {
+        _registrar.removeObserver(observer)
+      }
+      """
+
+    let withTransaction: DeclSyntax =
+      """
+      private func withTransaction<T>(_ apply: () throws -> T) rethrows -> T {
+        _registrar.beginAccess()
+        defer { _registrar.endAccess() }
+        return try apply()
+      }
+      """
+
+    let memberList = declaration.memberBlock.members.filter {
+      $0.decl.isObservableStoredProperty
+    }
+
+    let storageStruct: DeclSyntax =
+      """
+      private struct Storage {
+      \(memberList)
+      }
+      """
+
+    let storage: DeclSyntax =
+      """
+      private var _storage = Storage()
+      """
+
+    return [
+      registrar,
+      addObserver,
+      removeObserver,
+      withTransaction,
+      storageStruct,
+      storage,
+    ]
+  }
+
+  // MARK: - MemberAttributeMacro
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [SwiftSyntax.AttributeSyntax] {
+    guard member.isObservableStoredProperty else {
+      return []
+    }
+
+    return [
+      AttributeSyntax(
+        attributeName: IdentifierTypeSyntax(
+          name: .identifier("ObservableProperty")
+        )
+      )
+    ]
+  }
+
+}
+
+extension ObservableMacro: ConformanceMacro {
+  public static func expansion<Declaration, Context>(
+    of node: AttributeSyntax,
+    providingConformancesOf declaration: Declaration,
+    in context: Context
+  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] where Declaration: DeclGroupSyntax, Context: MacroExpansionContext {
+    return [("Observable", nil)]
+  }
+}
+
+public struct ObservablePropertyMacro: AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    guard let property = declaration.as(VariableDeclSyntax.self),
+      let binding = property.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      binding.accessorBlock == nil
+    else {
+      return []
+    }
+
+    let getAccessor: AccessorDeclSyntax =
+      """
+      get {
+        _registrar.beginAccess(\\.\(identifier))
+        defer { _registrar.endAccess() }
+        return _storage.\(identifier)
+      }
+      """
+
+    let setAccessor: AccessorDeclSyntax =
+      """
+      set {
+        _registrar.beginAccess(\\.\(identifier))
+        _registrar.register(observable: self, willSet: \\.\(identifier), to: newValue)
+        defer {
+          _registrar.register(observable: self, didSet: \\.\(identifier))
+          _registrar.endAccess()
+        }
+        _storage.\(identifier) = newValue
+      }
+      """
+
+    return [getAccessor, setAccessor]
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/OptionSetMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/OptionSetMacro.swift
@@ -1,0 +1,196 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+enum OptionSetMacroDiagnostic {
+  case requiresStruct
+  case requiresStringLiteral(String)
+  case requiresOptionsEnum(String)
+  case requiresOptionsEnumRawType
+}
+
+extension OptionSetMacroDiagnostic: DiagnosticMessage {
+  func diagnose(at node: some SyntaxProtocol) -> Diagnostic {
+    Diagnostic(node: Syntax(node), message: self)
+  }
+
+  var message: String {
+    switch self {
+    case .requiresStruct:
+      return "'OptionSet' macro can only be applied to a struct"
+
+    case .requiresStringLiteral(let name):
+      return "'OptionSet' macro argument \(name) must be a string literal"
+
+    case .requiresOptionsEnum(let name):
+      return "'OptionSet' macro requires nested options enum '\(name)'"
+
+    case .requiresOptionsEnumRawType:
+      return "'OptionSet' macro requires a raw type"
+    }
+  }
+
+  var severity: DiagnosticSeverity { .error }
+
+  var diagnosticID: MessageID {
+    MessageID(domain: "Swift", id: "OptionSet.\(self)")
+  }
+}
+
+/// The label used for the OptionSet macro argument that provides the name of
+/// the nested options enum.
+private let optionsEnumNameArgumentLabel = "optionsName"
+
+/// The default name used for the nested "Options" enum. This should
+/// eventually be overridable.
+private let defaultOptionsEnumName = "Options"
+
+extension LabeledExprListSyntax {
+  /// Retrieve the first element with the given label.
+  func first(labeled name: String) -> Element? {
+    return first { element in
+      if let label = element.label, label.text == name {
+        return true
+      }
+
+      return false
+    }
+  }
+}
+
+public struct OptionSetMacro {
+  /// Decodes the arguments to the macro expansion.
+  ///
+  /// - Returns: the important arguments used by the various roles of this
+  /// macro inhabits, or nil if an error occurred.
+  static func decodeExpansion(
+    of attribute: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) -> (StructDeclSyntax, EnumDeclSyntax, TypeSyntax)? {
+    // Determine the name of the options enum.
+    let optionsEnumName: String
+    if case let .argumentList(arguments) = attribute.arguments,
+      let optionEnumNameArg = arguments.first(labeled: optionsEnumNameArgumentLabel)
+    {
+      // We have a options name; make sure it is a string literal.
+      guard let stringLiteral = optionEnumNameArg.expression.as(StringLiteralExprSyntax.self),
+        stringLiteral.segments.count == 1,
+        case let .stringSegment(optionsEnumNameString)? = stringLiteral.segments.first
+      else {
+        context.diagnose(OptionSetMacroDiagnostic.requiresStringLiteral(optionsEnumNameArgumentLabel).diagnose(at: optionEnumNameArg.expression))
+        return nil
+      }
+
+      optionsEnumName = optionsEnumNameString.content.text
+    } else {
+      optionsEnumName = defaultOptionsEnumName
+    }
+
+    // Only apply to structs.
+    guard let structDecl = decl.as(StructDeclSyntax.self) else {
+      context.diagnose(OptionSetMacroDiagnostic.requiresStruct.diagnose(at: decl))
+      return nil
+    }
+
+    // Find the option enum within the struct.
+    guard
+      let optionsEnum = decl.memberBlock.members.compactMap({ member in
+        if let enumDecl = member.decl.as(EnumDeclSyntax.self),
+          enumDecl.name.text == optionsEnumName
+        {
+          return enumDecl
+        }
+
+        return nil
+      }).first
+    else {
+      context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnum(optionsEnumName).diagnose(at: decl))
+      return nil
+    }
+
+    // Retrieve the raw type from the attribute.
+    guard let genericArgs = attribute.attributeName.as(IdentifierTypeSyntax.self)?.genericArgumentClause,
+      let rawType = genericArgs.arguments.first?.argument
+    else {
+      context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnumRawType.diagnose(at: attribute))
+      return nil
+    }
+
+    return (structDecl, optionsEnum, rawType)
+  }
+}
+
+extension OptionSetMacro: ConformanceMacro {
+  public static func expansion(
+    of attribute: AttributeSyntax,
+    providingConformancesOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
+    // Decode the expansion arguments.
+    guard let (structDecl, _, _) = decodeExpansion(of: attribute, attachedTo: decl, in: context) else {
+      return []
+    }
+
+    // If there is an explicit conformance to OptionSet already, don't add one.
+    if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypes,
+      inheritedTypes.contains(where: { inherited in inherited.type.trimmedDescription == "OptionSet" })
+    {
+      return []
+    }
+
+    return [("OptionSet", nil)]
+  }
+}
+
+extension OptionSetMacro: MemberMacro {
+  public static func expansion(
+    of attribute: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // Decode the expansion arguments.
+    guard let (_, optionsEnum, rawType) = decodeExpansion(of: attribute, attachedTo: decl, in: context) else {
+      return []
+    }
+
+    // Find all of the case elements.
+    let caseElements = optionsEnum.memberBlock.members.flatMap { member in
+      guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+        return Array<EnumCaseElementSyntax>()
+      }
+
+      return Array(caseDecl.elements)
+    }
+
+    // Dig out the access control keyword we need.
+    let access = decl.modifiers?.first(where: \.isNeededAccessLevelModifier)
+
+    let staticVars = caseElements.map { (element) -> DeclSyntax in
+      """
+      \(access) static let \(element.name): Self =
+        Self(rawValue: 1 << \(optionsEnum.name).\(element.name).rawValue)
+      """
+    }
+
+    return [
+      "\(access)typealias RawValue = \(rawType)",
+      "\(access)var rawValue: RawValue",
+      "\(access)init() { self.rawValue = 0 }",
+      "\(access)init(rawValue: RawValue) { self.rawValue = rawValue }",
+    ] + staticVars
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/OptionSetMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/OptionSetMacro.swift
@@ -134,14 +134,16 @@ public struct OptionSetMacro {
   }
 }
 
-extension OptionSetMacro: ConformanceMacro {
+extension OptionSetMacro: ExtensionMacro {
   public static func expansion(
-    of attribute: AttributeSyntax,
-    providingConformancesOf decl: some DeclGroupSyntax,
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
-  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
+  ) throws -> [ExtensionDeclSyntax] {
     // Decode the expansion arguments.
-    guard let (structDecl, _, _) = decodeExpansion(of: attribute, attachedTo: decl, in: context) else {
+    guard let (structDecl, _, _) = decodeExpansion(of: node, attachedTo: declaration, in: context) else {
       return []
     }
 
@@ -152,7 +154,7 @@ extension OptionSetMacro: ConformanceMacro {
       return []
     }
 
-    return [("OptionSet", nil)]
+    return [try ExtensionDeclSyntax("extension \(type): OptionSet {}")]
   }
 }
 
@@ -177,7 +179,7 @@ extension OptionSetMacro: MemberMacro {
     }
 
     // Dig out the access control keyword we need.
-    let access = decl.modifiers?.first(where: \.isNeededAccessLevelModifier)
+    let access = decl.modifiers.first(where: \.isNeededAccessLevelModifier)
 
     let staticVars = caseElements.map { (element) -> DeclSyntax in
       """

--- a/Examples/Sources/MacroExamples/Implementation/Plugin.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Plugin.swift
@@ -23,6 +23,7 @@ struct MyPlugin: CompilerPlugin {
     FontLiteralMacro.self,
     WrapStoredPropertiesMacro.self,
     DictionaryStorageMacro.self,
+    DictionaryStoragePropertyMacro.self,
     ObservableMacro.self,
     ObservablePropertyMacro.self,
     AddCompletionHandlerMacro.self,

--- a/Examples/Sources/MacroExamples/Implementation/Plugin.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Plugin.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(SwiftCompilerPlugin)
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct MyPlugin: CompilerPlugin {
+  let providingMacros: [Macro.Type] = [
+    StringifyMacro.self,
+    AddBlocker.self,
+    WarningMacro.self,
+    FontLiteralMacro.self,
+    WrapStoredPropertiesMacro.self,
+    DictionaryStorageMacro.self,
+    ObservableMacro.self,
+    ObservablePropertyMacro.self,
+    AddCompletionHandlerMacro.self,
+    AddAsyncMacro.self,
+    CaseDetectionMacro.self,
+    MetaEnumMacro.self,
+    CodableKey.self,
+    CustomCodable.self,
+    OptionSetMacro.self,
+    NewTypeMacro.self,
+    URLMacro.self,
+  ]
+}
+#endif

--- a/Examples/Sources/MacroExamples/Implementation/StringifyMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/StringifyMacro.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Implementation of the `stringify` macro, which takes an expression
+/// of any type and produces a tuple containing the value of that expression
+/// and the source code that produced the value. For example
+///
+///     #stringify(x + y)
+///
+///  will expand to
+///
+///     (x + y, "x + y")
+public struct StringifyMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = node.argumentList.first?.expression else {
+      fatalError("compiler bug: the macro does not have any arguments")
+    }
+
+    return "(\(argument), \(literal: argument.description))"
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/URLMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/URLMacro.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Creates a non-optional URL from a static string. The string is checked to
+/// be valid during compile time.
+public struct URLMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+
+    guard let argument = node.argumentList.first?.expression,
+      let segments = argument.as(StringLiteralExprSyntax.self)?.segments,
+      segments.count == 1,
+      case .stringSegment(let literalSegment)? = segments.first
+    else {
+      throw CustomError.message("#URL requires a static string literal")
+    }
+
+    guard let _ = URL(string: literalSegment.content.text) else {
+      throw CustomError.message("malformed url: \(argument)")
+    }
+
+    return "URL(string: \(argument))!"
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/WarningMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/WarningMacro.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Implementation of the `myWarning` macro, which mimics the behavior of the
+/// built-in `#warning`.
+public struct WarningMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    guard let firstElement = macro.argumentList.first,
+      let stringLiteral = firstElement.expression
+        .as(StringLiteralExprSyntax.self),
+      stringLiteral.segments.count == 1,
+      case let .stringSegment(messageString)? = stringLiteral.segments.first
+    else {
+      throw CustomError.message("#myWarning macro requires a string literal")
+    }
+
+    context.diagnose(
+      Diagnostic(
+        node: Syntax(macro),
+        message: SimpleDiagnosticMessage(
+          message: messageString.content.description,
+          diagnosticID: MessageID(domain: "test", id: "error"),
+          severity: .warning
+        )
+      )
+    )
+
+    return "()"
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/WrapStoredPropertiesMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/WrapStoredPropertiesMacro.swift
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Implementation of the `wrapStoredProperties` macro, which can be
+/// used to apply an attribute to all of the stored properties of a type.
+///
+/// This macro demonstrates member-attribute macros, which allow an attribute
+/// written on a type or extension to apply attributes to the members
+/// declared within that type or extension.
+public struct WrapStoredPropertiesMacro: MemberAttributeMacro {
+  public static func expansion<
+    Declaration: DeclGroupSyntax,
+    Context: MacroExpansionContext
+  >(
+    of node: AttributeSyntax,
+    attachedTo decl: Declaration,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: Context
+  ) throws -> [AttributeSyntax] {
+    guard let property = member.as(VariableDeclSyntax.self),
+      property.isStoredProperty
+    else {
+      return []
+    }
+
+    guard case let .argumentList(arguments) = node.arguments,
+      let firstElement = arguments.first,
+      let stringLiteral = firstElement.expression
+        .as(StringLiteralExprSyntax.self),
+      stringLiteral.segments.count == 1,
+      case let .stringSegment(wrapperName)? = stringLiteral.segments.first
+    else {
+      throw CustomError.message("macro requires a string literal containing the name of an attribute")
+    }
+
+    return [
+      AttributeSyntax(
+        attributeName: IdentifierTypeSyntax(
+          name: .identifier(wrapperName.content.text)
+        )
+      )
+      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
+    ]
+  }
+}
+
+extension VariableDeclSyntax {
+  /// Determine whether this variable has the syntax of a stored property.
+  ///
+  /// This syntactic check cannot account for semantic adjustments due to,
+  /// e.g., accessor macros or property wrappers.
+  var isStoredProperty: Bool {
+    if bindings.count != 1 {
+      return false
+    }
+
+    let binding = bindings.first!
+    switch binding.accessorBlock?.accessors {
+    case .none:
+      return true
+
+    case .accessors(let accessors):
+      for accessor in accessors {
+        switch accessor.accessorSpecifier.tokenKind {
+        case .keyword(.willSet), .keyword(.didSet):
+          // Observers can occur on a stored property.
+          break
+
+        default:
+          // Other accessors make it a computed property.
+          return false
+        }
+      }
+
+      return true
+
+    case .getter:
+      return false
+    }
+  }
+}
+
+extension DeclGroupSyntax {
+  /// Enumerate the stored properties that syntactically occur in this
+  /// declaration.
+  func storedProperties() -> [VariableDeclSyntax] {
+    return memberBlock.members.compactMap { member in
+      guard let variable = member.decl.as(VariableDeclSyntax.self),
+        variable.isStoredProperty
+      else {
+        return nil
+      }
+
+      return variable
+    }
+  }
+}

--- a/Examples/Sources/MacroExamples/Interface/Macros.swift
+++ b/Examples/Sources/MacroExamples/Interface/Macros.swift
@@ -1,0 +1,161 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// "Stringify" the provided value and produce a tuple that includes both the
+/// original value as well as the source code that generated it.
+@freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroExamplesImplementation", type: "StringifyMacro")
+
+/// Macro that produces a warning on "+" operators within the expression, and
+/// suggests changing them to "-".
+@freestanding(expression) public macro addBlocker<T>(_ value: T) -> T = #externalMacro(module: "MacroExamplesImplementation", type: "AddBlocker")
+
+/// Macro that produces a warning, as a replacement for the built-in
+/// #warning("...").
+@freestanding(expression) public macro myWarning(_ message: String) = #externalMacro(module: "MacroExamplesImplementation", type: "WarningMacro")
+
+public enum FontWeight {
+  case thin
+  case normal
+  case medium
+  case semiBold
+  case bold
+}
+
+public protocol ExpressibleByFontLiteral {
+  init(fontLiteralName: String, size: Int, weight: FontWeight)
+}
+
+/// Font literal similar to, e.g., #colorLiteral.
+@freestanding(expression) public macro fontLiteral<T>(name: String, size: Int, weight: FontWeight) -> T =
+  #externalMacro(module: "MacroExamplesImplementation", type: "FontLiteralMacro")
+where T: ExpressibleByFontLiteral
+
+/// Check if provided string literal is a valid URL and produce a non-optional
+/// URL value. Emit error otherwise.
+@freestanding(expression) public macro URL(_ stringLiteral: String) -> URL = #externalMacro(module: "MacroExamplesImplementation", type: "URLMacro")
+
+/// Apply the specified attribute to each of the stored properties within the
+/// type or member to which the macro is attached. The string can be
+/// any attribute (without the `@`).
+@attached(memberAttribute)
+public macro wrapStoredProperties(_ attributeName: String) = #externalMacro(module: "MacroExamplesImplementation", type: "WrapStoredPropertiesMacro")
+
+/// Wrap up the stored properties of the given type in a dictionary,
+/// turning them into computed properties.
+///
+/// This macro composes three different kinds of macro expansion:
+///   * Member-attribute macro expansion, to put itself on all stored properties
+///     of the type it is attached to.
+///   * Member macro expansion, to add a `_storage` property with the actual
+///     dictionary.
+///   * Accessor macro expansion, to turn the stored properties into computed
+///     properties that look for values in the `_storage` property.
+@attached(accessor)
+@attached(member, names: named(_storage))
+@attached(memberAttribute)
+public macro DictionaryStorage() = #externalMacro(module: "MacroExamplesImplementation", type: "DictionaryStorageMacro")
+
+public protocol Observable {}
+
+public protocol Observer<Subject> {
+  associatedtype Subject: Observable
+}
+
+public struct ObservationRegistrar<Subject: Observable> {
+  public init() {}
+
+  public func addObserver(_ observer: some Observer<Subject>) {}
+
+  public func removeObserver(_ observer: some Observer<Subject>) {}
+
+  public func beginAccess<Value>(_ keyPath: KeyPath<Subject, Value>) {
+    print("beginning access for \(keyPath)")
+  }
+
+  public func beginAccess() {
+    print("beginning access in \(Subject.self)")
+  }
+
+  public func endAccess() {
+    print("ending access in \(Subject.self)")
+  }
+
+  public func register<Value>(observable: Subject, willSet: KeyPath<Subject, Value>, to: Value) {
+    print("registering willSet event for \(willSet)")
+  }
+
+  public func register<Value>(observable: Subject, didSet: KeyPath<Subject, Value>) {
+    print("registering didSet event for \(didSet)")
+  }
+}
+
+@attached(member, names: named(Storage), named(_storage), named(_registrar), named(addObserver), named(removeObserver), named(withTransaction))
+@attached(memberAttribute)
+@attached(conformance)
+public macro Observable() = #externalMacro(module: "MacroExamplesImplementation", type: "ObservableMacro")
+
+@attached(accessor)
+public macro ObservableProperty() = #externalMacro(module: "MacroExamplesImplementation", type: "ObservablePropertyMacro")
+
+/// Adds a "completionHandler" variant of an async function, which creates a new
+/// task , calls thh original async function, and delivers its result to the completion
+/// handler.
+@attached(peer, names: overloaded)
+public macro AddCompletionHandler() =
+  #externalMacro(module: "MacroExamplesImplementation", type: "AddCompletionHandlerMacro")
+
+@attached(peer, names: overloaded)
+public macro AddAsync() =
+  #externalMacro(module: "MacroExamplesImplementation", type: "AddAsyncMacro")
+
+/// Add computed properties named `is<Case>` for each case element in the enum.
+@attached(member, names: arbitrary)
+public macro CaseDetection() = #externalMacro(module: "MacroExamplesImplementation", type: "CaseDetectionMacro")
+
+@attached(member, names: named(Meta))
+public macro MetaEnum() = #externalMacro(module: "MacroExamplesImplementation", type: "MetaEnumMacro")
+
+@attached(member)
+public macro CodableKey(name: String) = #externalMacro(module: "MacroExamplesImplementation", type: "CodableKey")
+
+@attached(member, names: named(CodingKeys))
+public macro CustomCodable() = #externalMacro(module: "MacroExamplesImplementation", type: "CustomCodable")
+
+/// Create an option set from a struct that contains a nested `Options` enum.
+///
+/// Attach this macro to a struct that contains a nested `Options` enum
+/// with an integer raw value. The struct will be transformed to conform to
+/// `OptionSet` by
+///   1. Introducing a `rawValue` stored property to track which options are set,
+///    along with the necessary `RawType` typealias and initializers to satisfy
+///    the `OptionSet` protocol.
+///   2. Introducing static properties for each of the cases within the `Options`
+///    enum, of the type of the struct.
+///
+/// The `Options` enum must have a raw value, where its case elements
+/// each indicate a different option in the resulting option set. For example,
+/// the struct and its nested `Options` enum could look like this:
+///
+///     @MyOptionSet
+///     struct ShippingOptions {
+///       private enum Options: Int {
+///         case nextDay
+///         case secondDay
+///         case priority
+///         case standard
+///       }
+///     }
+@attached(member, names: arbitrary)
+@attached(conformance)
+public macro MyOptionSet<RawType>() = #externalMacro(module: "MacroExamplesImplementation", type: "OptionSetMacro")

--- a/Examples/Sources/MacroExamples/Interface/Macros.swift
+++ b/Examples/Sources/MacroExamples/Interface/Macros.swift
@@ -54,17 +54,17 @@ public macro wrapStoredProperties(_ attributeName: String) = #externalMacro(modu
 /// Wrap up the stored properties of the given type in a dictionary,
 /// turning them into computed properties.
 ///
-/// This macro composes three different kinds of macro expansion:
-///   * Member-attribute macro expansion, to put itself on all stored properties
-///     of the type it is attached to.
+/// This macro composes two different kinds of macro expansion:
+///   * Member-attribute macro expansion, to put `DictionaryStorageProperty` macro on
+///    all stored properties of the type it is attached to.
 ///   * Member macro expansion, to add a `_storage` property with the actual
 ///     dictionary.
-///   * Accessor macro expansion, to turn the stored properties into computed
-///     properties that look for values in the `_storage` property.
-@attached(accessor)
-@attached(member, names: named(_storage))
 @attached(memberAttribute)
+@attached(member, names: named(_storage))
 public macro DictionaryStorage() = #externalMacro(module: "MacroExamplesImplementation", type: "DictionaryStorageMacro")
+
+@attached(accessor)
+public macro DictionaryStorageProperty() = #externalMacro(module: "MacroExamplesImplementation", type: "DictionaryStoragePropertyMacro")
 
 public protocol Observable {}
 
@@ -102,7 +102,7 @@ public struct ObservationRegistrar<Subject: Observable> {
 
 @attached(member, names: named(Storage), named(_storage), named(_registrar), named(addObserver), named(removeObserver), named(withTransaction))
 @attached(memberAttribute)
-@attached(conformance)
+@attached(extension, conformances: Observable)
 public macro Observable() = #externalMacro(module: "MacroExamplesImplementation", type: "ObservableMacro")
 
 @attached(accessor)
@@ -126,7 +126,7 @@ public macro CaseDetection() = #externalMacro(module: "MacroExamplesImplementati
 @attached(member, names: named(Meta))
 public macro MetaEnum() = #externalMacro(module: "MacroExamplesImplementation", type: "MetaEnumMacro")
 
-@attached(member)
+@attached(peer)
 public macro CodableKey(name: String) = #externalMacro(module: "MacroExamplesImplementation", type: "CodableKey")
 
 @attached(member, names: named(CodingKeys))
@@ -157,5 +157,5 @@ public macro CustomCodable() = #externalMacro(module: "MacroExamplesImplementati
 ///       }
 ///     }
 @attached(member, names: arbitrary)
-@attached(conformance)
+@attached(extension, conformances: OptionSet)
 public macro MyOptionSet<RawType>() = #externalMacro(module: "MacroExamplesImplementation", type: "OptionSetMacro")

--- a/Examples/Sources/MacroExamples/Interface/NewType.swift
+++ b/Examples/Sources/MacroExamples/Interface/NewType.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@attached(
+  member,
+  names: named(RawValue),
+  named(rawValue),
+  arbitrary  // should be named(init(_:)) but that doesn't compile as of swift-DEVELOPMENT-SNAPSHOT-2023-02-02-a
+)
+public macro NewType<T>(_: T.Type) = #externalMacro(module: "MacroExamplesImplementation", type: "NewTypeMacro")
+
+public protocol NewTypeProtocol: RawRepresentable {
+  init(_ rawValue: RawValue)
+}
+
+extension NewTypeProtocol {
+  public init(rawValue: RawValue) { self.init(rawValue) }
+}
+
+// We can automate conformance of a `NewType` to an arbitrary protocol `P` by extending `NewTypeProtocol`. A small but common set of examples follow.
+
+extension NewTypeProtocol where Self: Equatable, RawValue: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool { lhs.rawValue == rhs.rawValue }
+}
+
+extension NewTypeProtocol where Self: Comparable, RawValue: Comparable {
+  public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+extension NewTypeProtocol where Self: Hashable, RawValue: Hashable {
+  public func hash(into hasher: inout Hasher) { rawValue.hash(into: &hasher) }
+}
+
+extension NewTypeProtocol where Self: Encodable, RawValue: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}
+
+extension NewTypeProtocol where Self: Decodable, RawValue: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.init(try container.decode(RawValue.self))
+  }
+}
+
+extension NewTypeProtocol where Self: CustomStringConvertible, RawValue: CustomStringConvertible {
+  public var description: String { rawValue.description }
+}

--- a/Examples/Sources/MacroExamples/Playground/main.swift
+++ b/Examples/Sources/MacroExamples/Playground/main.swift
@@ -1,0 +1,209 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import MacroExamplesInterface
+import Foundation
+
+let x = 1
+let y = 2
+let z = 3
+
+// "Stringify" macro turns the expression into a string.
+print(#stringify(x + y))
+
+// "AddBlocker" complains about addition operations. We emit a warning
+// so it doesn't block compilation.
+print(#addBlocker(x * y + z))
+
+#myWarning("remember to pass a string literal here")
+
+// Uncomment to get an error out of the macro.
+// let text = "oops"
+// #myWarning(text)
+
+struct Font: ExpressibleByFontLiteral {
+  init(fontLiteralName: String, size: Int, weight: MacroExamplesInterface.FontWeight) {
+  }
+}
+
+let _: Font = #fontLiteral(name: "Comic Sans", size: 14, weight: .thin)
+
+// "#URL" macro provides compile time checked URL construction. If the URL is
+// malformed an error is emitted. Otherwise a non-optional URL is expanded.
+print(#URL("https://swift.org/"))
+
+let domain = "domain.com"
+//print(#URL("https://\(domain)/api/path")) // error: #URL requires a static string literal
+//print(#URL("https://not a url.com")) // error: Malformed url
+
+// Use the "wrapStoredProperties" macro to deprecate all of the stored
+// properties.
+@wrapStoredProperties(#"available(*, deprecated, message: "hands off my data")"#)
+struct OldStorage {
+  var x: Int
+}
+
+// The deprecation warning below comes from the deprecation attribute
+// introduced by @wrapStoredProperties on OldStorage.
+_ = OldStorage(x: 5).x
+
+// Move the storage from each of the stored properties into a dictionary
+// called `_storage`, turning the stored properties into computed properties.
+@DictionaryStorage
+struct Point {
+  var x: Int = 1
+  var y: Int = 2
+}
+
+@CaseDetection
+enum Pet {
+  case dog
+  case cat(curious: Bool)
+  case parrot
+  case snake
+}
+
+let pet: Pet = .cat(curious: true)
+print("Pet is dog: \(pet.isDog)")
+print("Pet is cat: \(pet.isCat)")
+
+var point = Point()
+print("Point storage begins as an empty dictionary: \(point)")
+print("Default value for point.x: \(point.x)")
+point.y = 17
+print("Point storage contains only the value we set:  \(point)")
+
+// MARK: - ObservableMacro
+
+struct Treat {}
+
+@Observable
+final class Dog {
+  var name: String?
+  var treat: Treat?
+
+  var isHappy: Bool = true
+
+  init() {}
+
+  func bark() {
+    print("bork bork")
+  }
+}
+
+let dog = Dog()
+print(dog.name ?? "")
+dog.name = "George"
+dog.treat = Treat()
+print(dog.name ?? "")
+dog.bark()
+
+// MARK: NewType
+
+@NewType(String.self)
+struct Hostname:
+  NewTypeProtocol,
+  Hashable,
+  CustomStringConvertible
+{}
+
+@NewType(String.self)
+struct Password:
+  NewTypeProtocol,
+  Hashable,
+  CustomStringConvertible
+{
+  var description: String { "(redacted)" }
+}
+
+let hostname = Hostname("localhost")
+print("hostname: description=\(hostname) hashValue=\(hostname.hashValue)")
+
+let password = Password("squeamish ossifrage")
+print("password: description=\(password) hashValue=\(password.hashValue)")
+
+struct MyStruct {
+  @AddCompletionHandler
+  func f(a: Int, for b: String, _ value: Double) async -> String {
+    return b
+  }
+
+  @AddAsync
+  func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
+    completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
+  }
+
+  @AddAsync
+  func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
+    completionBlock(true)
+  }
+}
+
+@CustomCodable
+struct CustomCodableString: Codable {
+
+  @CodableKey(name: "OtherName")
+  var propertyWithOtherName: String
+
+  var propertyWithSameName: Bool
+
+  func randomFunction() {
+
+  }
+}
+
+Task {
+  let myStruct = MyStruct()
+  _ = try? await myStruct.c(a: 5, for: "Test", 20)
+
+  _ = await myStruct.d(a: 10, for: "value", 40)
+}
+
+MyStruct().f(a: 1, for: "hello", 3.14159) { result in
+  print("Eventually received \(result + "!")")
+}
+
+let json = """
+  {
+    "OtherName": "Name",
+    "propertyWithSameName": true
+  }
+
+  """.data(using: .utf8)!
+
+let jsonDecoder = JSONDecoder()
+let product = try jsonDecoder.decode(CustomCodableString.self, from: json)
+print(product.propertyWithOtherName)
+
+@MyOptionSet<UInt8>
+struct ShippingOptions {
+  private enum Options: Int {
+    case nextDay
+    case secondDay
+    case priority
+    case standard
+  }
+
+  static let express: ShippingOptions = [.nextDay, .secondDay]
+  static let all: ShippingOptions = [.express, .priority, .standard]
+}
+
+// `@MetaEnum` adds a nested enum called `Meta` with the same cases, but no
+// associated values/payloads. Handy for e.g. describing a schema.
+@MetaEnum enum Value {
+  case integer(Int)
+  case text(String)
+  case boolean(Bool)
+  case null
+}
+
+print(Value.Meta(.integer(42)) == .integer)

--- a/Examples/Tests/MacroExamples/Implementation/MacroExamplesPluginTest.swift
+++ b/Examples/Tests/MacroExamples/Implementation/MacroExamplesPluginTest.swift
@@ -14,6 +14,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import MacroExamplesImplementation
+import SwiftSyntaxMacroExpansion
 import XCTest
 
 var testMacros: [String: Macro.Type] = [
@@ -43,7 +44,7 @@ final class MacroExamplesPluginTests: XCTestCase {
   func testURL() throws {
     let sf: SourceFileSyntax =
       #"""
-      let invalid = #URL("not a url")
+      let invalid = #URL("https://not a url.com")
       let valid = #URL("https://swift.org/")
       """#
     let context = BasicMacroExpansionContext.init(
@@ -53,13 +54,13 @@ final class MacroExamplesPluginTests: XCTestCase {
     XCTAssertEqual(
       transformedSF.description,
       #"""
-      let invalid = #URL("not a url")
+      let invalid = #URL("https://not a url.com")
       let valid = URL(string: "https://swift.org/")!
       """#
     )
     XCTAssertEqual(context.diagnostics.count, 1)
     let diagnostic = try XCTUnwrap(context.diagnostics.first)
-    XCTAssertEqual(diagnostic.message, #"malformed url: "not a url""#)
+    XCTAssertEqual(diagnostic.message, #"malformed url: "https://not a url.com""#)
     XCTAssertEqual(diagnostic.diagMessage.severity, .error)
   }
 }

--- a/Examples/Tests/MacroExamples/Implementation/MacroExamplesPluginTest.swift
+++ b/Examples/Tests/MacroExamples/Implementation/MacroExamplesPluginTest.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import MacroExamplesImplementation
+import XCTest
+
+var testMacros: [String: Macro.Type] = [
+  "stringify": StringifyMacro.self
+]
+
+final class MacroExamplesPluginTests: XCTestCase {
+  func testStringify() {
+    let sf: SourceFileSyntax =
+      #"""
+      let a = #stringify(x + y)
+      let b = #stringify("Hello, \(name)")
+      """#
+    let context = BasicMacroExpansionContext.init(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+    let transformedSF = sf.expand(macros: testMacros, in: context)
+    XCTAssertEqual(
+      transformedSF.description,
+      #"""
+      let a = (x + y, "x + y")
+      let b = ("Hello, \(name)", #""Hello, \(name)""#)
+      """#
+    )
+  }
+
+  func testURL() throws {
+    let sf: SourceFileSyntax =
+      #"""
+      let invalid = #URL("not a url")
+      let valid = #URL("https://swift.org/")
+      """#
+    let context = BasicMacroExpansionContext.init(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+    let transformedSF = sf.expand(macros: ["URL": URLMacro.self], in: context)
+    XCTAssertEqual(
+      transformedSF.description,
+      #"""
+      let invalid = #URL("not a url")
+      let valid = URL(string: "https://swift.org/")!
+      """#
+    )
+    XCTAssertEqual(context.diagnostics.count, 1)
+    let diagnostic = try XCTUnwrap(context.diagnostics.first)
+    XCTAssertEqual(diagnostic.message, #"malformed url: "not a url""#)
+    XCTAssertEqual(diagnostic.diagMessage.severity, .error)
+  }
+}

--- a/Examples/Tests/MacroExamples/Implementation/MetaEnumMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/MetaEnumMacroTests.swift
@@ -14,7 +14,8 @@ import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
-import MacroExamplesPlugin
+import MacroExamplesImplementation
+import SwiftSyntaxMacroExpansion
 
 final class CaseMacroTests: XCTestCase {
   let testMacros: [String: Macro.Type] = [
@@ -44,25 +45,26 @@ final class CaseMacroTests: XCTestCase {
         case text(String)
         case boolean(Bool)
         case null
-        enum Meta {
-          case integer
-          case text
-          case boolean
-          case null
 
-          init(_ __macro_local_6parentfMu_: Cell) {
-            switch __macro_local_6parentfMu_ {
-            case .integer:
-              self = .integer
-            case .text:
-              self = .text
-            case .boolean:
-              self = .boolean
-            case .null:
-              self = .null
+          enum Meta {
+                  case integer
+                  case text
+                  case boolean
+                  case null
+
+                  init(_ __macro_local_6parentfMu_: Cell) {
+                      switch __macro_local_6parentfMu_ {
+                      case .integer:
+                          self = .integer
+                      case .text:
+                          self = .text
+                      case .boolean:
+                          self = .boolean
+                      case .null:
+                          self = .null
+                      }
+                  }
             }
-          }
-        }
       }
       """
     )
@@ -89,22 +91,23 @@ final class CaseMacroTests: XCTestCase {
         case integer(Int)
         case text(String)
         case boolean(Bool)
-        public enum Meta {
-          case integer
-          case text
-          case boolean
 
-          public init(_ __macro_local_6parentfMu_: Cell) {
-            switch __macro_local_6parentfMu_ {
-            case .integer:
-              self = .integer
-            case .text:
-              self = .text
-            case .boolean:
-              self = .boolean
+          public enum Meta {
+                  case integer
+                  case text
+                  case boolean
+
+                  public init(_ __macro_local_6parentfMu_: Cell) {
+                      switch __macro_local_6parentfMu_ {
+                      case .integer:
+                          self = .integer
+                      case .text:
+                          self = .text
+                      case .boolean:
+                          self = .boolean
+                      }
+                  }
             }
-          }
-        }
       }
       """
     )

--- a/Examples/Tests/MacroExamples/Implementation/MetaEnumMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/MetaEnumMacroTests.swift
@@ -1,0 +1,143 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import MacroExamplesPlugin
+
+final class CaseMacroTests: XCTestCase {
+  let testMacros: [String: Macro.Type] = [
+    "MetaEnum": MetaEnumMacro.self
+  ]
+
+  func testBasic() throws {
+    let sf: SourceFileSyntax = """
+      @MetaEnum enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+        case null
+      }
+      """
+
+    let context = BasicMacroExpansionContext(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+
+    let transformed = sf.expand(macros: testMacros, in: context)
+    XCTAssertEqual(
+      transformed.description,
+      """
+      enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+        case null
+        enum Meta {
+          case integer
+          case text
+          case boolean
+          case null
+
+          init(_ __macro_local_6parentfMu_: Cell) {
+            switch __macro_local_6parentfMu_ {
+            case .integer:
+              self = .integer
+            case .text:
+              self = .text
+            case .boolean:
+              self = .boolean
+            case .null:
+              self = .null
+            }
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testPublic() throws {
+    let sf: SourceFileSyntax = """
+      @MetaEnum public enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+      }
+      """
+
+    let context = BasicMacroExpansionContext(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+
+    let transformed = sf.expand(macros: testMacros, in: context)
+    XCTAssertEqual(
+      transformed.description,
+      """
+      public enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+        public enum Meta {
+          case integer
+          case text
+          case boolean
+
+          public init(_ __macro_local_6parentfMu_: Cell) {
+            switch __macro_local_6parentfMu_ {
+            case .integer:
+              self = .integer
+            case .text:
+              self = .text
+            case .boolean:
+              self = .boolean
+            }
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testNonEnum() throws {
+    let sf: SourceFileSyntax = """
+      @MetaEnum struct Cell {
+        let integer: Int
+        let text: String
+        let boolean: Bool
+      }
+      """
+
+    let context = BasicMacroExpansionContext(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+
+    let transformed = sf.expand(macros: testMacros, in: context)
+    XCTAssertEqual(
+      transformed.description,
+      """
+      struct Cell {
+        let integer: Int
+        let text: String
+        let boolean: Bool
+      }
+      """
+    )
+
+    XCTAssertEqual(context.diagnostics.count, 1)
+    let diag = try XCTUnwrap(context.diagnostics.first)
+    XCTAssertEqual(diag.message, "'@MetaEnum' can only be attached to an enum, not a struct")
+    XCTAssertEqual(diag.diagMessage.severity, .error)
+  }
+}

--- a/Examples/Tests/MacroExamples/Implementation/NewTypePluginTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/NewTypePluginTests.swift
@@ -13,7 +13,8 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
-import MacroExamplesPlugin
+import MacroExamplesImplementation
+import SwiftSyntaxMacroExpansion
 import XCTest
 
 final class NewTypePluginTests: XCTestCase {
@@ -44,9 +45,14 @@ final class NewTypePluginTests: XCTestCase {
       #"""
 
       public struct MyString {
-      public typealias RawValue = String
-      public var rawValue: RawValue
-      public init(_ rawValue: RawValue) { self.rawValue = rawValue }
+
+          public typealias RawValue = String
+
+          public var rawValue: RawValue
+
+          public init(_ rawValue: RawValue) {
+              self.rawValue = rawValue
+          }
       }
       """#
     )

--- a/Examples/Tests/MacroExamples/Implementation/NewTypePluginTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/NewTypePluginTests.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import MacroExamplesPlugin
+import XCTest
+
+final class NewTypePluginTests: XCTestCase {
+  let testMacros: [String: Macro.Type] = [
+    "NewType": NewTypeMacro.self
+  ]
+
+  func testNewType() {
+    let sf: SourceFileSyntax =
+      #"""
+      @NewType(String.self)
+      public struct MyString {
+      }
+      """#
+
+    // print(sf.recursiveDescription)
+
+    let context = BasicMacroExpansionContext(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+
+    let transformed = sf.expand(macros: testMacros, in: context)
+
+    // print(transformed.recursiveDescription)
+
+    XCTAssertEqual(
+      transformed.description,
+      #"""
+
+      public struct MyString {
+      public typealias RawValue = String
+      public var rawValue: RawValue
+      public init(_ rawValue: RawValue) { self.rawValue = rawValue }
+      }
+      """#
+    )
+  }
+}


### PR DESCRIPTION
This PR consists of two main commits.

1. **Incorporating Code and Renaming Targets**:
    - Introduced new targets in the `Examples` package, organized as follows:
    ```
    Examples
     ├─ Sources
     |   └─ MacroExamples
     |       └─ Implementation (Contains macro target `MacroExamplesImplementation`)
     |       └─ Interface (Contains target `MacroExamplesInterface`)
     |       └─ Playground (Contains executable target `MacroExamplesPlayground`)
     └─ Tests
         └─ MacroExamples
             └─ Implementation (Contains test target `MacroExamplesImplementationTests`)
    ``` 
    The new target names correspond to the original ones as:
      - `MacroExamplesPlugin` -> `MacroExamplesImplementation`
      - `MacroExamplesLib` -> `MacroExamplesInterface`
      - `MacroExamples` -> `MacroExamplesPlayground`
      - (newly added) -> `MacroExamplesImplementationTests`

    I believe the new naming convention and directory structure are more intuitive, especially for newcomers. However, I'm always open to feedback and discussion ❤️.
    
    - Transferred Doug's code to `swift-syntax/Examples` and updated references in the `#externalMacro` to the new module names.
    - Run `swift-format` to ensure consistent coding style.

2. **Fixing Errors and Warnings**:
    - Made essential changes to ensure that the macro examples build successfully in the latest environment.

For future improvements, I have several ideas to enhance the clarity and consistency of these examples, especially for newcomers. There are some inconsistencies in the macro creation process and our test methods could benefit from the latest APIs for faster and more consistent execution. We'll also address gaps in documentation. These improvements will be tackled in subsequent PRs, as discussed in #2026.

Resolves #2026.