### PR TITLE
Update unit tests after the removal of the `QualifiedDeclNameSyntax`

### DIFF
--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -680,7 +680,6 @@ class ValidateSyntaxNodes: XCTestCase {
         ValidationFailure(node: .memberType, message: "child 'baseType' should not end with 'Type'"),
         ValidationFailure(node: .metatypeType, message: "child 'baseType' should not end with 'Type'"),
         ValidationFailure(node: .optionalType, message: "child 'wrappedType' should not end with 'Type'"),
-        ValidationFailure(node: .qualifiedDeclName, message: "child 'baseType' should not end with 'Type'"),
         ValidationFailure(node: .sameTypeRequirement, message: "child 'leftType' should not end with 'Type'"),
         ValidationFailure(node: .sameTypeRequirement, message: "child 'rightType' should not end with 'Type'"),
         // MARK: Adjective + Expr


### PR DESCRIPTION
After removing the `QualifiedDeclNameSyntax` #2045, we should also remove this case from unit tests. 

The unit tests for the `CodeGeneration` package are not building on the main branch.