### PR TITLE
Do not add whitespace between right angle and period

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -334,6 +334,7 @@ open class BasicFormat: SyntaxRewriter {
       (.regexLiteralPattern, _),
       (.regexSlash, .regexPoundDelimiter),  // closing extended regex delimiter should never be separate by a space
       (.rightAngle, .leftParen),  // func foo<T>(x: T)
+      (.rightAngle, .period),  // Foo<T>.bar
       (.rightBrace, .leftParen),  // { return 1 }()
       (.rightParen, .leftParen),  // returnsClosure()()
       (.rightParen, .period),  // foo().bar

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -531,4 +531,11 @@ final class BasicFormatTest: XCTestCase {
       )
     }
   }
+
+  func testRightAnglePeriodNotFormatted() {
+    assertFormatted(
+      tree: ExprSyntax("Foo<T>.bar"),
+      expected: "Foo<T>.bar"
+    )
+  }
 }


### PR DESCRIPTION
`Foo<T>.bar` should not have whitespace added between `>` and `.`.