### PR TITLE
Ignore .vscode and cmake build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,16 @@
 UserInterfaceState.xcuserstate
 xcuserdata/
 
+# Ignore VScode workspace settings and launch configurations
+.vscode
+
 # Ignore bazel symlinks
 /bazel-*
 
-# We always build swiftSyntax of trunk dependencies. Ignore any fixed 
+# Ignore cmake build configuration and output
+build/
+
+# We always build swiftSyntax of trunk dependencies. Ignore any fixed
 # dependency versions.
 Package.resolved
 


### PR DESCRIPTION
## Summary

- Ignore `.vscode` workspace settings and launch config
- Ignore `build/` where CMake puts its generated build config and output

## API Changes

None. Just the `.gitignore` change.

## Review

Most other Apple repositories do not ignore `.vscode`. I'm not sure if that'll be controversial or not (asked on Slack here: https://swift-open-source.slack.com/archives/C04N0ET1K3Q/p1693439399150369

