### PR TITLE
Limit conditions for inferencing a possible FuncDecl

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -281,9 +281,10 @@ extension Parser {
         )
       }
 
-      let isProbablyFuncDecl = self.at(.identifier, .wildcard) || self.at(anyIn: Operator.self) != nil
-
-      if isProbablyFuncDecl {
+      let isPossibleFuncIdentifier = self.at(.identifier, .wildcard)
+      let isPossibleFuncParen = self.peek(isAt: .leftParen, .binaryOperator)
+      // Treat operators specially because they're likely to be functions.
+      if (isPossibleFuncIdentifier && isPossibleFuncParen) || self.at(anyIn: Operator.self) != nil {
         return RawDeclSyntax(self.parseFuncDeclaration(attrs, .missing(.keyword(.func))))
       }
     }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -91,6 +91,61 @@ final class DeclarationTests: ParserTestCase {
         type: IdentifierTypeSyntax(name: .identifier("Int"))
       )
     )
+      
+    assertParse(
+      """
+      class MyClass {
+        1️⃣foo()
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected 'func' in function",
+          fixIts: ["insert 'func'"]
+        )
+      ],
+      fixedSource: """
+      class MyClass {
+        func foo()
+      }
+      """
+    )
+    
+    assertParse(
+      """
+      class MyClass {
+        1️⃣foo<Int>2️⃣
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected 'func' in function",
+          fixIts: ["insert 'func'"]
+        ),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature", fixIts: ["insert parameter clause"]),
+      ],
+      fixedSource: """
+      class MyClass {
+        func foo<Int>()
+      }
+      """
+    )
+      
+    assertParse(
+      """
+      class MyClass {
+        1️⃣foo
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "unexpected code 'foo' in class"
+        )
+      ]
+    )
   }
 
   func testFuncAfterUnbalancedClosingBrace() {
@@ -1822,19 +1877,17 @@ final class DeclarationTests: ParserTestCase {
       """
       struct Foo {
         #1️⃣
-        2️⃣myMacroName3️⃣
+        2️⃣myMacroName
       }
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"]),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected 'func' in function", fixIts: ["insert 'func'"]),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected parameter clause in function signature", fixIts: ["insert parameter clause"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code 'myMacroName' in struct"),
       ],
       fixedSource: """
         struct Foo {
           #<#identifier#>
-          func
-          myMacroName()
+          myMacroName
         }
         """
     )
@@ -2360,18 +2413,15 @@ final class DeclarationTests: ParserTestCase {
       class A ℹ️{
         1️⃣^
       }
-      unowned 2️⃣B 3️⃣{
-      }4️⃣
+      unowned 2️⃣B {
+      }
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code before modifier"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected 'func' in function", fixIts: ["insert 'func'"]),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected parameter clause in function signature", fixIts: ["insert parameter clause"]),
         DiagnosticSpec(
-          locationMarker: "4️⃣",
-          message: "expected '}' to end class",
-          notes: [NoteSpec(message: "to match this opening '{'")],
-          fixIts: ["insert '}'"]
+          locationMarker: "2️⃣",
+          message: "expected declaration and '}' after 'unowned' modifier",
+          fixIts: ["insert declaration and '}'"]
         ),
       ],
       fixedSource:
@@ -2379,8 +2429,8 @@ final class DeclarationTests: ParserTestCase {
         class A {
           ^
         }
-        unowned func B() {
-        }
+        unowned <#declaration#>
+        }B {
         }
         """
     )

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -91,7 +91,7 @@ final class DeclarationTests: ParserTestCase {
         type: IdentifierTypeSyntax(name: .identifier("Int"))
       )
     )
-      
+
     assertParse(
       """
       class MyClass {
@@ -106,12 +106,12 @@ final class DeclarationTests: ParserTestCase {
         )
       ],
       fixedSource: """
-      class MyClass {
-        func foo()
-      }
-      """
+        class MyClass {
+          func foo()
+        }
+        """
     )
-    
+
     assertParse(
       """
       class MyClass {
@@ -127,12 +127,12 @@ final class DeclarationTests: ParserTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature", fixIts: ["insert parameter clause"]),
       ],
       fixedSource: """
-      class MyClass {
-        func foo<Int>()
-      }
-      """
+        class MyClass {
+          func foo<Int>()
+        }
+        """
     )
-      
+
     assertParse(
       """
       class MyClass {


### PR DESCRIPTION
Follow-up from https://github.com/apple/swift-syntax/issues/2109

```
class MyClass {
  word1 // Parsed as FunctionDecl
}
```

Currently, the parser consumes the `word1` token as an incomplete function declaration since most declarations within a MemberDeclList are functions. 

However, without more information around the token like `func` or `()` which would indicate that it is a possible FuncDecl, it could also be other declarations, like `let`, `var`, or even something like `typealias`.

This PR peeks the tokens after the identifier and checks if it has `(` or `<` which would indicate that it's a function. 

Any freestanding identifiers as shown in the example above would be parsed as `MissingDeclSyntax`, which spits out `unexpected 'word1' in MyClass`.

This would affect existing test cases that rely on the previous behavior and change the resulting diagnostics.

---

I've validated that this change is compatible with most test cases, but I'm not sure how(if I'm allowed to) to fix existing test cases, and add test cases(because many of them are translations from swift repo)

Also, I think a better diagnostic in the example above is something like: ``expected keyword before `word1`. did you mean to add `func` or `var`?``, but I'm not yet sure how I can feed the parsed information from Parser to Diagnostics.