### PR TITLE
Introduce leaf protocols to prevent leaf nodes from being casted 

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/SyntaxNodeKind.swift
@@ -368,6 +368,19 @@ public enum SyntaxNodeKind: String, CaseIterable {
     }
   }
 
+  /// For base node types, generates the name of the protocol to which all
+  /// concrete leaf nodes that derive from this base kind should conform.
+  ///
+  /// - Warning: This property can only be accessed for base node kinds; attempting to
+  /// access it for a non-base kind will result in a runtime error.
+  public var leafProtocolType: TypeSyntax {
+    if isBase {
+      return "_Leaf\(syntaxType)NodeProtocol"
+    } else {
+      fatalError("Only base kind can define leaf protocol")
+    }
+  }
+
   /// If the syntax kind has been renamed, the previous raw value that is now
   /// deprecated.
   public var deprecatedRawValue: String? {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -72,6 +72,39 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           return self.as(S.self)!
         }
 
+        /// Checks if the current syntax node can be upcast to its base node type (``\#(node.kind.syntaxType)``).
+        ///
+        /// - Returns: `true` since the node can always be upcast to its base node.
+        ///
+        /// - Note: This method overloads the general `is` method and is marked deprecated to produce a warning
+        ///         informing the user that the upcast will always succeed.
+        @available(*, deprecated, message: "This cast will always succeed")
+        public func `is`(_ syntaxType: \#(node.kind.syntaxType).Type) -> Bool {
+          return true
+        }
+
+        /// Attempts to upcast the current syntax node to its base node type (``\#(node.kind.syntaxType)``).
+        ///
+        /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+        ///
+        /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+        ///         informing the user the upcast should be performed using the target base node's initializer.
+        @available(*, deprecated, message: "Use `\#(node.kind.syntaxType).init` for upcasting")
+        public func `as`(_ syntaxType: \#(node.kind.syntaxType).Type) -> \#(node.kind.syntaxType)? {
+          return \#(node.kind.syntaxType)(self)
+        }
+
+        /// Force-upcast the current syntax node to its base node type (``\#(node.kind.syntaxType)``).
+        ///
+        /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+        ///
+        /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+        ///         informing the user the upcast should be performed using the target base node's initializer.
+        @available(*, deprecated, message: "Use `\#(node.kind.syntaxType).init` for upcasting")
+        public func cast(_ syntaxType: \#(node.kind.syntaxType).Type) -> \#(node.kind.syntaxType) {
+          return \#(node.kind.syntaxType)(self)
+        }
+
         /// Checks if the current syntax node can be cast to a given node type from the different base node protocol hierarchy than ``\#(node.kind.protocolType)``.
         ///
         /// - Returns: `false` since the node can not be cast to the node type from different base node protocol hierarchy than ``\#(node.kind.protocolType)``.

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -41,7 +41,7 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
 
         \(documentation)
         \(node.node.apiAttributes())\
-        public struct \(node.kind.syntaxType): \(node.baseType.syntaxBaseName)Protocol, SyntaxHashable
+        public struct \(node.kind.syntaxType): \(node.baseType.syntaxBaseName)Protocol, SyntaxHashable, \(node.base.leafProtocolType)
         """
       ) {
         for child in node.children {

--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -25,6 +25,11 @@
 
 ## Deprecations
 
+- Leaf Node Casts
+  - Description: Syntax nodes that do not act as base nodes for other syntax types have the casting methods marked as deprecated. This prevents unsafe type-casting by issuing deprecation warnings for methods that will always result in failed casts.
+  - Issue: https://github.com/apple/swift-syntax/issues/2092
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2108
+  
 ## API-Incompatible Changes
 
 

--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -30,6 +30,11 @@
   - Issue: https://github.com/apple/swift-syntax/issues/2092
   - Pull Request: https://github.com/apple/swift-syntax/pull/2108
   
+- Same-Type Casts 
+  - Description: `is`, `as`, and `cast` overloads on `SyntaxProtocol` with same-type conversions are marked as deprecated. The deprecated methods emit a warning indicating the cast will always succeed.
+  - Issue: https://github.com/apple/swift-syntax/issues/2092
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2108
+  
 ## API-Incompatible Changes
 
 

--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -29,12 +29,17 @@
   - Description: Syntax nodes that do not act as base nodes for other syntax types have the casting methods marked as deprecated. This prevents unsafe type-casting by issuing deprecation warnings for methods that will always result in failed casts.
   - Issue: https://github.com/apple/swift-syntax/issues/2092
   - Pull Request: https://github.com/apple/swift-syntax/pull/2108
-  
+
 - Same-Type Casts 
   - Description: `is`, `as`, and `cast` overloads on `SyntaxProtocol` with same-type conversions are marked as deprecated. The deprecated methods emit a warning indicating the cast will always succeed.
   - Issue: https://github.com/apple/swift-syntax/issues/2092
   - Pull Request: https://github.com/apple/swift-syntax/pull/2108
-  
+
+- Base Node Casts
+  - Description: `is`, `as`, and `cast` methods on base node protocols with base-type conversions are marked as deprecated. The deprecated methods emit a warning that informs the developer that the cast will always succeed and should be done using the base node's initializer.
+  - Issue: https://github.com/apple/swift-syntax/issues/2092
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2108
+
 ## API-Incompatible Changes
 
 

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -789,7 +789,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       return .skipChildren
     }
     if let unexpected = node.unexpectedBetweenDeinitKeywordAndEffectSpecifiers,
-      let name = unexpected.presentTokens(satisfying: { $0.tokenKind.isIdentifier == true }).only?.as(TokenSyntax.self)
+      let name = unexpected.presentTokens(satisfying: { $0.tokenKind.isIdentifier == true }).only
     {
       addDiagnostic(
         name,
@@ -1146,8 +1146,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       return .skipChildren
     }
 
-    if node.conditions.count == 1,
-      node.conditions.first?.as(ConditionElementSyntax.self)?.condition.is(MissingExprSyntax.self) == true,
+    if node.conditions.only?.condition.is(MissingExprSyntax.self) == true,
       !node.body.leftBrace.isMissingAllTokens
     {
       addDiagnostic(node.conditions, MissingConditionInStatement(node: node), handledNodes: [node.conditions.id])
@@ -2024,8 +2023,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       return .skipChildren
     }
 
-    if node.conditions.count == 1,
-      node.conditions.first?.as(ConditionElementSyntax.self)?.condition.is(MissingExprSyntax.self) == true,
+    if node.conditions.only?.condition.is(MissingExprSyntax.self) == true,
       !node.body.leftBrace.isMissingAllTokens
     {
       addDiagnostic(node.conditions, MissingConditionInStatement(node: node), handledNodes: [node.conditions.id])

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -213,11 +213,33 @@ public extension SyntaxProtocol {
     return self.as(syntaxType) != nil
   }
 
+  /// Checks if the current syntax node can be cast to its own type.
+  ///
+  /// - Returns: `true` since the node is already of its own type.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always succeed.
+  @available(*, deprecated, message: "This cast will always succeed")
+  func `is`(_ syntaxType: Self.Type) -> Bool {
+    return true
+  }
+
   /// Attempts to cast the current syntax node to a given specialized syntax type.
   ///
   /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
   func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(self)
+  }
+
+  /// Casts the current syntax node to its own type.
+  ///
+  /// - Returns: The current syntax node.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always succeed.
+  @available(*, deprecated, message: "This cast will always succeed")
+  func `as`(_ syntaxType: Self.Type) -> Self? {
+    return self
   }
 
   /// Force-casts the current syntax node to a given specialized syntax type.
@@ -226,6 +248,17 @@ public extension SyntaxProtocol {
   /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
   func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
     return self.as(S.self)!
+  }
+
+  /// Force-casts the current syntax node to its own type.
+  ///
+  /// - Returns: The current syntax node.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always succeed.
+  @available(*, deprecated, message: "This cast will always succeed")
+  func cast(_ syntaxType: Self.Type) -> Self {
+    return self
   }
 }
 

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -213,6 +213,17 @@ public extension SyntaxProtocol {
     return self.as(syntaxType) != nil
   }
 
+  /// Checks if the current syntax node can be upcast to ``Syntax`` node.
+  ///
+  /// - Returns: `true` since the node can always be upcast to ``Syntax`` node.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked deprecated to produce a warning
+  ///         informing the user that the upcast will always succeed.
+  @available(*, deprecated, message: "This cast will always succeed")
+  func `is`(_ syntaxType: Syntax.Type) -> Bool {
+    return true
+  }
+
   /// Checks if the current syntax node can be cast to its own type.
   ///
   /// - Returns: `true` since the node is already of its own type.
@@ -229,6 +240,17 @@ public extension SyntaxProtocol {
   /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
   func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(self)
+  }
+
+  /// Attempts to upcast the current syntax node to ``Syntax`` node..
+  ///
+  /// - Returns: The ``Syntax`` node created from the current syntax node, as the node can always be upcast to ``Syntax`` node.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the base node's initializer.
+  @available(*, deprecated, message: "Use `Syntax.init` for upcasting.")
+  func `as`(_ syntaxType: Syntax.Type) -> Syntax? {
+    return Syntax(self)
   }
 
   /// Casts the current syntax node to its own type.
@@ -248,6 +270,17 @@ public extension SyntaxProtocol {
   /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
   func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
     return self.as(S.self)!
+  }
+
+  /// Force-cast the current syntax node to ``Syntax`` node..
+  ///
+  /// - Returns: The ``Syntax`` node created from the current syntax node, as the node can always be upcast to ``Syntax`` node.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the base node's initializer.
+  @available(*, deprecated, message: "Use `Syntax.init` for upcasting.")
+  func cast(_ syntaxType: Syntax.Type) -> Syntax {
+    return Syntax(self)
   }
 
   /// Force-casts the current syntax node to its own type.

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -196,8 +196,9 @@ extension SyntaxProtocol {
 
 // Casting functions to specialized syntax nodes.
 public extension SyntaxProtocol {
-  /// Converts the given specialized node to this type. Returns `nil` if the
-  /// conversion is not possible or the given node was `nil`.
+  /// Initializes a new instance of the conforming type from a given specialized syntax node.
+  ///
+  /// Returns `nil` if the conversion isn't possible, or if the provided node is `nil`.
   init?<S: SyntaxProtocol>(_ node: S?) {
     guard let node = node else {
       return nil
@@ -205,14 +206,24 @@ public extension SyntaxProtocol {
     self.init(node)
   }
 
+  /// Checks if the current syntax node can be cast to a given specialized syntax type.
+  ///
+  /// - Returns: `true` if the node can be cast, `false` otherwise.
   func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return self.as(syntaxType) != nil
   }
 
+  /// Attempts to cast the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
   func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(self)
   }
 
+  /// Force-casts the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type.
+  /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
   func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
     return self.as(S.self)!
   }

--- a/Sources/SwiftSyntax/TokenSyntax.swift
+++ b/Sources/SwiftSyntax/TokenSyntax.swift
@@ -154,6 +154,40 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   public var tokenDiagnostic: TokenDiagnostic? {
     return tokenView.tokenDiagnostic
   }
+
+  /// Checks if the current leaf syntax node can be cast to a different specified type.
+  ///
+  /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+
+  /// Attempts to cast the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: `nil` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+
+  /// Force-casts the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
 }
 
 extension TokenSyntax: CustomReflectable {

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -21,6 +21,85 @@
 ///  - Warning: Do not conform to this protocol yourself.
 public protocol DeclSyntaxProtocol: SyntaxProtocol {}
 
+/// Extension of ``DeclSyntaxProtocol`` to provide casting methods.
+///
+/// These methods enable casting between syntax node types within the same
+/// base node protocol hierarchy (e.g., ``DeclSyntaxProtocol``).
+///
+/// While ``SyntaxProtocol`` offers general casting methods (``SyntaxProtocol.as(_:)``, 
+/// ``SyntaxProtocol.is(_:)``, and ``SyntaxProtocol.cast(_:)``), these often aren't
+/// appropriate for use on types conforming to a specific base node protocol
+/// like ``DeclSyntaxProtocol``. That's because at this level,
+/// we know that the cast to another base node type (e.g., ``DeclSyntaxProtocol``
+/// when working with ``ExprSyntaxProtocol``) is guaranteed to fail.
+///
+/// To guide developers toward correct usage, this extension provides overloads
+/// of these casting methods that are restricted to the same base node type.
+/// Furthermore, it marks the inherited casting methods from ``SyntaxProtocol`` as 
+/// deprecated, indicating that they will always fail when used in this context.
+extension DeclSyntaxProtocol {
+  /// Checks if the current syntax node can be cast to a given specialized syntax type.
+  ///
+  /// - Returns: `true` if the node can be cast, `false` otherwise.
+  public func `is`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return self.as(syntaxType) != nil
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
+  public func `as`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return S.init(self)
+  }
+  
+
+  /// Force-casts the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type.
+  /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
+  public func cast<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    return self.as(S.self)!
+  }
+  
+
+  /// Checks if the current syntax node can be cast to a given node type from the different base node protocol hierarchy than ``DeclSyntaxProtocol``.
+  ///
+  /// - Returns: `false` since the node can not be cast to the node type from different base node protocol hierarchy than ``DeclSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given node type from the different base node protocol hierarchy than ``DeclSyntaxProtocol``.
+  ///
+  /// - Returns: `nil` since the node can not be cast to the node type from different base node protocol hierarchy than ``DeclSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+  
+
+  /// Force-casts the current syntax node to a given node type from the different base node protocol hierarchy than ``DeclSyntaxProtocol``.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
+
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// DeclSyntaxProtocol.
@@ -96,18 +175,6 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public func `is`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
-    return self.as(syntaxType) != nil
-  }
-  
-  public func `as`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(self)
-  }
-  
-  public func cast<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S {
-    return self.as(S.self)!
-  }
-  
   /// Syntax nodes always conform to `DeclSyntaxProtocol`. This API is just
   /// added for consistency.
   ///
@@ -154,6 +221,49 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 }
 
+/// Protocol that syntax nodes conform to if they don't have any semantic subtypes.
+/// These are syntax nodes that are not considered base nodes for other syntax types.
+///
+/// Syntax nodes conforming to this protocol have their inherited casting methods
+/// deprecated to prevent incorrect casting.
+public protocol _LeafDeclSyntaxNodeProtocol: DeclSyntaxProtocol {}
+
+public extension _LeafDeclSyntaxNodeProtocol {
+  /// Checks if the current leaf syntax node can be cast to a different specified type.
+  ///
+  /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `is`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+
+  /// Attempts to cast the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: `nil` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `as`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+
+  /// Force-casts the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  func cast<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
+
 // MARK: - ExprSyntax
 
 /// Protocol to which all ``ExprSyntax`` nodes conform. 
@@ -162,6 +272,85 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 ///
 ///  - Warning: Do not conform to this protocol yourself.
 public protocol ExprSyntaxProtocol: SyntaxProtocol {}
+
+/// Extension of ``ExprSyntaxProtocol`` to provide casting methods.
+///
+/// These methods enable casting between syntax node types within the same
+/// base node protocol hierarchy (e.g., ``DeclSyntaxProtocol``).
+///
+/// While ``SyntaxProtocol`` offers general casting methods (``SyntaxProtocol.as(_:)``, 
+/// ``SyntaxProtocol.is(_:)``, and ``SyntaxProtocol.cast(_:)``), these often aren't
+/// appropriate for use on types conforming to a specific base node protocol
+/// like ``ExprSyntaxProtocol``. That's because at this level,
+/// we know that the cast to another base node type (e.g., ``DeclSyntaxProtocol``
+/// when working with ``ExprSyntaxProtocol``) is guaranteed to fail.
+///
+/// To guide developers toward correct usage, this extension provides overloads
+/// of these casting methods that are restricted to the same base node type.
+/// Furthermore, it marks the inherited casting methods from ``SyntaxProtocol`` as 
+/// deprecated, indicating that they will always fail when used in this context.
+extension ExprSyntaxProtocol {
+  /// Checks if the current syntax node can be cast to a given specialized syntax type.
+  ///
+  /// - Returns: `true` if the node can be cast, `false` otherwise.
+  public func `is`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return self.as(syntaxType) != nil
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
+  public func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return S.init(self)
+  }
+  
+
+  /// Force-casts the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type.
+  /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
+  public func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    return self.as(S.self)!
+  }
+  
+
+  /// Checks if the current syntax node can be cast to a given node type from the different base node protocol hierarchy than ``ExprSyntaxProtocol``.
+  ///
+  /// - Returns: `false` since the node can not be cast to the node type from different base node protocol hierarchy than ``ExprSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given node type from the different base node protocol hierarchy than ``ExprSyntaxProtocol``.
+  ///
+  /// - Returns: `nil` since the node can not be cast to the node type from different base node protocol hierarchy than ``ExprSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+  
+
+  /// Force-casts the current syntax node to a given node type from the different base node protocol hierarchy than ``ExprSyntaxProtocol``.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
 
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
@@ -238,18 +427,6 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public func `is`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
-    return self.as(syntaxType) != nil
-  }
-  
-  public func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(self)
-  }
-  
-  public func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
-    return self.as(S.self)!
-  }
-  
   /// Syntax nodes always conform to `ExprSyntaxProtocol`. This API is just
   /// added for consistency.
   ///
@@ -324,6 +501,49 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 }
 
+/// Protocol that syntax nodes conform to if they don't have any semantic subtypes.
+/// These are syntax nodes that are not considered base nodes for other syntax types.
+///
+/// Syntax nodes conforming to this protocol have their inherited casting methods
+/// deprecated to prevent incorrect casting.
+public protocol _LeafExprSyntaxNodeProtocol: ExprSyntaxProtocol {}
+
+public extension _LeafExprSyntaxNodeProtocol {
+  /// Checks if the current leaf syntax node can be cast to a different specified type.
+  ///
+  /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `is`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+
+  /// Attempts to cast the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: `nil` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+
+  /// Force-casts the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
+
 // MARK: - PatternSyntax
 
 /// Protocol to which all ``PatternSyntax`` nodes conform. 
@@ -332,6 +552,85 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///
 ///  - Warning: Do not conform to this protocol yourself.
 public protocol PatternSyntaxProtocol: SyntaxProtocol {}
+
+/// Extension of ``PatternSyntaxProtocol`` to provide casting methods.
+///
+/// These methods enable casting between syntax node types within the same
+/// base node protocol hierarchy (e.g., ``DeclSyntaxProtocol``).
+///
+/// While ``SyntaxProtocol`` offers general casting methods (``SyntaxProtocol.as(_:)``, 
+/// ``SyntaxProtocol.is(_:)``, and ``SyntaxProtocol.cast(_:)``), these often aren't
+/// appropriate for use on types conforming to a specific base node protocol
+/// like ``PatternSyntaxProtocol``. That's because at this level,
+/// we know that the cast to another base node type (e.g., ``DeclSyntaxProtocol``
+/// when working with ``ExprSyntaxProtocol``) is guaranteed to fail.
+///
+/// To guide developers toward correct usage, this extension provides overloads
+/// of these casting methods that are restricted to the same base node type.
+/// Furthermore, it marks the inherited casting methods from ``SyntaxProtocol`` as 
+/// deprecated, indicating that they will always fail when used in this context.
+extension PatternSyntaxProtocol {
+  /// Checks if the current syntax node can be cast to a given specialized syntax type.
+  ///
+  /// - Returns: `true` if the node can be cast, `false` otherwise.
+  public func `is`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return self.as(syntaxType) != nil
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
+  public func `as`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return S.init(self)
+  }
+  
+
+  /// Force-casts the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type.
+  /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
+  public func cast<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    return self.as(S.self)!
+  }
+  
+
+  /// Checks if the current syntax node can be cast to a given node type from the different base node protocol hierarchy than ``PatternSyntaxProtocol``.
+  ///
+  /// - Returns: `false` since the node can not be cast to the node type from different base node protocol hierarchy than ``PatternSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given node type from the different base node protocol hierarchy than ``PatternSyntaxProtocol``.
+  ///
+  /// - Returns: `nil` since the node can not be cast to the node type from different base node protocol hierarchy than ``PatternSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+  
+
+  /// Force-casts the current syntax node to a given node type from the different base node protocol hierarchy than ``PatternSyntaxProtocol``.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
 
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
@@ -408,18 +707,6 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public func `is`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
-    return self.as(syntaxType) != nil
-  }
-  
-  public func `as`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(self)
-  }
-  
-  public func cast<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S {
-    return self.as(S.self)!
-  }
-  
   /// Syntax nodes always conform to `PatternSyntaxProtocol`. This API is just
   /// added for consistency.
   ///
@@ -449,6 +736,49 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   }
 }
 
+/// Protocol that syntax nodes conform to if they don't have any semantic subtypes.
+/// These are syntax nodes that are not considered base nodes for other syntax types.
+///
+/// Syntax nodes conforming to this protocol have their inherited casting methods
+/// deprecated to prevent incorrect casting.
+public protocol _LeafPatternSyntaxNodeProtocol: PatternSyntaxProtocol {}
+
+public extension _LeafPatternSyntaxNodeProtocol {
+  /// Checks if the current leaf syntax node can be cast to a different specified type.
+  ///
+  /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `is`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+
+  /// Attempts to cast the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: `nil` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `as`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+
+  /// Force-casts the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  func cast<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
+
 // MARK: - StmtSyntax
 
 /// Protocol to which all ``StmtSyntax`` nodes conform. 
@@ -457,6 +787,85 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 ///
 ///  - Warning: Do not conform to this protocol yourself.
 public protocol StmtSyntaxProtocol: SyntaxProtocol {}
+
+/// Extension of ``StmtSyntaxProtocol`` to provide casting methods.
+///
+/// These methods enable casting between syntax node types within the same
+/// base node protocol hierarchy (e.g., ``DeclSyntaxProtocol``).
+///
+/// While ``SyntaxProtocol`` offers general casting methods (``SyntaxProtocol.as(_:)``, 
+/// ``SyntaxProtocol.is(_:)``, and ``SyntaxProtocol.cast(_:)``), these often aren't
+/// appropriate for use on types conforming to a specific base node protocol
+/// like ``StmtSyntaxProtocol``. That's because at this level,
+/// we know that the cast to another base node type (e.g., ``DeclSyntaxProtocol``
+/// when working with ``ExprSyntaxProtocol``) is guaranteed to fail.
+///
+/// To guide developers toward correct usage, this extension provides overloads
+/// of these casting methods that are restricted to the same base node type.
+/// Furthermore, it marks the inherited casting methods from ``SyntaxProtocol`` as 
+/// deprecated, indicating that they will always fail when used in this context.
+extension StmtSyntaxProtocol {
+  /// Checks if the current syntax node can be cast to a given specialized syntax type.
+  ///
+  /// - Returns: `true` if the node can be cast, `false` otherwise.
+  public func `is`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return self.as(syntaxType) != nil
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
+  public func `as`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return S.init(self)
+  }
+  
+
+  /// Force-casts the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type.
+  /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
+  public func cast<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    return self.as(S.self)!
+  }
+  
+
+  /// Checks if the current syntax node can be cast to a given node type from the different base node protocol hierarchy than ``StmtSyntaxProtocol``.
+  ///
+  /// - Returns: `false` since the node can not be cast to the node type from different base node protocol hierarchy than ``StmtSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given node type from the different base node protocol hierarchy than ``StmtSyntaxProtocol``.
+  ///
+  /// - Returns: `nil` since the node can not be cast to the node type from different base node protocol hierarchy than ``StmtSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+  
+
+  /// Force-casts the current syntax node to a given node type from the different base node protocol hierarchy than ``StmtSyntaxProtocol``.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
 
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
@@ -533,18 +942,6 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public func `is`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
-    return self.as(syntaxType) != nil
-  }
-  
-  public func `as`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(self)
-  }
-  
-  public func cast<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S {
-    return self.as(S.self)!
-  }
-  
   /// Syntax nodes always conform to `StmtSyntaxProtocol`. This API is just
   /// added for consistency.
   ///
@@ -584,6 +981,49 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 }
 
+/// Protocol that syntax nodes conform to if they don't have any semantic subtypes.
+/// These are syntax nodes that are not considered base nodes for other syntax types.
+///
+/// Syntax nodes conforming to this protocol have their inherited casting methods
+/// deprecated to prevent incorrect casting.
+public protocol _LeafStmtSyntaxNodeProtocol: StmtSyntaxProtocol {}
+
+public extension _LeafStmtSyntaxNodeProtocol {
+  /// Checks if the current leaf syntax node can be cast to a different specified type.
+  ///
+  /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `is`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+
+  /// Attempts to cast the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: `nil` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `as`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+
+  /// Force-casts the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  func cast<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
+
 // MARK: - TypeSyntax
 
 /// Protocol to which all ``TypeSyntax`` nodes conform. 
@@ -592,6 +1032,85 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 ///
 ///  - Warning: Do not conform to this protocol yourself.
 public protocol TypeSyntaxProtocol: SyntaxProtocol {}
+
+/// Extension of ``TypeSyntaxProtocol`` to provide casting methods.
+///
+/// These methods enable casting between syntax node types within the same
+/// base node protocol hierarchy (e.g., ``DeclSyntaxProtocol``).
+///
+/// While ``SyntaxProtocol`` offers general casting methods (``SyntaxProtocol.as(_:)``, 
+/// ``SyntaxProtocol.is(_:)``, and ``SyntaxProtocol.cast(_:)``), these often aren't
+/// appropriate for use on types conforming to a specific base node protocol
+/// like ``TypeSyntaxProtocol``. That's because at this level,
+/// we know that the cast to another base node type (e.g., ``DeclSyntaxProtocol``
+/// when working with ``ExprSyntaxProtocol``) is guaranteed to fail.
+///
+/// To guide developers toward correct usage, this extension provides overloads
+/// of these casting methods that are restricted to the same base node type.
+/// Furthermore, it marks the inherited casting methods from ``SyntaxProtocol`` as 
+/// deprecated, indicating that they will always fail when used in this context.
+extension TypeSyntaxProtocol {
+  /// Checks if the current syntax node can be cast to a given specialized syntax type.
+  ///
+  /// - Returns: `true` if the node can be cast, `false` otherwise.
+  public func `is`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return self.as(syntaxType) != nil
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
+  public func `as`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return S.init(self)
+  }
+  
+
+  /// Force-casts the current syntax node to a given specialized syntax type.
+  ///
+  /// - Returns: An instance of the specialized type.
+  /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
+  public func cast<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    return self.as(S.self)!
+  }
+  
+
+  /// Checks if the current syntax node can be cast to a given node type from the different base node protocol hierarchy than ``TypeSyntaxProtocol``.
+  ///
+  /// - Returns: `false` since the node can not be cast to the node type from different base node protocol hierarchy than ``TypeSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+  
+
+  /// Attempts to cast the current syntax node to a given node type from the different base node protocol hierarchy than ``TypeSyntaxProtocol``.
+  ///
+  /// - Returns: `nil` since the node can not be cast to the node type from different base node protocol hierarchy than ``TypeSyntaxProtocol``.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+  
+
+  /// Force-casts the current syntax node to a given node type from the different base node protocol hierarchy than ``TypeSyntaxProtocol``.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  public func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
 
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
@@ -668,18 +1187,6 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public func `is`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
-    return self.as(syntaxType) != nil
-  }
-  
-  public func `as`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(self)
-  }
-  
-  public func cast<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S {
-    return self.as(S.self)!
-  }
-  
   /// Syntax nodes always conform to `TypeSyntaxProtocol`. This API is just
   /// added for consistency.
   ///
@@ -719,6 +1226,51 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
         ])
   }
 }
+
+/// Protocol that syntax nodes conform to if they don't have any semantic subtypes.
+/// These are syntax nodes that are not considered base nodes for other syntax types.
+///
+/// Syntax nodes conforming to this protocol have their inherited casting methods
+/// deprecated to prevent incorrect casting.
+public protocol _LeafTypeSyntaxNodeProtocol: TypeSyntaxProtocol {}
+
+public extension _LeafTypeSyntaxNodeProtocol {
+  /// Checks if the current leaf syntax node can be cast to a different specified type.
+  ///
+  /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `is`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+
+  /// Attempts to cast the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: `nil` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `as`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+
+  /// Force-casts the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  func cast<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
+  }
+}
+
+// MARK: - Syntax
 
 extension Syntax {
   public static var structure: SyntaxNodeStructure {
@@ -1001,5 +1553,48 @@ extension Syntax {
           .node(YieldedExpressionSyntax.self),
           .node(YieldedExpressionsClauseSyntax.self)
         ])
+  }
+}
+
+/// Protocol that syntax nodes conform to if they don't have any semantic subtypes.
+/// These are syntax nodes that are not considered base nodes for other syntax types.
+///
+/// Syntax nodes conforming to this protocol have their inherited casting methods
+/// deprecated to prevent incorrect casting.
+public protocol _LeafSyntaxNodeProtocol: SyntaxProtocol {}
+
+public extension _LeafSyntaxNodeProtocol {
+  /// Checks if the current leaf syntax node can be cast to a different specified type.
+  ///
+  /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return false
+  }
+
+  /// Attempts to cast the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: `nil` since the leaf node cannot be cast to a different specified type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  @available(*, deprecated, message: "This cast will always fail")
+  func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return nil
+  }
+
+  /// Force-casts the current leaf syntax node to a different specified type.
+  ///
+  /// - Returns: This method will always trigger a runtime crash and never return.
+  ///
+  /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
+  ///         informing the user that the cast will always fail.
+  /// - Warning: Invoking this method will lead to a fatal error.
+  @available(*, deprecated, message: "This cast will always fail")
+  func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    fatalError("\(Self.self) cannot be cast to \(S.self)")
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -63,6 +63,42 @@ extension DeclSyntaxProtocol {
   }
   
 
+  /// Checks if the current syntax node can be upcast to its base node type (``DeclSyntax``).
+  ///
+  /// - Returns: `true` since the node can always be upcast to its base node.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked deprecated to produce a warning
+  ///         informing the user that the upcast will always succeed.
+  @available(*, deprecated, message: "This cast will always succeed")
+  public func `is`(_ syntaxType: DeclSyntax.Type) -> Bool {
+    return true
+  }
+  
+
+  /// Attempts to upcast the current syntax node to its base node type (``DeclSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `DeclSyntax.init` for upcasting")
+  public func `as`(_ syntaxType: DeclSyntax.Type) -> DeclSyntax? {
+    return DeclSyntax(self)
+  }
+  
+
+  /// Force-upcast the current syntax node to its base node type (``DeclSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `DeclSyntax.init` for upcasting")
+  public func cast(_ syntaxType: DeclSyntax.Type) -> DeclSyntax {
+    return DeclSyntax(self)
+  }
+  
+
   /// Checks if the current syntax node can be cast to a given node type from the different base node protocol hierarchy than ``DeclSyntaxProtocol``.
   ///
   /// - Returns: `false` since the node can not be cast to the node type from different base node protocol hierarchy than ``DeclSyntaxProtocol``.
@@ -312,6 +348,42 @@ extension ExprSyntaxProtocol {
   /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
   public func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
     return self.as(S.self)!
+  }
+  
+
+  /// Checks if the current syntax node can be upcast to its base node type (``ExprSyntax``).
+  ///
+  /// - Returns: `true` since the node can always be upcast to its base node.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked deprecated to produce a warning
+  ///         informing the user that the upcast will always succeed.
+  @available(*, deprecated, message: "This cast will always succeed")
+  public func `is`(_ syntaxType: ExprSyntax.Type) -> Bool {
+    return true
+  }
+  
+
+  /// Attempts to upcast the current syntax node to its base node type (``ExprSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `ExprSyntax.init` for upcasting")
+  public func `as`(_ syntaxType: ExprSyntax.Type) -> ExprSyntax? {
+    return ExprSyntax(self)
+  }
+  
+
+  /// Force-upcast the current syntax node to its base node type (``ExprSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `ExprSyntax.init` for upcasting")
+  public func cast(_ syntaxType: ExprSyntax.Type) -> ExprSyntax {
+    return ExprSyntax(self)
   }
   
 
@@ -595,6 +667,42 @@ extension PatternSyntaxProtocol {
   }
   
 
+  /// Checks if the current syntax node can be upcast to its base node type (``PatternSyntax``).
+  ///
+  /// - Returns: `true` since the node can always be upcast to its base node.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked deprecated to produce a warning
+  ///         informing the user that the upcast will always succeed.
+  @available(*, deprecated, message: "This cast will always succeed")
+  public func `is`(_ syntaxType: PatternSyntax.Type) -> Bool {
+    return true
+  }
+  
+
+  /// Attempts to upcast the current syntax node to its base node type (``PatternSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `PatternSyntax.init` for upcasting")
+  public func `as`(_ syntaxType: PatternSyntax.Type) -> PatternSyntax? {
+    return PatternSyntax(self)
+  }
+  
+
+  /// Force-upcast the current syntax node to its base node type (``PatternSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `PatternSyntax.init` for upcasting")
+  public func cast(_ syntaxType: PatternSyntax.Type) -> PatternSyntax {
+    return PatternSyntax(self)
+  }
+  
+
   /// Checks if the current syntax node can be cast to a given node type from the different base node protocol hierarchy than ``PatternSyntaxProtocol``.
   ///
   /// - Returns: `false` since the node can not be cast to the node type from different base node protocol hierarchy than ``PatternSyntaxProtocol``.
@@ -827,6 +935,42 @@ extension StmtSyntaxProtocol {
   /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
   public func cast<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S {
     return self.as(S.self)!
+  }
+  
+
+  /// Checks if the current syntax node can be upcast to its base node type (``StmtSyntax``).
+  ///
+  /// - Returns: `true` since the node can always be upcast to its base node.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked deprecated to produce a warning
+  ///         informing the user that the upcast will always succeed.
+  @available(*, deprecated, message: "This cast will always succeed")
+  public func `is`(_ syntaxType: StmtSyntax.Type) -> Bool {
+    return true
+  }
+  
+
+  /// Attempts to upcast the current syntax node to its base node type (``StmtSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `StmtSyntax.init` for upcasting")
+  public func `as`(_ syntaxType: StmtSyntax.Type) -> StmtSyntax? {
+    return StmtSyntax(self)
+  }
+  
+
+  /// Force-upcast the current syntax node to its base node type (``StmtSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `StmtSyntax.init` for upcasting")
+  public func cast(_ syntaxType: StmtSyntax.Type) -> StmtSyntax {
+    return StmtSyntax(self)
   }
   
 
@@ -1072,6 +1216,42 @@ extension TypeSyntaxProtocol {
   /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
   public func cast<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S {
     return self.as(S.self)!
+  }
+  
+
+  /// Checks if the current syntax node can be upcast to its base node type (``TypeSyntax``).
+  ///
+  /// - Returns: `true` since the node can always be upcast to its base node.
+  ///
+  /// - Note: This method overloads the general `is` method and is marked deprecated to produce a warning
+  ///         informing the user that the upcast will always succeed.
+  @available(*, deprecated, message: "This cast will always succeed")
+  public func `is`(_ syntaxType: TypeSyntax.Type) -> Bool {
+    return true
+  }
+  
+
+  /// Attempts to upcast the current syntax node to its base node type (``TypeSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `TypeSyntax.init` for upcasting")
+  public func `as`(_ syntaxType: TypeSyntax.Type) -> TypeSyntax? {
+    return TypeSyntax(self)
+  }
+  
+
+  /// Force-upcast the current syntax node to its base node type (``TypeSyntax``).
+  ///
+  /// - Returns: The base node created from the current syntax node, as the node can always be upcast to its base type.
+  ///
+  /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
+  ///         informing the user the upcast should be performed using the target base node's initializer.
+  @available(*, deprecated, message: "Use `TypeSyntax.init` for upcasting")
+  public func cast(_ syntaxType: TypeSyntax.Type) -> TypeSyntax {
+    return TypeSyntax(self)
   }
   
 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -24,7 +24,7 @@
 /// 
 ///  - ``PatternBindingSyntax``.``PatternBindingSyntax/accessorBlock``
 ///  - ``SubscriptDeclSyntax``.``SubscriptDeclSyntax/accessorBlock``
-public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
+public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Accessors: SyntaxChildChoices, SyntaxHashable {
     case `accessors`(AccessorDeclListSyntax)
     case `getter`(CodeBlockItemListSyntax)
@@ -223,7 +223,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AccessorDeclListSyntax``
-public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -480,7 +480,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AccessorDeclSyntax``.``AccessorDeclSyntax/effectSpecifiers``
-public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
+public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -608,7 +608,7 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AccessorDeclSyntax``.``AccessorDeclSyntax/parameters``
-public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable {
+public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -763,7 +763,7 @@ public struct AccessorParametersSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `memberBlock`: ``MemberBlockSyntax``
-public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1102,7 +1102,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ArrayElementListSyntax``
-public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1226,7 +1226,7 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `leftSquare`: `'['`
 ///  - `elements`: ``ArrayElementListSyntax``
 ///  - `rightSquare`: `']'`
-public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1402,7 +1402,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `leftSquare`: `'['`
 ///  - `element`: ``TypeSyntax``
 ///  - `rightSquare`: `']'`
-public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1551,7 +1551,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `effectSpecifiers`: ``TypeEffectSpecifiersSyntax``?
 ///  - `arrow`: `'->'`
-public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1676,7 +1676,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `asKeyword`: `'as'`
 ///  - `questionOrExclamationMark`: (`'?'` | `'!'`)?
 ///  - `type`: ``TypeSyntax``
-public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1850,7 +1850,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `equal`: `'='`
-public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1966,7 +1966,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `initializer`: ``TypeInitializerClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
-public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2295,7 +2295,7 @@ public struct AssociatedTypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - ``AttributeListSyntax``
 ///  - ``SwitchCaseSyntax``.``SwitchCaseSyntax/attribute``
-public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
+public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Arguments: SyntaxChildChoices, SyntaxHashable {
     case `argumentList`(LabeledExprListSyntax)
     case `token`(TokenSyntax)
@@ -2771,7 +2771,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `specifier`: (`'inout'` | `'__shared'` | `'__owned'` | `'isolated'` | `'_const'` | `'borrowing'` | `'consuming'`)?
 ///  - `attributes`: ``AttributeListSyntax``
 ///  - `baseType`: ``TypeSyntax``
-public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2952,7 +2952,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AvailabilityArgumentListSyntax``
-public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Argument: SyntaxChildChoices, SyntaxHashable {
     case `token`(TokenSyntax)
     case `availabilityVersionRestriction`(PlatformVersionSyntax)
@@ -3138,7 +3138,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ConditionElementSyntax``.``ConditionElementSyntax/condition``
-public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
+public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3346,7 +3346,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AvailabilityArgumentSyntax``.``AvailabilityArgumentSyntax/argument``
-public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Value: SyntaxChildChoices, SyntaxHashable {
     case `string`(SimpleStringLiteralExprSyntax)
     case `version`(VersionTupleSyntax)
@@ -3543,7 +3543,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 /// 
 ///  - `awaitKeyword`: `'await'`
 ///  - `expression`: ``ExprSyntax``
-public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3673,7 +3673,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3853,7 +3853,7 @@ public struct BackDeployedAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashab
 /// ### Children
 /// 
 ///  - `operator`: `<binaryOperator>`
-public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3937,7 +3937,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `literal`: (`'true'` | `'false'`)
-public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4022,7 +4022,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `borrowKeyword`: `'_borrow'`
 ///  - `expression`: ``ExprSyntax``
-public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4145,7 +4145,7 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `breakKeyword`: `'break'`
 ///  - `label`: `<identifier>`?
-public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesC.swift
@@ -21,7 +21,7 @@
 ///  - `importPath`: `<identifier>`
 ///  - `versionInfo`: ``CanImportVersionInfoSyntax``?
 ///  - `rightParen`: `')'`
-public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -228,7 +228,7 @@ public struct CanImportExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``CanImportExprSyntax``.``CanImportExprSyntax/versionInfo``
-public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -408,7 +408,7 @@ public struct CanImportVersionInfoSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``CatchClauseListSyntax``
-public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -588,7 +588,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``CatchItemListSyntax``
-public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
+public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -767,7 +767,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `memberBlock`: ``MemberBlockSyntax``
-public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1113,7 +1113,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `classKeyword`: `'class'`
-public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1203,7 +1203,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ClosureSignatureSyntax``.``ClosureSignatureSyntax/capture``
-public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1384,7 +1384,7 @@ public struct ClosureCaptureClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ClosureCaptureSyntax``.``ClosureCaptureSyntax/specifier``
-public struct ClosureCaptureSpecifierSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ClosureCaptureSpecifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1566,7 +1566,7 @@ public struct ClosureCaptureSpecifierSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ClosureCaptureListSyntax``
-public struct ClosureCaptureSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ClosureCaptureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1777,7 +1777,7 @@ public struct ClosureCaptureSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``MacroExpansionExprSyntax``.``MacroExpansionExprSyntax/trailingClosure``
 ///  - ``MultipleTrailingClosureElementSyntax``.``MultipleTrailingClosureElementSyntax/closure``
 ///  - ``SubscriptCallExprSyntax``.``SubscriptCallExprSyntax/trailingClosure``
-public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1983,7 +1983,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ClosureSignatureSyntax``.``ClosureSignatureSyntax/parameterClause``
-public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2174,7 +2174,7 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ClosureParameterListSyntax``
-public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2521,7 +2521,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ClosureShorthandParameterListSyntax``
-public struct ClosureShorthandParameterSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ClosureShorthandParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2652,7 +2652,7 @@ public struct ClosureShorthandParameterSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ClosureExprSyntax``.``ClosureExprSyntax/signature``
-public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum ParameterClause: SyntaxChildChoices, SyntaxHashable {
     case `simpleInput`(ClosureShorthandParameterListSyntax)
     case `parameterClause`(ClosureParameterClauseSyntax)
@@ -2953,7 +2953,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``CodeBlockItemListSyntax``
-public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
+public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Item: SyntaxChildChoices, SyntaxHashable {
     case `decl`(DeclSyntax)
     case `stmt`(StmtSyntax)
@@ -3150,7 +3150,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``InitializerDeclSyntax``.``InitializerDeclSyntax/body``
 ///  - ``RepeatStmtSyntax``.``RepeatStmtSyntax/body``
 ///  - ``WhileStmtSyntax``.``WhileStmtSyntax/body``
-public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
+public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3329,7 +3329,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``CompositionTypeElementListSyntax``
-public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3451,7 +3451,7 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `elements`: ``CompositionTypeElementListSyntax``
-public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3566,7 +3566,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ConditionElementListSyntax``
-public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Condition: SyntaxChildChoices, SyntaxHashable {
     case `expression`(ExprSyntax)
     case `availability`(AvailabilityConditionSyntax)
@@ -3763,7 +3763,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``GenericRequirementSyntax``.``GenericRequirementSyntax/requirement``
-public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3912,7 +3912,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `consumeKeyword`: (`'_move'` | `'consume'`)
 ///  - `expression`: ``ExprSyntax``
-public struct ConsumeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct ConsumeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4035,7 +4035,7 @@ public struct ConsumeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `continueKeyword`: `'continue'`
 ///  - `label`: `<identifier>`?
-public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4167,7 +4167,7 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4377,7 +4377,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4526,7 +4526,7 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
 /// 
 ///  - `copyKeyword`: `'copy'`
 ///  - `expression`: ``ExprSyntax``
-public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct CopyExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -23,7 +23,7 @@
 /// ### Contained in
 /// 
 ///  - ``DeclModifierSyntax``.``DeclModifierSyntax/detail``
-public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -177,7 +177,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - ``AccessorDeclSyntax``.``AccessorDeclSyntax/modifier``
 ///  - ``DeclModifierListSyntax``
-public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -304,7 +304,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``DeclNameArgumentListSyntax``
-public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -432,7 +432,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``DeclReferenceExprSyntax``.``DeclReferenceExprSyntax/argumentNames``
-public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -615,7 +615,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``KeyPathPropertyComponentSyntax``.``KeyPathPropertyComponentSyntax/declName``
 ///  - ``MemberAccessExprSyntax``.``MemberAccessExprSyntax/declName``
 ///  - ``SpecializeTargetFunctionArgumentSyntax``.``SpecializeTargetFunctionArgumentSyntax/declName``
-public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -738,7 +738,7 @@ public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `deferKeyword`: `'defer'`
 ///  - `body`: ``CodeBlockSyntax``
-public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -873,7 +873,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 ///  - `deinitKeyword`: `'deinit'`
 ///  - `effectSpecifiers`: ``DeinitializerEffectSpecifiersSyntax``?
 ///  - `body`: ``CodeBlockSyntax``?
-public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1137,7 +1137,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``DeinitializerDeclSyntax``.``DeinitializerDeclSyntax/effectSpecifiers``
-public struct DeinitializerEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DeinitializerEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1233,7 +1233,7 @@ public struct DeinitializerEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashabl
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct DerivativeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DerivativeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1500,7 +1500,7 @@ public struct DerivativeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 /// ### Contained in
 /// 
 ///  - ``DesignatedTypeListSyntax``
-public struct DesignatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DesignatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1629,7 +1629,7 @@ public struct DesignatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``DictionaryElementListSyntax``
-public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1805,7 +1805,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `leftSquare`: `'['`
 ///  - `content`: (`':'` | ``DictionaryElementListSyntax``)
 ///  - `rightSquare`: `']'`
-public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public enum Content: SyntaxChildChoices, SyntaxHashable {
     case `colon`(TokenSyntax)
     case `elements`(DictionaryElementListSyntax)
@@ -1999,7 +1999,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `colon`: `':'`
 ///  - `value`: ``TypeSyntax``
 ///  - `rightSquare`: `']'`
-public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2207,7 +2207,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - ``DifferentiabilityArgumentListSyntax``
 ///  - ``DifferentiabilityWithRespectToArgumentSyntax``.``DifferentiabilityWithRespectToArgumentSyntax/arguments``
-public struct DifferentiabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DifferentiabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2337,7 +2337,7 @@ public struct DifferentiabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``DifferentiabilityWithRespectToArgumentSyntax``.``DifferentiabilityWithRespectToArgumentSyntax/arguments``
-public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2522,7 +2522,7 @@ public struct DifferentiabilityArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - ``DerivativeAttributeArgumentsSyntax``.``DerivativeAttributeArgumentsSyntax/arguments``
 ///  - ``DifferentiableAttributeArgumentsSyntax``.``DifferentiableAttributeArgumentsSyntax/arguments``
-public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Arguments: SyntaxChildChoices, SyntaxHashable {
     case `argument`(DifferentiabilityArgumentSyntax)
     case `argumentList`(DifferentiabilityArgumentsSyntax)
@@ -2726,7 +2726,7 @@ public struct DifferentiabilityWithRespectToArgumentSyntax: SyntaxProtocol, Synt
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2932,7 +2932,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
 /// ### Children
 /// 
 ///  - `wildcard`: `'_'`
-public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3017,7 +3017,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `discardKeyword`: `'discard'`
 ///  - `expression`: ``ExprSyntax``
-public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3141,7 +3141,7 @@ public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 ///  - `doKeyword`: `'do'`
 ///  - `body`: ``CodeBlockSyntax``
 ///  - `catchClauses`: ``CatchClauseListSyntax``
-public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3322,7 +3322,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``DocumentationAttributeArgumentListSyntax``
-public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Value: SyntaxChildChoices, SyntaxHashable {
     case `token`(TokenSyntax)
     case `string`(StringLiteralExprSyntax)
@@ -3548,7 +3548,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct DynamicReplacementAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesEF.swift
@@ -21,7 +21,7 @@
 ///  - `attributes`: ``AttributeListSyntax``
 ///  - `modifiers`: ``DeclModifierListSyntax``
 ///  - `placeholder`: `<identifier>`
-public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -227,7 +227,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `placeholder`: `<identifier>`
-public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -316,7 +316,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `modifiers`: ``DeclModifierListSyntax``
 ///  - `caseKeyword`: `'case'`
 ///  - `elements`: ``EnumCaseElementListSyntax``
-public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -585,7 +585,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``EnumCaseElementListSyntax``
-public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -773,7 +773,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``EnumCaseElementSyntax``.``EnumCaseElementSyntax/parameterClause``
-public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -963,7 +963,7 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``EnumCaseParameterListSyntax``
-public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
+public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1258,7 +1258,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `memberBlock`: ``MemberBlockSyntax``
-public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1612,7 +1612,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1760,7 +1760,7 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `expression`: ``ExprSyntax``
-public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
+public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1852,7 +1852,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``StringLiteralSegmentListSyntax``
-public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2078,7 +2078,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `expression`: ``ExprSyntax``
-public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2168,7 +2168,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `memberBlock`: ``MemberBlockSyntax``
-public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2474,7 +2474,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `fallthroughKeyword`: `'fallthrough'`
-public struct FallThroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct FallThroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2558,7 +2558,7 @@ public struct FallThroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `literal`: `<floatLiteral>`
-public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2651,7 +2651,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `sequence`: ``ExprSyntax``
 ///  - `whereClause`: ``WhereClauseSyntax``?
 ///  - `body`: ``CodeBlockSyntax``
-public struct ForStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct ForStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2982,7 +2982,7 @@ public struct ForStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `expression`: ``ExprSyntax``
 ///  - `exclamationMark`: `'!'`
-public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3109,7 +3109,7 @@ public struct ForceUnwrapExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `rightParen`: `')'`?
 ///  - `trailingClosure`: ``ClosureExprSyntax``?
 ///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
-public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3394,7 +3394,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `signature`: ``FunctionSignatureSyntax``
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `body`: ``CodeBlockSyntax``?
-public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3733,7 +3733,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``FunctionSignatureSyntax``.``FunctionSignatureSyntax/effectSpecifiers``
-public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
+public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3862,7 +3862,7 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - ``FunctionSignatureSyntax``.``FunctionSignatureSyntax/parameterClause``
 ///  - ``SubscriptDeclSyntax``.``SubscriptDeclSyntax/parameterClause``
-public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4048,7 +4048,7 @@ public struct FunctionParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``FunctionParameterListSyntax``
-public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
+public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4412,7 +4412,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``FunctionDeclSyntax``.``FunctionDeclSyntax/signature``
 ///  - ``InitializerDeclSyntax``.``InitializerDeclSyntax/signature``
 ///  - ``MacroDeclSyntax``.``MacroDeclSyntax/signature``
-public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
+public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4564,7 +4564,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `rightParen`: `')'`
 ///  - `effectSpecifiers`: ``TypeEffectSpecifiersSyntax``?
 ///  - `returnClause`: ``ReturnClauseSyntax``
-public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
@@ -28,7 +28,7 @@
 ///  - ``MacroExpansionDeclSyntax``.``MacroExpansionDeclSyntax/genericArgumentClause``
 ///  - ``MacroExpansionExprSyntax``.``MacroExpansionExprSyntax/genericArgumentClause``
 ///  - ``MemberTypeSyntax``.``MemberTypeSyntax/genericArgumentClause``
-public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -207,7 +207,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``GenericArgumentListSyntax``
-public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -347,7 +347,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``StructDeclSyntax``.``StructDeclSyntax/genericParameterClause``
 ///  - ``SubscriptDeclSyntax``.``SubscriptDeclSyntax/genericParameterClause``
 ///  - ``TypeAliasDeclSyntax``.``TypeAliasDeclSyntax/genericParameterClause``
-public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -564,7 +564,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``GenericParameterListSyntax``
-public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
+public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -821,7 +821,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``GenericRequirementListSyntax``
-public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Requirement: SyntaxChildChoices, SyntaxHashable {
     case `sameTypeRequirement`(SameTypeRequirementSyntax)
     case `conformanceRequirement`(ConformanceRequirementSyntax)
@@ -997,7 +997,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `expression`: ``ExprSyntax``
 ///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``
-public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1140,7 +1140,7 @@ public struct GenericSpecializationExprSyntax: ExprSyntaxProtocol, SyntaxHashabl
 ///  - ``StructDeclSyntax``.``StructDeclSyntax/genericWhereClause``
 ///  - ``SubscriptDeclSyntax``.``SubscriptDeclSyntax/genericWhereClause``
 ///  - ``TypeAliasDeclSyntax``.``TypeAliasDeclSyntax/genericWhereClause``
-public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1295,7 +1295,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `conditions`: ``ConditionElementListSyntax``
 ///  - `elseKeyword`: `'else'`
 ///  - `body`: ``CodeBlockSyntax``
-public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1495,7 +1495,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `identifier`: (`<identifier>` | `'self'` | `'init'`)
-public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
+public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1580,7 +1580,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `name`: (`<identifier>` | `'Self'` | `'Any'` | `'_'`)
 ///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``?
-public struct IdentifierTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct IdentifierTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1708,7 +1708,7 @@ public struct IdentifierTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``IfConfigClauseListSyntax``
-public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Elements: SyntaxChildChoices, SyntaxHashable {
     case `statements`(CodeBlockItemListSyntax)
     case `switchCases`(SwitchCaseListSyntax)
@@ -1944,7 +1944,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``AttributeListSyntax``
 ///  - ``PostfixIfConfigExprSyntax``.``PostfixIfConfigExprSyntax/config``
 ///  - ``SwitchCaseListSyntax``
-public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2100,7 +2100,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``IfExprSyntax``.``IfExprSyntax/elseBody``
-public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public enum ElseBody: SyntaxChildChoices, SyntaxHashable {
     case `ifExpr`(IfExprSyntax)
     case `codeBlock`(CodeBlockSyntax)
@@ -2376,7 +2376,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2531,7 +2531,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 /// 
 ///  - `wrappedType`: ``TypeSyntax``
 ///  - `exclamationMark`: `'!'`
-public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2665,7 +2665,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 ///  - `importKeyword`: `'import'`
 ///  - `importKindSpecifier`: (`'typealias'` | `'struct'` | `'class'` | `'enum'` | `'protocol'` | `'var'` | `'let'` | `'func'` | `'inout'`)?
 ///  - `path`: ``ImportPathComponentListSyntax``
-public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2960,7 +2960,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ImportPathComponentListSyntax``
-public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3083,7 +3083,7 @@ public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `ampersand`: `'&'`
 ///  - `expression`: ``ExprSyntax``
-public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3207,7 +3207,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `leftOperand`: ``ExprSyntax``
 ///  - `operator`: ``ExprSyntax``
 ///  - `rightOperand`: ``ExprSyntax``
-public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3366,7 +3366,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - ``ExtensionDeclSyntax``.``ExtensionDeclSyntax/inheritanceClause``
 ///  - ``ProtocolDeclSyntax``.``ProtocolDeclSyntax/inheritanceClause``
 ///  - ``StructDeclSyntax``.``StructDeclSyntax/inheritanceClause``
-public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3519,7 +3519,7 @@ public struct InheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``InheritedTypeListSyntax``
-public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
+public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3652,7 +3652,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``MatchingPatternConditionSyntax``.``MatchingPatternConditionSyntax/initializer``
 ///  - ``OptionalBindingConditionSyntax``.``OptionalBindingConditionSyntax/initializer``
 ///  - ``PatternBindingSyntax``.``PatternBindingSyntax/initializer``
-public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3792,7 +3792,7 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `signature`: ``FunctionSignatureSyntax``
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `body`: ``CodeBlockSyntax``?
-public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4138,7 +4138,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `literal`: `<integerLiteral>`
-public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4234,7 +4234,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `expression`: ``ExprSyntax``
 ///  - `isKeyword`: `'is'`
 ///  - `type`: ``TypeSyntax``
-public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4389,7 +4389,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `isKeyword`: `'is'`
 ///  - `type`: ``TypeSyntax``
-public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
+public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -22,7 +22,7 @@
 /// ### Contained in
 /// 
 ///  - ``KeyPathComponentListSyntax``
-public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Component: SyntaxChildChoices, SyntaxHashable {
     case `property`(KeyPathPropertyComponentSyntax)
     case `subscript`(KeyPathSubscriptComponentSyntax)
@@ -199,7 +199,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `backslash`: `'\'`
 ///  - `root`: ``TypeSyntax``?
 ///  - `components`: ``KeyPathComponentListSyntax``
-public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -377,7 +377,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``KeyPathComponentSyntax``.``KeyPathComponentSyntax/component``
-public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -466,7 +466,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``KeyPathComponentSyntax``.``KeyPathComponentSyntax/component``
-public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -594,7 +594,7 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``KeyPathComponentSyntax``.``KeyPathComponentSyntax/component``
-public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -775,7 +775,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``LabeledExprListSyntax``
-public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable {
+public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -958,7 +958,7 @@ public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``SpecializeAttributeArgumentListSyntax``
-public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1142,7 +1142,7 @@ public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `label`: `<identifier>`
 ///  - `colon`: `':'`
 ///  - `statement`: ``StmtSyntax``
-public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1301,7 +1301,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``GenericRequirementSyntax``.``GenericRequirementSyntax/requirement``
-public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1586,7 +1586,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `signature`: ``FunctionSignatureSyntax``
 ///  - `definition`: ``InitializerClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
-public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1929,7 +1929,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 ///  - `rightParen`: `')'`?
 ///  - `trailingClosure`: ``ClosureExprSyntax``?
 ///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
-public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2372,7 +2372,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 ///  - `rightParen`: `')'`?
 ///  - `trailingClosure`: ``ClosureExprSyntax``?
 ///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
-public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2711,7 +2711,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ConditionElementSyntax``.``ConditionElementSyntax/condition``
-public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
+public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2889,7 +2889,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `base`: ``ExprSyntax``?
 ///  - `period`: `'.'`
 ///  - `declName`: ``DeclReferenceExprSyntax``
-public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3048,7 +3048,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``MemberBlockItemListSyntax``
-public struct MemberBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
+public struct MemberBlockItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3185,7 +3185,7 @@ public struct MemberBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``ExtensionDeclSyntax``.``ExtensionDeclSyntax/memberBlock``
 ///  - ``ProtocolDeclSyntax``.``ProtocolDeclSyntax/memberBlock``
 ///  - ``StructDeclSyntax``.``StructDeclSyntax/memberBlock``
-public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable {
+public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3362,7 +3362,7 @@ public struct MemberBlockSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `period`: `'.'`
 ///  - `name`: (`<identifier>` | `'self'`)
 ///  - `genericArgumentClause`: ``GenericArgumentClauseSyntax``?
-public struct MemberTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct MemberTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3538,7 +3538,7 @@ public struct MemberTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 ///  - `baseType`: ``TypeSyntax``
 ///  - `period`: `'.'`
 ///  - `metatypeSpecifier`: (`'Type'` | `'Protocol'`)
-public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3690,7 +3690,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 ///  - `attributes`: ``AttributeListSyntax``
 ///  - `modifiers`: ``DeclModifierListSyntax``
 ///  - `placeholder`: `<identifier>`
-public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3900,7 +3900,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `placeholder`: `<identifier>`
-public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3990,7 +3990,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `placeholder`: `<identifier>`
-public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
+public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4080,7 +4080,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `placeholder`: `<identifier>`
-public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4170,7 +4170,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `placeholder`: `<identifier>`
-public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
+public struct MissingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4260,7 +4260,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `placeholder`: `<identifier>`
-public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4354,7 +4354,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``MultipleTrailingClosureElementListSyntax``
-public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4503,7 +4503,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
 /// 
 ///  - `genericParameterClause`: ``GenericParameterClauseSyntax``
 ///  - `type`: ``TypeSyntax``
-public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4627,7 +4627,7 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `nilKeyword`: `'nil'`
-public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesOP.swift
@@ -24,7 +24,7 @@
 /// ### Contained in
 /// 
 ///  - ``ObjCSelectorPieceListSyntax``
-public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -154,7 +154,7 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -311,7 +311,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
 ///  - `operatorKeyword`: `'operator'`
 ///  - `name`: (`<binaryOperator>` | `<prefixOperator>` | `<postfixOperator>`)
 ///  - `operatorPrecedenceAndTypes`: ``OperatorPrecedenceAndTypesSyntax``?
-public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -497,7 +497,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``OperatorDeclSyntax``.``OperatorDeclSyntax/operatorPrecedenceAndTypes``
-public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
+public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -682,7 +682,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ConditionElementSyntax``.``ConditionElementSyntax/condition``
-public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
+public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -857,7 +857,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `expression`: ``ExprSyntax``
 ///  - `questionMark`: `'?'`
-public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -980,7 +980,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `wrappedType`: ``TypeSyntax``
 ///  - `questionMark`: `'?'`
-public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1112,7 +1112,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1339,7 +1339,7 @@ public struct OriginallyDefinedInAttributeArgumentsSyntax: SyntaxProtocol, Synta
 /// 
 ///  - `eachKeyword`: `'each'`
 ///  - `pack`: ``ExprSyntax``
-public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1462,7 +1462,7 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `eachKeyword`: `'each'`
 ///  - `pack`: ``TypeSyntax``
-public struct PackElementTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct PackElementTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1585,7 +1585,7 @@ public struct PackElementTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `repeatKeyword`: `'repeat'`
 ///  - `repetitionPattern`: ``ExprSyntax``
-public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1708,7 +1708,7 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `repeatKeyword`: `'repeat'`
 ///  - `repetitionPattern`: ``TypeSyntax``
-public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1840,7 +1840,7 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``PatternBindingListSyntax``
-public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
+public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2060,7 +2060,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `pattern`: ``PatternSyntax``
-public struct PatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct PatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2151,7 +2151,7 @@ public struct PatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``PlatformVersionItemListSyntax``
-public struct PlatformVersionItemSyntax: SyntaxProtocol, SyntaxHashable {
+public struct PlatformVersionItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2283,7 +2283,7 @@ public struct PlatformVersionItemSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - ``AvailabilityArgumentSyntax``.``AvailabilityArgumentSyntax/argument``
 ///  - ``PlatformVersionItemSyntax``.``PlatformVersionItemSyntax/platformVersion``
-public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable {
+public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2414,7 +2414,7 @@ public struct PlatformVersionSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `base`: ``ExprSyntax``?
 ///  - `config`: ``IfConfigDeclSyntax``
-public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2537,7 +2537,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `expression`: ``ExprSyntax``
 ///  - `operator`: `<postfixOperator>`
-public struct PostfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct PostfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2669,7 +2669,7 @@ public struct PostfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``PoundSourceLocationSyntax``.``PoundSourceLocationSyntax/arguments``
-public struct PoundSourceLocationArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct PoundSourceLocationArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2924,7 +2924,7 @@ public struct PoundSourceLocationArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 ///  - `leftParen`: `'('`
 ///  - `arguments`: ``PoundSourceLocationArgumentsSyntax``?
 ///  - `rightParen`: `')'`
-public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3106,7 +3106,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``PrecedenceGroupAttributeListSyntax``
-public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3264,7 +3264,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``PrecedenceGroupAttributeListSyntax``
-public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable {
+public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3422,7 +3422,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 ///  - `leftBrace`: `'{'`
 ///  - `groupAttributes`: ``PrecedenceGroupAttributeListSyntax``
 ///  - `rightBrace`: `'}'`
-public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3765,7 +3765,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``PrecedenceGroupNameListSyntax``
-public struct PrecedenceGroupNameSyntax: SyntaxProtocol, SyntaxHashable {
+public struct PrecedenceGroupNameSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3895,7 +3895,7 @@ public struct PrecedenceGroupNameSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``PrecedenceGroupAttributeListSyntax``
-public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
+public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4074,7 +4074,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `operator`: `<prefixOperator>`
 ///  - `expression`: ``ExprSyntax``
-public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4202,7 +4202,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``ProtocolDeclSyntax``.``ProtocolDeclSyntax/primaryAssociatedTypeClause``
-public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4381,7 +4381,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
 /// ### Contained in
 /// 
 ///  - ``PrimaryAssociatedTypeListSyntax``
-public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
+public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4520,7 +4520,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `memberBlock`: ``MemberBlockSyntax``
-public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesQRS.swift
@@ -21,7 +21,7 @@
 ///  - `regex`: `<regexLiteralPattern>`
 ///  - `closingSlash`: `'/'`
 ///  - `closingPounds`: `<regexPoundDelimiter>`?
-public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -224,7 +224,7 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `body`: ``CodeBlockSyntax``
 ///  - `whileKeyword`: `'while'`
 ///  - `condition`: ``ExprSyntax``
-public struct RepeatStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct RepeatStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -406,7 +406,7 @@ public struct RepeatStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 ///  - ``FunctionSignatureSyntax``.``FunctionSignatureSyntax/returnClause``
 ///  - ``FunctionTypeSyntax``.``FunctionTypeSyntax/returnClause``
 ///  - ``SubscriptDeclSyntax``.``SubscriptDeclSyntax/returnClause``
-public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -529,7 +529,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `returnKeyword`: `'return'`
 ///  - `expression`: ``ExprSyntax``?
-public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -657,7 +657,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``GenericRequirementSyntax``.``GenericRequirementSyntax/requirement``
-public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -805,7 +805,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `elements`: ``ExprListSyntax``
-public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -924,7 +924,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - ``AvailabilityLabeledArgumentSyntax``.``AvailabilityLabeledArgumentSyntax/value``
 ///  - ``PoundSourceLocationArgumentsSyntax``.``PoundSourceLocationArgumentsSyntax/fileName``
-public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1105,7 +1105,7 @@ public struct SimpleStringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable 
 /// 
 ///  - `someOrAnySpecifier`: (`'some'` | `'any'`)
 ///  - `constraint`: ``TypeSyntax``
-public struct SomeOrAnyTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct SomeOrAnyTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1229,7 +1229,7 @@ public struct SomeOrAnyTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 ///  - `shebang`: `<shebang>`?
 ///  - `statements`: ``CodeBlockItemListSyntax``
 ///  - `endOfFileToken`: `''`
-public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
+public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1414,7 +1414,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``SpecializeAttributeArgumentListSyntax``
-public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1627,7 +1627,7 @@ public struct SpecializeAvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashab
 /// ### Contained in
 /// 
 ///  - ``SpecializeAttributeArgumentListSyntax``
-public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1824,7 +1824,7 @@ public struct SpecializeTargetFunctionArgumentSyntax: SyntaxProtocol, SyntaxHash
 ///  - ``OriginallyDefinedInAttributeArgumentsSyntax``.``OriginallyDefinedInAttributeArgumentsSyntax/moduleName``
 ///  - ``UnavailableFromAsyncAttributeArgumentsSyntax``.``UnavailableFromAsyncAttributeArgumentsSyntax/message``
 ///  - ``UnderscorePrivateAttributeArgumentsSyntax``.``UnderscorePrivateAttributeArgumentsSyntax/filename``
-public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2055,7 +2055,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - ``SimpleStringLiteralSegmentListSyntax``
 ///  - ``StringLiteralSegmentListSyntax``
-public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2204,7 +2204,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `inheritanceClause`: ``InheritanceClauseSyntax``?
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `memberBlock`: ``MemberBlockSyntax``
-public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2555,7 +2555,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 ///  - `rightSquare`: `']'`
 ///  - `trailingClosure`: ``ClosureExprSyntax``?
 ///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
-public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2840,7 +2840,7 @@ public struct SubscriptCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `returnClause`: ``ReturnClauseSyntax``
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
 ///  - `accessorBlock`: ``AccessorBlockSyntax``?
-public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3174,7 +3174,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `superKeyword`: `'super'`
-public struct SuperExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct SuperExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3259,7 +3259,7 @@ public struct SuperExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `withoutTilde`: `<prefixOperator>`
 ///  - `type`: ``TypeSyntax``
-public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3387,7 +3387,7 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``SwitchCaseItemListSyntax``
-public struct SwitchCaseItemSyntax: SyntaxProtocol, SyntaxHashable {
+public struct SwitchCaseItemSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3541,7 +3541,7 @@ public struct SwitchCaseItemSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``SwitchCaseSyntax``.``SwitchCaseSyntax/label``
-public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
+public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3721,7 +3721,7 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``SwitchCaseListSyntax``
-public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public enum Label: SyntaxChildChoices, SyntaxHashable {
     case `default`(SwitchDefaultLabelSyntax)
     case `case`(SwitchCaseLabelSyntax)
@@ -3944,7 +3944,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``SwitchCaseSyntax``.``SwitchCaseSyntax/label``
-public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
+public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4070,7 +4070,7 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `leftBrace`: `'{'`
 ///  - `cases`: ``SwitchCaseListSyntax``
 ///  - `rightBrace`: `'}'`
-public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -21,7 +21,7 @@
 ///  - `thenExpression`: ``ExprSyntax``
 ///  - `colon`: `':'`
 ///  - `elseExpression`: ``ExprSyntax``
-public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -230,7 +230,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `thenKeyword`: `'then'`
 ///  - `expression`: ``ExprSyntax``
-public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -353,7 +353,7 @@ public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `throwKeyword`: `'throw'`
 ///  - `expression`: ``ExprSyntax``
-public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -477,7 +477,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 ///  - `tryKeyword`: `'try'`
 ///  - `questionOrExclamationMark`: (`'?'` | `'!'`)?
 ///  - `expression`: ``ExprSyntax``
-public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -627,7 +627,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `leftParen`: `'('`
 ///  - `elements`: ``LabeledExprListSyntax``
 ///  - `rightParen`: `')'`
-public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -808,7 +808,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``TuplePatternElementListSyntax``
-public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -984,7 +984,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `leftParen`: `'('`
 ///  - `elements`: ``TuplePatternElementListSyntax``
 ///  - `rightParen`: `')'`
-public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
+public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1168,7 +1168,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``TupleTypeElementListSyntax``
-public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
+public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1422,7 +1422,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `leftParen`: `'('`
 ///  - `elements`: ``TupleTypeElementListSyntax``
 ///  - `rightParen`: `')'`
-public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1602,7 +1602,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 ///  - `genericParameterClause`: ``GenericParameterClauseSyntax``?
 ///  - `initializer`: ``TypeInitializerClauseSyntax``
 ///  - `genericWhereClause`: ``GenericWhereClauseSyntax``?
-public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -1919,7 +1919,7 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 ///  - ``OptionalBindingConditionSyntax``.``OptionalBindingConditionSyntax/typeAnnotation``
 ///  - ``PatternBindingSyntax``.``PatternBindingSyntax/typeAnnotation``
 ///  - ``WildcardPatternSyntax``.``WildcardPatternSyntax/typeAnnotation``
-public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
+public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2048,7 +2048,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``ArrowExprSyntax``.``ArrowExprSyntax/effectSpecifiers``
 ///  - ``ClosureSignatureSyntax``.``ClosureSignatureSyntax/effectSpecifiers``
 ///  - ``FunctionTypeSyntax``.``FunctionTypeSyntax/effectSpecifiers``
-public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
+public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2170,7 +2170,7 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `type`: ``TypeSyntax``
-public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2260,7 +2260,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - ``AssociatedTypeDeclSyntax``.``AssociatedTypeDeclSyntax/initializer``
 ///  - ``TypeAliasDeclSyntax``.``TypeAliasDeclSyntax/initializer``
-public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2390,7 +2390,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct UnavailableFromAsyncAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct UnavailableFromAsyncAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2546,7 +2546,7 @@ public struct UnavailableFromAsyncAttributeArgumentsSyntax: SyntaxProtocol, Synt
 /// ### Contained in
 /// 
 ///  - ``AttributeSyntax``.``AttributeSyntax/arguments``
-public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2695,7 +2695,7 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
 /// 
 ///  - `asKeyword`: `'as'`
 ///  - `questionOrExclamationMark`: (`'?'` | `'!'`)?
-public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2817,7 +2817,7 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// ### Children
 /// 
 ///  - `isKeyword`: `'is'`
-public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -2903,7 +2903,7 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 ///  - `questionMark`: `'?'`
 ///  - `thenExpression`: ``ExprSyntax``
 ///  - `colon`: `':'`
-public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3052,7 +3052,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `bindingSpecifier`: (`'let'` | `'var'` | `'inout'` | `'_mutating'` | `'_borrowing'` | `'_consuming'`)
 ///  - `pattern`: ``PatternSyntax``
-public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
+public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3182,7 +3182,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 ///  - `modifiers`: ``DeclModifierListSyntax``
 ///  - `bindingSpecifier`: (`'let'` | `'var'` | `'inout'` | `'_mutating'` | `'_borrowing'` | `'_consuming'`)
 ///  - `bindings`: ``PatternBindingListSyntax``
-public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3455,7 +3455,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``VersionComponentListSyntax``
-public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable {
+public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3590,7 +3590,7 @@ public struct VersionComponentSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``AvailabilityLabeledArgumentSyntax``.``AvailabilityLabeledArgumentSyntax/value``
 ///  - ``CanImportVersionInfoSyntax``.``CanImportVersionInfoSyntax/version``
 ///  - ``PlatformVersionSyntax``.``PlatformVersionSyntax/version``
-public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
+public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3749,7 +3749,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - ``CatchItemSyntax``.``CatchItemSyntax/whereClause``
 ///  - ``ForStmtSyntax``.``ForStmtSyntax/whereClause``
 ///  - ``SwitchCaseItemSyntax``.``SwitchCaseItemSyntax/whereClause``
-public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -3873,7 +3873,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 ///  - `whileKeyword`: `'while'`
 ///  - `conditions`: ``ConditionElementListSyntax``
 ///  - `body`: ``CodeBlockSyntax``
-public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4048,7 +4048,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `wildcard`: `'_'`
 ///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
-public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
+public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4171,7 +4171,7 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 /// 
 ///  - `yieldKeyword`: `'yield'`
 ///  - `yieldedExpressions`: (``YieldedExpressionsClauseSyntax`` | ``ExprSyntax``)
-public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public enum YieldedExpressions: SyntaxChildChoices, SyntaxHashable {
     case `multiple`(YieldedExpressionsClauseSyntax)
     case `single`(ExprSyntax)
@@ -4340,7 +4340,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``YieldedExpressionListSyntax``
-public struct YieldedExpressionSyntax: SyntaxProtocol, SyntaxHashable {
+public struct YieldedExpressionSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {
@@ -4468,7 +4468,7 @@ public struct YieldedExpressionSyntax: SyntaxProtocol, SyntaxHashable {
 /// ### Contained in
 /// 
 ///  - ``YieldStmtSyntax``.``YieldStmtSyntax/yieldedExpressions``
-public struct YieldedExpressionsClauseSyntax: SyntaxProtocol, SyntaxHashable {
+public struct YieldedExpressionsClauseSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
   public init?(_ node: some SyntaxProtocol) {

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -18,7 +18,6 @@ public class EntryTests: ParserTestCase {
   func testTopLevelStringParse() throws {
     let source = "func test() {}"
     let tree = Parser.parse(source: source)
-    XCTAssert(tree.is(SourceFileSyntax.self))
     XCTAssert(!tree.hasError)
     XCTAssertEqual(tree.description, source)
   }
@@ -27,7 +26,6 @@ public class EntryTests: ParserTestCase {
     var source = "func test() {}"
     source.makeContiguousUTF8()
     let tree = source.withUTF8 { Parser.parse(source: $0) }
-    XCTAssert(tree.is(SourceFileSyntax.self))
     XCTAssert(!tree.hasError)
     XCTAssertEqual(tree.description, source)
   }

--- a/Tests/SwiftRefactorTest/ExpandEditorPlaceholdersTests.swift
+++ b/Tests/SwiftRefactorTest/ExpandEditorPlaceholdersTests.swift
@@ -111,7 +111,7 @@ fileprivate func assertRefactorPlaceholderCall(
 ) throws {
   var parser = Parser(expr)
   let call = try XCTUnwrap(ExprSyntax.parse(from: &parser).as(FunctionCallExprSyntax.self), file: file, line: line)
-  let arg = try XCTUnwrap(call.arguments[call.arguments.index(at: placeholder)].as(LabeledExprSyntax.self), file: file, line: line)
+  let arg = call.arguments[call.arguments.index(at: placeholder)]
   let token: TokenSyntax = try XCTUnwrap(arg.expression.as(EditorPlaceholderExprSyntax.self), file: file, line: line).placeholder
 
   try assertRefactor(token, context: (), provider: ExpandEditorPlaceholders.self, expected: [SourceEdit.replace(call, with: expected)], file: file, line: line)
@@ -126,7 +126,7 @@ fileprivate func assertRefactorPlaceholderToken(
 ) throws {
   var parser = Parser(expr)
   let call = try XCTUnwrap(ExprSyntax.parse(from: &parser).as(FunctionCallExprSyntax.self), file: file, line: line)
-  let arg = try XCTUnwrap(call.arguments[call.arguments.index(at: placeholder)].as(LabeledExprSyntax.self), file: file, line: line)
+  let arg = call.arguments[call.arguments.index(at: placeholder)]
   let token: TokenSyntax = try XCTUnwrap(arg.expression.as(EditorPlaceholderExprSyntax.self), file: file, line: line).placeholder
 
   try assertRefactor(token, context: (), provider: ExpandEditorPlaceholders.self, expected: [SourceEdit.replace(token, with: expected)], file: file, line: line)

--- a/Tests/SwiftRefactorTest/ReformatIntegerLiteral.swift
+++ b/Tests/SwiftRefactorTest/ReformatIntegerLiteral.swift
@@ -18,59 +18,48 @@ import _SwiftSyntaxTestSupport
 
 final class ReformatIntegerLiteralTest: XCTestCase {
   func testSeparatorPlacement() throws {
-    let tests = [
-      (
-        #line, literal: ExprSyntax("0b101010101").cast(IntegerLiteralExprSyntax.self),
-        expectation: ExprSyntax("0b1_0101_0101").cast(IntegerLiteralExprSyntax.self)
-      ),
-      (
-        #line, literal: ExprSyntax("0xFFFFFFFF").cast(IntegerLiteralExprSyntax.self), expectation: ExprSyntax("0xFFFF_FFFF").cast(IntegerLiteralExprSyntax.self)
-      ),
-      (#line, literal: ExprSyntax("0xFFFFF").cast(IntegerLiteralExprSyntax.self), expectation: ExprSyntax("0xF_FFFF").cast(IntegerLiteralExprSyntax.self)),
-      (#line, literal: ExprSyntax("0o777777").cast(IntegerLiteralExprSyntax.self), expectation: ExprSyntax("0o777_777").cast(IntegerLiteralExprSyntax.self)),
-      (
-        #line, literal: ExprSyntax("424242424242").cast(IntegerLiteralExprSyntax.self),
-        expectation: ExprSyntax("424_242_424_242").cast(IntegerLiteralExprSyntax.self)
-      ),
-      (#line, literal: ExprSyntax("100").cast(IntegerLiteralExprSyntax.self), expectation: ExprSyntax("100").cast(IntegerLiteralExprSyntax.self)),
-      (
-        #line, literal: ExprSyntax("0xF_F_F_F_F_F_F_F").cast(IntegerLiteralExprSyntax.self),
-        expectation: ExprSyntax("0xFFFF_FFFF").cast(IntegerLiteralExprSyntax.self)
-      ),
-      (#line, literal: ExprSyntax("0xFF_F_FF").cast(IntegerLiteralExprSyntax.self), expectation: ExprSyntax("0xF_FFFF").cast(IntegerLiteralExprSyntax.self)),
-      (#line, literal: ExprSyntax("0o7_77777").cast(IntegerLiteralExprSyntax.self), expectation: ExprSyntax("0o777_777").cast(IntegerLiteralExprSyntax.self)),
-      (
-        #line, literal: ExprSyntax("4_24242424242").cast(IntegerLiteralExprSyntax.self),
-        expectation: ExprSyntax("424_242_424_242").cast(IntegerLiteralExprSyntax.self)
-      ),
+    let tests: [(Int, literal: ExprSyntax, expectation: ExprSyntax)] = [
+      (#line, literal: ExprSyntax("0b101010101"), expectation: ExprSyntax("0b1_0101_0101")),
+      (#line, literal: ExprSyntax("0xFFFFFFFF"), expectation: ExprSyntax("0xFFFF_FFFF")),
+      (#line, literal: ExprSyntax("0xFFFFF"), expectation: ExprSyntax("0xF_FFFF")),
+      (#line, literal: ExprSyntax("0o777777"), expectation: ExprSyntax("0o777_777")),
+      (#line, literal: ExprSyntax("424242424242"), expectation: ExprSyntax("424_242_424_242")),
+      (#line, literal: ExprSyntax("100"), expectation: ExprSyntax("100")),
+      (#line, literal: ExprSyntax("0xF_F_F_F_F_F_F_F"), expectation: ExprSyntax("0xFFFF_FFFF")),
+      (#line, literal: ExprSyntax("0xFF_F_FF"), expectation: ExprSyntax("0xF_FFFF")),
+      (#line, literal: ExprSyntax("0o7_77777"), expectation: ExprSyntax("0o777_777")),
+      (#line, literal: ExprSyntax("4_24242424242"), expectation: ExprSyntax("424_242_424_242")),
     ]
 
     for (line, literal, expectation) in tests {
-      try assertRefactor(literal, context: (), provider: AddSeparatorsToIntegerLiteral.self, expected: expectation, line: UInt(line))
+      try assertRefactor(
+        literal.cast(IntegerLiteralExprSyntax.self),
+        context: (),
+        provider: AddSeparatorsToIntegerLiteral.self,
+        expected: expectation.cast(IntegerLiteralExprSyntax.self),
+        line: UInt(line)
+      )
     }
   }
 
   func testSeparatorRemoval() throws {
-    let tests = [
-      (
-        #line, literal: ExprSyntax("0b1_0_1_0_1_0_1_0_1").cast(IntegerLiteralExprSyntax.self),
-        expectation: ExprSyntax("0b101010101").cast(IntegerLiteralExprSyntax.self)
-      ),
-      (
-        #line, literal: ExprSyntax("0xFFF_F_FFFF").cast(IntegerLiteralExprSyntax.self),
-        expectation: ExprSyntax("0xFFFFFFFF").cast(IntegerLiteralExprSyntax.self)
-      ),
-      (#line, literal: ExprSyntax("0xFF_FFF").cast(IntegerLiteralExprSyntax.self), expectation: ExprSyntax("0xFFFFF").cast(IntegerLiteralExprSyntax.self)),
-      (#line, literal: ExprSyntax("0o777_777").cast(IntegerLiteralExprSyntax.self), expectation: ExprSyntax("0o777777").cast(IntegerLiteralExprSyntax.self)),
-      (
-        #line, literal: ExprSyntax("424_242_424_242").cast(IntegerLiteralExprSyntax.self),
-        expectation: ExprSyntax("424242424242").cast(IntegerLiteralExprSyntax.self)
-      ),
-      (#line, literal: ExprSyntax("100").cast(IntegerLiteralExprSyntax.self), expectation: ExprSyntax("100").cast(IntegerLiteralExprSyntax.self)),
+    let tests: [(Int, literal: ExprSyntax, expectation: ExprSyntax)] = [
+      (#line, literal: ExprSyntax("0b1_0_1_0_1_0_1_0_1"), expectation: ExprSyntax("0b101010101")),
+      (#line, literal: ExprSyntax("0xFFF_F_FFFF"), expectation: ExprSyntax("0xFFFFFFFF")),
+      (#line, literal: ExprSyntax("0xFF_FFF"), expectation: ExprSyntax("0xFFFFF")),
+      (#line, literal: ExprSyntax("0o777_777"), expectation: ExprSyntax("0o777777")),
+      (#line, literal: ExprSyntax("424_242_424_242"), expectation: ExprSyntax("424242424242")),
+      (#line, literal: ExprSyntax("100"), expectation: ExprSyntax("100")),
     ]
 
     for (line, literal, expectation) in tests {
-      try assertRefactor(literal, context: (), provider: RemoveSeparatorsFromIntegerLiteral.self, expected: expectation, line: UInt(line))
+      try assertRefactor(
+        literal.cast(IntegerLiteralExprSyntax.self),
+        context: (),
+        provider: RemoveSeparatorsFromIntegerLiteral.self,
+        expected: expectation.cast(IntegerLiteralExprSyntax.self),
+        line: UInt(line)
+      )
     }
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/BreakStmtSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/BreakStmtSyntaxTests.swift
@@ -17,7 +17,7 @@ import XCTest
 final class BreakStmtSyntaxTests: XCTestCase {
   func testBreakStmtSyntax() {
     let testCases: [UInt: (StmtSyntax, String)] = [
-      #line: (BreakStmtSyntax().as(StmtSyntax.self)!, "break"),
+      #line: (StmtSyntax(BreakStmtSyntax()), "break"),
       #line: (StmtSyntax("break"), "break"),
     ]
 

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -94,7 +94,6 @@ final class StringInterpolationTests: XCTestCase {
 
   func testAttributeInterpolation() {
     let attrSyntax: AttributeSyntax = "@discardableResult"
-    XCTAssertTrue(attrSyntax.is(AttributeSyntax.self))
     XCTAssertEqual(attrSyntax.description, "@discardableResult")
   }
 
@@ -382,7 +381,6 @@ final class StringInterpolationTests: XCTestCase {
         _storage = newValue
       }
       """
-    XCTAssertTrue(setter.is(AccessorDeclSyntax.self))
     assertStringsEqualWithDiff(
       setter.description,
       """
@@ -431,7 +429,6 @@ final class StringInterpolationTests: XCTestCase {
       }
       """
 
-    XCTAssertTrue(codeBlockItem.is(CodeBlockItemSyntax.self))
     assertStringsEqualWithDiff(
       codeBlockItem.description,
       """

--- a/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
@@ -56,9 +56,7 @@ final class CodeItemMacroTests: XCTestCase {
         }
         let errorThrower = node.trailingClosure
         let identifiers = try node.arguments.map { argument in
-          guard let tupleElement = argument.as(LabeledExprSyntax.self),
-            let declReferenceExpr = tupleElement.expression.as(DeclReferenceExprSyntax.self)
-          else {
+          guard let declReferenceExpr = argument.expression.as(DeclReferenceExprSyntax.self) else {
             throw MacroExpansionErrorMessage("Arguments must be identifiers")
           }
           return declReferenceExpr.baseName


### PR DESCRIPTION
To-Do after concept approval:
- [x] Fix all warnings related to API changes across the entire repo
- [x] Add documentation for Code Generation and the new API

I'm opening this PR as a draft to initiate a discussion about the proposed changes.

In issue #2092, @ahoppen mentioned:
> What we should do instead, is to only have a `as(_: ExprSyntaxProtocol.Type)` function on `ExprSyntax` (analogous for `StmtSyntax` and the other base nodes).
>
> The `as` function on `SyntaxProtocol` can then be marked as deprecated and produce a warning that the cast will always fail.

Best to my understanding, we cannot remove the `as` method from `SyntaxProtocol`. This function is necessary due to entities like `Syntax` or `ExprSyntax`. Without these entities, we could use the `is`/`as` Swift keywords. To illustrate, consider the example below:
```swift
func visit(node: some SyntaxProtocol) {
  if node is ClassExprSyntax { ... }
}
```
The following argument can be passed to this function:
```swift
let node = Syntax(ClassExprSyntax("class Foo {}"))

visit(node)
```
In this scenario, using the `is` Swift keyword won't correctly identify that the argument is actually of type `ClassExprSyntax`.

Consequently, I've tried to enhance the downcasting API in a slightly more intricate manner by adding casting methods for lower types.

If any decisions are unclear, please let me know. I'm also eager to hear your general feedback!

This PR resolves part of #2092.