### PR TITLE
Add IncrementalParseResult

### DIFF
--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -10,13 +10,22 @@
   - Description: `is`, `as`, and `cast` methods for types not contained in the choice node are marked as deprecated. The deprecated methods will emit a warning, indicating that the cast will always fail.
   - Issue: https://github.com/apple/swift-syntax/issues/2092
   - Pull Request: https://github.com/apple/swift-syntax/pull/2184
-  
+
+- `IncrementalParseTransition`:
+  - Description: The initializer `IncrementalParseTransition.init(previousTree:edits:lookaheadRanges:reusedNodeCallback:)` is marked as deprecated. Use `IncrementalParseTransition.init(previousIncrementalParseResult:edits:reusedNodeCallback:)` instead.
+  - Issue: https://github.com/apple/swift-syntax/issues/2267
+  - Pull request: https://github.com/apple/swift-syntax/pull/2272
+
 ## API-Incompatible Changes
 
 - Effect specifiers:
   - Description: The `unexpectedAfterThrowsSpecifier` node of the various effect specifiers has been removed.
   - Pull request: https://github.com/apple/swift-syntax/pull/2219
 
+- `Parser.parseIncrementally(source:parseTransition:)` and `Parser.parseIncrementally(source:maximumNestingLevel:parseTransition:)`:
+  - Description: The default versions of `Parser.parseIncrementally` return a `IncrementalParseResult` instead of a tuple. Access to the struct should be compatible with the tuple in almost all cases unless the tuple is stored into a variable and then destructed or passed to a function that expects a tuple.
+  - Issue: https://github.com/apple/swift-syntax/issues/2267
+  - Pull request: https://github.com/apple/swift-syntax/pull/2272
 
 ## Template
 

--- a/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
+++ b/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
@@ -44,18 +44,17 @@ public func assertIncrementalParse(
   let originalString = String(originalSource)
   let editedString = String(editedSource)
 
-  let (originalTree, lookaheadRanges) = Parser.parseIncrementally(source: originalString, parseTransition: nil)
+  let parseResult = Parser.parseIncrementally(source: originalString, parseTransition: nil)
 
   var reusedNodes: [Syntax] = []
   let transition = IncrementalParseTransition(
-    previousTree: originalTree,
+    previousIncrementalParseResult: parseResult,
     edits: concurrentEdits,
-    lookaheadRanges: lookaheadRanges,
     reusedNodeCallback: { reusedNodes.append($0) }
   )
 
   let newTree = Parser.parse(source: editedString)
-  let (incrementallyParsedNewTree, _) = Parser.parseIncrementally(source: editedString, parseTransition: transition)
+  let incrementallyParsedNewTree = Parser.parseIncrementally(source: editedString, parseTransition: transition).tree
 
   // Round-trip
   assertStringsEqualWithDiff(

--- a/SwiftParserCLI/Sources/swift-parser-cli/Commands/PerformanceTest.swift
+++ b/SwiftParserCLI/Sources/swift-parser-cli/Commands/PerformanceTest.swift
@@ -47,15 +47,14 @@ struct PerformanceTest: ParsableCommand {
       /// The initial parse for incremental parsing
       for file in files {
         file.withUnsafeBytes { buf in
-          let (tree, lookaheadRanges) = Parser.parseIncrementally(
+          let parseResult = Parser.parseIncrementally(
             source: buf.bindMemory(to: UInt8.self),
             parseTransition: nil
           )
 
           fileTransition[file] = IncrementalParseTransition(
-            previousTree: tree,
-            edits: ConcurrentEdits(fromSequential: []),
-            lookaheadRanges: lookaheadRanges
+            previousIncrementalParseResult: parseResult,
+            edits: ConcurrentEdits(fromSequential: [])
           )
         }
       }


### PR DESCRIPTION
## Motivation
* https://github.com/apple/swift-syntax/issues/2267
## Changes
* Added
    * `IncrementalParseResult ` type
    * `parseIncrementally` with `IncrementalParseResult ` return type
    *  `IncrementalParseTransition` init with `IncrementalParseResult ` type
* Changed
   * `parseIncrementally` with tuple return type is deprecated
   *  `IncrementalParseTransition` init with `previousTree` and `lookaheadRanges` is deprecated


