### PR TITLE
Fixes a small threading issue in code generation and a TODO

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
@@ -216,9 +216,9 @@ struct GenerateSwiftSyntax: ParsableCommand {
 struct ComposititeError: Error, CustomStringConvertible {
   var errors: [Error]
   var description: String {
-    "Multiple errors emitted:\n" +
-    errors
-      .map(String.init(describing: ))
+    "Multiple errors emitted:\n"
+      + errors
+      .map(String.init(describing:))
       .joined(separator: "\n")
   }
 }

--- a/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/GenerateSwiftSyntax.swift
@@ -181,15 +181,6 @@ struct GenerateSwiftSyntax: ParsableCommand {
     }
 
     if errors.count > 0 {
-      struct ComposititeError: Error, CustomStringConvertible {
-        var errors: [Error]
-        var description: String {
-          "Multiple errors emitted: \n" +
-          errors
-            .map(String.init(describing: ))
-            .joined(separator: "\n")
-        }
-      }
       throw ComposititeError(errors: errors)
     }
 
@@ -219,5 +210,15 @@ struct GenerateSwiftSyntax: ParsableCommand {
     if verbose {
       print("Generated \(destination.path) in \((Date().timeIntervalSince(start) * 1000).rounded() / 1000)s")
     }
+  }
+}
+
+struct ComposititeError: Error, CustomStringConvertible {
+  var errors: [Error]
+  var description: String {
+    "Multiple errors emitted:\n" +
+    errors
+      .map(String.init(describing: ))
+      .joined(separator: "\n")
   }
 }


### PR DESCRIPTION
`errors` was potentially mutated on multiple threads. `previouslyGeneratedFiles`, which is mutated on every loop, is locked just above it, so clearly we need to lock on _all_ state that's mutated here. 

I also cleaned up the TODO. 