### PR TITLE
Add messages for some `assertStringsEqualWithDiff`

### DIFF
--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -12,9 +12,12 @@
 
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
-/// Describes how distinctive a token is for parser recovery. When expecting a
-/// token, tokens with a lower token precedence may be skipped and considered
-/// unexpected.
+/// Describes how distinctive a token is for parser recovery.
+///
+/// When expecting a token, tokens with a lower token precedence may be skipped
+/// and considered unexpected.
+///
+/// - Seealso: <doc:ParserRecovery>
 enum TokenPrecedence: Comparable {
   /// An unknown token. This is known garbage and should always be allowed to be skipped.
   case unknownToken

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -294,6 +294,7 @@ public func assertMacroExpansion(
   assertStringsEqualWithDiff(
     expandedSourceFile.description.trimmingCharacters(in: .newlines),
     expectedExpandedSource.trimmingCharacters(in: .newlines),
+    "Macro expansion did not produce the expected expanded source",
     additionalInfo: """
       Actual expanded source:
       \(expandedSourceFile)

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -412,6 +412,7 @@ func assertDiagnostic<T: SyntaxProtocol>(
   assertStringsEqualWithDiff(
     diag.highlights.map(\.description).joined().trimmingTrailingWhitespace(),
     highlight.trimmingTrailingWhitespace(),
+    "Highlighted source code did not match",
     file: spec.file,
     line: spec.line
   )
@@ -703,6 +704,7 @@ extension ParserTestCase {
       assertStringsEqualWithDiff(
         fixedTreeDescription.trimmingTrailingWhitespace(),
         expectedFixedSource.trimmingTrailingWhitespace(),
+        "Applying all Fix-Its didn’t produce the expected fixed source",
         file: file,
         line: line
       )


### PR DESCRIPTION
The motivation was that it’s ambiguous what’s going wrong `assertParse` fails because applying all Fix-Its does not produce the fixed source.

CC @gottesmm 