### PR TITLE
Add an option to swift-syntax-dev-utils to treat all warnings as errors

### DIFF
--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildArguments.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildArguments.swift
@@ -65,6 +65,9 @@ struct BuildArguments: ParsableArguments {
   )
   var enableTestFuzzing: Bool = false
 
+  @Flag(help: "Treat all warnings as errors.")
+  var warningsAsErrors: Bool = false
+
   @Flag(help: "Enable verbose logging.")
   var verbose: Bool = false
 }

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildCommand.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildCommand.swift
@@ -46,6 +46,10 @@ extension BuildCommand {
       args += ["--scratch-path", buildDir]
     }
 
+    if self.arguments.warningsAsErrors {
+      args += ["-Xswiftc", "-warnings-as-errors"]
+    }
+
     #if !canImport(Darwin)
     args += ["--enable-test-discovery"]
     #endif


### PR DESCRIPTION
This allows me to verify that there are no warnings in the swift-syntax package before creating a release tag.