### PR TITLE
build: emit additional content even in sub-build mode

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -124,22 +124,20 @@ function(add_swift_syntax_library name)
     endif()
   endif()
 
-  if(PROJECT_IS_TOP_LEVEL)
-    # Install this target
-    install(TARGETS ${name}
-      EXPORT SwiftSyntaxTargets
-      ARCHIVE DESTINATION lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}
-      LIBRARY DESTINATION lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}
-      RUNTIME DESTINATION bin
-    )
+  # Install this target
+  install(TARGETS ${name}
+    EXPORT SwiftSyntaxTargets
+    ARCHIVE DESTINATION lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}
+    LIBRARY DESTINATION lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}
+    RUNTIME DESTINATION bin
+  )
 
-    # Install the module files.
-    install(
-      DIRECTORY ${module_base}
-      DESTINATION lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}
-      FILES_MATCHING PATTERN "*.swiftinterface"
-    )
-  else()
+  # Install the module files.
+  install(DIRECTORY ${module_base}
+          DESTINATION lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}
+          FILES_MATCHING PATTERN "*.swiftinterface")
+
+  if(NOT PROJECT_IS_TOP_LEVEL)
     set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
   endif()
 endfunction()

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,5 +1,3 @@
-if(PROJECT_IS_TOP_LEVEL)
-  export(EXPORT SwiftSyntaxTargets
-         FILE ${CMAKE_CURRENT_BINARY_DIR}/SwiftSyntaxConfig.cmake
-         NAMESPACE SwiftSyntax::)
-endif()
+export(EXPORT SwiftSyntaxTargets
+       FILE ${CMAKE_CURRENT_BINARY_DIR}/SwiftSyntaxConfig.cmake
+       NAMESPACE SwiftSyntax::)


### PR DESCRIPTION
Enable installing the additional content of the swiftmodules and cmake when built under the Swift compiler. This allows us to build the LSP against the same copy of Swift Syntax as the compiler, shaving ~6MiB off of SourceKit-LSP.