### PR TITLE
Set `-derivedDataPath` when building the EditorExtension Xcode project

### DIFF
--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Build.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Build.swift
@@ -26,7 +26,7 @@ struct Build: ParsableCommand, BuildCommand {
   private func buildEditorExtension() throws {
     #if os(macOS)
     logSection("Building Editor Extension")
-    try invokeXcodeBuild(projectPath: Paths.editorExtensionProjectPath)
+    try invokeXcodeBuild(projectPath: Paths.editorExtensionProjectPath, scheme: "SwiftRefactorExtension")
     #endif
   }
 }

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/VerifySourceCode.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/VerifySourceCode.swift
@@ -22,8 +22,10 @@ struct VerifySourceCode: ParsableCommand, SourceCodeGeneratorCommand {
   var arguments: SourceCodeGeneratorArguments
 
   func run() throws {
-    let tempDir = FileManager.default.temporaryDirectory
+    try withTemporaryDirectory(verifyCodeGeneratedFiles(tempDir:))
+  }
 
+  private func verifyCodeGeneratedFiles(tempDir: URL) throws {
     try self.runCodeGeneration(sourceDir: tempDir)
 
     logSection("Verifing code generated files")

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Utils.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Utils.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Executes body with a URL to a temporary directory that will be deleted after
+/// the closure finishes executing.
+func withTemporaryDirectory<T>(_ body: (URL) throws -> T) throws -> T {
+  let tempDirURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: tempDirURL, withIntermediateDirectories: true)
+  defer {
+    try? FileManager.default.removeItem(at: tempDirURL)
+  }
+  return try body(tempDirURL)
+}


### PR DESCRIPTION
Previously, we were sometimes seeing a `build` directory being created in the `swift-syntax` sources directory, which contained dummy input files that didn’t have a trailing newline, which caused swift-format to complain about their formatting.

And while at it, also make sure that we clean the temporary directory that we create to verify the generated files.