### PR TITLE
Fixes a typo in the cli abstract string

### DIFF
--- a/SwiftParserCLI/Sources/swift-parser-cli/Commands/PrintDiags.swift
+++ b/SwiftParserCLI/Sources/swift-parser-cli/Commands/PrintDiags.swift
@@ -18,7 +18,7 @@ import SwiftParserDiagnostics
 struct PrintDiags: ParsableCommand, ParseCommand {
   static var configuration = CommandConfiguration(
     commandName: "print-diags",
-    abstract: "Print the diagnostics produced by parsing a soruce file"
+    abstract: "Print the diagnostics produced by parsing a source file"
   )
 
   @OptionGroup


### PR DESCRIPTION
The `print-diags` command for the swift parser cli has a typo in the abstract. This PR just fixes the typo as per the diff. There are no tests or other automation that uses the abstract so this change is standalone.