### PR TITLE
Disallow attaching peer macro to variable with multiple bindings in `assertMacroExpansion`

### DIFF
--- a/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
@@ -229,7 +229,7 @@ final class AccessorMacroTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(
           message:
-            "swift-syntax applies macros syntactically and there is no way to represent a variable declaration with multiple bindings that have accessors syntactically. While the compiler allows this expansion, swift-syntax cannot represent it and thus disallows it.",
+            "accessor macro can only be applied to a single variable",
           line: 1,
           column: 1,
           severity: .error


### PR DESCRIPTION
The compiler currently invokes `expansion` twice with the exact same syntax node (rdar://114996981), which causes the same member to be generated twice, effectively disallowing the application of peer macro on variables with multiple bindings. Disallow them in `assertMacroExpansion` with a nice error message.