### PR TITLE
Fix ExperimentalFeatures raw values

### DIFF
--- a/Sources/SwiftParser/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/ExperimentalFeatures.swift
@@ -17,13 +17,13 @@ extension Parser {
     public init(rawValue: UInt) {
       self.rawValue = rawValue
     }
-
-    /// Whether to enable the parsing of 'reference bindings'.
-    public static let referenceBindings = Self(rawValue: 1 << 0)
   }
 }
 
 extension Parser.ExperimentalFeatures {
+  /// Whether to enable the parsing of 'reference bindings'.
+  public static let referenceBindings = Self(rawValue: 1 << 0)
+
   /// Whether to enable the parsing of 'then' statements.
-  public static let thenStatements = Self(rawValue: 1 << 0)
+  public static let thenStatements = Self(rawValue: 1 << 1)
 }


### PR DESCRIPTION
Looks like we had a race between PRs and ended up assigning the first bit for both 'then' statements and reference bindings. Correct the assignment here.