### PR TITLE
Diagnostic format improvements

### DIFF
--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -9,6 +9,10 @@
   - Description: Returns the index of the n-th element in a `SyntaxCollection`. This computation is in O(n) and `SyntaxCollection` is not subscriptable by an integer.
   - Pull Request: https://github.com/apple/swift-syntax/pull/2014
 
+- `DiagnosticSeverity` and `PluginMessage.Diagnostic.Severity` now have new case named `remark`
+  - Description: Remarks are used by the Swift compiler and other tools to describe some aspect of translation that doesn't reflect correctness, but may be useful for the user. Remarks have been added to the diagnostic severity enums to align with the Swift compiler.
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2143
+
 ## API Behavior Changes
 
 ## Deprecations

--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -53,6 +53,7 @@ extension PluginMessage.Diagnostic.Severity {
     case .error: self = .error
     case .warning: self = .warning
     case .note: self = .note
+    case .remark: self = .remark
     }
   }
 }

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
@@ -155,6 +155,7 @@ public enum PluginMessage {
       case error
       case warning
       case note
+      case remark
     }
     public struct Position: Codable {
       public var fileName: String

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -321,26 +321,31 @@ public struct DiagnosticsFormatter {
   /// Annotates the given ``DiagnosticMessage`` with an appropriate ANSI color code (if the value of the `colorize`
   /// property is `true`) and returns the result as a printable string.
   func colorizeIfRequested(_ message: DiagnosticMessage) -> String {
-    switch message.severity {
-    case .error:
-      let annotation = ANSIAnnotation(color: .red, trait: .bold)
-      return colorizeIfRequested("error: \(message.message)", annotation: annotation)
-
-    case .warning:
-      let color = ANSIAnnotation(color: .yellow)
-      let prefix = colorizeIfRequested("warning: ", annotation: color.withTrait(.bold))
-
-      return prefix + colorizeIfRequested(message.message, annotation: color);
-    case .note:
-      return colorizeNoteIfRequested(message.message)
-    }
+    colorizeIfRequested(severity: message.severity, message: message.message)
   }
 
-  /// Annotate a note with an appropriate ANSI color code (if requested).
-  func colorizeNoteIfRequested(_ message: String) -> String {
-    let color = ANSIAnnotation(color: .default, trait: .bold)
-    let prefix = colorizeIfRequested("note: ", annotation: color)
-    return prefix + message
+  /// Annotates a diagnostic message with the given severity and text with an appropriate ANSI color code.
+  func colorizeIfRequested(severity: DiagnosticSeverity, message: String) -> String {
+    let severityText: String
+    let severityAnnotation: ANSIAnnotation
+
+    switch severity {
+    case .error:
+      severityText = "error"
+      severityAnnotation = .errorText
+
+    case .warning:
+      severityText = "warning"
+      severityAnnotation = .warningText
+
+    case .note:
+      severityText = "note"
+      severityAnnotation = .noteText
+    }
+
+    let prefix = colorizeIfRequested("\(severityText): ", annotation: severityAnnotation)
+
+    return prefix + colorizeIfRequested(message, annotation: .diagnosticText);
   }
 
   /// Apply the given color and trait to the specified text, when we are
@@ -417,5 +422,21 @@ struct ANSIAnnotation {
   /// Annotation used for highlighting source text.
   static var sourceHighlight: ANSIAnnotation {
     ANSIAnnotation(color: .default, trait: .underline)
+  }
+
+  static var diagnosticText: ANSIAnnotation {
+    ANSIAnnotation(color: .default, trait: .bold)
+  }
+
+  static var errorText: ANSIAnnotation {
+    ANSIAnnotation(color: .red, trait: .bold)
+  }
+
+  static var warningText: ANSIAnnotation {
+    ANSIAnnotation(color: .yellow, trait: .bold)
+  }
+
+  static var noteText: ANSIAnnotation {
+    ANSIAnnotation(color: .default, trait: .bold)
   }
 }

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -332,10 +332,15 @@ public struct DiagnosticsFormatter {
 
       return prefix + colorizeIfRequested(message.message, annotation: color);
     case .note:
-      let color = ANSIAnnotation(color: .default, trait: .bold)
-      let prefix = colorizeIfRequested("note: ", annotation: color)
-      return prefix + message.message
+      return colorizeNoteIfRequested(message.message)
     }
+  }
+
+  /// Annotate a note with an appropriate ANSI color code (if requested).
+  func colorizeNoteIfRequested(_ message: String) -> String {
+    let color = ANSIAnnotation(color: .default, trait: .bold)
+    let prefix = colorizeIfRequested("note: ", annotation: color)
+    return prefix + message
   }
 
   /// Apply the given color and trait to the specified text, when we are

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -341,6 +341,10 @@ public struct DiagnosticsFormatter {
     case .note:
       severityText = "note"
       severityAnnotation = .noteText
+
+    case .remark:
+      severityText = "remark"
+      severityAnnotation = .remarkText
     }
 
     let prefix = colorizeIfRequested("\(severityText): ", annotation: severityAnnotation)
@@ -438,5 +442,9 @@ struct ANSIAnnotation {
 
   static var noteText: ANSIAnnotation {
     ANSIAnnotation(color: .default, trait: .bold)
+  }
+
+  static var remarkText: ANSIAnnotation {
+    ANSIAnnotation(color: .blue, trait: .bold)
   }
 }

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -176,11 +176,6 @@ public struct DiagnosticsFormatter {
     return resultSourceString
   }
 
-  struct PrimaryDiagnostic {
-    var location: SourceLocation
-    var diagnostic: Diagnostic
-  }
-
   /// Print given diagnostics for a given syntax tree on the command line
   ///
   /// - Parameters:

--- a/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
+++ b/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
@@ -150,7 +150,8 @@ extension GroupedDiagnostics {
 
     // If this is a root note, take the first note.
     if sourceFile.parent == nil,
-       let note = sourceFile.diagnostics.first {
+      let note = sourceFile.diagnostics.first
+    {
       return (sourceFile, note)
     }
 
@@ -205,7 +206,8 @@ extension GroupedDiagnostics {
         // Provide a link back to the original source file where this generated buffer occurred, so it's easy to find if
         // (for example) the generated buffer is no longer available.
         if sourceFile.id != primaryDiagSourceFile.id,
-           var (rootSourceID, rootPosition) = primaryDiagSourceFile.parent {
+          var (rootSourceID, rootPosition) = primaryDiagSourceFile.parent
+        {
           // Go all the way up to the root to find the absolute position of the outermost generated buffer within the
           // root source file.
           while let parent = sourceFiles[rootSourceID.id].parent {

--- a/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
+++ b/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
@@ -214,7 +214,8 @@ extension GroupedDiagnostics {
 
           if rootSourceID == sourceFileID {
             let bufferLoc = slc.location(for: rootPosition)
-            prefixString += "╰─ \(bufferLoc.file):\(bufferLoc.line):\(bufferLoc.column): \(formatter.colorizeNoteIfRequested("expanded code originates here"))\n"
+            let coloredMessage = formatter.colorizeIfRequested(severity: .note, message: "expanded code originates here")
+            prefixString += "╰─ \(bufferLoc.file):\(bufferLoc.line):\(bufferLoc.column): \(coloredMessage)\n"
           }
         }
       } else {

--- a/Sources/SwiftDiagnostics/Message.swift
+++ b/Sources/SwiftDiagnostics/Message.swift
@@ -30,6 +30,7 @@ public enum DiagnosticSeverity {
   case error
   case warning
   case note
+  case remark
 }
 
 /// Types conforming to this protocol represent diagnostic messages that can be

--- a/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
@@ -101,7 +101,7 @@ final class DiagnosticsFormatterTests: XCTestCase {
 
     let expectedOutput = """
       \u{001B}[0;36m1 │\u{001B}[0;0m var foo = bar +
-        \u{001B}[0;36m│\u{001B}[0;0m                ╰─ \u{001B}[1;31merror: expected expression after operator\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m                ╰─ \u{001B}[1;31merror: \u{001B}[0;0m\u{001B}[1;39mexpected expression after operator\u{001B}[0;0m
 
       """
     assertStringsEqualWithDiff(annotate(source: source, colorize: true), expectedOutput)
@@ -113,9 +113,9 @@ final class DiagnosticsFormatterTests: XCTestCase {
       """
     let expectedOutput = """
       \u{001B}[0;36m1 │\u{001B}[0;0m foo.[].[].[]
-        \u{001B}[0;36m│\u{001B}[0;0m     │  │  ╰─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
-        \u{001B}[0;36m│\u{001B}[0;0m     │  ╰─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
-        \u{001B}[0;36m│\u{001B}[0;0m     ╰─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m     │  │  ╰─ \u{001B}[1;31merror: \u{001B}[0;0m\u{001B}[1;39mexpected name in member access\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m     │  ╰─ \u{001B}[1;31merror: \u{001B}[0;0m\u{001B}[1;39mexpected name in member access\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m     ╰─ \u{001B}[1;31merror: \u{001B}[0;0m\u{001B}[1;39mexpected name in member access\u{001B}[0;0m
 
       """
     assertStringsEqualWithDiff(annotate(source: source, colorize: true), expectedOutput)
@@ -128,8 +128,8 @@ final class DiagnosticsFormatterTests: XCTestCase {
 
     let expectedOutput = """
       \u{001B}[0;36m1 │\u{001B}[0;0m for \u{001B}[4;39m(i\u{001B}[0;0m \u{001B}[4;39m= 🐮; i != 👩‍👩‍👦‍👦; i += 1)\u{001B}[0;0m { }
-        \u{001B}[0;36m│\u{001B}[0;0m │      ╰─ \u{001B}[1;31merror: expected ')' to end tuple pattern\u{001B}[0;0m
-        \u{001B}[0;36m│\u{001B}[0;0m ╰─ \u{001B}[1;31merror: C-style for statement has been removed in Swift 3\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m │      ╰─ \u{001B}[1;31merror: \u{001B}[0;0m\u{001B}[1;39mexpected ')' to end tuple pattern\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m ╰─ \u{001B}[1;31merror: \u{001B}[0;0m\u{001B}[1;39mC-style for statement has been removed in Swift 3\u{001B}[0;0m
 
       """
 

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -112,8 +112,7 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
     assertStringsEqualWithDiff(
       annotated,
       """
-      === main.swift:5 ===
-        ┆
+      main.swift:6:14: error: expected ')' to end function call
       3 │ // test
       4 │ let pi = 3.14159
       5 │ #myAssert(pi == 3)
@@ -141,7 +140,7 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       """
       let pi = 3.14159
       1️⃣#myAssert(pi == 3)
-      print("hello"
+      print("hello")
       """,
       displayName: "main.swift",
       extraDiagnostics: ["1️⃣": ("in expansion of macro 'myAssert' here", .note)]
@@ -181,7 +180,7 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
     assertStringsEqualWithDiff(
       annotated,
       """
-      === main.swift:2 ===
+      #invertedEqualityCheck:1:7: error: no matching operator '==' for types 'Double' and 'Int'
       1 │ let pi = 3.14159
       2 │ #myAssert(pi == 3)
         │ ╰─ note: in expansion of macro 'myAssert' here
@@ -197,8 +196,7 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
         │4 │   fatalError("assertion failed: pi != 3")
         │5 │ }
         ╰─────────────────────────────────────────────────────────────────────
-      3 │ print("hello"
-        │              ╰─ error: expected ')' to end function call
+      3 │ print("hello")
 
       """
     )

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -181,6 +181,7 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       annotated,
       """
       #invertedEqualityCheck:1:7: error: no matching operator '==' for types 'Double' and 'Int'
+      ╰─ main.swift:2:1: note: expanded code originates here
       1 │ let pi = 3.14159
       2 │ #myAssert(pi == 3)
         │ ╰─ note: in expansion of macro 'myAssert' here


### PR DESCRIPTION
Introduce a few improvements to make the "grouped" diagnostics more similar to the diagnostics provided by the existing Swift compiler, as a step toward enabling these diagnostics by default:

* Emit the "primary diagnostic" on the first line, matching the style of the existing compiler diagnostics and making it easier for humans tools to find the primary issue. 
* When the "primary diagnostic" is in a generated buffer, such as a macro expansion buffer, also show the outermost source file that triggered the generation of that buffer, so it's easy to find that.
* Only colorize the severity (`error`, `warning`, etc.) and not the whole diagnostic message, to match the Swift compiler's current style.
* Add `remark` diagnostic severity, which is used by the Swift compiler and needs to be representable.

Example now:
```
t.swift:5:3: error: no exact matches in call to global function 'f'
1 │ func f(a: Int) { }
  │      ╰─ note: incorrect labels for candidate (have: '(_:)', expected: '(a:)')
2 │ func f(b: Int) { }
  │      ╰─ note: incorrect labels for candidate (have: '(_:)', expected: '(b:)')
3 │ 
4 │ func g() {
5 │   f(1)
  │   ╰─ error: no exact matches in call to global function 'f'
6 │   f(a: 2.5)
7 │ }
```
