### PR TITLE
Order all imports lexicographically

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -10,6 +10,7 @@
         "AlwaysUseLowerCamelCase": false,
         "AmbiguousTrailingClosureOverload": false,
         "NoBlockComments": false,
+        "OrderedImports": true,
         "UseLetInEveryBoundCaseVariable": false,
         "UseSynthesizedInitializer": false
     }

--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.7
 
-import PackageDescription
 import Foundation
+import PackageDescription
 
 let package = Package(
   name: "CodeGeneration",

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-import SyntaxSupport
 import SwiftSyntaxBuilder
+import SyntaxSupport
 import Utils
 
 let resultBuildersFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-import SyntaxSupport
 import SwiftSyntaxBuilder
+import SyntaxSupport
 import Utils
 
 let syntaxExpressibleByStringInterpolationConformancesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {

--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import SyntaxSupport
-
 import XCTest
 
 fileprivate func assertNoFailures(

--- a/EditorExtension/SwiftRefactorExtension/CommandDiscovery.swift
+++ b/EditorExtension/SwiftRefactorExtension/CommandDiscovery.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Darwin
-import MachO
 import Foundation
+import MachO
 import SwiftRefactor
 
 extension SourceEditorExtension {

--- a/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
+++ b/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import XcodeKit
 import SwiftParser
 import SwiftRefactor
 import SwiftSyntax
+import XcodeKit
 
 enum ExtensionError: Error {
   case unsupportedContentType

--- a/EditorExtension/SwiftRefactorExtension/SourceEditorExtension.swift
+++ b/EditorExtension/SwiftRefactorExtension/SourceEditorExtension.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import XcodeKit
 import SwiftRefactor
+import XcodeKit
 
 final class SourceEditorExtension: NSObject, XCSourceEditorExtension {
   func extensionDidFinishLaunching() {

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version: 5.9
 
-import PackageDescription
 import CompilerPluginSupport
+import PackageDescription
 
 let package = Package(
   name: "Examples",

--- a/Examples/Sources/AddOneToIntegerLiterals/AddOneToIntegerLiterals.swift
+++ b/Examples/Sources/AddOneToIntegerLiterals/AddOneToIntegerLiterals.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 /// AddOneToIntegerLiterals will visit each token in the Syntax tree, and
 /// (if it is an integer literal token) add 1 to the integer and return the

--- a/Examples/Sources/MacroExamples/Implementation/AddBlocker.swift
+++ b/Examples/Sources/MacroExamples/Implementation/AddBlocker.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntaxMacros
-import SwiftSyntax
-import SwiftOperators
 import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntax
+import SwiftSyntaxMacros
 
 /// Implementation of the `addBlocker` macro, which demonstrates how to
 /// produce detailed diagnostics from a macro implementation for an utterly

--- a/Examples/Sources/MacroExamples/Implementation/Diagnostics.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Diagnostics.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
 import SwiftDiagnostics
+import SwiftSyntax
 
 struct SimpleDiagnosticMessage: DiagnosticMessage, Error {
   let message: String

--- a/Examples/Sources/MacroExamples/Implementation/MetaEnumMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/MetaEnumMacro.swift
@@ -12,8 +12,8 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
 
 public struct MetaEnumMacro {
   let parentTypeName: TokenSyntax

--- a/Examples/Sources/MacroExamples/Playground/main.swift
+++ b/Examples/Sources/MacroExamples/Playground/main.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import MacroExamplesInterface
 import Foundation
+import MacroExamplesInterface
 
 let x = 1
 let y = 2

--- a/Examples/Tests/MacroExamples/Implementation/MacroExamplesPluginTest.swift
+++ b/Examples/Tests/MacroExamples/Implementation/MacroExamplesPluginTest.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import MacroExamplesImplementation
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftSyntaxMacros
-import MacroExamplesImplementation
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import XCTest
 
 var testMacros: [String: Macro.Type] = [

--- a/Examples/Tests/MacroExamples/Implementation/MetaEnumMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/MetaEnumMacroTests.swift
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import MacroExamplesImplementation
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftSyntaxMacros
-import MacroExamplesImplementation
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
+import XCTest
 
 final class CaseMacroTests: XCTestCase {
   let testMacros: [String: Macro.Type] = [

--- a/Examples/Tests/MacroExamples/Implementation/NewTypePluginTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/NewTypePluginTests.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import MacroExamplesImplementation
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftSyntaxMacros
-import MacroExamplesImplementation
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import XCTest
 
 final class NewTypePluginTests: XCTestCase {

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.7
 
-import PackageDescription
 import Foundation
+import PackageDescription
 
 var swiftSyntaxSwiftSettings: [SwiftSetting] = []
 var swiftSyntaxBuilderSwiftSettings: [SwiftSetting] = []

--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -12,10 +12,10 @@
 // NOTE: This basic plugin mechanism is mostly copied from
 // https://github.com/apple/swift-package-manager/blob/main/Sources/PackagePlugin/Plugin.swift
 
-import SwiftSyntaxMacros
-@_implementationOnly import SwiftCompilerPluginMessageHandling
-
 @_implementationOnly import Foundation
+@_implementationOnly import SwiftCompilerPluginMessageHandling
+import SwiftSyntaxMacros
+
 #if os(Windows)
 @_implementationOnly import ucrt
 #endif

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -14,8 +14,8 @@ import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 
 extension CompilerPluginMessageHandler {
   /// Get concrete macro type from a pair of module name and type name.

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-import SwiftParser
 import SwiftOperators
+import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxMacros
 

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftDiagnostics
 import SwiftBasicFormat
+import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
 
 extension FixIt {

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(Diagnostics) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 
 fileprivate let diagnosticDomain: String = "SwiftLexer"
 

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftBasicFormat
 import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
-import SwiftBasicFormat
 
 // MARK: - Shared code
 

--- a/Sources/SwiftParserDiagnostics/MissingTokenError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingTokenError.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(Diagnostics) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 
 extension ParseDiagnosticsGenerator {
   func handleMissingToken(_ missingToken: TokenSyntax) {

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(Diagnostics) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 
 fileprivate let diagnosticDomain: String = "SwiftParser"
 

--- a/Sources/SwiftParserDiagnostics/PresenceUtils.swift
+++ b/Sources/SwiftParserDiagnostics/PresenceUtils.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 import SwiftBasicFormat
+@_spi(RawSyntax) import SwiftSyntax
 
 /// Walks a tree and checks whether the tree contained any present tokens.
 class PresentNodeChecker: SyntaxAnyVisitor {

--- a/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(Diagnostics) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 
 extension UnexpectedNodesSyntax {
   func presentTokens(satisfying isIncluded: (TokenSyntax) -> Bool) -> [TokenSyntax] {

--- a/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
+++ b/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 
 /// ``MigrateToNewIfLetSyntax`` will visit each if expression in the Syntax tree, and
 /// checks if there is an if condition which is of the pre Swift 5.7 "if-let-style"

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step10.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step10.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 @main struct ImportFormatter {
   static func main() {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 @main struct ImportFormatter {
   static func main() {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step3.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step3.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 @main struct ImportFormatter {
   static func main() {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step4.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step4.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 @main struct ImportFormatter {
   static func main() {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step5.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step5.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 @main struct ImportFormatter {
   static func main() {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step6.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step6.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 @main struct ImportFormatter {
   static func main() {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step7.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step7.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 @main struct ImportFormatter {
   static func main() {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step8.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step8.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 @main struct ImportFormatter {
   static func main() {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step9.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step9.swift
@@ -1,6 +1,6 @@
-import SwiftSyntax
-import SwiftParser
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 @main struct ImportFormatter {
   static func main() {

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -12,8 +12,8 @@
 
 import SwiftBasicFormat
 import SwiftDiagnostics
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) @_spi(Testing) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 
 /// An individual interpolated syntax node.
 struct InterpolatedSyntaxNode {

--- a/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
@@ -11,9 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-import SwiftSyntax
 import SwiftParser
 import SwiftParserDiagnostics
+import SwiftSyntax
+
 // Don't introduce a dependency on OSLog when building SwiftSyntax using CMake
 // for the compiler.
 #if canImport(OSLog) && !SWIFTSYNTAX_NO_OSLOG_DEPENDENCY

--- a/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
 import SwiftDiagnostics
 import SwiftParserDiagnostics
+import SwiftSyntax
 
 extension SyntaxProtocol {
   /// If `node` has contains no syntax errors, return `node`, otherwise

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
 import SwiftBasicFormat
+import SwiftSyntax
 @_spi(MacroExpansion) import SwiftSyntaxMacros
 
 public enum MacroRole {

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
+@_spi(MacroExpansion) import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxBuilder
-@_spi(MacroExpansion) import SwiftParser
 @_spi(MacroExpansion) import SwiftSyntaxMacros
 
 // MARK: - Public entry function

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -10,15 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftSyntaxTestSupport
 import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import XCTest
+import _SwiftSyntaxTestSupport
 
 // MARK: - Note
 

--- a/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
+++ b/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 import XCTest
 
 /// This function is used to verify the correctness of incremental parsing

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftBasicFormat
+@_spi(Testing) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
 import SwiftSyntaxBuilder
-@_spi(Testing) import SwiftParser
 
 private class InitializerExprFormat: BasicFormat {
   public init() {

--- a/Sources/swift-parser-cli/BasicFormat.swift
+++ b/Sources/swift-parser-cli/BasicFormat.swift
@@ -13,9 +13,9 @@
 import ArgumentParser
 import SwiftBasicFormat
 import SwiftDiagnostics
-import SwiftSyntax
 import SwiftParser
 import SwiftParserDiagnostics
+import SwiftSyntax
 
 struct BasicFormat: ParsableCommand, ParseCommand {
   enum Error: Swift.Error, CustomStringConvertible {

--- a/Sources/swift-parser-cli/Commands/PerformanceTest.swift
+++ b/Sources/swift-parser-cli/Commands/PerformanceTest.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _InstructionCounter
 import ArgumentParser
 import Foundation
 import SwiftParser
 import SwiftSyntax
+import _InstructionCounter
 
 struct PerformanceTest: ParsableCommand {
   static var configuration = CommandConfiguration(

--- a/Sources/swift-parser-cli/Commands/PrintTree.swift
+++ b/Sources/swift-parser-cli/Commands/PrintTree.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 
 struct PrintTree: ParsableCommand, ParseCommand {
   static var configuration = CommandConfiguration(

--- a/Sources/swift-parser-cli/Commands/Reduce.swift
+++ b/Sources/swift-parser-cli/Commands/Reduce.swift
@@ -12,6 +12,7 @@
 
 import ArgumentParser
 import Foundation
+
 #if os(Windows)
 import WinSDK
 #endif

--- a/Sources/swift-parser-cli/Commands/VerifyRoundTrip.swift
+++ b/Sources/swift-parser-cli/Commands/VerifyRoundTrip.swift
@@ -12,9 +12,9 @@
 
 import ArgumentParser
 import SwiftDiagnostics
-import SwiftSyntax
 import SwiftParser
 import SwiftParserDiagnostics
+import SwiftSyntax
 
 struct VerifyRoundTrip: ParsableCommand, ParseCommand {
   static var configuration = CommandConfiguration(

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -10,14 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _InstructionCounter
+import ArgumentParser
+import Foundation
 import SwiftDiagnostics
-import SwiftSyntax
+import SwiftOperators
 import SwiftParser
 import SwiftParserDiagnostics
-import SwiftOperators
-import Foundation
-import ArgumentParser
+import SwiftSyntax
+import _InstructionCounter
+
 #if os(Windows)
 import WinSDK
 #endif

--- a/SwiftSyntaxDevUtils/Package.swift
+++ b/SwiftSyntaxDevUtils/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.7
 
-import PackageDescription
 import Foundation
+import PackageDescription
 
 let package = Package(
   name: "swift-syntax-dev-utils",

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SourceCodeGeneratorCommand.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SourceCodeGeneratorCommand.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import ArgumentParser
 import Dispatch
 import Foundation

--- a/Tests/PerformanceTest/ParsingPerformanceTests.swift
+++ b/Tests/PerformanceTest/ParsingPerformanceTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
+import XCTest
 
 public class ParsingPerformanceTests: XCTestCase {
 

--- a/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
+++ b/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftIDEUtils
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
+import XCTest
 
 public class SyntaxClassifierPerformanceTests: XCTestCase {
 

--- a/Tests/PerformanceTest/VisitorPerformanceTests.swift
+++ b/Tests/PerformanceTest/VisitorPerformanceTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
+import XCTest
 
 public class VisitorPerformanceTests: XCTestCase {
 

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -12,9 +12,8 @@
 
 import SwiftBasicFormat
 import SwiftParser
-@_spi(Testing) import SwiftSyntaxBuilder
 import SwiftSyntax
-
+@_spi(Testing) import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftCompilerPluginTest/CompilerPluginTests.swift
+++ b/Tests/SwiftCompilerPluginTest/CompilerPluginTests.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftCompilerPlugin
 import SwiftSyntax
 import SwiftSyntaxMacros
+import XCTest
 
 /// Dummy macro
 struct DummyMacro: ExpressionMacro {

--- a/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftSyntaxTestSupport
-import XCTest
 import SwiftDiagnostics
 import SwiftParser
 import SwiftParserDiagnostics
+import XCTest
+import _SwiftSyntaxTestSupport
 
 final class DiagnosticsFormatterTests: XCTestCase {
 

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftSyntaxTestSupport
-import XCTest
 import SwiftDiagnostics
 import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax
+import XCTest
+import _SwiftSyntaxTestSupport
 
 struct SimpleDiagnosticMessage: DiagnosticMessage {
   let message: String

--- a/Tests/SwiftIDEUtilsTest/Assertions.swift
+++ b/Tests/SwiftIDEUtilsTest/Assertions.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftIDEUtils
 import SwiftParser
 import SwiftSyntax
+import XCTest
 import _SwiftSyntaxTestSupport
 
 /// Parse `source` and checks its `classifications` is the same as `expected`.

--- a/Tests/SwiftIDEUtilsTest/ClassificationTests.swift
+++ b/Tests/SwiftIDEUtilsTest/ClassificationTests.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftIDEUtils
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
+import XCTest
 import _SwiftSyntaxTestSupport
 
 public class ClassificationTests: XCTestCase {

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -1,3 +1,6 @@
+@_spi(Testing) import SwiftOperators
+import SwiftParser
+import SwiftSyntax
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -10,9 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import SwiftSyntax
-import SwiftParser
-@_spi(Testing) import SwiftOperators
 import _SwiftSyntaxTestSupport
 
 /// Visitor that looks for ExprSequenceSyntax nodes.

--- a/Tests/SwiftOperatorsTest/SyntaxSynthesisTests.swift
+++ b/Tests/SwiftOperatorsTest/SyntaxSynthesisTests.swift
@@ -1,3 +1,5 @@
+import SwiftOperators
+import SwiftSyntax
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -10,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import SwiftSyntax
-import SwiftOperators
 
 public class SyntaxSynthesisTests: XCTestCase {
   func testInfixOperator() {

--- a/Tests/SwiftParserDiagnosticsTest/DiagnosticInfrastructureTests.swift
+++ b/Tests/SwiftParserDiagnosticsTest/DiagnosticInfrastructureTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftDiagnostics
 import SwiftParserDiagnostics
+import XCTest
 
 public class DiagnosticInfrastructureTests: XCTestCase {
   public func testDiagnosticID() {

--- a/Tests/SwiftParserTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftParserTest/AbsolutePositionTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
+import XCTest
 import _SwiftSyntaxTestSupport
 
 public class AbsolutePositionTests: ParserTestCase {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-@_spi(RawSyntax) import SwiftSyntax
+import SwiftDiagnostics
 @_spi(Testing) @_spi(RawSyntax) @_spi(AlternateTokenIntrospection) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) import SwiftParserDiagnostics
-import SwiftDiagnostics
+@_spi(RawSyntax) import SwiftSyntax
+import XCTest
 import _SwiftSyntaxTestSupport
 
 // MARK: Lexing Assertions

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class AttributeTests: ParserTestCase {

--- a/Tests/SwiftParserTest/AvailabilityTests.swift
+++ b/Tests/SwiftParserTest/AvailabilityTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class AvailabilityTests: ParserTestCase {

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
-@_spi(Testing) @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
-import SwiftSyntaxBuilder
 import SwiftBasicFormat
+@_spi(Testing) @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
 import XCTest
 
 final class DeclarationTests: ParserTestCase {

--- a/Tests/SwiftParserTest/DirectiveTests.swift
+++ b/Tests/SwiftParserTest/DirectiveTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class DirectiveTests: ParserTestCase {

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class ExpressionTests: ParserTestCase {

--- a/Tests/SwiftParserTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftParserTest/IncrementalParsingTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
+import XCTest
 import _SwiftSyntaxTestSupport
 
 public class IncrementalParsingTests: ParserTestCase {

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) @_spi(Testing) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
+import XCTest
 
 fileprivate func lex(_ sourceBytes: [UInt8], body: ([Lexer.Lexeme]) throws -> Void) rethrows {
   let lookaheadTracker = UnsafeMutablePointer<LookaheadTracker>.allocate(capacity: 1)

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 import XCTest
 
 public class EntryTests: ParserTestCase {

--- a/Tests/SwiftParserTest/ParserTestCase.swift
+++ b/Tests/SwiftParserTest/ParserTestCase.swift
@@ -10,10 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import SwiftSyntax
-
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
+import SwiftSyntax
+import XCTest
 
 /// The base class for all parser test cases.
 public class ParserTestCase: XCTestCase {

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftSyntaxTestSupport
 import Dispatch
-import XCTest
-import SwiftSyntax
 import SwiftParser
 import SwiftParserDiagnostics
+import SwiftSyntax
+import XCTest
+import _SwiftSyntaxTestSupport
 
 public class ParserTests: ParserTestCase {
   /// Run a single parse test.

--- a/Tests/SwiftParserTest/PatternTests.swift
+++ b/Tests/SwiftParserTest/PatternTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class PatternTests: ParserTestCase {

--- a/Tests/SwiftParserTest/RegexLiteralTests.swift
+++ b/Tests/SwiftParserTest/RegexLiteralTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class RegexLiteralTests: ParserTestCase {

--- a/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
+++ b/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
+import XCTest
 import _SwiftSyntaxTestSupport
 
 let longString = """

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class StatementTests: ParserTestCase {

--- a/Tests/SwiftParserTest/StringLiteralRepresentedLiteralValueTests.swift
+++ b/Tests/SwiftParserTest/StringLiteralRepresentedLiteralValueTests.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 /// Test ``StringLiteralExprSyntax/representedLiteralValue``.
 ///

--- a/Tests/SwiftParserTest/SyntaxTransformVisitorTest.swift
+++ b/Tests/SwiftParserTest/SyntaxTransformVisitorTest.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftParser
 @_spi(SyntaxTransformVisitor) import SwiftSyntax
+import XCTest
 
 final class SyntaxTransformVisitorTest: ParserTestCase {
   public func testFunctionCounter() {

--- a/Tests/SwiftParserTest/ThenStatementTests.swift
+++ b/Tests/SwiftParserTest/ThenStatementTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 import XCTest
 
 final class ThenStatementTests: ParserTestCase {

--- a/Tests/SwiftParserTest/TriviaParserTests.swift
+++ b/Tests/SwiftParserTest/TriviaParserTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) @_spi(Testing) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
+import XCTest
 
 final class TriviaParserTests: ParserTestCase {
 

--- a/Tests/SwiftParserTest/TypeCompositionTests.swift
+++ b/Tests/SwiftParserTest/TypeCompositionTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 import XCTest
 
 final class TypeCompositionTests: ParserTestCase {

--- a/Tests/SwiftParserTest/TypeMemberTests.swift
+++ b/Tests/SwiftParserTest/TypeMemberTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 import XCTest
 
 final class TypeMemberTests: ParserTestCase {

--- a/Tests/SwiftParserTest/TypeMetatypeTests.swift
+++ b/Tests/SwiftParserTest/TypeMetatypeTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 import XCTest
 
 final class TypeMetatypeTests: ParserTestCase {

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class TypeTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -13,7 +13,6 @@
 // This test file has been translated from swift/test/Parse/errors.swift
 
 import SwiftSyntax
-
 import XCTest
 
 final class ErrorsTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
@@ -12,8 +12,8 @@
 
 // This test file has been translated from swift/test/StringProcessing/Parse/forward-slash-regex.swift
 
-@_spi(RawSyntax) import SwiftSyntax
 @_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
 import XCTest
 
 final class ForwardSlashRegexTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
+++ b/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
@@ -13,7 +13,6 @@
 // This test file has been translated from swift/test/Parse/generic_disambiguation.swift
 
 import SwiftSyntax
-
 import XCTest
 
 final class GenericDisambiguationTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
@@ -13,7 +13,6 @@
 // This test file has been translated from swift/test/Parse/hashbang_library.swift
 
 import SwiftSyntax
-
 import XCTest
 
 final class HashbangLibraryTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -12,8 +12,8 @@
 
 // This test file has been translated from swift/test/Parse/ifconfig_expr.swift
 
-import XCTest
 import SwiftSyntax
+import XCTest
 
 final class IfconfigExprTests: ParserTestCase {
   func testIfconfigExpr1() {

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -13,7 +13,6 @@
 // This test file has been translated from swift/test/Parse/init_deinit.swift
 
 import SwiftSyntax
-
 import XCTest
 
 final class InitDeinitTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -12,9 +12,8 @@
 
 // This test file has been translated from swift/test/Parse/matching_patterns.swift
 
-import XCTest
-
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
+import XCTest
 
 final class MatchingPatternsTests: ParserTestCase {
   func testMatchingPatterns1() {

--- a/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
@@ -12,9 +12,8 @@
 
 // This test file has been translated from swift/test/Parse/multiline_errors.swift
 
-import XCTest
-
 import SwiftSyntax
+import XCTest
 
 extension ParserTestCase {
   fileprivate func assertParseWithAllNewlineEndings(

--- a/Tests/SwiftParserTest/translated/MultilineStringTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineStringTests.swift
@@ -13,7 +13,6 @@
 // This test file has been translated from swift/test/StringProcessing/Parse/multiline_string.swift
 
 import SwiftSyntax
-
 import XCTest
 
 final class MultilineStringTests: ParserTestCase {

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
@@ -12,9 +12,8 @@
 
 // This test file has been translated from swift/test/Parse/pattern_without_variables.swift
 
-import XCTest
-
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
+import XCTest
 
 final class PatternWithoutVariablesTests: ParserTestCase {
   func testPatternWithoutVariables1() {

--- a/Tests/SwiftParserTest/translated/TypeExprTests.swift
+++ b/Tests/SwiftParserTest/translated/TypeExprTests.swift
@@ -12,8 +12,8 @@
 
 // This test file has been translated from swift/test/Parse/type_expr.swift
 
-import XCTest
 import SwiftSyntax
+import XCTest
 
 // Types in expression contexts must be followed by a member access or
 // constructor call.

--- a/Tests/SwiftRefactorTest/ExpandEditorPlaceholderTests.swift
+++ b/Tests/SwiftRefactorTest/ExpandEditorPlaceholderTests.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftBasicFormat
-import SwiftRefactor
 import SwiftParser
+import SwiftRefactor
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import XCTest

--- a/Tests/SwiftRefactorTest/FormatRawStringLiteral.swift
+++ b/Tests/SwiftRefactorTest/FormatRawStringLiteral.swift
@@ -12,9 +12,8 @@
 
 import SwiftParser
 import SwiftRefactor
-import SwiftSyntaxBuilder
 import SwiftSyntax
-
+import SwiftSyntaxBuilder
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftRefactorTest/IntegerLiteralUtilities.swift
+++ b/Tests/SwiftRefactorTest/IntegerLiteralUtilities.swift
@@ -13,7 +13,6 @@
 import SwiftRefactor
 import SwiftSyntax
 import SwiftSyntaxBuilder
-
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftRefactorTest/MigrateToNewIfLetSyntax.swift
+++ b/Tests/SwiftRefactorTest/MigrateToNewIfLetSyntax.swift
@@ -13,7 +13,6 @@
 import SwiftRefactor
 import SwiftSyntax
 import SwiftSyntaxBuilder
-
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftRefactorTest/OpaqueParameterToGeneric.swift
+++ b/Tests/SwiftRefactorTest/OpaqueParameterToGeneric.swift
@@ -13,7 +13,6 @@
 import SwiftRefactor
 import SwiftSyntax
 import SwiftSyntaxBuilder
-
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftRefactorTest/ReformatIntegerLiteral.swift
+++ b/Tests/SwiftRefactorTest/ReformatIntegerLiteral.swift
@@ -13,7 +13,6 @@
 import SwiftRefactor
 import SwiftSyntax
 import SwiftSyntaxBuilder
-
 import XCTest
 import _SwiftSyntaxTestSupport
 

--- a/Tests/SwiftSyntaxBuilderTest/ArrayExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ArrayExprTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class ArrayExprTests: XCTestCase {
   func testPlainArrayExpr() {

--- a/Tests/SwiftSyntaxBuilderTest/Assertions.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Assertions.swift
@@ -12,9 +12,8 @@
 
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import _SwiftSyntaxTestSupport
-
 import XCTest
+import _SwiftSyntaxTestSupport
 
 func assertBuildResult<T: SyntaxProtocol>(
   _ buildable: T,

--- a/Tests/SwiftSyntaxBuilderTest/AttributeListSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/AttributeListSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class AttributeListSyntaxTests: XCTestCase {
   func testAttributeListSyntaxSpacing() {

--- a/Tests/SwiftSyntaxBuilderTest/BooleanLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/BooleanLiteralTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class BooleanLiteralTests: XCTestCase {
   func testBooleanLiteral() {

--- a/Tests/SwiftSyntaxBuilderTest/BreakStmtSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/BreakStmtSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class BreakStmtSyntaxTests: XCTestCase {
   func testBreakStmtSyntax() {

--- a/Tests/SwiftSyntaxBuilderTest/ClassDeclSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ClassDeclSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class ClassDeclSyntaxTests: XCTestCase {
   func testThrowableClassWithStringInterpolation() throws {

--- a/Tests/SwiftSyntaxBuilderTest/ClosureExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ClosureExprTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class ClosureExprTests: XCTestCase {
   func testClosureExpr() {

--- a/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class CollectionNodeFlatteningTests: XCTestCase {
   func test_FlattenCodeBlockItemListWithBuilder() {

--- a/Tests/SwiftSyntaxBuilderTest/CustomAttributeTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/CustomAttributeTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class CustomAttributeTests: XCTestCase {
   func testCustomAttributeConvenienceInitializer() {

--- a/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class DictionaryExprTests: XCTestCase {
   func testPlainDictionaryExpr() {

--- a/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class DoStmtTests: XCTestCase {
   func testDoStmt() {

--- a/Tests/SwiftSyntaxBuilderTest/EnumCaseElementTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/EnumCaseElementTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class EnumCaseElementTests: XCTestCase {
   func testEnumInit() {

--- a/Tests/SwiftSyntaxBuilderTest/ExprListTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExprListTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class ExprListTests: XCTestCase {
   func testExprList() {

--- a/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class ExtensionDeclTests: XCTestCase {
   func testExtensionDecl() {

--- a/Tests/SwiftSyntaxBuilderTest/FloatLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FloatLiteralTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class FloatLiteralTests: XCTestCase {
   func testFloatLiteral() {

--- a/Tests/SwiftSyntaxBuilderTest/ForInStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ForInStmtTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class ForInStmtTests: XCTestCase {
   func testEmptyForInStmtSyntax() throws {

--- a/Tests/SwiftSyntaxBuilderTest/FunctionParameterSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionParameterSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class FunctionParameterSyntaxTests: XCTestCase {
   func testFunctionParameterSyntaxSpacing() {

--- a/Tests/SwiftSyntaxBuilderTest/FunctionSignatureSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionSignatureSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class FunctionSignatureSyntaxTests: XCTestCase {
   func testFunctionEffectSpecifiersSyntax() throws {

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import SwiftBasicFormat
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftBasicFormat
+import XCTest
 import _SwiftSyntaxTestSupport
 
 final class FunctionTests: XCTestCase {

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTypeSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTypeSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class FunctionTypeSyntaxTests: XCTestCase {
   func testFunctionEffectSpecifiersSyntax() throws {

--- a/Tests/SwiftSyntaxBuilderTest/IfConfigDeclSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IfConfigDeclSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class IfConfigDeclSyntaxTests: XCTestCase {
   func testIfConfigClauseSyntax() {

--- a/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class IfStmtTests: XCTestCase {
   func testEmptyIfExpr() {

--- a/Tests/SwiftSyntaxBuilderTest/ImportDeclSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ImportDeclSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class ImportDeclSyntaxTests: XCTestCase {
   func testImportDeclSyntax() {

--- a/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class InitializerDeclTests: XCTestCase {
   func testInitializerDecl() {

--- a/Tests/SwiftSyntaxBuilderTest/IntegerLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IntegerLiteralTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class IntegerLiteralTests: XCTestCase {
   func testIntegerLiteral() {

--- a/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class ProtocolDeclTests: XCTestCase {
   func testProtocolDecl() throws {

--- a/Tests/SwiftSyntaxBuilderTest/ReturnStmsTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ReturnStmsTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class ReturnStmtTests: XCTestCase {
   func testReturnStmt() {

--- a/Tests/SwiftSyntaxBuilderTest/SourceFileTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/SourceFileTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class SourceFileTests: XCTestCase {
   func testSourceFile() {

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -10,13 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftSyntaxTestSupport
+import SwiftBasicFormat
+import SwiftParser
 import SwiftSyntax
 @_spi(Testing) import SwiftSyntaxBuilder
-import SwiftParser
-import SwiftBasicFormat
-
 import XCTest
+import _SwiftSyntaxTestSupport
 
 class TwoSpacesFormat: BasicFormat {
   public init() {

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralExprSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralExprSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class StringLiteralExprSyntaxTests: XCTestCase {
   func testStringLiteral() {

--- a/Tests/SwiftSyntaxBuilderTest/StructTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StructTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class StructTests: XCTestCase {
   func testEmptyStruct() {

--- a/Tests/SwiftSyntaxBuilderTest/SwitchCaseLabelSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/SwitchCaseLabelSyntaxTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class SwitchCaseLabelSyntaxTests: XCTestCase {
   func testSwitchCaseLabelSyntax() {

--- a/Tests/SwiftSyntaxBuilderTest/SwitchTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/SwitchTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class SwitchTests: XCTestCase {
   func testSwitch() {

--- a/Tests/SwiftSyntaxBuilderTest/TernaryExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TernaryExprTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class TernaryExprTests: XCTestCase {
   func testStringLiteralTernaryExpr() {

--- a/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class TriviaTests: XCTestCase {
   func testLeadingTrivia() {

--- a/Tests/SwiftSyntaxBuilderTest/TupleTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TupleTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class TupleTests: XCTestCase {
   func testLabeledElementList() {

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 
 final class VariableTests: XCTestCase {
   func testVariableDecl() {

--- a/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
@@ -20,8 +20,8 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
@@ -20,8 +20,8 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
@@ -19,8 +19,8 @@
 //==========================================================================//
 
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
@@ -20,8 +20,8 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
@@ -14,8 +14,8 @@ import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
-import _SwiftSyntaxTestSupport
 import XCTest
+import _SwiftSyntaxTestSupport
 
 final class MacroReplacementTests: XCTestCase {
   func testMacroDefinitionGood() throws {

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
@@ -20,8 +20,8 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
@@ -19,8 +19,8 @@
 //==========================================================================//
 
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/MultiRoleMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MultiRoleMacroTests.swift
@@ -19,8 +19,8 @@
 //==========================================================================//
 
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
@@ -20,8 +20,8 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 

--- a/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePositionTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftSyntaxTestSupport
 import SwiftSyntax
 import XCTest
+import _SwiftSyntaxTestSupport
 
 public class AbsolutePositionTests: XCTestCase {
   public func testRecursion() {

--- a/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
+++ b/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 @_spi(Testing) import SwiftSyntax
+import XCTest
 
 final class BumpPtrAllocatorTests: XCTestCase {
 

--- a/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
+++ b/Tests/SwiftSyntaxTest/DebugDescriptionTests.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import SwiftSyntax
-import _SwiftSyntaxTestSupport
 import SwiftParser
+import SwiftSyntax
+import XCTest
+import _SwiftSyntaxTestSupport
 
 private extension String {
   // This implementation is really slow; to use it outside a test it should be optimized.

--- a/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
+++ b/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 @_spi(Testing) import SwiftSyntax
+import XCTest
 
 #if DEBUG
 final class MemoryLayoutTest: XCTestCase {

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 @_spi(RawSyntax) import SwiftSyntax
+import XCTest
 
 extension SyntaxProtocol {
   subscript<S: SyntaxProtocol>(as type: S.Type) -> S {

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 @_spi(RawSyntax) import SwiftSyntax
+import XCTest
 
 fileprivate func cannedStructDecl(arena: SyntaxArena) -> RawStructDeclSyntax {
   let structKW = RawTokenSyntax(

--- a/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
+++ b/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftSyntaxTestSupport
 @_spi(RawSyntax) import SwiftSyntax
 import SwiftSyntaxBuilder
 import XCTest
+import _SwiftSyntaxTestSupport
 
 fileprivate func assertPresumedSourceLocation(
   _ source: SourceFileSyntax,

--- a/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
+import XCTest
 import _SwiftSyntaxTestSupport
 
 public class SyntaxChildrenTests: XCTestCase {

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
+import XCTest
 import _SwiftSyntaxTestSupport
 
 fileprivate func intElement(_ int: Int) -> ArrayElementSyntax {

--- a/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
+import XCTest
 
 fileprivate func cannedStructDecl() -> StructDeclSyntax {
   let structKW = TokenSyntax.keyword(.struct, trailingTrivia: .space)

--- a/Tests/SwiftSyntaxTest/SyntaxTextTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTextTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 @_spi(RawSyntax) import SwiftSyntax
+import XCTest
 
 final class SyntaxTextTests: XCTestCase {
   func testLiteral() {

--- a/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
+import XCTest
 
 fileprivate func cannedVarDecl() -> VariableDeclSyntax {
   let identifierPattern = IdentifierPatternSyntax(

--- a/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
 import SwiftSyntaxBuilder
+import XCTest
 import _SwiftSyntaxTestSupport
 
 public class SyntaxVisitorTests: XCTestCase {

--- a/Tests/SwiftSyntaxTest/TriviaTests.swift
+++ b/Tests/SwiftSyntaxTest/TriviaTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
+import XCTest
 
 public class TriviaTests: XCTestCase {
 

--- a/Tests/SwiftSyntaxTest/VisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
+import XCTest
 
 public class VisitorTests: XCTestCase {
   public func testVisitMissingNodes() {

--- a/Tests/SwiftSyntaxTestSupportTest/IncrementalParseTestUtilsTest.swift
+++ b/Tests/SwiftSyntaxTestSupportTest/IncrementalParseTestUtilsTest.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 import SwiftSyntax
+import XCTest
 import _SwiftSyntaxTestSupport
 
 public class IncrementalParseUtilTest: XCTestCase {

--- a/Tests/SwiftSyntaxTestSupportTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxTestSupportTest/SyntaxComparisonTests.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftSyntaxTestSupport
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 import XCTest
+import _SwiftSyntaxTestSupport
 
 private func parse(source: String) -> Syntax {
   return Syntax(Parser.parse(source: source))

--- a/format.py
+++ b/format.py
@@ -87,7 +87,7 @@ def find_swiftformat(swift_format: str) -> Path:
 def get_files_to_format() -> List[Path]:
     package_dir = Path(__file__).parent
     files_to_format = package_dir.glob('**/*.swift')
-    
+
     def should_exclude(path: Path) -> bool:
         if 'lit_tests' in path.parts:
             return True


### PR DESCRIPTION
## Motivation
- Part of #2136

## Changes
- Adds `OrderedImports` rule to `.swift-format`
- Removes a trailing space in `format.py`
- Formats the codebase to comply with `OrderedImports`