### PR TITLE
Small refactoring improvements around `ExprFlavor`

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
@@ -89,7 +89,7 @@ struct GenerateSwiftSyntax: ParsableCommand {
     var fileSpecs: [GeneratedFileSpec] = [
       // SwiftParser
       GeneratedFileSpec(swiftParserGeneratedDir + ["IsLexerClassified.swift"], isLexerClassifiedFile),
-      GeneratedFileSpec(swiftParserGeneratedDir + ["LayoutNodes+Parsable.swift"], parserEntryFile),
+      GeneratedFileSpec(swiftParserGeneratedDir + ["LayoutNodes+Parsable.swift"], layoutNodesParsableFile),
       GeneratedFileSpec(swiftParserGeneratedDir + ["Parser+TokenSpecSet.swift"], parserTokenSpecSetFile),
       GeneratedFileSpec(swiftParserGeneratedDir + ["TokenSpecStaticMembers.swift"], tokenSpecStaticMembersFile),
 

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LayoutNodesParsableFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/LayoutNodesParsableFile.swift
@@ -15,7 +15,7 @@ import SwiftSyntaxBuilder
 import SyntaxSupport
 import Utils
 
-let parserEntryFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
+let layoutNodesParsableFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   DeclSyntax("@_spi(RawSyntax) import SwiftSyntax")
 
   DeclSyntax(
@@ -71,6 +71,14 @@ let parserEntryFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           )
         }
         return node
+      }
+      """
+    )
+
+    DeclSyntax(
+      """
+      mutating func parseExpression() -> RawExprSyntax {
+        return self.parseExpression(flavor: .basic, pattern: .none)
       }
       """
     )

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1251,7 +1251,6 @@ extension Parser {
               )
             ),
             .basic,
-            forDirective: false,
             pattern: .none
           )
           initializer = RawInitializerClauseSyntax(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -799,7 +799,7 @@ extension Parser {
         // See if there's a raw value expression.
         let rawValue: RawInitializerClauseSyntax?
         if let eq = self.consume(if: .equal) {
-          let value = self.parseExpression()
+          let value = self.parseExpression(flavor: .basic, pattern: .none)
           rawValue = RawInitializerClauseSyntax(
             equal: eq,
             value: value,
@@ -1219,7 +1219,7 @@ extension Parser {
         // Parse an initializer if present.
         let initializer: RawInitializerClauseSyntax?
         if let equal = self.consume(if: .equal) {
-          var value = self.parseExpression()
+          var value = self.parseExpression(flavor: .basic, pattern: .none)
           if hasTryBeforeIntroducer && !value.is(RawTryExprSyntax.self) {
             value = RawExprSyntax(
               RawTryExprSyntax(
@@ -1250,7 +1250,7 @@ extension Parser {
                 arena: self.arena
               )
             ),
-            .basic,
+            flavor: .basic,
             pattern: .none
           )
           initializer = RawInitializerClauseSyntax(
@@ -1267,7 +1267,7 @@ extension Parser {
           )
         } else if self.atStartOfExpression(), !self.at(.leftBrace), !self.atStartOfLine {
           let missingEqual = RawTokenSyntax(missing: .equal, arena: self.arena)
-          let expr = self.parseExpression()
+          let expr = self.parseExpression(flavor: .basic, pattern: .none)
           initializer = RawInitializerClauseSyntax(
             equal: missingEqual,
             value: expr,
@@ -1848,7 +1848,7 @@ extension Parser {
     // Initializer, if any.
     let definition: RawInitializerClauseSyntax?
     if let equal = self.consume(if: .equal) {
-      let expr = self.parseExpression()
+      let expr = self.parseExpression(flavor: .basic, pattern: .none)
       definition = RawInitializerClauseSyntax(
         equal: equal,
         value: expr,
@@ -1932,10 +1932,10 @@ extension Parser {
     let trailingClosure: RawClosureExprSyntax?
     let additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax
     if self.at(.leftBrace),
-      self.withLookahead({ $0.atValidTrailingClosure(.trailingClosure) })
+      self.withLookahead({ $0.atValidTrailingClosure(flavor: .basic) })
     {
       (trailingClosure, additionalTrailingClosures) =
-        self.parseTrailingClosures(.trailingClosure)
+        self.parseTrailingClosures(flavor: .basic)
     } else {
       trailingClosure = nil
       additionalTrailingClosures = self.emptyCollection(RawMultipleTrailingClosureElementListSyntax.self)

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -70,7 +70,7 @@ extension Parser {
 
     // Parse #if
     let (unexpectedBeforePoundIf, poundIf) = self.expect(.poundIf)
-    let condition = RawExprSyntax(self.parseSequenceExpression(.basic, forDirective: true))
+    let condition = RawExprSyntax(self.parseSequenceExpression(.poundIfDirective))
     let unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
 
     clauses.append(
@@ -95,14 +95,14 @@ extension Parser {
       switch match {
       case .poundElseif:
         (unexpectedBeforePound, pound) = self.eat(handle)
-        condition = RawExprSyntax(self.parseSequenceExpression(.basic, forDirective: true))
+        condition = RawExprSyntax(self.parseSequenceExpression(.poundIfDirective))
         unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
       case .poundElse:
         (unexpectedBeforePound, pound) = self.eat(handle)
         if let ifToken = self.consume(if: .init(.if, allowAtStartOfLine: false)) {
           unexpectedBeforePound = RawUnexpectedNodesSyntax(combining: unexpectedBeforePound, pound, ifToken, arena: self.arena)
           pound = self.missingToken(.poundElseif)
-          condition = RawExprSyntax(self.parseSequenceExpression(.basic, forDirective: true))
+          condition = RawExprSyntax(self.parseSequenceExpression(.poundIfDirective))
         } else {
           condition = nil
         }
@@ -115,7 +115,7 @@ extension Parser {
           }
           unexpectedBeforePound = RawUnexpectedNodesSyntax(combining: unexpectedBeforePound, pound, elif, arena: self.arena)
           pound = self.missingToken(.poundElseif)
-          condition = RawExprSyntax(self.parseSequenceExpression(.basic, forDirective: true))
+          condition = RawExprSyntax(self.parseSequenceExpression(.poundIfDirective))
           unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
         } else {
           break LOOP

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -70,7 +70,7 @@ extension Parser {
 
     // Parse #if
     let (unexpectedBeforePoundIf, poundIf) = self.expect(.poundIf)
-    let condition = RawExprSyntax(self.parseSequenceExpression(.poundIfDirective))
+    let condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
     let unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
 
     clauses.append(
@@ -95,14 +95,14 @@ extension Parser {
       switch match {
       case .poundElseif:
         (unexpectedBeforePound, pound) = self.eat(handle)
-        condition = RawExprSyntax(self.parseSequenceExpression(.poundIfDirective))
+        condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
         unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
       case .poundElse:
         (unexpectedBeforePound, pound) = self.eat(handle)
         if let ifToken = self.consume(if: .init(.if, allowAtStartOfLine: false)) {
           unexpectedBeforePound = RawUnexpectedNodesSyntax(combining: unexpectedBeforePound, pound, ifToken, arena: self.arena)
           pound = self.missingToken(.poundElseif)
-          condition = RawExprSyntax(self.parseSequenceExpression(.poundIfDirective))
+          condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
         } else {
           condition = nil
         }
@@ -115,7 +115,7 @@ extension Parser {
           }
           unexpectedBeforePound = RawUnexpectedNodesSyntax(combining: unexpectedBeforePound, pound, elif, arena: self.arena)
           pound = self.missingToken(.poundElseif)
-          condition = RawExprSyntax(self.parseSequenceExpression(.poundIfDirective))
+          condition = RawExprSyntax(self.parseSequenceExpression(flavor: .poundIfDirective))
           unexpectedBetweenConditionAndElements = self.consumeRemainingTokenOnLine()
         } else {
           break LOOP

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -252,7 +252,7 @@ extension Parser {
     // matching-pattern ::= expr
     // Fall back to expression parsing for ambiguous forms. Name lookup will
     // disambiguate.
-    let patternSyntax = self.parseSequenceExpression(.basic, pattern: context)
+    let patternSyntax = self.parseSequenceExpression(flavor: .stmtCondition, pattern: context)
     if let pat = patternSyntax.as(RawPatternExprSyntax.self) {
       // The most common case here is to parse something that was a lexically
       // obvious pattern, which will come back wrapped in an immediate

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -240,7 +240,7 @@ extension Parser {
     } else if self.atStartOfStatement() {
       return self.parseStatementItem()
     } else if self.atStartOfExpression() {
-      return .expr(self.parseExpression())
+      return .expr(self.parseExpression(flavor: .basic, pattern: .none))
     } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl, allowRecovery: true) {
       return .decl(self.parseDeclaration())
     } else if self.atStartOfStatement(allowRecovery: true) {

--- a/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
+++ b/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
@@ -345,4 +345,8 @@ fileprivate extension Parser {
     }
     return node
   }
+  
+  mutating func parseExpression() -> RawExprSyntax {
+    return self.parseExpression(flavor: .basic, pattern: .none)
+  }
 }


### PR DESCRIPTION
- Unify `forDirective` with `ExprFlavor`, getting rid of one boolean parameter in expression parsing
- Rename `ExprFlavor.basic` -> `stmtCondition` because this case is used primarily in statement conditions that need to disambiguate trailing closures from the statement’s body
- Rename `ExprFlavor.trailingClosure` -> `basic` because this is the base case that we use inside normal expression parsing
- Add argument labels to `flavor` to match the `pattern` parameter that also has a label and make `parseExpression` parameters required so that each caller needs to make a conscious choice about the values and so it’s easier to search for where each of the flavors is being used.