### PR TITLE
[509] Fix macro expansion diagnostic for multi-binding variable declarations in MacroSystem

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -618,6 +618,10 @@ private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
   }
 
   override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
+    guard !macroAttributes(attachedTo: DeclSyntax(node), ofType: AccessorMacro.Type.self).isEmpty else {
+      return super.visit(node).cast(DeclSyntax.self)
+    }
+
     var node = super.visit(node).cast(VariableDeclSyntax.self)
     guard node.bindings.count == 1, let binding = node.bindings.first else {
       context.addDiagnostics(from: MacroApplicationError.accessorMacroOnVariableWithMultipleBindings, node: node)

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroSystemTests.swift
@@ -660,6 +660,19 @@ public struct DeclsFromStringsMacroNoAttrs: DeclarationMacro {
   }
 }
 
+fileprivate struct NoOpMemberMacro: MemberMacro {
+  public static func expansion<
+    Declaration: DeclGroupSyntax,
+    Context: MacroExpansionContext
+  >(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+    return []
+  }
+}
+
 // MARK: Tests
 
 /// The set of test macros we use here.
@@ -1892,6 +1905,46 @@ final class MacroSystemTests: XCTestCase {
         var peer: Int
         """,
       macros: ["decl": DeclMacro.self, "Peer": MyPeerMacro.self]
+    )
+  }
+
+  func testStructVariableDeclWithMultipleBindings() {
+    assertMacroExpansion(
+      """
+      @Test
+      struct S {
+        var x: Int, y: Int
+      }
+      """,
+      expandedSource: """
+        struct S {
+          var x: Int, y: Int
+        }
+        """,
+      macros: ["Test": NoOpMemberMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
+  func testNestedStructVariableDeclWithMultipleBindings() {
+    assertMacroExpansion(
+      """
+      @Test
+      struct Q {
+        struct R {
+          var i: Int, j: Int
+        }
+      }
+      """,
+      expandedSource: """
+        struct Q {
+          struct R {
+            var i: Int, j: Int
+          }
+        }
+        """,
+      macros: ["Test": NoOpMemberMacro.self],
+      indentationWidth: indentationWidth
     )
   }
 }


### PR DESCRIPTION
Cherry-pick #2139 to package-release/509.

---

When there are no macro attributes attached to the visited `VariableDeclSyntax` node, proceed without performing any additional checks or transformations.

- Addressed the erroneous triggering of `MacroApplicationError.accessorMacroOnVariableWithMultipleBindings` diagnostic for nested multi-binding variable declarations.
- Added corresponding tests to validate the fix.
- Introduce fileprivate `NoOpMemberMacro`, extracted from `testCommentAroundeAttachedMacro` and used in 2 new tests.

Fixes #2133
rdar://114836887