### PR TITLE
Only enable `_borrowing`, `_consuming` and `_mutating` as declaration start keywors if the experimental feature is enabled

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -138,6 +138,8 @@ extension TokenConsumer {
       // FIXME: C++ parser returns true if this is a top-level non-"script" files.
       // But we don't have "is library" flag.
       return false
+    case .rhs(._borrowing), .rhs(._consuming), .rhs(._mutating):
+      return experimentalFeatures.contains(.referenceBindings)
     case .some(_):
       // All other decl start keywords unconditionally start a decl.
       return true

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -17,6 +17,10 @@ protocol TokenConsumer {
   associatedtype Token
   /// The current token syntax being examined by the consumer
   var currentToken: Lexer.Lexeme { get }
+
+  /// The experimental features that have been enabled.
+  var experimentalFeatures: Parser.ExperimentalFeatures { get }
+
   /// Whether the current token matches the given kind.
   mutating func consumeAnyToken() -> Token
 

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
@@ -117,4 +117,7 @@ final class PatternWithoutVariablesTests: ParserTestCase {
     )
   }
 
+  func testMutatingNotADeclarationStartIfNotEnabled() {
+    assertParse("_mutating = 2")
+  }
 }


### PR DESCRIPTION
Otherwise `_mutating = 2` was rejected where it was previously accepted.

rdar://115348117