### PR TITLE
[5.9][CMake] Add padding to RUNPATH in linux

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -66,10 +66,16 @@ function(add_swift_host_library name)
   )
 
   get_target_property(lib_type ${name} TYPE)
-  if(lib_type STREQUAL SHARED_LIBRARY AND CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    # Allow install_name_tool to update paths (for rdar://109473564)
-    set_property(TARGET ${name} APPEND_STRING PROPERTY
-                 LINK_FLAGS " -Xlinker -headerpad_max_install_names")
+  if(lib_type STREQUAL SHARED_LIBRARY)
+    if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      # Allow install_name_tool to update paths (for rdar://109473564)
+      set_property(TARGET ${name} APPEND_STRING PROPERTY
+                   LINK_FLAGS " -Xlinker -headerpad_max_install_names")
+    elseif (CMAKE_SYSTEM_NAME STREQUAL Linux)
+      # Make some room to update paths.
+      set_property(TARGET ${name} APPEND PROPERTY
+                   INSTALL_RPATH ":::::::::::::::::::::::::::::::::::::::::::::::::::::::")
+    endif()
   endif()
 
   # Install this target


### PR DESCRIPTION
Cherry-pick #2090 into `release/5.9`

* **Explanation**: Companion of https://github.com/apple/swift/pull/68190. In the swift repository, swift-syntax libraries are copied to swift build directory, get the RUNPATH rewritten, and installed from there. To rewrite the RUNPATH, the initial length of it must be longer than the new RUNPATH. This PR add some padding to make enough room to be rewritten
* **Scope**: Swift compiler build script
* **Risk**: Low. This change itself just adds a non-harmful padding to the binary
* **Testing**: Passes current test suite
* **Issue**: rdar://104346187 
* **Reviewer**: Ben Barham (@bnbarham)