### PR TITLE
Fix missing space in LabeledExprSyntax init

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -346,7 +346,7 @@ extension LabeledExprSyntax {
   public init(label: String? = nil, expression: some ExprSyntaxProtocol) {
     self.init(
       label: label.map { .identifier($0) },
-      colon: label == nil ? nil : .colonToken(),
+      colon: label == nil ? nil : .colonToken(trailingTrivia: .space),
       expression: expression
     )
   }

--- a/Tests/SwiftSyntaxBuilderTest/Assertions.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Assertions.swift
@@ -23,7 +23,8 @@ func assertBuildResult<T: SyntaxProtocol>(
   file: StaticString = #file,
   line: UInt = #line
 ) {
-  var buildableDescription = format
+  var buildableDescription =
+    format
     ? buildable.formatted().description
     : buildable.description
   var expectedResult = expectedResult

--- a/Tests/SwiftSyntaxBuilderTest/Assertions.swift
+++ b/Tests/SwiftSyntaxBuilderTest/Assertions.swift
@@ -19,10 +19,13 @@ func assertBuildResult<T: SyntaxProtocol>(
   _ buildable: T,
   _ expectedResult: String,
   trimTrailingWhitespace: Bool = true,
+  format: Bool = true,
   file: StaticString = #file,
   line: UInt = #line
 ) {
-  var buildableDescription = buildable.formatted().description
+  var buildableDescription = format
+    ? buildable.formatted().description
+    : buildable.description
   var expectedResult = expectedResult
   if trimTrailingWhitespace {
     buildableDescription = buildableDescription.trimmingTrailingWhitespace()

--- a/Tests/SwiftSyntaxBuilderTest/LabeledExprSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/LabeledExprSyntaxTests.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import XCTest
+
+final class LabeledExprSyntaxTests: XCTestCase {
+  func testLabeledExprSyntax() {
+    let syntax = LabeledExprSyntax(label: "arg", expression: NilLiteralExprSyntax())
+    assertBuildResult(syntax, "arg: nil", format: false)
+  }
+}


### PR DESCRIPTION
Updates LabeledExprSyntax convenience initializer to include a trailing space trivia after the colon if an argument label is specified. This ensures the rendered description is 'arg: value' instead of 'arg:value'.