### PR TITLE
Resolve Warnings: Update Deprecated APIs and Remove Redundant Modifiers

### DIFF
--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -52,7 +52,7 @@ public extension DeclGroupSyntax {
 
 public extension FreestandingMacroExpansionSyntax {
   @available(*, deprecated, renamed: "pound")
-  public var poundToken: TokenSyntax {
+  var poundToken: TokenSyntax {
     get {
       return pound
     }
@@ -62,7 +62,7 @@ public extension FreestandingMacroExpansionSyntax {
   }
 
   @available(*, deprecated, renamed: "macroName")
-  public var macro: TokenSyntax {
+  var macro: TokenSyntax {
     get {
       return macroName
     }
@@ -82,7 +82,7 @@ public extension FreestandingMacroExpansionSyntax {
   }
 
   @available(*, deprecated, renamed: "arguments")
-  public var argumentList: LabeledExprListSyntax {
+  var argumentList: LabeledExprListSyntax {
     get {
       return arguments
     }

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExpressionMacroTests.swift
@@ -240,7 +240,7 @@ final class ExpressionMacroTests: XCTestCase {
         of node: some FreestandingMacroExpansionSyntax,
         in context: some MacroExpansionContext
       ) throws -> ExprSyntax {
-        guard let argument = node.argumentList.first?.expression else {
+        guard let argument = node.arguments.first?.expression else {
           fatalError("Must receive an argument")
         }
         guard var node = argument.as(InfixOperatorExprSyntax.self) else {
@@ -265,7 +265,7 @@ final class ExpressionMacroTests: XCTestCase {
         of node: some FreestandingMacroExpansionSyntax,
         in context: some MacroExpansionContext
       ) throws -> ExprSyntax {
-        guard let argument = node.argumentList.first?.expression else {
+        guard let argument = node.arguments.first?.expression else {
           fatalError("Must receive an argument")
         }
         context.addDiagnostics(from: MyError(), node: argument)


### PR DESCRIPTION
1. **Update Deprecated API Usages**: Replaced deprecated methods with their newer equivalents across multiple files to resolve deprecation warnings.

2. **Remove Redundant 'public' Modifier**: Removed the unnecessary 'public' keyword from properties in public extensions, cleaning up the code and resolving compiler warnings.
