### PR TITLE
Fix a string interpolation error in CodeGeneration

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -321,6 +321,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     }
 
     leafProtocolDecl(type: node.kind.leafProtocolType, inheritedType: node.kind.protocolType)
+    leafProtocolExtension(type: node.kind.leafProtocolType, inheritedType: node.kind.protocolType)
   }
 
   try! ExtensionDeclSyntax(
@@ -350,18 +351,25 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   }
 
   leafProtocolDecl(type: "_LeafSyntaxNodeProtocol", inheritedType: "SyntaxProtocol")
+  leafProtocolExtension(type: "_LeafSyntaxNodeProtocol", inheritedType: "SyntaxProtocol")
 }
 
 private func leafProtocolDecl(type: TypeSyntax, inheritedType: TypeSyntax) -> DeclSyntax {
   DeclSyntax(
-    #"""
+    """
     /// Protocol that syntax nodes conform to if they don't have any semantic subtypes.
     /// These are syntax nodes that are not considered base nodes for other syntax types.
     ///
     /// Syntax nodes conforming to this protocol have their inherited casting methods
     /// deprecated to prevent incorrect casting.
-    public protocol \#(type): \#(inheritedType) {}
+    public protocol \(type): \(inheritedType) {}
+    """
+  )
+}
 
+private func leafProtocolExtension(type: TypeSyntax, inheritedType: TypeSyntax) -> DeclSyntax {
+  DeclSyntax(
+    #"""
     public extension \#(type) {
       /// Checks if the current leaf syntax node can be cast to a different specified type.
       ///

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -275,6 +275,7 @@ public extension _LeafDeclSyntaxNodeProtocol {
   func `is`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
+  
 
   /// Attempts to cast the current leaf syntax node to a different specified type.
   ///
@@ -286,6 +287,7 @@ public extension _LeafDeclSyntaxNodeProtocol {
   func `as`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
+  
 
   /// Force-casts the current leaf syntax node to a different specified type.
   ///
@@ -591,6 +593,7 @@ public extension _LeafExprSyntaxNodeProtocol {
   func `is`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
+  
 
   /// Attempts to cast the current leaf syntax node to a different specified type.
   ///
@@ -602,6 +605,7 @@ public extension _LeafExprSyntaxNodeProtocol {
   func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
+  
 
   /// Force-casts the current leaf syntax node to a different specified type.
   ///
@@ -862,6 +866,7 @@ public extension _LeafPatternSyntaxNodeProtocol {
   func `is`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
+  
 
   /// Attempts to cast the current leaf syntax node to a different specified type.
   ///
@@ -873,6 +878,7 @@ public extension _LeafPatternSyntaxNodeProtocol {
   func `as`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
+  
 
   /// Force-casts the current leaf syntax node to a different specified type.
   ///
@@ -1143,6 +1149,7 @@ public extension _LeafStmtSyntaxNodeProtocol {
   func `is`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
+  
 
   /// Attempts to cast the current leaf syntax node to a different specified type.
   ///
@@ -1154,6 +1161,7 @@ public extension _LeafStmtSyntaxNodeProtocol {
   func `as`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
+  
 
   /// Force-casts the current leaf syntax node to a different specified type.
   ///
@@ -1425,6 +1433,7 @@ public extension _LeafTypeSyntaxNodeProtocol {
   func `is`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
+  
 
   /// Attempts to cast the current leaf syntax node to a different specified type.
   ///
@@ -1436,6 +1445,7 @@ public extension _LeafTypeSyntaxNodeProtocol {
   func `as`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
+  
 
   /// Force-casts the current leaf syntax node to a different specified type.
   ///
@@ -1754,6 +1764,7 @@ public extension _LeafSyntaxNodeProtocol {
   func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
+  
 
   /// Attempts to cast the current leaf syntax node to a different specified type.
   ///
@@ -1765,6 +1776,7 @@ public extension _LeafSyntaxNodeProtocol {
   func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
+  
 
   /// Force-casts the current leaf syntax node to a different specified type.
   ///


### PR DESCRIPTION
`leafProtocolDecl` placed two declarations within the same `DeclSyntax`, which didn’t parse correctly, triggering `logStringInterpolationParsingError`. Split the function so that one returns the protocol declaration and the other returns the extension.