### PR TITLE
Add support for '@retroactive' conformances in SwiftSyntaxParser

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -240,6 +240,7 @@ public enum Keyword: CaseIterable {
   case `repeat`
   case required
   case `rethrows`
+  case retroactive
   case `return`
   case reverse
   case right
@@ -611,6 +612,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("required")
     case .rethrows:
       return KeywordSpec("rethrows", isLexerClassified: true)
+    case .retroactive:
+      return KeywordSpec("retroactive")
     case .return:
       return KeywordSpec("return", isLexerClassified: true)
     case .reverse:

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -248,6 +248,7 @@ enum TokenPrecedence: Comparable {
       .noDerivative,
       .noescape,
       .Sendable,
+      .retroactive,
       .unchecked:
       self = .exprKeyword
 

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -630,6 +630,7 @@ enum TypeAttribute: TokenSpecSet {
   case escaping
   case noDerivative
   case noescape
+  case retroactive
   case Sendable
   case unchecked
 
@@ -646,6 +647,7 @@ enum TypeAttribute: TokenSpecSet {
     case TokenSpec(.noDerivative): self = .noDerivative
     case TokenSpec(.noescape): self = .noescape
     case TokenSpec(.Sendable): self = .Sendable
+    case TokenSpec(.retroactive): self = .retroactive
     case TokenSpec(.unchecked): self = .unchecked
     default: return nil
     }
@@ -663,6 +665,7 @@ enum TypeAttribute: TokenSpecSet {
     case .escaping: return .keyword(.escaping)
     case .noDerivative: return .keyword(.noDerivative)
     case .noescape: return .keyword(.noescape)
+    case .retroactive: return .keyword(.retroactive)
     case .Sendable: return .keyword(.Sendable)
     case .unchecked: return .keyword(.unchecked)
     }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -925,7 +925,7 @@ extension Parser {
   mutating func parseTypeAttribute() -> RawAttributeListSyntax.Element {
     switch peek(isAtAnyIn: TypeAttribute.self) {
     case ._local, ._noMetadata, .async, .escaping, .noDerivative, .noescape,
-        .retroactive, .Sendable, .unchecked, .autoclosure:
+      .retroactive, .Sendable, .unchecked, .autoclosure:
       // Known type attribute that doesn't take any arguments
       return parseAttributeWithoutArguments()
     case .differentiable:

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -924,7 +924,8 @@ extension Parser {
 
   mutating func parseTypeAttribute() -> RawAttributeListSyntax.Element {
     switch peek(isAtAnyIn: TypeAttribute.self) {
-    case ._local, ._noMetadata, .async, .escaping, .noDerivative, .noescape, .Sendable, .unchecked, .autoclosure:
+    case ._local, ._noMetadata, .async, .escaping, .noDerivative, .noescape,
+        .retroactive, .Sendable, .unchecked, .autoclosure:
       // Known type attribute that doesn't take any arguments
       return parseAttributeWithoutArguments()
     case .differentiable:

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -182,6 +182,7 @@ public enum Keyword: UInt8, Hashable {
   case `repeat`
   case required
   case `rethrows`
+  case retroactive
   case `return`
   case reverse
   case right
@@ -620,6 +621,8 @@ public enum Keyword: UInt8, Hashable {
         self = .nonisolated
       case "nonmutating":
         self = .nonmutating
+      case "retroactive":
+        self = .retroactive
       case "unavailable":
         self = .unavailable
       default:
@@ -940,6 +943,7 @@ public enum Keyword: UInt8, Hashable {
       "repeat", 
       "required", 
       "rethrows", 
+      "retroactive", 
       "return", 
       "reverse", 
       "right", 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -705,6 +705,14 @@ final class DeclarationTests: ParserTestCase {
     )
   }
 
+  func testParseRetroactiveExtension() {
+    assertParse(
+      """
+      extension Int: @retroactive Identifiable {}
+      """
+    )
+  }
+
   func testParseDynamicReplacement() {
     assertParse(
       """


### PR DESCRIPTION
This is a companion to https://github.com/apple/swift/pull/36068, teaching the SwiftParser about `@retroactive` conformances explicitly and providing keywords for clients who are building macros/SwiftSyntax tools.