### PR TITLE
Set the privacy level of string interpolation errors in os_log to private

### DIFF
--- a/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
@@ -51,7 +51,7 @@ extension SyntaxParseable {
         """
         Parsing a `\(Self.self)` node from string interpolation produced the following parsing errors.
         Set a breakpoint in `SyntaxParseable.logStringInterpolationParsingError()` to debug the failure.
-        \(formattedDiagnostics)
+        \(formattedDiagnostics, privacy: .private)
         """
       )
     }


### PR DESCRIPTION
If string interpolation results in parsing errors, we create an os_log fault to notify the user about a potential bug. This log message contains the source code with the syntax error, which could be sensitive.

Set the os_log privacy level to `private` to make sure the source code does not get persisted in logs. It will still show up in the Xcode console.