### PR TITLE
Add HasDeclModifierList trait

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -73,6 +73,12 @@ public let TRAITS: [Trait] = [
     ]
   ),
   Trait(
+    traitName: "HasDeclModifierList",
+    children: [
+      Child(name: "modifers", kind: .node(kind: .declModifierList), isOptional: false),
+    ]
+  ),
+  Trait(
     traitName: "NamedDecl",
     children: [
       Child(name: "name", kind: .token(choices: [.token(.identifier)]))

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -394,6 +394,7 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/DeclGroupSyntax>
 - <doc:SwiftSyntax/EffectSpecifiersSyntax>
 - <doc:SwiftSyntax/FreestandingMacroExpansionSyntax>
+- <doc:SwiftSyntax/HasDeclModifierListSyntax>
 - <doc:SwiftSyntax/NamedDeclSyntax>
 - <doc:SwiftSyntax/MissingNodeSyntax>
 - <doc:SwiftSyntax/ParenthesizedSyntax>

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -269,6 +269,43 @@ public extension SyntaxProtocol {
   }
 }
 
+// MARK: - HasDeclModifierListSyntax
+
+
+public protocol HasDeclModifierListSyntax: SyntaxProtocol {
+  var modifers: DeclModifierListSyntax {
+    get
+    set
+  }
+}
+
+public extension HasDeclModifierListSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<HasDeclModifierListSyntax, T>, _ newChild: T) -> HasDeclModifierListSyntax {
+    var copy: HasDeclModifierListSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
+}
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to
+  /// `HasDeclModifierListSyntax`.
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: HasDeclModifierListSyntax.Protocol) -> Bool {
+    return self.asProtocol(HasDeclModifierListSyntax.self) != nil
+  }
+  
+  /// Return the non-type erased version of this syntax node if it conforms to
+  /// `HasDeclModifierListSyntax`. Otherwise return `nil`.
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: HasDeclModifierListSyntax.Protocol) -> HasDeclModifierListSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? HasDeclModifierListSyntax
+  }
+}
+
 // MARK: - NamedDeclSyntax
 
 


### PR DESCRIPTION
Adds a new protocol to enable accessing the modifiers of a decl without needing to switch over concrete syntaxes which contain modifiers. This allows users to extract AccessLevels and other modifiers from decls in a generic manner.