### PR TITLE
Rename some properties on `FreestandingMacroExpansionSyntax`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -62,11 +62,11 @@ public let TRAITS: [Trait] = [
   Trait(
     traitName: "FreestandingMacroExpansion",
     children: [
-      Child(name: "poundToken", kind: .token(choices: [.token(.pound)])),
-      Child(name: "macro", kind: .token(choices: [.token(.identifier)])),
+      Child(name: "pound", deprecatedName: "poundToken", kind: .token(choices: [.token(.pound)])),
+      Child(name: "macroName", deprecatedName: "macro", kind: .token(choices: [.token(.identifier)])),
       Child(name: "genericArgumentClause", kind: .node(kind: .genericArgumentClause), isOptional: true),
       Child(name: "leftParen", kind: .token(choices: [.token(.leftParen)]), isOptional: true),
-      Child(name: "argumentList", kind: .node(kind: .labeledExprList)),
+      Child(name: "arguments", deprecatedName: "argumentList", kind: .node(kind: .labeledExprList)),
       Child(name: "rightParen", kind: .token(choices: [.token(.rightParen)]), isOptional: true),
       Child(name: "trailingClosure", kind: .node(kind: .closureExpr), isOptional: true),
       Child(name: "additionalTrailingClosures", kind: .node(kind: .multipleTrailingClosureElementList)),

--- a/Examples/Sources/ExamplePlugin/Macros.swift
+++ b/Examples/Sources/ExamplePlugin/Macros.swift
@@ -11,7 +11,7 @@ struct EchoExpressionMacro: ExpressionMacro {
     of node: Node,
     in context: Context
   ) throws -> ExprSyntax {
-    let expr: ExprSyntax = node.argumentList.first!.expression
+    let expr: ExprSyntax = node.arguments.first!.expression
     return expr.with(\.leadingTrivia, [.blockComment("/* echo */")])
   }
 }
@@ -137,7 +137,7 @@ struct PrintAnyMacro: CodeItemMacro {
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
   ) throws -> [CodeBlockItemSyntax] {
-    guard let expr = node.argumentList.first?.expression else {
+    guard let expr = node.arguments.first?.expression else {
       return []
     }
     return ["print(\(expr))"]

--- a/Examples/Sources/MacroExamples/Implementation/AddBlocker.swift
+++ b/Examples/Sources/MacroExamples/Implementation/AddBlocker.swift
@@ -101,6 +101,6 @@ public struct AddBlocker: ExpressionMacro {
       context.diagnose(diag)
     }
 
-    return result.asProtocol(FreestandingMacroExpansionSyntax.self)!.argumentList.first!.expression
+    return result.asProtocol(FreestandingMacroExpansionSyntax.self)!.arguments.first!.expression
   }
 }

--- a/Examples/Sources/MacroExamples/Implementation/FontLiteralMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/FontLiteralMacro.swift
@@ -22,7 +22,7 @@ public struct FontLiteralMacro: ExpressionMacro {
     in context: some MacroExpansionContext
   ) -> ExprSyntax {
     let argList = replaceFirstLabel(
-      of: macro.argumentList,
+      of: macro.arguments,
       with: "fontLiteralName"
     )
     return ".init(\(argList))"

--- a/Examples/Sources/MacroExamples/Implementation/StringifyMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/StringifyMacro.swift
@@ -28,7 +28,7 @@ public struct StringifyMacro: ExpressionMacro {
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
   ) -> ExprSyntax {
-    guard let argument = node.argumentList.first?.expression else {
+    guard let argument = node.arguments.first?.expression else {
       fatalError("compiler bug: the macro does not have any arguments")
     }
 

--- a/Examples/Sources/MacroExamples/Implementation/URLMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/URLMacro.swift
@@ -22,7 +22,7 @@ public struct URLMacro: ExpressionMacro {
     in context: some MacroExpansionContext
   ) throws -> ExprSyntax {
 
-    guard let argument = node.argumentList.first?.expression,
+    guard let argument = node.arguments.first?.expression,
       let segments = argument.as(StringLiteralExprSyntax.self)?.segments,
       segments.count == 1,
       case .stringSegment(let literalSegment)? = segments.first

--- a/Examples/Sources/MacroExamples/Implementation/WarningMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/WarningMacro.swift
@@ -21,7 +21,7 @@ public struct WarningMacro: ExpressionMacro {
     of macro: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
   ) throws -> ExprSyntax {
-    guard let firstElement = macro.argumentList.first,
+    guard let firstElement = macro.arguments.first,
       let stringLiteral = firstElement.expression
         .as(StringLiteralExprSyntax.self),
       stringLiteral.segments.count == 1,

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -51,6 +51,26 @@ public extension DeclGroupSyntax {
 }
 
 public extension FreestandingMacroExpansionSyntax {
+  @available(*, deprecated, renamed: "pound")
+  public var poundToken: TokenSyntax {
+    get {
+      return pound
+    }
+    set {
+      pound = newValue
+    }
+  }
+
+  @available(*, deprecated, renamed: "macroName")
+  public var macro: TokenSyntax {
+    get {
+      return macroName
+    }
+    set {
+      macroName = newValue
+    }
+  }
+
   @available(*, deprecated, renamed: "genericArgumentClause")
   var genericArguments: GenericArgumentClauseSyntax? {
     get {
@@ -58,6 +78,16 @@ public extension FreestandingMacroExpansionSyntax {
     }
     set {
       genericArgumentClause = newValue
+    }
+  }
+
+  @available(*, deprecated, renamed: "arguments")
+  public var argumentList: LabeledExprListSyntax {
+    get {
+      return arguments
+    }
+    set {
+      arguments = newValue
     }
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -173,12 +173,12 @@ public extension SyntaxProtocol {
 
 
 public protocol FreestandingMacroExpansionSyntax: SyntaxProtocol {
-  var poundToken: TokenSyntax {
+  var pound: TokenSyntax {
     get
     set
   }
   
-  var macro: TokenSyntax {
+  var macroName: TokenSyntax {
     get
     set
   }
@@ -193,7 +193,7 @@ public protocol FreestandingMacroExpansionSyntax: SyntaxProtocol {
     set
   }
   
-  var argumentList: LabeledExprListSyntax {
+  var arguments: LabeledExprListSyntax {
     get
     set
   }

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -278,7 +278,7 @@ extension MacroDeclSyntax {
     replacements: [MacroDefinition.Replacement]
   ) -> ExprSyntax {
     return expand(
-      argumentList: node.argumentList,
+      argumentList: node.arguments,
       definition: definition,
       replacements: replacements
     )

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -847,7 +847,7 @@ extension MacroApplication {
     expandMacro: (_ macro: Macro.Type, _ node: any FreestandingMacroExpansionSyntax) throws -> ExpandedMacroType?
   ) -> ExpandedMacroType? {
     guard let node,
-      let macro = macroSystem.lookup(node.macro.text)
+      let macro = macroSystem.lookup(node.macroName.text)
     else {
       return nil
     }

--- a/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
@@ -31,7 +31,7 @@ fileprivate struct DeclsFromStringsMacro: DeclarationMacro {
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     var strings: [String] = []
-    for arg in node.argumentList {
+    for arg in node.arguments {
       guard let value = arg.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue else {
         continue
       }
@@ -51,11 +51,11 @@ final class CodeItemMacroTests: XCTestCase {
         of node: some FreestandingMacroExpansionSyntax,
         in context: some MacroExpansionContext
       ) throws -> [CodeBlockItemSyntax] {
-        guard !node.argumentList.isEmpty else {
+        guard !node.arguments.isEmpty else {
           throw MacroExpansionErrorMessage("'#unwrap' requires arguments")
         }
         let errorThrower = node.trailingClosure
-        let identifiers = try node.argumentList.map { argument in
+        let identifiers = try node.arguments.map { argument in
           guard let tupleElement = argument.as(LabeledExprSyntax.self),
             let declReferenceExpr = tupleElement.expression.as(DeclReferenceExprSyntax.self)
           else {

--- a/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
@@ -31,7 +31,7 @@ fileprivate struct DeclsFromStringsMacro: DeclarationMacro {
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     var strings: [String] = []
-    for arg in node.argumentList {
+    for arg in node.arguments {
       guard let value = arg.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue else {
         continue
       }
@@ -51,7 +51,7 @@ final class DeclarationMacroTests: XCTestCase {
         of node: some FreestandingMacroExpansionSyntax,
         in context: some MacroExpansionContext
       ) throws -> [DeclSyntax] {
-        guard let firstElement = node.argumentList.first,
+        guard let firstElement = node.arguments.first,
           let stringLiteral = firstElement.expression
             .as(StringLiteralExprSyntax.self),
           stringLiteral.segments.count == 1,
@@ -106,7 +106,7 @@ final class DeclarationMacroTests: XCTestCase {
         of node: some FreestandingMacroExpansionSyntax,
         in context: some MacroExpansionContext
       ) throws -> [DeclSyntax] {
-        guard let stringLiteral = node.argumentList.first?.expression.as(StringLiteralExprSyntax.self),
+        guard let stringLiteral = node.arguments.first?.expression.as(StringLiteralExprSyntax.self),
           stringLiteral.segments.count == 1,
           case let .stringSegment(prefix) = stringLiteral.segments.first
         else {
@@ -153,7 +153,7 @@ final class DeclarationMacroTests: XCTestCase {
         in context: some MacroExpansionContext
       ) throws -> [DeclSyntax] {
         var strings: [String] = []
-        for arg in node.argumentList {
+        for arg in node.arguments {
           guard let value = arg.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue else {
             continue
           }

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
@@ -29,7 +29,7 @@ fileprivate struct StringifyMacro: ExpressionMacro {
     of macro: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
   ) throws -> ExprSyntax {
-    guard let argument = macro.argumentList.first?.expression else {
+    guard let argument = macro.arguments.first?.expression else {
       throw MacroExpansionErrorMessage("missing argument")
     }
 
@@ -77,7 +77,7 @@ final class ExpressionMacroTests: XCTestCase {
         of macro: some FreestandingMacroExpansionSyntax,
         in context: some MacroExpansionContext
       ) -> ExprSyntax {
-        var argList = macro.argumentList
+        var argList = macro.arguments
         argList[argList.startIndex].label = .identifier("_colorLiteralRed")
         let initSyntax: ExprSyntax = ".init(\(argList))"
         return initSyntax

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
@@ -31,7 +31,7 @@ fileprivate struct DeclsFromStringsMacro: DeclarationMacro {
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     var strings: [String] = []
-    for arg in node.argumentList {
+    for arg in node.arguments {
       guard let value = arg.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue else {
         continue
       }


### PR DESCRIPTION
The requirements of `FreestandingMacroExpansionSyntax` still referred to the names of these properties before the big rename. Perform the same rename that we did on `MacroExpansionExprSyntax` on `FreestandingMacroExpansionSyntax`.