### PR TITLE
Support cancellation of subcommands in `swift-syntax-dev-utils` using Ctrl-C

### DIFF
--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/SwiftSyntaxDevUtils.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/SwiftSyntaxDevUtils.swift
@@ -31,4 +31,18 @@ struct SwiftSyntaxDevUtils: ParsableCommand {
       VerifySourceCode.self,
     ]
   )
+
+  public static func main() {
+    SigIntListener.registerSigIntSubprocessTerminationHandler()
+    do {
+      var command = try parseAsRoot(nil)
+      try command.run()
+    } catch {
+      if !SigIntListener.hasReceivedSigInt {
+        // No point printing an error message if the user requested the termination
+        // of the script.
+        exit(withError: error)
+      }
+    }
+  }
 }


### PR DESCRIPTION
It’s really quite unfortunate that we need to do all this handling ourselves…