### PR TITLE
[DNM] Add @attached(attribute) macro role

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -166,6 +166,7 @@ private extension MacroRole {
     case .declaration: self = .declaration
     case .accessor: self = .accessor
     case .memberAttribute: self = .memberAttribute
+    case .attribute: self = .attribute
     case .member: self = .member
     case .peer: self = .peer
     case .conformance: self = .extension

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
@@ -124,6 +124,7 @@ public enum PluginMessage {
     case conformance
     case codeItem
     case `extension`
+    case attribute
   }
 
   public struct SourceLocation: Codable {

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/MemberAttributeMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/MemberAttributeMacro.swift
@@ -32,3 +32,22 @@ public protocol MemberAttributeMacro: AttachedMacro {
     in context: some MacroExpansionContext
   ) throws -> [AttributeSyntax]
 }
+
+/// Describes a macro that can add attributes to the
+/// declaration it's attached to.
+public protocol AttributeMacro: AttachedMacro {
+  /// Expand an attached declaration macro to produce an attribute list for
+  /// a given member.
+  ///
+  /// - Parameters:
+  ///   - node: The custom attribute describing the attached macro.
+  ///   - declaration: The declaration to attach the resulting attributes to.
+  ///   - context: The context in which to perform the macro expansion.
+  ///
+  /// - Returns: the set of attributes to apply to the given member.
+  static func expansion(
+    of node: AttributeSyntax,
+    providingAttributesFor declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AttributeSyntax]
+}

--- a/Tests/SwiftSyntaxMacroExpansionTest/AttributeMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AttributeMacroTests.swift
@@ -1,0 +1,274 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//==========================================================================//
+// IMPORTANT: The macros defined in this file are intended to test the      //
+// behavior of MacroSystem. Many of them do not serve as good examples of   //
+// how macros should be written. In particular, they often lack error       //
+// handling because it is not needed in the few test cases in which these   //
+// macros are invoked.                                                      //
+//==========================================================================//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import SwiftParser
+import XCTest
+
+fileprivate struct FixedAttributes: AttributeMacro {
+  enum ExpansionError: Error {
+    case argumentHasLabel
+    case argumentNotString
+    case argumentHasInterpolations
+  }
+
+  static func expansion(
+    of node: AttributeSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    guard case .argumentList(let list)? = node.arguments else {
+      return []
+    }
+
+    return try list.map { labeledExpr in
+      guard labeledExpr.label == nil else {
+        throw ExpansionError.argumentHasLabel
+      }
+      guard let stringExpr = labeledExpr.expression.as(StringLiteralExprSyntax.self) else {
+        throw ExpansionError.argumentNotString
+      }
+      guard
+        stringExpr.segments.count == 1,
+        case .stringSegment(let segment)? = stringExpr.segments.first,
+        case .stringSegment(let text) = segment.content.tokenKind
+      else {
+        throw ExpansionError.argumentHasInterpolations
+      }
+
+      var parser = Parser(text)
+      return AttributeSyntax.parse(from: &parser)
+    }
+  }
+}
+
+final class AttributeMacroTests: XCTestCase {
+  private let indentationWidth: Trivia = .spaces(2)
+  private let macros: [String: Macro.Type] = ["fixedAttributes": FixedAttributes.self]
+
+  func testWrapAllProperties() {
+    assertMacroExpansion(
+      """
+      @fixedAttributes("@frozen", "@available(macOS 99, *)")
+      struct Point {
+        var x: Int
+        var y: Int
+        var description: String { "" }
+        var computed: Int {
+          get { 0 }
+          set {}
+        }
+
+        @fixedAttributes("@inlinable")
+        func test() {}
+      }
+      """,
+      expandedSource: """
+        @frozen @available(macOS 99, *)
+        struct Point {
+          var x: Int
+          var y: Int
+          var description: String { "" }
+          var computed: Int {
+            get { 0 }
+            set {}
+          }
+          @inlinable
+          func test() {}
+        }
+        """,
+      macros: macros,
+      indentationWidth: indentationWidth
+    )
+  }
+
+  #if false
+  func testAttributeMacroOnPropertyThatAlreadyHasAttribute() {
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        @available(*, deprecated) var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          @available(*, deprecated)
+          @Wrapper var x: Int
+        }
+        """,
+      macros: ["Test": TestMacro.self],
+      indentationWidth: indentationWidth
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        @available(*, deprecated) /* x */ var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          @available(*, deprecated)
+          @Wrapper /* x */ var x: Int
+        }
+        """,
+      macros: ["Test": TestMacro.self],
+      indentationWidth: indentationWidth
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        @available(*, deprecated)
+
+        var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          @available(*, deprecated)
+          @Wrapper
+
+          var x: Int
+        }
+        """,
+      macros: ["Test": TestMacro.self],
+      indentationWidth: indentationWidth
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        @available(*, deprecated) // some comment
+
+        var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          @available(*, deprecated)
+          @Wrapper // some comment
+
+          var x: Int
+        }
+        """,
+      macros: ["Test": TestMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+
+  func testMemberAttributeWithTriviaMacroOnPropertyThatAlreadyHasAttribute() {
+    struct TestMacro: MemberAttributeMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        attachedTo decl: some DeclGroupSyntax,
+        providingAttributesFor member: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+      ) throws -> [AttributeSyntax] {
+        return ["/* start */@Wrapper/* end */"]
+      }
+    }
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        @available(*, deprecated) var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          @available(*, deprecated)
+          /* start */@Wrapper/* end */ var x: Int
+        }
+        """,
+      macros: ["Test": TestMacro.self],
+      indentationWidth: indentationWidth
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        @available(*, deprecated) /* x */ var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          @available(*, deprecated)
+          /* start */@Wrapper/* end */ /* x */ var x: Int
+        }
+        """,
+      macros: ["Test": TestMacro.self],
+      indentationWidth: indentationWidth
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        @available(*, deprecated)
+
+        var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          @available(*, deprecated)
+          /* start */@Wrapper/* end */
+
+          var x: Int
+        }
+        """,
+      macros: ["Test": TestMacro.self],
+      indentationWidth: indentationWidth
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        @available(*, deprecated) // some comment
+
+        var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          @available(*, deprecated)
+          /* start */@Wrapper/* end */ // some comment
+
+          var x: Int
+        }
+        """,
+      macros: ["Test": TestMacro.self],
+      indentationWidth: indentationWidth
+    )
+  }
+  #endif
+}


### PR DESCRIPTION
A quick proof-of-concept implementation of an `@attached(attribute)` role, which *might* be useful to create a simple alias for a collection of identical attributes that are applied to many declarations. I haven't talked to anyone about whether this is a *good* idea, but it's certainly an idea.