### PR TITLE
Fix incorrect `if` condition in the main package manifest 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -332,12 +332,12 @@ package.targets.append(
 )
 
 if useLocalDependencies {
+  package.dependencies += [
+    .package(path: "../swift-argument-parser")
+  ]
+} else {
   // Building standalone.
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2")
-  ]
-} else {
-  package.dependencies += [
-    .package(path: "../swift-argument-parser")
   ]
 }


### PR DESCRIPTION
This PR corrects the conditional logic for loading local versus remote dependencies in the Package.swift file.

I believe in PR #2200 we have merged the incorrect `if` condition in the `Package.swift` file.