### PR TITLE
[5.10] Add missing dependency to SwiftSyntaxMacroExpansion.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -194,7 +194,7 @@ let package = Package(
 
     .target(
       name: "SwiftSyntaxMacroExpansion",
-      dependencies: ["SwiftSyntax", "SwiftSyntaxBuilder", "SwiftSyntaxMacros", "SwiftDiagnostics"],
+      dependencies: ["SwiftSyntax", "SwiftSyntaxBuilder", "SwiftSyntaxMacros", "SwiftDiagnostics", "SwiftOperators"],
       exclude: ["CMakeLists.txt"]
     ),
 


### PR DESCRIPTION
Cherry-pick #2285 to `release/5.10`.
 
<hr>

The SwiftSyntaxMacroExpansion module imports SwiftOperators but does not depend on it explicitly in Package.swift. This is no big deal in Swift 5.x, but I believe in Swift 6 this will become an error.
 
Also, other packages that depend on this package seem to have stricter build systems, and so the lack of this dependency is actually causing CI failures. For example, by updating [OpenAPIGenerator](https://github.com/apple/swift-openapi-generator/) to use SwiftSyntax 509 there is a [CI failure](https://ci.swiftserver.group/job/swift-openapi-generator-swift510-prb/40/console) due to this problem:
 
> error: Target SwiftSyntaxMacroExpansion imports another target (SwiftOperators) in the package without declaring it a dependency.

