### PR TITLE
Fix compilation errors in SwiftRefactorExtension.

### DIFF
--- a/EditorExtension/SwiftRefactorExtension/CommandDiscovery.swift
+++ b/EditorExtension/SwiftRefactorExtension/CommandDiscovery.swift
@@ -16,7 +16,7 @@ import Foundation
 import SwiftRefactor
 
 extension SourceEditorExtension {
-  static func forEachRefactoringProvider(_ action: (any RefactoringProvider.Type) -> Void) {
+  static func forEachRefactoringProvider(_ action: (any SyntaxRefactoringProvider.Type) -> Void) {
     guard let header = _dyld_get_image_header(0) else {
       return
     }
@@ -39,7 +39,7 @@ extension SourceEditorExtension {
         continue
       }
 
-      guard let typeMetadata = context.metadata(), let provider = typeMetadata as? any RefactoringProvider.Type else {
+      guard let typeMetadata = context.metadata(), let provider = typeMetadata as? any SyntaxRefactoringProvider.Type else {
         continue
       }
 

--- a/EditorExtension/SwiftRefactorExtension/RefactoringRegistry.swift
+++ b/EditorExtension/SwiftRefactorExtension/RefactoringRegistry.swift
@@ -15,15 +15,15 @@ import SwiftRefactor
 final class RefactoringRegistry {
   public static let shared = RefactoringRegistry()
 
-  public private(set) var providers = [any RefactoringProvider.Type]()
-  private var providersByName = [String: any RefactoringProvider.Type]()
+  public private(set) var providers = [any SyntaxRefactoringProvider.Type]()
+  private var providersByName = [String: any SyntaxRefactoringProvider.Type]()
 
-  func register(_ provider: any RefactoringProvider.Type) {
+  func register(_ provider: any SyntaxRefactoringProvider.Type) {
     self.providers.append(provider)
     self.providersByName[String(describing: provider)] = provider
   }
 
-  subscript(identifier: String) -> (any RefactoringProvider.Type)? {
+  subscript(identifier: String) -> (any SyntaxRefactoringProvider.Type)? {
     _read { yield self.providersByName[identifier] }
   }
 

--- a/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
+++ b/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
@@ -32,15 +32,15 @@ final class SourceEditorCommand: NSObject, XCSourceEditorCommand {
     }
 
     class Rewriter: SyntaxRewriter {
-      private let provider: any RefactoringProvider.Type
+      private let provider: any SyntaxRefactoringProvider.Type
 
-      init(provider: any RefactoringProvider.Type) {
+      init(provider: any SyntaxRefactoringProvider.Type) {
         self.provider = provider
         super.init(viewMode: .sourceAccurate)
       }
 
       override func visitAny(_ node: Syntax) -> Syntax? {
-        func withOpenedRefactoringProvider<T: RefactoringProvider>(_ providerType: T.Type) -> Syntax? {
+        func withOpenedRefactoringProvider<T: SyntaxRefactoringProvider>(_ providerType: T.Type) -> Syntax? {
           guard
             let input = node.as(providerType.Input.self),
             providerType.Context.self == Void.self


### PR DESCRIPTION
Changed `RefactoringProvider` to `EditRefactoringProvider` and `SyntaxRefactoringProvider`.  `RefactoringProvider` no longer exists. Current code seems to assume inherit `SyntaxRefactoringProvider`.