### PR TITLE
[5.10][CMake] Remove 'SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,11 +66,6 @@ endif()
 
 message(STATUS "Module triple: ${SWIFT_MODULE_TRIPLE}")
 
-# Force single-threaded-only syntax trees to eliminate the Darwin
-# dependency in the compiler.
-add_compile_definitions(
-  $<$<COMPILE_LANGUAGE:Swift>:SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED>
-)
 if (SWIFTSYNTAX_ENABLE_ASSERTIONS)
   add_compile_definitions(
     $<$<COMPILE_LANGUAGE:Swift>:SWIFTSYNTAX_ENABLE_ASSERTIONS>

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -10,14 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED
 #if canImport(Darwin)
 @_implementationOnly import Darwin
 #elseif canImport(Glibc)
 @_implementationOnly import Glibc
 #elseif canImport(Musl)
 @_implementationOnly import Musl
-#endif
 #endif
 
 /// Represent a string.
@@ -267,10 +265,7 @@ private func compareMemory(
   _ count: Int
 ) -> Bool {
   precondition(count >= 0)
-  #if SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED
-  return UnsafeBufferPointer(start: s1, count: count)
-    .elementsEqual(UnsafeBufferPointer(start: s2, count: count))
-  #elseif canImport(Darwin)
+  #if canImport(Darwin)
   return Darwin.memcmp(s1, s2, count) == 0
   #elseif canImport(Glibc)
   return Glibc.memcmp(s1, s2, count) == 0


### PR DESCRIPTION
Cherry-pick #2243 into release/5.10

* **Explanation**: Using 'Darwin' overlay is not an issue anymore. Since we couldn't use `Darwin` in the compiler, we used to use `Collection.elementsEqual(:_)` instead of `memcp` which was slow. This should improve the performance of Swift parser.
* **Scope**: Integrated SwiftParser
* **Risk**: Low. 
* **Issue**: rdar://116542708
* **Reviewer**: Ben Barham (@bnbarham)

