### PR TITLE
Fix StringifyMacro's interpolation test

### DIFF
--- a/Examples/Tests/MacroExamples/Implementation/Expression/StringifyMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/Expression/StringifyMacroTests.swift
@@ -33,12 +33,12 @@ final class StringifyMacroTests: XCTestCase {
 
   func testExpansionWithStringInterpolation() {
     assertMacroExpansion(
-      """
+      #"""
       let b = #stringify("Hello, \(name)")
-      """,
-      expandedSource: """
+      """#,
+      expandedSource: #"""
         let b = ("Hello, \(name)", #""Hello, \(name)""#)
-        """,
+        """#,
       macros: macros,
       indentationWidth: .spaces(2)
     )


### PR DESCRIPTION
While bringing in the latest macro tests into our [MacroTesting](https://github.com/pointfreeco/swift-macro-testing) project [here](https://github.com/pointfreeco/swift-macro-testing/pull/5), I noticed a regression in the stringify macro's test. The original test in the macro template asserts that raw interpolation is preserved by the macro, but it seems that this test accidentally is interpolating the XCTestCase's `name` property into the assertion instead.