### PR TITLE
[CMake] Remove set(CACHE) line for SWIFT_MODULE_ABI_NAME_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,6 @@ if(CMAKE_VERSION VERSION_LESS 3.21)
   endif()
 endif()
 
-set(SWIFT_MODULE_ABI_NAME_PREFIX CACHE STRING "ABI name prefix to avoid name conflicts")
-
 # The subdirectory into which host libraries will be installed.
 set(SWIFT_HOST_LIBRARIES_SUBDIRECTORY "swift/host")
 

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -79,6 +79,7 @@ function(add_swift_syntax_library name)
       -emit-module-interface-path;${module_interface_file}
     >)
   if(SWIFT_MODULE_ABI_NAME_PREFIX)
+    # ABI name prefix. this can be used to avoid name conflicts.
     target_compile_options("${name}" PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:
         "SHELL:-Xfrontend -module-abi-name"


### PR DESCRIPTION
Due to https://cmake.org/cmake/help/latest/policy/CMP0126.html `set(CACHE)` overwrites the existing value if the cache has not been set to any value. Since we don't need any default value, just remove it.