### PR TITLE
Refactor syntax node manipulation to use variable setters

### DIFF
--- a/Examples/Sources/AddOneToIntegerLiterals/AddOneToIntegerLiterals.swift
+++ b/Examples/Sources/AddOneToIntegerLiterals/AddOneToIntegerLiterals.swift
@@ -31,7 +31,8 @@ private class AddOneToIntegerLiterals: SyntaxRewriter {
     let int = Int(integerText)!
 
     // Create a new integer literal token with `int + 1` as its text.
-    let newIntegerLiteralToken = token.with(\.tokenKind, .integerLiteral("\(int + 1)"))
+    var newIntegerLiteralToken = token
+    newIntegerLiteralToken.tokenKind = .integerLiteral("\(int + 1)")
 
     // Return the new integer literal.
     return newIntegerLiteralToken

--- a/Examples/Sources/MacroExamples/Implementation/ComplexMacros/DictionaryIndirectionMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/ComplexMacros/DictionaryIndirectionMacro.swift
@@ -21,10 +21,7 @@ extension DictionaryStorageMacro: MemberMacro {
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    let storage: DeclSyntax = "var _storage: [String: Any] = [:]"
-    return [
-      storage.with(\.leadingTrivia, [.newlines(1), .spaces(2)])
-    ]
+    return ["\n  var _storage: [String: Any] = [:]"]
   }
 }
 
@@ -43,11 +40,11 @@ extension DictionaryStorageMacro: MemberAttributeMacro {
 
     return [
       AttributeSyntax(
+        leadingTrivia: [.newlines(1), .spaces(2)],
         attributeName: IdentifierTypeSyntax(
           name: .identifier("DictionaryStorageProperty")
         )
       )
-      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }

--- a/Examples/Sources/MacroExamples/Implementation/Expression/AddBlocker.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Expression/AddBlocker.swift
@@ -27,7 +27,7 @@ public struct AddBlocker: ExpressionMacro {
       _ node: InfixOperatorExprSyntax
     ) -> ExprSyntax {
       // Identify any infix operator + in the tree.
-      if let binOp = node.operator.as(BinaryOperatorExprSyntax.self) {
+      if var binOp = node.operator.as(BinaryOperatorExprSyntax.self) {
         if binOp.operator.text == "+" {
           // Form the warning
           let messageID = MessageID(domain: "silly", id: "addblock")
@@ -72,17 +72,9 @@ public struct AddBlocker: ExpressionMacro {
             )
           )
 
-          return ExprSyntax(
-            node.with(
-              \.operator,
-              ExprSyntax(
-                binOp.with(
-                  \.operator,
-                  binOp.operator.with(\.tokenKind, .binaryOperator("-"))
-                )
-              )
-            )
-          )
+          binOp.operator.tokenKind = .binaryOperator("-")
+
+          return ExprSyntax(node.with(\.operator, ExprSyntax(binOp)))
         }
       }
 

--- a/Examples/Sources/MacroExamples/Implementation/Expression/FontLiteralMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Expression/FontLiteralMacro.swift
@@ -35,14 +35,12 @@ private func replaceFirstLabel(
   of tuple: LabeledExprListSyntax,
   with newLabel: String
 ) -> LabeledExprListSyntax {
-  guard let firstElement = tuple.first else {
+  if tuple.isEmpty {
     return tuple
   }
 
   var tuple = tuple
-  tuple[tuple.startIndex] =
-    firstElement
-    .with(\.label, .identifier(newLabel))
-    .with(\.colon, .colonToken())
+  tuple[tuple.startIndex].label = .identifier(newLabel)
+  tuple[tuple.startIndex].colon = .colonToken()
   return tuple
 }

--- a/Examples/Sources/MacroExamples/Implementation/MemberAttribute/WrapStoredPropertiesMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/MemberAttribute/WrapStoredPropertiesMacro.swift
@@ -48,11 +48,11 @@ public struct WrapStoredPropertiesMacro: MemberAttributeMacro {
 
     return [
       AttributeSyntax(
+        leadingTrivia: [.newlines(1), .spaces(2)],
         attributeName: IdentifierTypeSyntax(
           name: .identifier(wrapperName.content.text)
         )
       )
-      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }

--- a/Examples/Sources/MacroExamples/Playground/PeerMacrosPlayground.swift
+++ b/Examples/Sources/MacroExamples/Playground/PeerMacrosPlayground.swift
@@ -54,7 +54,7 @@ func runPeerMacrosPlayground() {
     var value = 0
   }
 
-  let counter = Counter()
+  _ = Counter()
 
   //  print("Peer value with suffix name for \(Counter.self): \(String(describing: Counter_peer))")
 }


### PR DESCRIPTION
This commit replaces the use of `with` method for syntax node manipulation in SwiftSyntax examples with direct variable setters for better clarity and readability.