### PR TITLE
[509] Change `load` to `loadUnaligned`

### DIFF
--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -200,7 +200,7 @@ internal struct PluginHostConnection: MessageConnection {
 
     // Decode the count.
     let count = header.withUnsafeBytes {
-      UInt64(littleEndian: $0.load(as: UInt64.self))
+      UInt64(littleEndian: $0.loadUnaligned(as: UInt64.self))
     }
     guard count >= 2 else {
       throw PluginMessageError.invalidPayloadSize


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-syntax/pull/2312 to package-release/509.

---

Same fix as https://github.com/apple/swift-package-manager/pull/6929 since the code in swift-syntax is based on what is 
in SwiftPM.