### PR TITLE
Enable Memory Layout Tests in Release build

### DIFF
--- a/Sources/SwiftSyntax/MemoryLayout.swift
+++ b/Sources/SwiftSyntax/MemoryLayout.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if DEBUG
 // See `MemoryLayoutTest.swift`.
 @_spi(Testing) public enum SyntaxMemoryLayout {
   public struct Value: Equatable {
@@ -41,4 +40,3 @@
     return result
   }
 }
-#endif

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -944,7 +944,6 @@ extension RawSyntax: Identifiable {
   }
 }
 
-#if DEBUG
 /// See `SyntaxMemoryLayout`.
 var RawSyntaxDataMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
   "RawSyntaxData": .init(RawSyntaxData.self),
@@ -953,4 +952,3 @@ var RawSyntaxDataMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
   "RawSyntaxData.MaterializedToken": .init(RawSyntaxData.MaterializedToken.self),
   "RawSyntax?": .init(RawSyntax?.self),
 ]
-#endif

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -308,7 +308,6 @@ extension Syntax {
 @available(*, unavailable, message: "use 'Syntax' instead")
 public struct SyntaxNode {}
 
-#if DEBUG
 /// See `SyntaxMemoryLayout`.
 var SyntaxMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
   "Syntax": .init(Syntax.self),
@@ -316,4 +315,3 @@ var SyntaxMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
   "Syntax.Info.Root": .init(Syntax.Info.Root.self),
   "Syntax.Info.NonRoot": .init(Syntax.Info.NonRoot.self),
 ]
-#endif

--- a/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
+++ b/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
@@ -13,7 +13,6 @@
 @_spi(Testing) import SwiftSyntax
 import XCTest
 
-#if DEBUG
 final class MemoryLayoutTest: XCTestCase {
 
   func testMemoryLayouts() throws {
@@ -46,6 +45,4 @@ final class MemoryLayoutTest: XCTestCase {
       XCTAssertEqual(actualValue, exp.value, "Matching '\(exp.key)' values")
     }
   }
-
 }
-#endif


### PR DESCRIPTION
Remove `#if DEBUG` checks for `MemoryLayoutTests` and `SyntaxMemoryLayout`. 

Building and testing it on my local machine with RELEASE config passed without any changes. 

Addresses https://github.com/apple/swift-syntax/issues/2170