### PR TITLE
mark the BumpPtrAllocator class as @_spi(BumpPtrAllocator).

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) @_spi(BumpPtrAllocator) import SwiftSyntax
 
 extension SyntaxText {
   fileprivate func containsPlaceholderEnd() -> Bool {

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) @_spi(BumpPtrAllocator) import SwiftSyntax
 
 extension Lexer {
   /// A sequence of ``Lexer/Lexeme`` tokens starting from a ``Lexer/Cursor``

--- a/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
+++ b/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) @_spi(BumpPtrAllocator) import SwiftSyntax
 
 /// A separate lexer specifically for regex literals.
 fileprivate struct RegexLiteralLexer {

--- a/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
+++ b/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) @_spi(BumpPtrAllocator) import SwiftSyntax
 
 extension StringLiteralExprSyntax {
 

--- a/Sources/SwiftSyntax/BumpPtrAllocator.swift
+++ b/Sources/SwiftSyntax/BumpPtrAllocator.swift
@@ -13,7 +13,7 @@
 /// A ``BumpPtrAllocator`` that allocates `slabSize` at a time.
 /// Once all memory in a slab has been used, it allocates a new slab and no
 /// memory allocations are necessary until that slab is completely filled up.
-@_spi(RawSyntax) @_spi(Testing)
+@_spi(BumpPtrAllocator) @_spi(Testing)
 public class BumpPtrAllocator {
   typealias Slab = UnsafeMutableRawBufferPointer
 


### PR DESCRIPTION
mark the BumpPtrAllocator class as @_spi(BumpPtrAllocator) instead of @_spi(RawSyntax).
resolves the issue #68351 (https://github.com/apple/swift/issues/68351)