### PR TITLE
Add whitespace if needed when returning syntaxTextBytes

### DIFF
--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -399,4 +399,30 @@ final class FunctionTests: XCTestCase {
       """
     )
   }
+
+  func testFunctionDeclCreatedByStringInterpolation() throws {
+    let declModifierList = DeclModifierListSyntax {
+      DeclModifierSyntax(name: .keyword(.public))
+      DeclModifierSyntax(name: .keyword(.static))
+    }
+    let identifier = TokenSyntax.identifier("==")
+    let functionParameterClause = FunctionParameterClauseSyntax {
+      FunctionParameterSyntax(firstName: TokenSyntax.identifier("lhs"), colon: .colonToken(), type: TypeSyntax("String"))
+      FunctionParameterSyntax(firstName: TokenSyntax.identifier("rhs"), colon: .colonToken(), type: TypeSyntax("String"))
+    }
+    let returnClause = ReturnClauseSyntax(
+      type: IdentifierTypeSyntax(name: TokenSyntax.identifier("Bool"))
+    )
+    let functionDecl = try FunctionDeclSyntax("\(declModifierList) func \(identifier) \(functionParameterClause) \(returnClause)") {
+      "return lhs < rhs"
+    }
+    assertBuildResult(
+      functionDecl,
+      """
+      public static func == (lhs: String, rhs: String) -> Bool {
+          return lhs < rhs
+      }
+      """
+    )
+  }
 }

--- a/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
@@ -87,4 +87,28 @@ final class InitializerDeclTests: XCTestCase {
       """
     )
   }
+
+  func testInitializerDeclCreatedByStringInterpolation() throws {
+    let functionPrameterClause = FunctionParameterClauseSyntax {
+      FunctionParameterSyntax(firstName: "_", secondName: "name", type: TypeSyntax("String"))
+      FunctionParameterSyntax(firstName: "description", type: TypeSyntax("String"))
+    }
+    let functionSignature = FunctionSignatureSyntax(
+      parameterClause: functionPrameterClause,
+      effectSpecifiers: .init(asyncSpecifier: .keyword(.async), throwsSpecifier: .keyword(.throws))
+    )
+    let initializerDeclFromString = try InitializerDeclSyntax("init\(functionSignature)") {
+      "self.name = name"
+      "self.description = description"
+    }
+    assertBuildResult(
+      initializerDeclFromString,
+      """
+      init(_ name: String, description: String) async throws {
+          self.name = name
+          self.description = description
+      }
+      """
+    )
+  }
 }


### PR DESCRIPTION
Resolve #2107 

While it's not a problem if different kinds of tokens that can be distinguished by their kinds appear consecutively without whitespace; however, if tokens of the same kind are positioned without a delimiter, there arises an issue when converting syntaxTextBytes into a SyntaxNode.

When two indistinguishable(of the same kind) tokens are positioned consecutively without whitespace or punctuation, I have added whitespace for differentiation.