### PR TITLE
Format `expectedExpandedSource` in `assertStringsEqualWithDiff` before comparing

### DIFF
--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -292,8 +292,8 @@ public func assertMacroExpansion(
   }
 
   assertStringsEqualWithDiff(
-    expandedSourceFile.description.trimmingCharacters(in: .newlines),
-    Parser.parse(source: expectedExpandedSource).description.trimmingCharacters(in: .newlines),
+    expandedSourceFile.formatted().description.trimmingCharacters(in: .newlines),
+    Parser.parse(source: expectedExpandedSource).formatted().description.trimmingCharacters(in: .newlines),
     "Macro expansion did not produce the expected expanded source",
     additionalInfo: """
       Actual expanded source:

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -292,8 +292,8 @@ public func assertMacroExpansion(
   }
 
   assertStringsEqualWithDiff(
+    expandedSourceFile.description.trimmingCharacters(in: .newlines),
     Parser.parse(source: expectedExpandedSource).description.trimmingCharacters(in: .newlines),
-    expectedExpandedSource.trimmingCharacters(in: .newlines),
     "Macro expansion did not produce the expected expanded source",
     additionalInfo: """
       Actual expanded source:

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -292,7 +292,7 @@ public func assertMacroExpansion(
   }
 
   assertStringsEqualWithDiff(
-    expandedSourceFile.description.trimmingCharacters(in: .newlines),
+    Parser.parse(source: expectedExpandedSource).description.trimmingCharacters(in: .newlines),
     expectedExpandedSource.trimmingCharacters(in: .newlines),
     "Macro expansion did not produce the expected expanded source",
     additionalInfo: """


### PR DESCRIPTION
I was encountering mis-matches between my `expectedExpandedSource` and the source returned from the `expansion` of my macro, as tested by `assertStringsEqualWithDiff`.

[Discussed on swift-open-source Slack](https://swift-open-source.slack.com/archives/C04N0ET1K3Q/p1695275043763609)

As I understand what is happening, when I return a string in the `MemberMacro::expansion() -> [SwiftSyntax.DeclSyntax]`, it will be parsed and then its AST will be printed in `assertMacroExpansion()` using `expandedSourceFile.description` which will reflect the standard way of printing it, not the way it was written as a string in the macro code.

e.g. my macro code has:

```
return [
                """
                func aUselessFunction() {}
                """
            ]
```

and `expandedSourceFile.description` opens the brackets:

```
struct MyStruct{

    func aUselessFunction() {
    }
}
```

my test expectation is written as:

```
struct MyStruct{

    func aUselessFunction() {}
}
```

As I write the macro, I'm copying and pasting between the macro code and the test code, assuming most lines will remain the same.

Similarly, switch cases were expanded from one line to two

```
return [
    """
    func aUselessFunction() -> Bool? {
        let foo = "bar"
        switch "foo" {
            case "bar": return true
            default: return nil
        }
    }
    """
]
```

```
Actual expanded source:

struct MyStruct{

    func aUselessFunction() -> Bool? {
        let foo = "bar"
        switch "foo" {
            case "bar":
            return true
            default:
            return nil
        }
    }
}
```

By running the `expectedExpandedSource` through `Parser.parse()` and comparing it `.formatted()` with `expandedSourceFile.formatted()` we are comparing like with like.

The downside to this is that in the failure reports' "Macro expansion did not produce the expected expanded source", the "expected output" is now not _exactly_ what the user has in their test case.

I think that's a reasonable trade-off, especially since the code that really matters is the macro output and that is already formatted, so this is a time-saver for developers.

Let me know if that's ok and I'll add some tests to the PR.
