### PR TITLE
Require Swift 5.8 for SPI experimental feature syntax nodes

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -107,6 +107,16 @@ public class Node {
     return attrList.with(\.trailingTrivia, attrList.isEmpty ? [] : .newline)
   }
 
+  /// The documentation note to print for an experimental feature.
+  public var experimentalDocNote: SwiftSyntax.Trivia {
+    let comment = experimentalFeature.map {
+      """
+      - Experiment: Requires experimental feature `\($0.token)`.
+      """
+    }
+    return SwiftSyntax.Trivia.docCommentTrivia(from: comment)
+  }
+
   /// Construct the specification for a layout syntax node.
   init(
     kind: SyntaxNodeKind,

--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -98,7 +98,13 @@ public class Node {
   public func apiAttributes(forRaw: Bool = false) -> AttributeListSyntax {
     let attrList = AttributeListSyntax {
       if isExperimental {
-        "@_spi(ExperimentalLanguageFeatures)"
+        // SPI for enum cases currently requires Swift 5.8 to work correctly.
+        let experimentalSPI: AttributeListSyntax = """
+          #if compiler(>=5.8)
+          @_spi(ExperimentalLanguageFeatures)
+          #endif
+          """
+        experimentalSPI.with(\.trailingTrivia, .newline)
       }
       if forRaw {
         "@_spi(RawSyntax)"

--- a/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
@@ -587,8 +587,7 @@ public let STMT_NODES: [Node] = [
   Node(
     kind: .thenStmt,
     base: .stmt,
-    // FIXME: This should be marked experimental.
-    experimentalFeature: nil,
+    experimentalFeature: .thenStatements,
     nameForDiagnostics: "'then' statement",
     documentation: """
       A statement used to indicate the produced value from an if/switch

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -19,6 +19,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   for node in SYNTAX_NODES.compactMap(\.collectionNode) {
     let documentation = SwiftSyntax.Trivia(joining: [
       node.documentation,
+      node.experimentalDocNote,
       node.grammar,
       node.containedIn,
     ])

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -27,7 +27,7 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
         """
         // MARK: - \(node.kind.syntaxType)
 
-        \(SwiftSyntax.Trivia(joining: [node.documentation, node.grammar, node.containedIn]))
+        \(SwiftSyntax.Trivia(joining: [node.documentation, node.experimentalDocNote, node.grammar, node.containedIn]))
         \(node.node.apiAttributes())\
         public struct \(node.kind.syntaxType): \(node.baseType.syntaxBaseName)Protocol, SyntaxHashable, \(node.base.leafProtocolType)
         """

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -175,7 +175,6 @@ These articles are intended for developers wishing to contribute to SwiftSyntax
 - <doc:SwiftSyntax/LabeledStmtSyntax>
 - <doc:SwiftSyntax/RepeatStmtSyntax>
 - <doc:SwiftSyntax/ReturnStmtSyntax>
-- <doc:SwiftSyntax/ThenStmtSyntax>
 - <doc:SwiftSyntax/ThrowStmtSyntax>
 - <doc:SwiftSyntax/WhileStmtSyntax>
 - <doc:SwiftSyntax/YieldStmtSyntax>

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -2000,10 +2000,16 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
   
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
   override open func visit(_ node: ThenStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
   
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
   override open func visitPost(_ node: ThenStmtSyntax) {
     visitAnyPost(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -258,6 +258,9 @@ public enum SyntaxEnum {
   case switchDefaultLabel(SwitchDefaultLabelSyntax)
   case switchExpr(SwitchExprSyntax)
   case ternaryExpr(TernaryExprSyntax)
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
   case thenStmt(ThenStmtSyntax)
   case throwStmt(ThrowStmtSyntax)
   case tryExpr(TryExprSyntax)

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -258,6 +258,9 @@ public enum SyntaxKind: CaseIterable {
   case switchDefaultLabel
   case switchExpr
   case ternaryExpr
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
   case thenStmt
   case throwStmt
   case tryExpr

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -1784,6 +1784,9 @@ open class SyntaxRewriter {
   /// Visit a ``ThenStmtSyntax``.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
   open func visit(_ node: ThenStmtSyntax) -> StmtSyntax {
     return StmtSyntax(visitChildren(node))
   }

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -1235,11 +1235,6 @@ public protocol SyntaxTransformVisitor {
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: TernaryExprSyntax) -> ResultType
   
-  /// Visiting ``ThenStmtSyntax`` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: the sum of whatever the child visitors return.
-  func visit(_ node: ThenStmtSyntax) -> ResultType
-  
   /// Visiting ``ThrowStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -3110,6 +3105,9 @@ extension SyntaxTransformVisitor {
   /// Visiting ``ThenStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
   public func visit(_ node: ThenStmtSyntax) -> ResultType {
     visitAny(Syntax(node))
   }

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -2953,12 +2953,18 @@ open class SyntaxVisitor {
   /// Visiting ``ThenStmtSyntax`` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
   open func visit(_ node: ThenStmtSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
   
   /// The function called after visiting ``ThenStmtSyntax`` and its descendants.
   ///   - node: the node we just finished visiting.
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
   open func visitPost(_ node: ThenStmtSyntax) {
   }
   

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
@@ -107,6 +107,9 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
   }
 }
 
+#if compiler(>=5.8)
+@_spi(ExperimentalLanguageFeatures)
+#endif
 @_spi(RawSyntax)
 public struct RawThenStmtSyntax: RawStmtSyntaxNodeProtocol {
   @_spi(RawSyntax)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -233,10 +233,15 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _LeafExprSy
 /// then <expr>
 /// ```
 ///
+/// - Experiment: Requires experimental feature `thenStatements`.
+///
 /// ### Children
 /// 
 ///  - `thenKeyword`: `then`
 ///  - `expression`: ``ExprSyntax``
+#if compiler(>=5.8)
+@_spi(ExperimentalLanguageFeatures)
+#endif
 public struct ThenStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   


### PR DESCRIPTION
Swift versions prior to 5.8 did not correctly handle SPI enum cases, so avoid marking experimental feature nodes SPI if building with such a compiler.