### PR TITLE
[CMake] Add option to specify '-module-abi-name'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ if(CMAKE_VERSION VERSION_LESS 3.21)
   endif()
 endif()
 
+set(SWIFT_MODULE_ABI_NAME_PREFIX CACHE STRING "ABI name prefix to avoid name conflicts")
+
 # The subdirectory into which host libraries will be installed.
 set(SWIFT_HOST_LIBRARIES_SUBDIRECTORY "swift/host")
 

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -77,7 +77,14 @@ function(add_swift_syntax_library name)
       -emit-module-path;${module_file};
       -emit-module-source-info-path;${module_sourceinfo_file};
       -emit-module-interface-path;${module_interface_file}
+    >)
+  if(SWIFT_MODULE_ABI_NAME_PREFIX)
+    target_compile_options("${name}" PRIVATE
+      $<$<COMPILE_LANGUAGE:Swift>:
+        "SHELL:-Xfrontend -module-abi-name"
+        "SHELL:-Xfrontend ${SWIFT_MODULE_ABI_NAME_PREFIX}${name}"
       >)
+  endif()
 
   if(CMAKE_VERSION VERSION_LESS 3.26.0 AND SWIFT_SYNTAX_ENABLE_WMO_PRE_3_26)
     target_compile_options(${name} PRIVATE


### PR DESCRIPTION
Add 'SWIFT_MODULE_ABI_NAME_PREFIX' CMake variable. This can be used from compiler's CMake so its swift-syntax libraries can have unique names. That avoids symbol name conflicts when compiler libraries (e.g. sourcekitdInProc) is used from binaries linking with swift-syntax (e.g. via SwiftPM)

https://github.com/apple/swift/issues/68812
rdar://116951101