### PR TITLE
WIP: Make sure that we always build swift-syntax consistently in CI

### DIFF
--- a/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
+++ b/CodeGeneration/Tests/ValidateSyntaxNodes/ValidateSyntaxNodes.swift
@@ -515,6 +515,8 @@ class ValidateSyntaxNodes: XCTestCase {
         ValidationFailure(node: .differentiabilityArguments, message: "could conform to trait 'Parenthesized' but does not"),
         ValidationFailure(node: .editorPlaceholderDecl, message: "could conform to trait 'MissingNode' but does not"),
         ValidationFailure(node: .editorPlaceholderExpr, message: "could conform to trait 'MissingNode' but does not"),
+        ValidationFailure(node: .editorPlaceholderPattern, message: "could conform to trait 'MissingNode' but does not"),
+        ValidationFailure(node: .editorPlaceholderType, message: "could conform to trait 'MissingNode' but does not"),
         ValidationFailure(node: .enumCaseElement, message: "could conform to trait 'NamedDecl' but does not"),
         ValidationFailure(node: .genericParameter, message: "could conform to trait 'NamedDecl' but does not"),
         ValidationFailure(node: .precedenceGroupDecl, message: "could conform to trait 'Braced' but does not"),

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Test.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Test.swift
@@ -24,48 +24,47 @@ struct Test: ParsableCommand, BuildCommand {
   var arguments: BuildArguments
 
   func run() throws {
-    try buildExample(exampleName: "ExamplePlugin")
-
     try runTests()
+    try runCodeGenerationTests()
 
     logSection("All tests passed")
   }
 
   private func runTests() throws {
     logSection("Running SwiftSyntax Tests")
-    var swiftpmCallArguments: [String] = []
+    var swiftpmCallArguments = [
+      "--test-product", "swift-syntaxPackageTests",
+    ]
 
     if arguments.verbose {
       swiftpmCallArguments += ["--verbose"]
     }
 
-    swiftpmCallArguments += ["--test-product", "swift-syntaxPackageTests"]
-
-    var additionalEnvironment: [String: String] = [:]
-    additionalEnvironment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] = "1"
-
-    if arguments.enableRawSyntaxValidation {
-      additionalEnvironment["SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION"] = "1"
-    }
-
-    if arguments.enableTestFuzzing {
-      additionalEnvironment["SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION"] = "1"
-    }
-
-    // Tell other projects in the unified build to use local dependencies
-    additionalEnvironment["SWIFTCI_USE_LOCAL_DEPS"] = "1"
-    additionalEnvironment["SWIFT_SYNTAX_PARSER_LIB_SEARCH_PATH"] =
-      arguments.toolchain
-      .appendingPathComponent("lib")
-      .appendingPathComponent("swift")
-      .appendingPathComponent("macosx")
-      .path
-
     try invokeSwiftPM(
       action: "test",
       packageDir: Paths.packageDir,
       additionalArguments: swiftpmCallArguments,
-      additionalEnvironment: additionalEnvironment,
+      additionalEnvironment: swiftPMEnvironmentVariables,
+      captureStdout: false,
+      captureStderr: false
+    )
+  }
+
+  private func runCodeGenerationTests() throws {
+    logSection("Running CodeGeneration Tests")
+    var swiftpmCallArguments = [
+      "--test-product", "CodeGenerationPackageTests",
+    ]
+
+    if arguments.verbose {
+      swiftpmCallArguments += ["--verbose"]
+    }
+
+    try invokeSwiftPM(
+      action: "test",
+      packageDir: Paths.codeGenerationDir,
+      additionalArguments: swiftpmCallArguments,
+      additionalEnvironment: swiftPMEnvironmentVariables,
       captureStdout: false,
       captureStderr: false
     )

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Test.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Test.swift
@@ -32,18 +32,11 @@ struct Test: ParsableCommand, BuildCommand {
 
   private func runTests() throws {
     logSection("Running SwiftSyntax Tests")
-    var swiftpmCallArguments = [
-      "--test-product", "swift-syntaxPackageTests",
-    ]
-
-    if arguments.verbose {
-      swiftpmCallArguments += ["--verbose"]
-    }
 
     try invokeSwiftPM(
       action: "test",
       packageDir: Paths.packageDir,
-      additionalArguments: swiftpmCallArguments,
+      additionalArguments: ["--test-product", "swift-syntaxPackageTests"],
       additionalEnvironment: swiftPMEnvironmentVariables,
       captureStdout: false,
       captureStderr: false
@@ -52,18 +45,10 @@ struct Test: ParsableCommand, BuildCommand {
 
   private func runCodeGenerationTests() throws {
     logSection("Running CodeGeneration Tests")
-    var swiftpmCallArguments = [
-      "--test-product", "CodeGenerationPackageTests",
-    ]
-
-    if arguments.verbose {
-      swiftpmCallArguments += ["--verbose"]
-    }
-
     try invokeSwiftPM(
       action: "test",
       packageDir: Paths.codeGenerationDir,
-      additionalArguments: swiftpmCallArguments,
+      additionalArguments: ["--test-product", "CodeGenerationPackageTests"],
       additionalEnvironment: swiftPMEnvironmentVariables,
       captureStdout: false,
       captureStderr: false

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildArguments.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildArguments.swift
@@ -39,31 +39,8 @@ struct BuildArguments: ParsableArguments {
   )
   var multirootDataFile: URL?
 
-  @Flag(help: "Disable sandboxes when building with SwiftPM")
-  var disableSandbox: Bool = false
-
   @Flag(help: "Build in release mode.")
   var release: Bool = false
-
-  @Flag(
-    name: .customLong("enable-rawsyntax-validation"),
-    help:
-      """
-      When constructing RawSyntax nodes validate that their layout matches that
-      defined in `CodeGeneration` and that TokenSyntax nodes have a `tokenKind`
-      matching the ones specified in `CodeGeneration`.
-      """
-  )
-  var enableRawSyntaxValidation: Bool = false
-
-  @Flag(
-    help: """
-      For each `assertParse` test, perform mutations of the test case based on
-      alternate token choices that the parser checks, validating that there are
-      no round-trip or assertion failures.
-      """
-  )
-  var enableTestFuzzing: Bool = false
 
   @Flag(help: "Treat all warnings as errors.")
   var warningsAsErrors: Bool = false

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildCommand.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildCommand.swift
@@ -59,10 +59,6 @@ extension BuildCommand {
       args += ["--multiroot-data-file", multirootDataFile]
     }
 
-    if arguments.disableSandbox {
-      args += ["--disable-sandbox"]
-    }
-
     if arguments.verbose {
       args += ["--verbose"]
     }
@@ -116,14 +112,6 @@ extension BuildCommand {
   var swiftPMEnvironmentVariables: [String: String] {
     var additionalEnvironment: [String: String] = [:]
     additionalEnvironment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] = "1"
-
-    if arguments.enableRawSyntaxValidation {
-      additionalEnvironment["SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION"] = "1"
-    }
-
-    if arguments.enableTestFuzzing {
-      additionalEnvironment["SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION"] = "1"
-    }
 
     // Tell other projects in the unified build to use local dependencies
     additionalEnvironment["SWIFTCI_USE_LOCAL_DEPS"] = "1"

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SourceCodeGeneratorCommand.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SourceCodeGeneratorCommand.swift
@@ -32,15 +32,10 @@ extension SourceCodeGeneratorCommand {
       args += ["--verbose"]
     }
 
-    let additionalEnvironment = [
-      "SWIFT_BUILD_SCRIPT_ENVIRONMENT": "1",
-      "SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION": "1",
-    ]
-
     let process = ProcessRunner(
       executableURL: arguments.toolchain.appendingPathComponent("bin").appendingPathComponent("swift"),
       arguments: args,
-      additionalEnvironment: additionalEnvironment
+      additionalEnvironment: ["SWIFT_BUILD_SCRIPT_ENVIRONMENT": "1"]
     )
 
     try process.run(verbose: arguments.verbose)


### PR DESCRIPTION
We were currently setting the `SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION` and `SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION` environment variables when building swift-syntax in CI. But when building e.g. sourcekit-lsp from the same unified workspace, we weren’t setting these environment variables. I’m not actually sure what the behavior here was: Either we re-built swift-syntax (which we don’t want) or we used the already built swift-syntax that had had `RawSyntax` validation enabled, which didn’t actually match the build of sourcekit-lsp that was requested.

In either case, the solution is to have a single environment variable `SWIFT_BUILD_SCRIPT_ENVIRONMENT` that gets set by all projects building in the unfied SwiftPM workspace. That environment variable then enables all the things that we want to have enabled in CI.