### PR TITLE
[5.10][CMake] Add option to specify '-module-abi-name'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ if(CMAKE_VERSION VERSION_LESS 3.21)
   endif()
 endif()
 
+set(SWIFT_MODULE_ABI_NAME_PREFIX CACHE STRING "ABI name prefix to avoid name conflicts")
+
 # The subdirectory into which host libraries will be installed.
 set(SWIFT_HOST_LIBRARIES_SUBDIRECTORY "swift/host")
 

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -77,7 +77,14 @@ function(add_swift_syntax_library name)
       -emit-module-path;${module_file};
       -emit-module-source-info-path;${module_sourceinfo_file};
       -emit-module-interface-path;${module_interface_file}
+    >)
+  if(SWIFT_MODULE_ABI_NAME_PREFIX)
+    target_compile_options("${name}" PRIVATE
+      $<$<COMPILE_LANGUAGE:Swift>:
+        "SHELL:-Xfrontend -module-abi-name"
+        "SHELL:-Xfrontend ${SWIFT_MODULE_ABI_NAME_PREFIX}${name}"
       >)
+  endif()
 
   if(CMAKE_VERSION VERSION_LESS 3.26.0 AND SWIFT_SYNTAX_ENABLE_WMO_PRE_3_26)
     target_compile_options(${name} PRIVATE


### PR DESCRIPTION
Cherry-pick #2282 into `release/5.10`

* **Explanation**: Add `SWIFT_MODULE_ABI_NAME_PREFIX` CMake variable to swift-syntax libraries. Without this, `(lib)sourcekitdInProc.{dylib|so|dll}` was unusable if the binary links with swift-syntax via SwiftPM dependency, because sourcekitdInProc's swift-syntax symbols conflict with them. By differentiating the ABI name of the compiler's swift-syntax libraries, it can avoids name conflicts.
* **Risk**: Low, no code change. `-module-abi-name` is a well-tested reliable option.
* **Testing**: Passes current test-suite
* **Issues**: rdar://116951101 , https://github.com/apple/swift/issues/68812
* **Reviewer**: Alex Hoppen (@ahoppen), Ben Barham (@bnbarham)