### PR TITLE
Revert "Fix incorrect `if` condition in the main package manifest "

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -332,12 +332,12 @@ package.targets.append(
 )
 
 if useLocalDependencies {
-  package.dependencies += [
-    .package(path: "../swift-argument-parser")
-  ]
-} else {
   // Building standalone.
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2")
+  ]
+} else {
+  package.dependencies += [
+    .package(path: "../swift-argument-parser")
   ]
 }


### PR DESCRIPTION
Reverts apple/swift-syntax#2217

Temporarily revert this to allow investigating why this is behaving incorrectly on Windows.