### PR TITLE
[5.9][CMake] Add option to specify '-module-abi-name'

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -54,7 +54,15 @@ function(add_swift_host_library name)
       -emit-module-path;${module_file};
       -emit-module-source-info-path;${module_sourceinfo_file};
       -emit-module-interface-path;${module_interface_file}
+    >)
+  if(SWIFT_MODULE_ABI_NAME_PREFIX)
+    # ABI name prefix. this can be used to avoid name conflicts.
+    target_compile_options("${name}" PRIVATE
+      $<$<COMPILE_LANGUAGE:Swift>:
+        "SHELL:-Xfrontend -module-abi-name"
+        "SHELL:-Xfrontend ${SWIFT_MODULE_ABI_NAME_PREFIX}${name}"
       >)
+  endif()
 
   # NOTE: workaround for CMake not setting up include flags yet
   set_target_properties(${name} PROPERTIES


### PR DESCRIPTION
Cherry-pick #2282 into release/5.9

* **Explanation**: Add `SWIFT_MODULE_ABI_NAME_PREFIX` CMake variable to swift-syntax libraries. Without this, `(lib)sourcekitdInProc.{dylib|so|dll}` was unusable if the binary links with swift-syntax via SwiftPM dependency, because sourcekitdInProc's swift-syntax symbols conflict with them. By differentiating the ABI name of the compiler's swift-syntax libraries, it can avoids name conflicts.
* **Risk**: Low, no code change. `-module-abi-name` is a well-tested reliable option.
* **Testing**: Passes current test-suite
* **Issues**: rdar://116951101 , https://github.com/apple/swift/issues/68812
* **Reviewer**: Alex Hoppen (@ahoppen), Ben Barham (@bnbarham)