### PR TITLE
MacroSystem should remove the initializer for an accessor macro

### DIFF
--- a/Examples/Tests/MacroExamples/Implementation/ComplexMacros/DictionaryIndirectionMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/ComplexMacros/DictionaryIndirectionMacroTests.swift
@@ -32,7 +32,7 @@ final class DictionaryStorageMacroTests: XCTestCase {
       """,
       expandedSource: """
         struct Point {
-          var x: Int = 1 {
+          var x: Int {
             get {
               _storage["x", default: 1] as! Int
             }
@@ -40,7 +40,7 @@ final class DictionaryStorageMacroTests: XCTestCase {
               _storage["x"] = newValue
             }
           }
-          var y: Int = 2 {
+          var y: Int {
             get {
               _storage["y", default: 2] as! Int
             }

--- a/Examples/Tests/MacroExamples/Implementation/ComplexMacros/ObservableMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/ComplexMacros/ObservableMacroTests.swift
@@ -77,7 +77,7 @@ final class ObservableMacroTests: XCTestCase {
             }
           }
 
-          var isHappy: Bool = true {
+          var isHappy: Bool {
             get {
               _registrar.beginAccess(\.isHappy)
               defer {


### PR DESCRIPTION
SE-0389 specifies that a macro returning either a getter or setter should remove the initializer, if one exists.

Resolves rdar://117442713 (#2310)