### PR TITLE
Add a global variable to check if long tests should be skipped

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -309,7 +309,7 @@ let package = Package(
 
     .testTarget(
       name: "PerformanceTest",
-      dependencies: ["_InstructionCounter", "SwiftIDEUtils", "SwiftParser", "SwiftSyntax"],
+      dependencies: ["_InstructionCounter", "_SwiftSyntaxTestSupport", "SwiftIDEUtils", "SwiftParser", "SwiftSyntax"],
       exclude: ["Inputs"]
     ),
   ]

--- a/Sources/_SwiftSyntaxTestSupport/LongTestsDisabled.swift
+++ b/Sources/_SwiftSyntaxTestSupport/LongTestsDisabled.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public var longTestsDisabled: Bool {
+  if let value = ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] {
+    return value == "1" || value == "YES"
+  }
+  return false
+}

--- a/Tests/PerformanceTest/ParsingPerformanceTests.swift
+++ b/Tests/PerformanceTest/ParsingPerformanceTests.swift
@@ -13,6 +13,7 @@
 import SwiftParser
 import SwiftSyntax
 import XCTest
+import _SwiftSyntaxTestSupport
 
 public class ParsingPerformanceTests: XCTestCase {
 
@@ -24,7 +25,7 @@ public class ParsingPerformanceTests: XCTestCase {
   }
 
   func testNativeParsingPerformance() throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
+    try XCTSkipIf(longTestsDisabled)
 
     let source = try String(contentsOf: inputFile)
 

--- a/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
+++ b/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
@@ -14,6 +14,7 @@ import SwiftIDEUtils
 import SwiftParser
 import SwiftSyntax
 import XCTest
+import _SwiftSyntaxTestSupport
 
 public class SyntaxClassifierPerformanceTests: XCTestCase {
 
@@ -25,7 +26,7 @@ public class SyntaxClassifierPerformanceTests: XCTestCase {
   }
 
   func testClassifierPerformance() throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
+    try XCTSkipIf(longTestsDisabled)
 
     let source = try String(contentsOf: inputFile)
     let parsed = Parser.parse(source: source)

--- a/Tests/PerformanceTest/VisitorPerformanceTests.swift
+++ b/Tests/PerformanceTest/VisitorPerformanceTests.swift
@@ -13,6 +13,7 @@
 import SwiftParser
 import SwiftSyntax
 import XCTest
+import _SwiftSyntaxTestSupport
 
 public class VisitorPerformanceTests: XCTestCase {
 
@@ -24,7 +25,7 @@ public class VisitorPerformanceTests: XCTestCase {
   }
 
   func testEmptyVisitorPerformance() throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
+    try XCTSkipIf(longTestsDisabled)
     class EmptyVisitor: SyntaxVisitor {}
 
     let source = try String(contentsOf: inputFile)
@@ -37,7 +38,7 @@ public class VisitorPerformanceTests: XCTestCase {
   }
 
   func testEmptyRewriterPerformance() throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
+    try XCTSkipIf(longTestsDisabled)
     class EmptyRewriter: SyntaxRewriter {}
 
     let source = try String(contentsOf: inputFile)
@@ -50,7 +51,7 @@ public class VisitorPerformanceTests: XCTestCase {
   }
 
   func testEmptyAnyVisitorPerformance() throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
+    try XCTSkipIf(longTestsDisabled)
     class EmptyAnyVisitor: SyntaxAnyVisitor {}
 
     let source = try String(contentsOf: inputFile)

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -599,11 +599,9 @@ extension ParserTestCase {
     var (markerLocations, source) = extractMarkers(markedSource)
     markerLocations["START"] = 0
 
-    let enableLongTests = ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] != "1"
-
     var parser = Parser(source, experimentalFeatures: experimentalFeatures)
     #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
-    if enableLongTests {
+    if !longTestsDisabled {
       parser.enableAlternativeTokenChoices()
     }
     #endif
@@ -684,7 +682,7 @@ extension ParserTestCase {
       assertBasicFormat(source: source, parse: parse, experimentalFeatures: experimentalFeatures, file: file, line: line)
     }
 
-    if enableLongTests {
+    if !longTestsDisabled {
       DispatchQueue.concurrentPerform(iterations: Array(tree.tokens(viewMode: .all)).count) { tokenIndex in
         let flippedTokenTree = TokenPresenceFlipper(flipTokenAtIndex: tokenIndex).rewrite(Syntax(tree))
         _ = ParseDiagnosticsGenerator.diagnostics(for: flippedTokenTree)

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -93,7 +93,7 @@ public class ParserTests: ParserTestCase {
   func testSelfParse() throws {
     // Allow skipping the self parse test in local development environments
     // because it takes very long compared to all the other tests.
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
+    try XCTSkipIf(longTestsDisabled)
     let currentDir =
       packageDir
       .appendingPathComponent("Sources")
@@ -108,7 +108,7 @@ public class ParserTests: ParserTestCase {
   /// This requires the Swift compiler to have been checked out into the "swift"
   /// directory alongside swift-syntax.
   func testSwiftTestsuite() throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
+    try XCTSkipIf(longTestsDisabled)
     let testDir =
       packageDir
       .deletingLastPathComponent()
@@ -125,7 +125,7 @@ public class ParserTests: ParserTestCase {
   /// Swift compiler. This requires the Swift compiler to have been checked
   /// out into the "swift" directory alongside swift-syntax.
   func testSwiftValidationTestsuite() throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
+    try XCTSkipIf(longTestsDisabled)
     let testDir =
       packageDir
       .deletingLastPathComponent()


### PR DESCRIPTION
This centralizes the check for the environment variable.