### PR TITLE
Fix newline detection logic for carriage return line feeds

### DIFF
--- a/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
@@ -131,7 +131,7 @@ final class MultiLineStringLiteralIndentationDiagnosticsGenerator: SyntaxVisitor
     }
     switch previousToken.tokenKind {
     case .stringSegment(let stringSegment):
-      return stringSegment.hasSuffix("\r") || stringSegment.hasSuffix("\n")
+      return stringSegment.last?.isNewline ?? false
     default:
       // FIXME: newlines should never be part of trailing trivia
       return previousToken.trailingTrivia.contains(where: { $0.isNewline })

--- a/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
@@ -27,17 +27,19 @@ extension ParserTestCase {
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    // FIXME: We should run `assertParse` with every possible line ending here.
-    assertParse(
-      markedSource,
-      substructure: expectedSubstructure,
-      substructureAfterMarker: substructureAfterMarker,
-      diagnostics: expectedDiagnostics,
-      applyFixIts: applyFixIts,
-      fixedSource: expectedFixedSource,
-      file: file,
-      line: line
-    )
+    for newline in ["\n", "\r", "\r\n"] {
+      assertParse(
+        markedSource.replacingOccurrences(of: "\n", with: newline),
+        substructure: expectedSubstructure,
+        substructureAfterMarker: substructureAfterMarker,
+        diagnostics: expectedDiagnostics,
+        applyFixIts: applyFixIts,
+        fixedSource: expectedFixedSource,
+        options: [.normalizeNewlinesInFixedSource],
+        file: file,
+        line: line
+      )
+    }
   }
 }
 


### PR DESCRIPTION
`\r\n` is considered a single character in Unicode and we thus need to check for it specifically and checking for `\n` on its own is not sufficient.

Also reverts #2100 since the tests are passing again now.

rdar://114406758