### PR TITLE
[509] Don’t add any accessors if accessor macro returned an empty array

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -259,7 +259,8 @@ private func expandAccessorMacroWithoutExistingAccessors(
       conformanceList: nil,
       in: context,
       indentationWidth: indentationWidth
-    )
+    ),
+    !expanded.isEmpty
   else {
     return nil
   }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-syntax/pull/2187 to 509.

---

If an accessor macro returns an empty array, MacroSystem was failing with internal error messages because it tried ot parse an `AccessorBlockSyntax` from an empty string.

To fix this, check if the expanded source is empty before trying to parse the `AccessorBlockSyntax`.