### PR TITLE
Make CodeGeneration depend on swift-syntax 509.0.0

### DIFF
--- a/CodeGeneration/README.md
+++ b/CodeGeneration/README.md
@@ -4,17 +4,6 @@ This directory contains file to generate source code that is part of the SwiftSy
 
 Some source code inside SwiftSyntax is generated using [SwiftSyntaxBuilder](../Sources/SwiftSyntaxBuilder), a Swift library whose purpose is to generate Swift code using Swift itself. This kind of code generation is performed by the Swift package defined in this directory.
 
-This directory is a standalone package that uses swift-syntax from the outer directory. 
-If you are making significant changes to `CodeGeneration` locally and want to avoid breaking the build of `CodeGeneration` itself by generating new files in the parent swift-syntax package, it is encouraged to change the dependency from
-```swift
-.package(path: "..")
-```
-to 
-```swift
-.package(url: "https://github.com/apple/swift-syntax", branch: "main")
-```
-That way `CodeGeneration` has its own checkout of swift-syntax that is unaffected by the newly generated files. Be sure to revert the change before committing your changes.
-
 To re-generate the files after changing `CodeGeneration` run the `generate-swift-syntax` 
 target of `CodeGeneration` and pass `path/to/swift-syntax/Sources` as the argument.
 

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -218,9 +218,9 @@ func rawSyntaxNodesFile(nodesStartingWith: [Character]) -> SourceFileSyntax {
               let list = ExprListSyntax {
                 ExprSyntax("layout.initialize(repeating: nil)")
                 for (index, child) in node.children.enumerated() {
-                  let optionalMark = child.isOptional ? TokenSyntax.postfixQuestionMarkToken() : nil
+                  let optionalMark = child.isOptional ? "?" : ""
 
-                  ExprSyntax("layout[\(raw: index)] = \(child.varOrCaseName.backtickedIfNeeded)\(optionalMark).raw")
+                  ExprSyntax("layout[\(raw: index)] = \(child.varOrCaseName.backtickedIfNeeded)\(raw: optionalMark).raw")
                     .with(\.leadingTrivia, .newline)
                 }
               }
@@ -241,12 +241,12 @@ func rawSyntaxNodesFile(nodesStartingWith: [Character]) -> SourceFileSyntax {
 
           for (index, child) in node.children.enumerated() {
             try VariableDeclSyntax("public var \(child.varOrCaseName.backtickedIfNeeded): Raw\(child.buildableType.buildable)") {
-              let exclamationMark = child.isOptional ? nil : TokenSyntax.exclamationMarkToken()
+              let exclamationMark = child.isOptional ? "" : "!"
 
               if child.syntaxNodeKind == .syntax {
-                ExprSyntax("layoutView.children[\(raw: index)]\(exclamationMark)")
+                ExprSyntax("layoutView.children[\(raw: index)]\(raw: exclamationMark)")
               } else {
-                ExprSyntax("layoutView.children[\(raw: index)].map(\(child.syntaxNodeKind.rawType).init(raw:))\(exclamationMark)")
+                ExprSyntax("layoutView.children[\(raw: index)].map(\(child.syntaxNodeKind.rawType).init(raw:))\(raw: exclamationMark)")
               }
             }
           }

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -26,12 +26,12 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
     ) {
       for child in trait.children {
-        let questionMark = child.isOptional ? TokenSyntax.postfixQuestionMarkToken() : nil
+        let questionMark = child.isOptional ? "?" : ""
 
         DeclSyntax(
           """
           \(child.documentation)
-          \(child.apiAttributes)var \(child.varOrCaseName): \(child.syntaxNodeKind.syntaxType)\(questionMark) { get set }
+          \(child.apiAttributes)var \(child.varOrCaseName): \(child.syntaxNodeKind.syntaxType)\(raw: questionMark) { get set }
           """
         )
       }

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/ProcessRunner.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/ProcessRunner.swift
@@ -44,12 +44,15 @@ public class ProcessRunner {
   public init(
     executableURL: URL,
     arguments: [String],
-    additionalEnvironment: [String: String] = [:]
+    additionalEnvironment: [String: String?] = [:]
   ) {
     process = Process()
     process.executableURL = executableURL
     process.arguments = arguments
-    process.environment = additionalEnvironment.merging(ProcessInfo.processInfo.environment) { (additional, _) in additional }
+    process.environment = ProcessInfo.processInfo.environment
+    for (key, value) in additionalEnvironment {
+      process.environment![key] = value
+    }
   }
 
   @discardableResult

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SourceCodeGeneratorCommand.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SourceCodeGeneratorCommand.swift
@@ -35,6 +35,7 @@ extension SourceCodeGeneratorCommand {
     let additionalEnvironment = [
       "SWIFT_BUILD_SCRIPT_ENVIRONMENT": "1",
       "SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION": "1",
+      "SWIFTCI_USE_LOCAL_DEPS": nil,
     ]
 
     let process = ProcessRunner(


### PR DESCRIPTION
Having CodeGeneration depend on a stable version of swift-syntax makes rebasing changes a lot easier because CodeGeneration no longer depends on itself.