### PR TITLE
Add a convenience init to ClosureCaptureSyntax

### DIFF
--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -3,11 +3,19 @@
 ## New APIs
 
 - `SyntaxStringInterpolation.appendInterpolation(_: (some SyntaxProtocol)?)`
-  - Descriptions: Allows optional syntax nodes to be used inside string interpolation of syntax nodes. If the node is `nil`, nothing will get added to the string interpolation.
+  - Description: Allows optional syntax nodes to be used inside string interpolation of syntax nodes. If the node is `nil`, nothing will get added to the string interpolation.
   - Pull Request: https://github.com/apple/swift-syntax/pull/2085
 - `SyntaxCollection.index(at:)`
   - Description: Returns the index of the n-th element in a `SyntaxCollection`. This computation is in O(n) and `SyntaxCollection` is not subscriptable by an integer.
   - Pull Request: https://github.com/apple/swift-syntax/pull/2014
+- Convenience initializer `ClosureCaptureSyntax.init()`
+  - Description: Provides a convenience initializer for `ClosureCaptureSyntax` that takes a concrete `name` argument and automatically adds `equal = TokenSyntax.equalToken()` to it.
+  - Issue: https://github.com/apple/swift-syntax/issues/1984
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2127
+- Convenience initializer `EnumCaseParameterSyntax.init()`
+  - Description: Provides a convenience initializer for `EnumCaseParameterSyntax` that takes a concrete `firstName` value and adds `colon = TokenSyntax.colonToken()` automatically to it.
+  - Issue: https://github.com/apple/swift-syntax/issues/1984
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2112
 
 ## API Behavior Changes
 

--- a/Sources/SwiftSyntax/Convenience.swift
+++ b/Sources/SwiftSyntax/Convenience.swift
@@ -12,7 +12,7 @@
 
 extension ClosureCaptureSyntax {
 
-  /// Creates a `ClosureCaptureSyntax` with a `name`, and automatically adds an `equal` token to it since the name is non-optional.
+  /// Creates a ``ClosureCaptureSyntax`` with a `name`, and automatically adds an `equal` token to it since the name is non-optional.
   ///
   /// - SeeAlso: ``ClosureCaptureSyntax/init(leadingTrivia:_:specifier:_:name:_:equal:_:expression:_:trailingComma:_:trailingTrivia:)``.
   ///
@@ -39,7 +39,7 @@ extension ClosureCaptureSyntax {
 
 extension EnumCaseParameterSyntax {
 
-  /// Creates an `EnumCaseParameterSyntax` with a `firstName`, and automatically adds a `colon` to it.
+  /// Creates an ``EnumCaseParameterSyntax`` with a `firstName`, and automatically adds a `colon` to it.
   ///
   ///  - SeeAlso: For more information on the arguments, see ``EnumCaseParameterSyntax/init(leadingTrivia:_:modifiers:_:firstName:_:secondName:_:colon:_:type:_:defaultArgument:_:trailingComma:_:trailingTrivia:)``
   ///

--- a/Sources/SwiftSyntax/Convenience.swift
+++ b/Sources/SwiftSyntax/Convenience.swift
@@ -10,6 +10,33 @@
 //
 //===----------------------------------------------------------------------===//
 
+extension ClosureCaptureSyntax {
+
+  /// Creates a `ClosureCaptureSyntax` with a `name`, and automatically adds an `equal` token to it since the name is non-optional.
+  ///
+  /// - SeeAlso: ``ClosureCaptureSyntax/init(leadingTrivia:_:specifier:_:name:_:equal:_:expression:_:trailingComma:_:trailingTrivia:)``.
+  ///
+  public init(
+    leadingTrivia: Trivia? = nil,
+    specifier: ClosureCaptureSpecifierSyntax? = nil,
+    name: TokenSyntax,
+    equal: TokenSyntax = TokenSyntax.equalToken(),
+    expression: some ExprSyntaxProtocol,
+    trailingComma: TokenSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      specifier: specifier,
+      name: name as TokenSyntax?,
+      equal: equal,
+      expression: expression,
+      trailingComma: trailingComma,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
 extension EnumCaseParameterSyntax {
 
   /// Creates an `EnumCaseParameterSyntax` with a `firstName`, and automatically adds a `colon` to it.

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -133,4 +133,12 @@ public class SyntaxTests: XCTestCase {
     let node = EnumCaseParameterSyntax(firstName: "label", type: TypeSyntax("MyType"))
     XCTAssertEqual(node.formatted().description, "label: MyType")
   }
+
+  public func testClosureCaptureSyntaxConvenienceInitWithEqual() {
+    let noNameClosureCapture = ClosureCaptureSyntax(expression: ExprSyntax("123"))
+    XCTAssertEqual(noNameClosureCapture.formatted().description, "123")
+
+    let node = ClosureCaptureSyntax(name: "test", expression: ExprSyntax("123"))
+    XCTAssertEqual(node.formatted().description, "test = 123")
+  }
 }


### PR DESCRIPTION
## Summary

This adds a convenience `init` to `ClosureCaptureSyntax` that adds an `equal` token if the provided `name` is not nil.

It's supposed to be used by developers, so it omits the unexpected tokens.

Related: #1984