### PR TITLE
Print environment variables for commands executed by `swift-syntax-dev-utils`

### DIFF
--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Logger.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Logger.swift
@@ -20,6 +20,10 @@ extension Process {
   var command: String {
     var message = ""
 
+    for (key, value) in environment?.sorted(by: { $0.key < $1.key }) ?? [] {
+      message += "\(key)='\(value)' "
+    }
+
     if let executableURL = executableURL {
       message += executableURL.path
     }


### PR DESCRIPTION
Environment variables are as much input to the executed subprocess as the parameters and we should be logging them as well in verbose mode.