### PR TITLE
Add experimental-skip-synthesized-symbols parameter for doc generation on SPI

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -22,4 +22,3 @@ builder:
       - SwiftSyntaxMacroExpansion
       - SwiftSyntaxMacrosTestSupport
       custom_documentation_parameters: [--experimental-skip-synthesized-symbols]
-      swift_version: '5.9'

--- a/.spi.yml
+++ b/.spi.yml
@@ -21,3 +21,5 @@ builder:
       - SwiftSyntaxMacros
       - SwiftSyntaxMacroExpansion
       - SwiftSyntaxMacrosTestSupport
+      custom_documentation_parameters: [--experimental-skip-synthesized-symbols]
+      swift_version: '5.9'


### PR DESCRIPTION
As just discussed on the Documentation WG, setting this parameter shrinks the generated docs down dramatically:

```
normal:
mb size:    708.0
file count: 84,619


skip synthesized symbols:
mb size:    155.0
file count: 17,537
```

cc @ethan-kusters 