### PR TITLE
Fix macro expansion diagnostic for multi-binding variable declarations in MacroSystem

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -606,6 +606,10 @@ private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
   }
 
   override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
+    guard !macroAttributes(attachedTo: DeclSyntax(node), ofType: AccessorMacro.Type.self).isEmpty else {
+      return super.visit(node).cast(DeclSyntax.self)
+    }
+
     var node = super.visit(node).cast(VariableDeclSyntax.self)
     guard node.bindings.count == 1, let binding = node.bindings.first else {
       context.addDiagnostics(from: MacroApplicationError.accessorMacroOnVariableWithMultipleBindings, node: node)


### PR DESCRIPTION
When there are no macro attributes attached to the visited `VariableDeclSyntax` node, proceed without performing any additional checks or transformations.

- Addressed the erroneous triggering of `MacroApplicationError.accessorMacroOnVariableWithMultipleBindings` diagnostic for nested multi-binding variable declarations.
- Added corresponding tests to validate the fix.
- Introduce fileprivate `NoOpMemberMacro`, extracted from `testCommentAroundeAttachedMacro` and used in 2 new tests.

Fixes #2133
rdar://114836887
