### PR TITLE
Disable testable imports when testing swift-syntax

### DIFF
--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildCommand.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/BuildCommand.swift
@@ -42,6 +42,9 @@ extension BuildCommand {
     captureStderr: Bool = true
   ) throws -> ProcessResult {
     var args = [action]
+    if action == "test" {
+      args += ["--disable-testable-imports"]
+    }
     args += ["--package-path", packageDir.path]
 
     if let buildDir = arguments.buildDir?.path {


### PR DESCRIPTION
Enabling testable imports caused us to re-compile swift-syntax for testing, which takes quite a while in release mode. This should reduce CI time by ~5 minutes.