### PR TITLE
Remove `SyntaxKind` conformance to `CaseIterable`

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxKindFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxKindFile.swift
@@ -19,7 +19,7 @@ let syntaxKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
     /// Enumerates the known kinds of Syntax represented in the Syntax tree.
-    public enum SyntaxKind: CaseIterable
+    public enum SyntaxKind
     """
   ) {
     DeclSyntax("case token")

--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -16,6 +16,9 @@
 - Effect specifiers:
   - Description: The `unexpectedAfterThrowsSpecifier` node of the various effect specifiers has been removed.
   - Pull request: https://github.com/apple/swift-syntax/pull/2219
+- `SyntaxKind` removed conformance to `CaseIterable`
+  - Description: `SyntaxKind` no longer conforms to `CaseIterable` since there is no good use case to iterate over all syntax kinds. 
+  - Pull request: https://github.com/apple/swift-syntax/pull/2292
 
 
 ## Template

--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -19,6 +19,9 @@
 - `SyntaxKind` removed conformance to `CaseIterable`
   - Description: `SyntaxKind` no longer conforms to `CaseIterable` since there is no good use case to iterate over all syntax kinds. 
   - Pull request: https://github.com/apple/swift-syntax/pull/2292
+- `IntegerLiteralExprSyntax.Radix` removed conformance to `CaseIterable`
+  - Description: `IntegerLiteralExprSyntax.Radix` no longer conforms to `CaseIterable` since there is no good use case to iterate over all radix kinds. 
+  - Pull request: https://github.com/apple/swift-syntax/pull/2292
 
 
 ## Template

--- a/Sources/SwiftRefactor/IntegerLiteralUtilities.swift
+++ b/Sources/SwiftRefactor/IntegerLiteralUtilities.swift
@@ -13,7 +13,7 @@
 import SwiftSyntax
 
 extension IntegerLiteralExprSyntax {
-  public enum Radix: CaseIterable {
+  public enum Radix {
     case binary
     case octal
     case decimal

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
-public enum SyntaxKind: CaseIterable {
+public enum SyntaxKind {
   case token
   case accessorBlock
   case accessorDeclList

--- a/SwiftParserCLI/Sources/swift-parser-cli/BasicFormat.swift
+++ b/SwiftParserCLI/Sources/swift-parser-cli/BasicFormat.swift
@@ -47,8 +47,15 @@ struct BasicFormat: ParsableCommand, ParseCommand {
   var nodeType: String = "SourceFileSyntax"
 
   func run() throws {
-    let parsableMetatypes = SyntaxKind.allCases.compactMap {
-      $0.syntaxNodeType as? SyntaxParseable.Type
+    guard case .choices(let choices) = Syntax.structure else {
+      fatalError("Expected `Syntax.structure` to be the `choices` case")
+    }
+
+    let parsableMetatypes = choices.compactMap { (choice) -> SyntaxParseable.Type? in
+      guard case .node(let nodeType) = choice else {
+        return nil
+      }
+      return nodeType as? SyntaxParseable.Type
     }
     let parsableMetatypesByName = Dictionary(
       parsableMetatypes.map {


### PR DESCRIPTION
There’s no good reason to iterate over all cases in `SyntaxKind` and if `SyntaxKind` conforms to `CaseIterable`, we can’t mark members of it as deprecated (https://github.com/apple/swift-syntax/pull/2237/files#r1359917461)

While doing this I noticed that `IntegerLiteralExprSyntax.Radix` also conformed to `CaseIterable`. Similarly, there’s no good reason to iterate over all radix kinds, so I removed that conformance as well.