### PR TITLE
Rename `NoteMessage.fixItID` to `noteID`

### DIFF
--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -42,6 +42,10 @@
 
 ## API-Incompatible Changes
 
+- `NoteMessage.fixItID` renamed to `noteID`
+  - Description: This was an error that it was named `fixItID` and should have been named `noteID` instead. Accesses to `fixItID` are deprecated and forward to `noteID`. Any types that conform `NoteMessage` it will need to be updated to provide a `noteID` instead of a `fixItID`.
+  - Issue: https://github.com/apple/swift-syntax/issues/2261
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2264
 
 ## Template
 

--- a/Sources/SwiftDiagnostics/Note.swift
+++ b/Sources/SwiftDiagnostics/Note.swift
@@ -20,7 +20,14 @@ public protocol NoteMessage {
   var message: String { get }
 
   /// See ``MessageID``.
-  var fixItID: MessageID { get }
+  var noteID: MessageID { get }
+}
+
+extension NoteMessage {
+  @available(*, deprecated, message: "Use noteID instead.", renamed: "noteID")
+  public var fixItID: MessageID {
+    return noteID
+  }
 }
 
 /// A note that points to another node that's relevant for a Diagnostic.

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -36,16 +36,21 @@ public extension ParserError {
 }
 
 public protocol ParserNote: NoteMessage {
-  var fixItID: MessageID { get }
+  var noteID: MessageID { get }
 }
 
 public extension ParserNote {
+  @available(*, deprecated, message: "Use noteID instead.", renamed: "noteID")
   static var fixItID: MessageID {
+    return Self.noteID
+  }
+
+  static var noteID: MessageID {
     return MessageID(domain: diagnosticDomain, id: "\(self)")
   }
 
-  var fixItID: MessageID {
-    return Self.fixItID
+  var noteID: MessageID {
+    return Self.noteID
   }
 }
 
@@ -594,7 +599,7 @@ public struct StaticParserNote: NoteMessage {
     self.messageID = messageID
   }
 
-  public var fixItID: MessageID {
+  public var noteID: MessageID {
     MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(messageID)")
   }
 }


### PR DESCRIPTION
Fixes #2261