### PR TITLE
load => loadUnaligned

### DIFF
--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -198,7 +198,7 @@ internal struct PluginHostConnection: MessageConnection {
 
     // Decode the count.
     let count = header.withUnsafeBytes {
-      UInt64(littleEndian: $0.load(as: UInt64.self))
+      UInt64(littleEndian: $0.loadUnaligned(as: UInt64.self))
     }
     guard count >= 2 else {
       throw PluginMessageError.invalidPayloadSize


### PR DESCRIPTION
Same fix as https://github.com/apple/swift-package-manager/pull/6929 since the code in swift-syntax is based on what is in SwiftPM.