### PR TITLE
[509] Fix issue that caused errors thrown from macro expansion to show up twice in MacroSystem

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -485,10 +485,14 @@ private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
     // Note that 'MacroExpansionExpr'/'MacroExpansionExprDecl' at code item
     // position are handled by 'visit(_:CodeBlockItemListSyntax)'.
     // Only expression expansions inside other syntax nodes is handled here.
-    if let expanded = expandExpr(node: node) {
+    switch expandExpr(node: node) {
+    case .success(let expanded):
       return Syntax(visit(expanded))
+    case .failure:
+      return Syntax(node)
+    case .notAMacro:
+      break
     }
-
     if let declSyntax = node.as(DeclSyntax.self),
       let attributedNode = node.asProtocol(WithAttributesSyntax.self),
       !attributedNode.attributes.isEmpty
@@ -510,15 +514,20 @@ private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
     var newItems: [CodeBlockItemSyntax] = []
     func addResult(_ node: CodeBlockItemSyntax) {
       // Expand freestanding macro.
-      if let expanded = expandCodeBlockItem(node: node) {
+      switch expandCodeBlockItem(node: node) {
+      case .success(let expanded):
         for item in expanded {
           addResult(item)
         }
         return
+      case .failure:
+        // Expanding the macro threw an error. We don't have an expanded source.
+        // Retain the macro node as-is.
+        newItems.append(node)
+      case .notAMacro:
+        // Recurse on the child node
+        newItems.append(visit(node))
       }
-
-      // Recurse on the child node
-      newItems.append(visit(node))
 
       // Expand any peer macro on this item.
       if case .decl(let decl) = node.item {
@@ -552,15 +561,18 @@ private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
 
     func addResult(_ node: MemberBlockItemSyntax) {
       // Expand freestanding macro.
-      if let expanded = expandMemberDecl(node: node) {
+      switch expandMemberDecl(node: node) {
+      case .success(let expanded):
         for item in expanded {
           addResult(item)
         }
         return
+      case .failure:
+        newItems.append(node)
+      case .notAMacro:
+        // Recurse on the child node.
+        newItems.append(visit(node))
       }
-
-      // Recurse on the child node.
-      newItems.append(visit(node))
 
       // Expand any peer macro on this member.
       for peer in expandMemberDeclPeers(of: node.decl) {
@@ -842,20 +854,36 @@ extension MacroApplication {
 // MARK: Freestanding macro expansion
 
 extension MacroApplication {
+  enum MacroExpansionResult<ResultType> {
+    /// Expansion of the macro succeeded.
+    case success(ResultType)
+
+    /// Macro system found the macro to expand but running the expansion threw
+    /// an error and thus no expansion result exists.
+    case failure
+
+    /// The node that should be expanded was not a macro known to the macro system.
+    case notAMacro
+  }
+
   private func expandFreestandingMacro<ExpandedMacroType: SyntaxProtocol>(
     _ node: (any FreestandingMacroExpansionSyntax)?,
     expandMacro: (_ macro: Macro.Type, _ node: any FreestandingMacroExpansionSyntax) throws -> ExpandedMacroType?
-  ) -> ExpandedMacroType? {
+  ) -> MacroExpansionResult<ExpandedMacroType> {
     guard let node,
       let macro = macroSystem.lookup(node.macro.text)
     else {
-      return nil
+      return .notAMacro
     }
     do {
-      return try expandMacro(macro, node)
+      if let expanded = try expandMacro(macro, node) {
+        return .success(expanded)
+      } else {
+        return .failure
+      }
     } catch {
       context.addDiagnostics(from: error, node: node)
-      return nil
+      return .failure
     }
   }
 
@@ -867,7 +895,7 @@ extension MacroApplication {
   ///   #foo
   /// }
   /// ```
-  func expandCodeBlockItem(node: CodeBlockItemSyntax) -> CodeBlockItemListSyntax? {
+  func expandCodeBlockItem(node: CodeBlockItemSyntax) -> MacroExpansionResult<CodeBlockItemListSyntax> {
     return expandFreestandingMacro(node.item.asProtocol(FreestandingMacroExpansionSyntax.self)) { macro, node in
       return try expandFreestandingCodeItemList(
         definition: macro,
@@ -886,7 +914,7 @@ extension MacroApplication {
   ///   #foo
   /// }
   /// ```
-  func expandMemberDecl(node: MemberBlockItemSyntax) -> MemberBlockItemListSyntax? {
+  func expandMemberDecl(node: MemberBlockItemSyntax) -> MacroExpansionResult<MemberBlockItemListSyntax> {
     return expandFreestandingMacro(node.decl.as(MacroExpansionDeclSyntax.self)) { macro, node in
       return try expandFreestandingMemberDeclList(
         definition: macro,
@@ -904,7 +932,7 @@ extension MacroApplication {
   /// ```swift
   /// let a = #foo
   /// ```
-  func expandExpr(node: Syntax) -> ExprSyntax? {
+  func expandExpr(node: Syntax) -> MacroExpansionResult<ExprSyntax> {
     return expandFreestandingMacro(node.as(MacroExpansionExprSyntax.self)) { macro, node in
       return try expandFreestandingExpr(
         definition: macro,


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-syntax/pull/2115 to `package-release/509`.

---

If the macro expansion of a freestanding expression macro throws an error, `expandCodeBlockItem` returned `nil` while adding the thrown error to the macro expansion context. `visit(_:CodeBlockItemListSyntax).addResult` took the `nil` return value as an indicator that the macro wasn’t expanded because its macro definition wasn’t found and ended up calling the expansion again in

```swift
// Recurse on the child node
newItems.append(visit(node))
```

Change the return value of `expandCodeBlockItem` to an enum that indicates whether the macro was not found or if the expansion failed. If the macro was found but the expansion threw an error, we just just retain the macro as-is without calling into `visit` again.

Fixes #2111
rdar://114592410