### PR TITLE
Add `appendInterpolation` with optional syntax nodes

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -217,8 +217,9 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             let list = ExprListSyntax {
               ExprSyntax("layout.initialize(repeating: nil)")
               for (index, child) in node.children.enumerated() {
-                let optionalMark = child.isOptional ? "?" : ""
-                ExprSyntax("layout[\(raw: index)] = \(child.varOrCaseName.backtickedIfNeeded)\(raw: optionalMark).raw")
+                let optionalMark = child.isOptional ? TokenSyntax.postfixQuestionMarkToken() : nil
+
+                ExprSyntax("layout[\(raw: index)] = \(child.varOrCaseName.backtickedIfNeeded)\(optionalMark).raw")
                   .with(\.leadingTrivia, .newline)
               }
             }
@@ -239,12 +240,12 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
         for (index, child) in node.children.enumerated() {
           try VariableDeclSyntax("public var \(child.varOrCaseName.backtickedIfNeeded): Raw\(child.buildableType.buildable)") {
-            let iuoMark = child.isOptional ? "" : "!"
+            let exclamationMark = child.isOptional ? nil : TokenSyntax.exclamationMarkToken()
 
             if child.syntaxNodeKind == .syntax {
-              ExprSyntax("layoutView.children[\(raw: index)]\(raw: iuoMark)")
+              ExprSyntax("layoutView.children[\(raw: index)]\(exclamationMark)")
             } else {
-              ExprSyntax("layoutView.children[\(raw: index)].map(\(child.syntaxNodeKind.rawType).init(raw:))\(raw: iuoMark)")
+              ExprSyntax("layoutView.children[\(raw: index)].map(\(child.syntaxNodeKind.rawType).init(raw:))\(exclamationMark)")
             }
           }
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -177,10 +177,12 @@ func syntaxNode(emitKind: SyntaxNodeKind) -> SourceFileSyntax {
               }
             }
 
+            let questionMark = child.isOptional ? TokenSyntax.postfixQuestionMarkToken() : nil
+
             AccessorDeclSyntax(
               """
               set(value) {
-                self = \(node.kind.syntaxType)(data.replacingChild(at: \(raw: index), with: value\(raw: child.isOptional ? "?" : "").data, arena: SyntaxArena()))
+                self = \(node.kind.syntaxType)(data.replacingChild(at: \(raw: index), with: value\(questionMark).data, arena: SyntaxArena()))
               }
               """
             )

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -26,10 +26,12 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       for child in trait.children {
+        let questionMark = child.isOptional ? TokenSyntax.postfixQuestionMarkToken() : nil
+
         DeclSyntax(
           """
           \(child.documentation)
-          var \(child.varOrCaseName): \(child.syntaxNodeKind.syntaxType)\(raw: child.isOptional ? "?" : "") { get set }
+          var \(child.varOrCaseName): \(child.syntaxNodeKind.syntaxType)\(questionMark) { get set }
           """
         )
       }

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -63,6 +63,12 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
   }
 
   /// Append a syntax node to the interpolation.
+  ///
+  /// This method accepts a syntax node and appends it to the interpolation.
+  /// If there was a previous indentation value, the method will indent the
+  /// syntax node with that value. If not, it will use the syntax node as-is.
+  ///
+  /// - Parameter node: A syntax node that conforms to `SyntaxProtocol`.
   public mutating func appendInterpolation<Node: SyntaxProtocol>(
     _ node: Node
   ) {
@@ -82,6 +88,20 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
       )
     )
     self.lastIndentation = nil
+  }
+
+  /// Append an optional syntax node to the interpolation.
+  ///
+  /// This method accepts an optional syntax node and appends it to the interpolation
+  /// if it exists. If the syntax node is nil, this method does nothing.
+  ///
+  /// - Parameter node: An optional syntax node that conforms to `SyntaxProtocol`.
+  public mutating func appendInterpolation<Node: SyntaxProtocol>(
+    _ node: Node?
+  ) {
+    if let node {
+      appendInterpolation(node)
+    }
   }
 
   public mutating func appendInterpolation<T>(raw value: T) {

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -72,6 +72,22 @@ final class StringInterpolationTests: XCTestCase {
     )
   }
 
+  func testOptionalInterpolationWithNil() {
+    let tokenSyntax: TokenSyntax? = nil
+
+    let funcSyntax: DeclSyntax = "func foo\(tokenSyntax)()"
+    XCTAssertTrue(funcSyntax.is(FunctionDeclSyntax.self))
+    XCTAssertEqual(funcSyntax.description, "func foo()")
+  }
+
+  func testOptionalInterpolationWithValue() {
+    let tokenSyntax: TokenSyntax? = .identifier("Bar")
+
+    let funcSyntax: DeclSyntax = "func foo\(tokenSyntax)()"
+    XCTAssertTrue(funcSyntax.is(FunctionDeclSyntax.self))
+    XCTAssertEqual(funcSyntax.description, "func fooBar()")
+  }
+
   func testPatternInterpolation() {
     let letPattern: PatternSyntax = "let x"
     XCTAssertTrue(letPattern.is(ValueBindingPatternSyntax.self))


### PR DESCRIPTION
This PR introduces a new method, `appendInterpolation`, to the `SyntaxStringInterpolation` struct, which takes an optional syntax node parameter. If the provided node is nil, no interpolation is added. Otherwise, interpolation is performed as usual.

Additionally, this new method has been integrated into the CodeGeneration package to eliminate the usage of interpolation.

Resolves part of #1977