### PR TITLE
Improve swift-syntax-dev-utils 

### DIFF
--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Test.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Test.swift
@@ -138,7 +138,9 @@ struct Test: ParsableCommand, BuildCommand {
       action: "test",
       packageDir: Paths.packageDir,
       additionalArguments: swiftpmCallArguments,
-      additionalEnvironment: additionalEnvironment
+      additionalEnvironment: additionalEnvironment,
+      captureStdout: false,
+      captureStderr: false
     )
   }
 
@@ -148,7 +150,7 @@ struct Test: ParsableCommand, BuildCommand {
       packageDir: packageDir,
       additionalArguments: ["--show-bin-path"],
       additionalEnvironment: [:]
-    )
+    ).stdout
   }
 
   /// This returns a path to the build examples folder.

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildCommand.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildCommand.swift
@@ -37,8 +37,10 @@ extension BuildCommand {
     action: String,
     packageDir: URL,
     additionalArguments: [String],
-    additionalEnvironment: [String: String]
-  ) throws -> String {
+    additionalEnvironment: [String: String],
+    captureStdout: Bool = true,
+    captureStderr: Bool = true
+  ) throws -> ProcessResult {
     var args = [action]
     args += ["--package-path", packageDir.path]
 
@@ -74,9 +76,13 @@ extension BuildCommand {
       additionalEnvironment: additionalEnvironment
     )
 
-    let result = try processRunner.run(verbose: arguments.verbose)
+    let result = try processRunner.run(
+      captureStdout: captureStdout,
+      captureStderr: captureStderr,
+      verbose: arguments.verbose
+    )
 
-    return result.stdout
+    return result
   }
 
   private func build(packageDir: URL, name: String, isProduct: Bool) throws {
@@ -112,7 +118,9 @@ extension BuildCommand {
       action: "build",
       packageDir: packageDir,
       additionalArguments: args,
-      additionalEnvironment: additionalEnvironment
+      additionalEnvironment: additionalEnvironment,
+      captureStdout: false,
+      captureStderr: false
     )
   }
 }

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Logger.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Logger.swift
@@ -16,16 +16,18 @@ func logSection(_ text: String) {
   print("** \(text) **")
 }
 
-func logProcessCommand(executableURL: URL?, arguments: [String]?) {
-  var message = ""
+extension Process {
+  var command: String {
+    var message = ""
 
-  if let executableURL = executableURL {
-    message += executableURL.absoluteString
+    if let executableURL = executableURL {
+      message += executableURL.path
+    }
+
+    if let arguments = arguments {
+      message += " \(arguments.joined(separator: " "))"
+    }
+
+    return message
   }
-
-  if let arguments = arguments {
-    message += " \(arguments.joined(separator: " "))"
-  }
-
-  print(message)
 }


### PR DESCRIPTION
- Improve error message if a subprocess finishes with a non-zero exit code
- Don’t capture stdout and stderr for `swift build` and `swift test` commands
  - We want the output of those processes to show up in console, so we shouldn’t capture it