### PR TITLE
Don’t add any accessors if accessor macro returned an empty array

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -267,7 +267,8 @@ private func expandAccessorMacroWithoutExistingAccessors(
       conformanceList: nil,
       in: context,
       indentationWidth: indentationWidth
-    )
+    ),
+    !expanded.isEmpty
   else {
     return nil
   }

--- a/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
@@ -133,4 +133,23 @@ final class CodeItemMacroTests: XCTestCase {
       indentationWidth: indentationWidth
     )
   }
+
+  func testEmpty() {
+    struct TestMacro: CodeItemMacro {
+      static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+      ) throws -> [CodeBlockItemSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      "#test",
+      expandedSource: "",
+      macros: [
+        "test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
@@ -389,4 +389,22 @@ final class DeclarationMacroTests: XCTestCase {
     )
   }
 
+  func testEmpty() {
+    struct TestMacro: DeclarationMacro {
+      static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+      ) throws -> [DeclSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      "#test",
+      expandedSource: "",
+      macros: [
+        "test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
@@ -106,4 +106,26 @@ final class ExtensionMacroTests: XCTestCase {
       indentationWidth: indentationWidth
     )
   }
+
+  func testEmpty() {
+    struct TestMacro: ExtensionMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+      ) throws -> [ExtensionDeclSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      "@Test struct Foo {}",
+      expandedSource: "struct Foo {}",
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
@@ -354,4 +354,48 @@ final class MemberAttributeMacroTests: XCTestCase {
     )
   }
 
+  func testEmpty() {
+    struct TestMacro: MemberAttributeMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingAttributesFor member: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+      ) throws -> [AttributeSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          var x: Int
+        }
+        """,
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+        }
+        """,
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
@@ -255,4 +255,48 @@ final class MemberMacroTests: XCTestCase {
     )
   }
 
+  func testEmpty() {
+    struct TestMacro: MemberMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+      ) throws -> [DeclSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          var x: Int
+        }
+        """,
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+        }
+        """,
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
@@ -173,4 +173,24 @@ final class PeerMacroTests: XCTestCase {
       macros: ["Test": TestMacro.self]
     )
   }
+
+  func testEmpty() {
+    struct TestMacro: PeerMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+      ) throws -> [DeclSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      "@Test var x: Int",
+      expandedSource: "var x: Int",
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+  }
 }


### PR DESCRIPTION
If an accessor macro returns an empty array, MacroSystem was failing with internal error messages because it tried ot parse an `AccessorBlockSyntax` from an empty string.

To fix this, check if the expanded source is empty before trying to parse the `AccessorBlockSyntax`.