### PR TITLE
Globals strict concurrency opt out nonisolated unsafe

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -17,11 +17,11 @@ extension DeclarationModifier {
     switch self {
     case .__consuming, .__setter_access, ._const, ._local, .async,
       .borrowing, .class, .consuming, .convenience, .distributed, .dynamic,
-      .final, .indirect, .infix, .isolated, .lazy, .mutating, .nonisolated,
-      .nonmutating, .optional, .override, .postfix, .prefix, .reasync,
-      .required, .rethrows, .static, .weak:
+      .final, .indirect, .infix, .isolated, .lazy, .mutating, .nonmutating,
+      .optional, .override, .postfix, .prefix, .reasync, .required,
+      .rethrows, .static, .weak:
       return false
-    case .fileprivate, .internal, .package, .open, .private,
+    case .fileprivate, .internal, .nonisolated, .package, .open, .private,
       .public, .unowned:
       return true
     }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -185,6 +185,19 @@ final class DeclarationTests: ParserTestCase {
     )
   }
 
+  func testNonisolatedUnsafeParsing() {
+    assertParse(
+      """
+      nonisolated(unsafe) let a = 0
+
+      struct A {
+        nonisolated(unsafe) let b = 0
+        nonisolated(unsafe) var c: Int { 0 }
+      }
+      """
+    )
+  }
+
   func testProtocolParsing() {
     assertParse("protocol Foo {}")
 


### PR DESCRIPTION
cherry-pick from main