### PR TITLE
Mark `SyntaxChildrenIndex` as `Sendable`

### DIFF
--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -14,7 +14,7 @@
 
 /// The data for an index in a syntax children collection that is not the end
 /// index. See ``SyntaxChildrenIndex`` for the representation of the end index.
-struct SyntaxChildrenIndexData: Hashable, Comparable {
+struct SyntaxChildrenIndexData: Hashable, Comparable, Sendable {
   /// The UTF-8 offset of the item at this index in the source file
   /// See `AbsoluteSyntaxPosition.offset`
   let offset: UInt32
@@ -50,7 +50,7 @@ struct SyntaxChildrenIndexData: Hashable, Comparable {
 }
 
 /// An index in a syntax children collection.
-public struct SyntaxChildrenIndex: Hashable, Comparable, ExpressibleByNilLiteral {
+public struct SyntaxChildrenIndex: Hashable, Comparable, ExpressibleByNilLiteral, Sendable {
   /// Construct the `endIndex` of a ``SyntaxChildren`` collection.
   public init(nilLiteral: ()) {
     self.data = nil

--- a/Sources/SwiftSyntax/SyntaxIdentifier.swift
+++ b/Sources/SwiftSyntax/SyntaxIdentifier.swift
@@ -12,7 +12,7 @@
 
 /// Represents a unique value for a node within its own tree.
 @_spi(RawSyntax)
-public struct SyntaxIndexInTree: Comparable, Hashable {
+public struct SyntaxIndexInTree: Comparable, Hashable, Sendable {
   let indexInTree: UInt32
 
   static var zero: SyntaxIndexInTree = SyntaxIndexInTree(indexInTree: 0)


### PR DESCRIPTION
Otherwise consumers of SwiftSyntax may encounter warnings when compiling with `-strict-concurrency=complete`.

For example:

```swift
extension DeclModifierListSyntax {
    var fileprivateModifierIndex: DeclModifierListSyntax.Index? {
        firstIndex(where: { $0.name.tokenKind == .keyword(.fileprivate) })
    }

    var fileprivateModifier: DeclModifierSyntax? {
        fileprivateModifierIndex.flatMap { self[$0] }
    }

    func replacing(fileprivateModifierIndex: DeclModifierListSyntax.Index) -> DeclModifierListSyntax {
        let fileprivateModifier = self[fileprivateModifierIndex]
        return with(
            \.[fileprivateModifierIndex],
            fileprivateModifier.with(
                \.name,
                .keyword(
                    .private,
                    leadingTrivia: fileprivateModifier.leadingTrivia,
                    trailingTrivia: fileprivateModifier.trailingTrivia
                )
            )
        )
    }
}
```

Produces the following warning:

> cannot form key path that captures non-sendable type 'DeclModifierListSyntax.Index' (aka 'SyntaxChildrenIndex')