### PR TITLE
Optimized Type Checker performance in UnicodeScalarExtensions and SyntaxText

### DIFF
--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -19,52 +19,58 @@ extension Unicode.Scalar {
     // N1518: Recommendations for extended identifier characters for C and C++
     // Proposed Annex X.1: Ranges of characters allowed
     let c = self.value
-    return c == 0x00A8 || c == 0x00AA || c == 0x00AD || c == 0x00AF
-      || (c >= 0x00B2 && c <= 0x00B5) || (c >= 0x00B7 && c <= 0x00BA)
-      || (c >= 0x00BC && c <= 0x00BE) || (c >= 0x00C0 && c <= 0x00D6)
-      || (c >= 0x00D8 && c <= 0x00F6) || (c >= 0x00F8 && c <= 0x00FF)
+    return (c == 0x00A8) as Bool
+      || (c == 0x00AA) as Bool
+      || (c == 0x00AD) as Bool
+      || (c == 0x00AF) as Bool
+      || (c >= 0x00B2 && c <= 0x00B5) as Bool
+      || (c >= 0x00B7 && c <= 0x00BA) as Bool
+      || (c >= 0x00BC && c <= 0x00BE) as Bool
+      || (c >= 0x00C0 && c <= 0x00D6) as Bool
+      || (c >= 0x00D8 && c <= 0x00F6) as Bool
+      || (c >= 0x00F8 && c <= 0x00FF) as Bool
 
-      || (c >= 0x0100 && c <= 0x167F)
-      || (c >= 0x1681 && c <= 0x180D)
-      || (c >= 0x180F && c <= 0x1FFF)
+      || (c >= 0x0100 && c <= 0x167F) as Bool
+      || (c >= 0x1681 && c <= 0x180D) as Bool
+      || (c >= 0x180F && c <= 0x1FFF) as Bool
 
-      || (c >= 0x200B && c <= 0x200D)
-      || (c >= 0x202A && c <= 0x202E)
-      || (c >= 0x203F && c <= 0x2040)
-      || c == 0x2054
-      || (c >= 0x2060 && c <= 0x206F)
+      || (c >= 0x200B && c <= 0x200D) as Bool
+      || (c >= 0x202A && c <= 0x202E) as Bool
+      || (c >= 0x203F && c <= 0x2040) as Bool
+      || (c == 0x2054) as Bool
+      || (c >= 0x2060 && c <= 0x206F) as Bool
 
-      || (c >= 0x2070 && c <= 0x218F)
-      || (c >= 0x2460 && c <= 0x24FF)
-      || (c >= 0x2776 && c <= 0x2793)
-      || (c >= 0x2C00 && c <= 0x2DFF)
-      || (c >= 0x2E80 && c <= 0x2FFF)
+      || (c >= 0x2070 && c <= 0x218F) as Bool
+      || (c >= 0x2460 && c <= 0x24FF) as Bool
+      || (c >= 0x2776 && c <= 0x2793) as Bool
+      || (c >= 0x2C00 && c <= 0x2DFF) as Bool
+      || (c >= 0x2E80 && c <= 0x2FFF) as Bool
 
-      || (c >= 0x3004 && c <= 0x3007)
-      || (c >= 0x3021 && c <= 0x302F)
-      || (c >= 0x3031 && c <= 0x303F)
+      || (c >= 0x3004 && c <= 0x3007) as Bool
+      || (c >= 0x3021 && c <= 0x302F) as Bool
+      || (c >= 0x3031 && c <= 0x303F) as Bool
 
-      || (c >= 0x3040 && c <= 0xD7FF)
+      || (c >= 0x3040 && c <= 0xD7FF) as Bool
 
-      || (c >= 0xF900 && c <= 0xFD3D)
-      || (c >= 0xFD40 && c <= 0xFDCF)
-      || (c >= 0xFDF0 && c <= 0xFE44)
-      || (c >= 0xFE47 && c <= 0xFFF8)
+      || (c >= 0xF900 && c <= 0xFD3D) as Bool
+      || (c >= 0xFD40 && c <= 0xFDCF) as Bool
+      || (c >= 0xFDF0 && c <= 0xFE44) as Bool
+      || (c >= 0xFE47 && c <= 0xFFF8) as Bool
 
-      || (c >= 0x10000 && c <= 0x1FFFD)
-      || (c >= 0x20000 && c <= 0x2FFFD)
-      || (c >= 0x30000 && c <= 0x3FFFD)
-      || (c >= 0x40000 && c <= 0x4FFFD)
-      || (c >= 0x50000 && c <= 0x5FFFD)
-      || (c >= 0x60000 && c <= 0x6FFFD)
-      || (c >= 0x70000 && c <= 0x7FFFD)
-      || (c >= 0x80000 && c <= 0x8FFFD)
-      || (c >= 0x90000 && c <= 0x9FFFD)
-      || (c >= 0xA0000 && c <= 0xAFFFD)
-      || (c >= 0xB0000 && c <= 0xBFFFD)
-      || (c >= 0xC0000 && c <= 0xCFFFD)
-      || (c >= 0xD0000 && c <= 0xDFFFD)
-      || (c >= 0xE0000 && c <= 0xEFFFD)
+      || (c >= 0x10000 && c <= 0x1FFFD) as Bool
+      || (c >= 0x20000 && c <= 0x2FFFD) as Bool
+      || (c >= 0x30000 && c <= 0x3FFFD) as Bool
+      || (c >= 0x40000 && c <= 0x4FFFD) as Bool
+      || (c >= 0x50000 && c <= 0x5FFFD) as Bool
+      || (c >= 0x60000 && c <= 0x6FFFD) as Bool
+      || (c >= 0x70000 && c <= 0x7FFFD) as Bool
+      || (c >= 0x80000 && c <= 0x8FFFD) as Bool
+      || (c >= 0x90000 && c <= 0x9FFFD) as Bool
+      || (c >= 0xA0000 && c <= 0xAFFFD) as Bool
+      || (c >= 0xB0000 && c <= 0xBFFFD) as Bool
+      || (c >= 0xC0000 && c <= 0xCFFFD) as Bool
+      || (c >= 0xD0000 && c <= 0xDFFFD) as Bool
+      || (c >= 0xE0000 && c <= 0xEFFFD) as Bool
   }
 
   var isValidIdentifierStartCodePoint: Bool {

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -100,7 +100,9 @@ public struct SyntaxText {
     guard !self.isEmpty && !other.isEmpty else {
       return self.isEmpty && other.isEmpty
     }
-    return (other.baseAddress! <= self.baseAddress! && self.baseAddress! + count <= other.baseAddress! + other.count)
+    let selfEndBound = UnsafePointer<UInt8>(self.baseAddress! + count)
+    let otherEndBound = UnsafePointer<UInt8>(other.baseAddress! + other.count)
+    return (other.baseAddress! <= self.baseAddress!) && (selfEndBound <= otherEndBound)
   }
 
   /// Returns `true` if `other` is a substring of this ``SyntaxText``.


### PR DESCRIPTION
## Description

This PR optimizes swift code to accommodate slowness of Type Checker.

## Context

The following two methods are currently slow to compile in `swift-syntax` package:

1. `UnicodeScalarExtensions.isValidIdentifierContinuationCodePoint`
2. `SyntaxText.isSlice(of:)`

The optimization is about making the code a bit less "sweet" (as from "syntax sugar"), but a bit faster to get parsed.
Approach is simple: add type annotations, introduce local variables annotated with types.

## Measurements

I have measured the performance of the following command:
```bash
xcodebuild -scheme swift-syntax-Package ONLY_ACTIVE_ARCH=YES -destination 'platform=macos' clean build > /dev/null
```

using `time`. The output of `time` was the following:

Before|After
:-:|:-:
2.10s user 0.53s system 20% cpu 12.784 total|2.08s user 0.51s system 20% cpu 12.629 total
2.11s user 0.50s system 20% cpu 12.896 total|2.09s user 0.50s system 20% cpu 12.802 total
2.12s user 0.50s system 20% cpu 12.720 total|2.07s user 0.52s system 20% cpu 12.793 total
2.10s user 0.51s system 20% cpu 12.905 total|2.08s user 0.53s system 20% cpu 12.768 total
2.05s user 0.47s system 20% cpu 12.638 total|2.07s user 0.53s system 20% cpu 12.710 total
2.12s user 0.52s system 20% cpu 12.569 total|2.05s user 0.50s system 19% cpu 12.846 total
2.14s user 0.53s system 20% cpu 12.792 total|2.07s user 0.50s system 20% cpu 12.514 total


### More Details

I have used https://github.com/qonto/SwiftCompilationTimingParser to measure slow compiling code. The following were the top candidates for optimization:

location|symbol|ms
-- | -- | --
Sources\/SwiftSyntax\/generated\/SyntaxVisitor.swift:3438:16 | instance method visitationFunc(for:) | 407.71
Sources\/SwiftSyntax\/SyntaxText.swift:97:15 | instance method isSlice(of:) | 299.29
Sources\/SwiftSyntax\/generated\/ChildNameForKeyPath.swift:18:13 | global function childName(_:) | 293.93
Sources\/SwiftSyntax\/generated\/SyntaxRewriter.swift:2113:16 | instance method visitationFunc(for:) | 269.33
Sources\/SwiftParser\/Lexer\/UnicodeScalarExtensions.swift:14:52 | getter isValidIdentifierContinuationCodePoint | 123.67
Sources\/SwiftSyntax\/generated\/TokenKind.swift:730:22 | static method fromRaw(kind:text:) | 85.13
Sources\/SwiftSyntax\/generated\/SyntaxEnum.swift:306:8 | instance method as(_:) | 74.07

Out of these, there were only two which are not related to generated code.
After code optimization, the modified methods got the following timing:


location|symbol|ms|improvement
-- | -- | -- | --
UnicodeScalarExtensions.swift:14:52 | getter isValidIdentifierContinuationCodePoint | 20.72 | 83.3%
SyntaxText.swift:97:15 | instance method isSlice(of:) | 7.1 | 97.7%


While the comparison might seem unreasonable to get this PR merged, in my personal opinion and experience, under certain circumstances this type of optimization of swift code for Type Checker might play a big role in overall compilation performance in the long run. What's important is not to introduce a regression, and so thorough measurements should be made.