### PR TITLE
Add automatic colons or paranthesis to nodes when needed

### DIFF
--- a/Sources/SwiftSyntax/Convenience.swift
+++ b/Sources/SwiftSyntax/Convenience.swift
@@ -10,6 +10,37 @@
 //
 //===----------------------------------------------------------------------===//
 
+extension EnumCaseParameterSyntax {
+
+  /// Creates an `EnumCaseParameterSyntax` with a `firstName`, and automatically adds a `colon` to it.
+  ///
+  ///  - SeeAlso: For more information on the arguments, see ``EnumCaseParameterSyntax/init(leadingTrivia:_:modifiers:_:firstName:_:secondName:_:colon:_:type:_:defaultArgument:_:trailingComma:_:trailingTrivia:)``
+  ///
+  public init(
+    leadingTrivia: Trivia? = nil,
+    modifiers: DeclModifierListSyntax = [],
+    firstName: TokenSyntax,
+    secondName: TokenSyntax? = nil,
+    colon: TokenSyntax = TokenSyntax.colonToken(),
+    type: some TypeSyntaxProtocol,
+    defaultValue: InitializerClauseSyntax? = nil,
+    trailingComma: TokenSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      modifiers: modifiers,
+      firstName: firstName as TokenSyntax?,
+      secondName: secondName,
+      colon: colon,
+      type: type,
+      defaultValue: defaultValue,
+      trailingComma: trailingComma,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
 extension MemberAccessExprSyntax {
   /// Creates a new ``MemberAccessExprSyntax`` where the accessed member is represented by
   /// an identifier without specifying argument labels.
@@ -45,3 +76,8 @@ extension MemberAccessExprSyntax {
     )
   }
 }
+
+//==========================================================================//
+// IMPORTANT: If you are tempted to add an extension here, please insert    //
+// it in alphabetical order above                                           //
+//==========================================================================//

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -125,4 +125,12 @@ public class SyntaxTests: XCTestCase {
     XCTAssertEqual(funcKW.endPosition, AbsolutePosition(utf8Offset: 7))
     XCTAssertEqual(funcKW.trimmedLength, SourceLength(utf8Length: 4))
   }
+
+  public func testEnumCaseParameterSyntaxConvenienceInit() {
+    let noFirstName = EnumCaseParameterSyntax(type: TypeSyntax("MyType"))
+    XCTAssertEqual(noFirstName.formatted().description, "MyType")
+
+    let node = EnumCaseParameterSyntax(firstName: "label", type: TypeSyntax("MyType"))
+    XCTAssertEqual(node.formatted().description, "label: MyType")
+  }
 }


### PR DESCRIPTION
This pull request adds a convenience init to `EnumCaseParameterSyntax` so that when you're initializing it with a `firstName`, it adds `colon` automatically.

It's the first step in #1984.

## Changes
- `SwiftSyntax` already had a `Convenience.swift`, so I'm adding an extension there for now. The file is small and readable. 
- I've added a unit test to `SwiftSyntaxTest/SyntaxTest.swift`, however as we progress in #1984, I'll perhaps extract them into a `ConvenienceInitTests.swift`.

## How to review this
- I love tinkering with this, but I do feel like Alice in Wonderland. @ahoppen, did I capture your idea well, does this approach seem right? 
- I've used `let firstName: TokenSyntax? = firstName` to trick Swift into using the right overload with an optional `firstName` so that the underlying generated `init` will be called, instead of copying it over.
- While this PR might be self-sufficient, we should probably add the rest of the todos to this as well? 

## TODO
Copying over from the issue: 
And the same strategy can also be applied
- [ ] Other nodes that have an optional colon
- [ ] `ClosureCaptureSyntax.equal`
- Automatically add parentheses for the following nodes if arguments are present:
   - [ ] `AttributeSyntax`
   - [ ] `MacroExpansionDeclSyntax`
   - [ ] `ClosureCaptureModifierSyntax`
   - [ ] `FunctionCallExprSyntax`
   - [ ] `FreestandingMacroExpansionSyntax`
