### PR TITLE
Add test cases for parsing closures inside `if` statement conditions

### DIFF
--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -685,7 +685,7 @@ extension ParserTestCase {
       XCTFail("A fixed source was provided but the test case produces no diagnostics with Fix-Its", file: file, line: line)
     }
 
-    if expectedDiagnostics.isEmpty {
+    if expectedDiagnostics.isEmpty && diags.isEmpty {
       assertBasicFormat(source: source, parse: parse, experimentalFeatures: experimentalFeatures, file: file, line: line)
     }
 

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -728,4 +728,171 @@ final class StatementTests: ParserTestCase {
       """
     )
   }
+
+  func testTrailingClosureInIfCondition() {
+    assertParse("if test { $0 } {}")
+
+    assertParse(
+      """
+      if test {
+        $0
+      }1️⃣ {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by newline or ';'", fixIts: ["insert newline", "insert ';'"])
+      ],
+      fixedSource: """
+        if test {
+          $0
+        }
+        {}
+        """
+    )
+
+    assertParse(
+      """
+      if test { $0
+      } {}
+      """
+    )
+
+    assertParse(
+      """
+      if test { x in
+        x
+      } {}
+      """
+    )
+  }
+
+  func testClosureAtStartOfIfCondition() {
+    assertParse(
+      "if 1️⃣{x}() {}",
+      diagnostics: [
+        DiagnosticSpec(message: "missing condition in 'if' statement")
+      ]
+    )
+
+    assertParse(
+      """
+      if 1️⃣{
+        x
+      }() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "missing condition in 'if' statement")
+      ]
+    )
+
+    assertParse(
+      """
+      if 1️⃣{ x
+      }() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "missing condition in 'if' statement")
+      ]
+    )
+
+    assertParse(
+      """
+      if 1️⃣{ a 2️⃣in
+        x + a
+      }(1) {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "missing condition in 'if' statement"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code in 'if' statement"),
+      ]
+    )
+  }
+
+  func testClosureInsideIfCondition() {
+    assertParse("if true, {x}() {}")
+
+    assertParse(
+      """
+      if true, {
+        x
+      }() {}
+      """
+    )
+
+    assertParse(
+      """
+      if true, { x
+      }() {}
+      """
+    )
+
+    assertParse(
+      """
+      if true, { a in
+        x + a
+      }(1) {}
+      """
+    )
+  }
+
+  func testTrailingClosureInGuard() {
+    assertParse(
+      "guard test 1️⃣{ $0 } 2️⃣else {}",
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'else' in 'guard' statement", fixIts: ["insert 'else'"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code 'else {}' at top level"),
+      ],
+      fixedSource: "guard test else { $0 } else {}"
+    )
+
+    assertParse(
+      """
+      guard test 1️⃣{
+        $0
+      } 2️⃣else {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'else' in 'guard' statement", fixIts: ["insert 'else'"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code 'else {}' at top level"),
+      ],
+      fixedSource:
+        """
+        guard test else {
+          $0
+        } else {}
+        """
+    )
+
+    assertParse(
+      """
+      guard test 1️⃣{ $0
+      } 2️⃣else {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'else' in 'guard' statement", fixIts: ["insert 'else'"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code 'else {}' at top level"),
+      ],
+      fixedSource: """
+        guard test else { $0
+        } else {}
+        """
+    )
+
+    assertParse(
+      """
+      guard test 1️⃣{ x 2️⃣in
+        x
+      } 3️⃣else {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'else' in 'guard' statement", fixIts: ["insert 'else'"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code in 'guard' statement"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code 'else {}' at top level"),
+      ],
+      fixedSource: """
+        guard test else { x in
+          x
+        } else {}
+        """
+    )
+  }
 }


### PR DESCRIPTION
Add a bunch of test cases that verify that SwiftParser accepts closures inside `if` conditions if and only if the C++ parser does.

The only difference is that the C++ parser emits a warning in cases like `if test { $0 } {}`: `Trailing closure in this context is confusable with the body of the statement; pass as a parenthesized argument to silence this warning`. We currently don’t have any infrastructure to emit warnings from SwiftParser and I’m not sure if this warning is really necessary. NFC on whether we need it.

While writing the test cases, I found an issue in `BasicFormat` that adds a newline after the opening `{` of the closure inside these conditions, which causes the closure to get parsed as the statement’s body. Fixed that as well.

Fixes #795
rdar://99948919