### PR TITLE
Use note-blockquote instead of quoting-block to improve readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,16 @@
 
 swift-syntax is a SwiftPM package, so you can build and test it using anything that supports packages - opening in Xcode, Visual Studio Code with [Swift for Visual Studio Code](https://github.com/swift-server/vscode-swift) installed, or through the command line using `swift build` and `swift test`.
 
-> 💡 Tip: Running swift-syntax’s self-parse tests takes the majority of testing time. If you want to iterate quickly, you can skip these tests:
+> [!NOTE]
+> Running swift-syntax’s self-parse tests takes the majority of testing time. If you want to iterate quickly, you can skip these tests:
 > - In Xcode
 >   1. Product -> Scheme -> Edit Scheme…
 >   2. Select the Arguments tab in the Run section
 >   3. Add a `SKIP_LONG_TESTS` environment variable with value `1`
 > - On the command line: Set the `SKIP_LONG_TESTS` environment variable to `1` when running tests, e.g by running `SKIP_LONG_TESTS=1 swift test`
 
-> 💡 Tip: If you are only modifying the `SwiftParser` module, you can run only the parser tests by selecting the `SwiftParserTest` target. 
+> [!NOTE]
+> If you are only modifying the `SwiftParser` module, you can run only the parser tests by selecting the `SwiftParserTest` target. 
 > - In Xcode: Select the `SwiftParserTest` scheme. If you can’t find it in your Schemes, you need to manually add it using Product -> Scheme -> New Scheme…
 > - On the command line: Run `swift test --test-product SwiftParserTests`
 
@@ -61,7 +63,8 @@ When the `SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION` environment variable is set w
 
 If this validation hits an assertion failure that a token is not accepted at a certain position in the syntax tree, double-check if the token kind that is being stored in the syntax tree actually makes sense here. If it does not, check if there is a parser bug or whether you need to remap the token kind. If it does make sense, add the token kind to `.token(choices:)` of the syntax node in CodeGeneration, re-generate that source code and run tests again.
 
-> 💡 Tip: If you want to run tests in Xcode with RawSyntax validation enabled, you can also modify Package.swift and replace the check for `SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION` with `true`.
+> [!NOTE]
+> If you want to run tests in Xcode with RawSyntax validation enabled, you can also modify Package.swift and replace the check for `SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION` with `true`.
 
 ### Test Case Mutation
 


### PR DESCRIPTION
I've noticed that [`swift-testing`](https://github.com/apple/swift-testing) frequently uses these markdown highlights. I believe they drastically improve the readability of markdown files when viewed on GitHub. Therefore, I'd like to propose using them here.

For reference, here is some documentation: https://github.com/orgs/community/discussions/16925

Here's how the file looks before and after the changes:
<img width="1088" alt="Screenshot 2023-09-22 at 8 27 20 PM" src="https://github.com/apple/swift-syntax/assets/44930823/b2fcd1a3-a5b7-4fb1-83ad-e9c4c09090ab">
and after:
<img width="1123" alt="Screenshot 2023-09-22 at 8 27 57 PM" src="https://github.com/apple/swift-syntax/assets/44930823/13b24b6c-8474-4c35-93da-e1bec45b25e1">
