### PR TITLE
Split release notes for 510 and 511

### DIFF
--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -5,16 +5,13 @@
 - `SyntaxStringInterpolation.appendInterpolation(_: (some SyntaxProtocol)?)`
   - Description: Allows optional syntax nodes to be used inside string interpolation of syntax nodes. If the node is `nil`, nothing will get added to the string interpolation.
   - Pull Request: https://github.com/apple/swift-syntax/pull/2085
-  
 - `SyntaxCollection.index(at:)`
   - Description: Returns the index of the n-th element in a `SyntaxCollection`. This computation is in O(n) and `SyntaxCollection` is not subscriptable by an integer.
   - Pull Request: https://github.com/apple/swift-syntax/pull/2014
-  
 - Convenience initializer `ClosureCaptureSyntax.init()`
   - Description: Provides a convenience initializer for `ClosureCaptureSyntax` that takes a concrete `name` argument and automatically adds `equal = TokenSyntax.equalToken()` to it.
   - Issue: https://github.com/apple/swift-syntax/issues/1984
   - Pull Request: https://github.com/apple/swift-syntax/pull/2127
-  
 - Convenience initializer `EnumCaseParameterSyntax.init()`
   - Description: Provides a convenience initializer for `EnumCaseParameterSyntax` that takes a concrete `firstName` value and adds `colon = TokenSyntax.colonToken()` automatically to it.
   - Issue: https://github.com/apple/swift-syntax/issues/1984
@@ -42,17 +39,9 @@
   - Description: `is`, `as`, and `cast` methods on base node protocols with base-type conversions are marked as deprecated. The deprecated methods emit a warning that informs the developer that the cast will always succeed and should be done using the base node's initializer.
   - Issue: https://github.com/apple/swift-syntax/issues/2092
   - Pull Request: https://github.com/apple/swift-syntax/pull/2108
-  
-- Child Choice Node Casts
-  - Description: `is`, `as`, and `cast` methods for types not contained in the choice node are marked as deprecated. The deprecated methods will emit a warning, indicating that the cast will always fail.
-  - Issue: https://github.com/apple/swift-syntax/issues/2092
-  - Pull Request: https://github.com/apple/swift-syntax/pull/2184
 
 ## API-Incompatible Changes
 
-- Effect specifiers:
-  - Description: The `unexpectedAfterThrowsSpecifier` node of the various effect specifiers has been removed.
-  - Pull request: https://github.com/apple/swift-syntax/pull/2219
 
 ## Template
 

--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -1,0 +1,29 @@
+# Swift Syntax 510 Release Notes
+
+## New APIs
+
+## API Behavior Changes
+
+## Deprecations
+  
+- Child Choice Node Casts
+  - Description: `is`, `as`, and `cast` methods for types not contained in the choice node are marked as deprecated. The deprecated methods will emit a warning, indicating that the cast will always fail.
+  - Issue: https://github.com/apple/swift-syntax/issues/2092
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2184
+  
+## API-Incompatible Changes
+
+- Effect specifiers:
+  - Description: The `unexpectedAfterThrowsSpecifier` node of the various effect specifiers has been removed.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2219
+
+
+## Template
+
+- *Affected API or two word description*
+  - Description: *A 1-2 sentence description of the new/modified API*
+  - Issue: *If an issue exists for this change, a link to the issue*
+  - Pull Request: *Link to the pull request(s) that introduces this change*
+  - Notes: *In case of deprecations or API-incompatible changes, the reason why this change was made and the suggested alternative*
+
+*Insert entries in chronological order, with newer entries at the bottom*


### PR DESCRIPTION
We didn’t create a new release notes document after we branched release/5.10. Revert the version of `Release Notes/510.md` to the state that’s in release/5.10 and open a new `Release Notes/511.md` for changes made after branching for 510.