### PR TITLE
Add a release notes document for swift-syntax 510

### DIFF
--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -1,0 +1,27 @@
+# Swift Syntax 510 Release Notes
+
+## New APIs
+
+- `SyntaxStringInterpolation.appendInterpolation(_: (some SyntaxProtocol)?)`
+  - Descriptions: Allows optional syntax nodes to be used inside string interpolation of syntax nodes. If the node is `nil`, nothing will get added to the string interpolation.
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2085
+- `SyntaxCollection.index(at:)`
+  - Description: Returns the index of the n-th element in a `SyntaxCollection`. This computation is in O(n) and `SyntaxCollection` is not subscriptable by an integer.
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2014
+
+## API Behavior Changes
+
+## Deprecations
+
+## API-Incompatible Changes
+
+
+## Template
+
+- *Affected API or two word description*
+  - Description: *A 1-2 sentence description of the new/modified API*
+  - Issue: *If an issue exists for this change, a link to the issue*
+  - Pull Request: *Link to the pull request(s) that introduces this change*
+  - Notes: *In case of deprecations or API-incompatible changes, the reason why this change was made and the suggested alternative*
+
+*Insert entries in chronological order, with newer entries at the bottom*


### PR DESCRIPTION
My idea is that we can build up the list of changes during development. That will make it more transparent for adopters of the snapshot tags to see what has changed and, in case of deprecations or API-incompatible changes, how they need to update.

It will also make it easier to compose the list of changes for the proper (non-snapshot) release of swift-syntax.