### PR TITLE
improve parsing for suppression/inverse constraints

### DIFF
--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -2342,6 +2342,114 @@ final class DeclarationTests: ParserTestCase {
 
     assertParse(
       """
+      let _: any ~Copyable = 0
+      """,
+      substructure: SomeOrAnyTypeSyntax(
+        someOrAnySpecifier: .keyword(.any),
+        constraint: SuppressedTypeSyntax(
+          withoutTilde: .prefixOperator("~"),
+          type: TypeSyntax(stringLiteral: "Copyable")
+        )
+      )
+    )
+
+    assertParse(
+      """
+      typealias Z = ~Copyable.Type
+      """,
+      substructure: SuppressedTypeSyntax(
+        withoutTilde: .prefixOperator("~"),
+        type: MetatypeTypeSyntax(
+          baseType: TypeSyntax(stringLiteral: "Copyable"),
+          metatypeSpecifier: .keyword(.Type)
+        )
+      )
+    )
+
+    assertParse(
+      """
+      typealias Z = ~A.B.C
+      """,
+      substructure: SuppressedTypeSyntax(
+        withoutTilde: .prefixOperator("~"),
+        type: MemberTypeSyntax(
+          baseType: MemberTypeSyntax(
+            baseType: TypeSyntax(stringLiteral: "A"),
+            name: .identifier("B")
+          ),
+          name: .identifier("C")
+        )
+      )
+    )
+
+    assertParse(
+      """
+      typealias Z = ~A?
+      """,
+      substructure: SuppressedTypeSyntax(
+        withoutTilde: .prefixOperator("~"),
+        type: OptionalTypeSyntax(
+          wrappedType: IdentifierTypeSyntax(name: .identifier("A"))
+        )
+      )
+    )
+
+    assertParse(
+      """
+      typealias Z = ~A<T>
+      """,
+      substructure: SuppressedTypeSyntax(
+        withoutTilde: .prefixOperator("~"),
+        type: IdentifierTypeSyntax(
+          name: .identifier("A"),
+          genericArgumentClause: GenericArgumentClauseSyntax(
+            arguments: GenericArgumentListSyntax([
+              GenericArgumentSyntax(
+                argument:
+                  IdentifierTypeSyntax(name: .identifier("T"))
+              )
+            ])
+          )
+        )
+      )
+    )
+
+    assertParse(
+      """
+      struct Hello<T: ~Copyable> {}
+      """,
+      substructure: GenericParameterListSyntax([
+        GenericParameterSyntax(
+          attributes: AttributeListSyntax([]),
+          name: .identifier("T"),
+          colon: .colonToken(),
+          inheritedType: SuppressedTypeSyntax(
+            withoutTilde: .prefixOperator("~"),
+            type: TypeSyntax(stringLiteral: "Copyable")
+          )
+        )
+      ])
+    )
+
+    assertParse(
+      """
+      func henlo<T: ~Copyable>(_ t: T) {}
+      """,
+      substructure: GenericParameterListSyntax([
+        GenericParameterSyntax(
+          attributes: AttributeListSyntax([]),
+          name: .identifier("T"),
+          colon: .colonToken(),
+          inheritedType: SuppressedTypeSyntax(
+            withoutTilde: .prefixOperator("~"),
+            type: TypeSyntax(stringLiteral: "Copyable")
+          )
+        )
+      ])
+    )
+
+    assertParse(
+      """
       enum Whatever: Int, ~ Hashable, Equatable {}
       """,
       substructure: InheritanceClauseSyntax(
@@ -2365,7 +2473,7 @@ final class DeclarationTests: ParserTestCase {
 
     assertParse(
       """
-      typealias T = ~1️⃣Int 2️⃣-> Bool
+      typealias T = 1️⃣~Int 2️⃣-> Bool
       """,
       diagnostics: [
         DiagnosticSpec(
@@ -2380,20 +2488,24 @@ final class DeclarationTests: ParserTestCase {
         ),
       ],
       fixedSource: """
-        typealias T = ~(Int) -> Bool
+        typealias T = (~Int) -> Bool
         """
     )
 
     assertParse(
       """
-      typealias T = ~(Int) -> Bool
+      typealias T = (~Int) -> Bool
       """,
-      substructure: SuppressedTypeSyntax(
-        withoutTilde: .prefixOperator("~"),
-        type: FunctionTypeSyntax(
-          parameters: [TupleTypeElementSyntax(type: TypeSyntax("Int"))],
-          returnClause: ReturnClauseSyntax(type: TypeSyntax("Bool"))
-        )
+      substructure: FunctionTypeSyntax(
+        parameters: [
+          TupleTypeElementSyntax(
+            type: SuppressedTypeSyntax(
+              withoutTilde: .prefixOperator("~"),
+              type: IdentifierTypeSyntax(name: .identifier("Int"))
+            )
+          )
+        ],
+        returnClause: ReturnClauseSyntax(type: TypeSyntax("Bool"))
       )
     )
   }


### PR DESCRIPTION
Previous parsing implementation wouldn't handle types like `any ~Copyable` correctly.

rdar://115913356