### PR TITLE
Add fix-it handling tests for macro examples

### DIFF
--- a/Examples/Sources/MacroExamples/Implementation/Peer/AddCompletionHandlerMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Peer/AddCompletionHandlerMacro.swift
@@ -34,9 +34,9 @@ public struct AddCompletionHandlerMacro: PeerMacro {
       var newEffects: FunctionEffectSpecifiersSyntax
       if let existingEffects = funcDecl.signature.effectSpecifiers {
         newEffects = existingEffects
-        newEffects.asyncSpecifier = .keyword(.async)
+        newEffects.asyncSpecifier = .keyword(.async, trailingTrivia: .space)
       } else {
-        newEffects = FunctionEffectSpecifiersSyntax(asyncSpecifier: .keyword(.async))
+        newEffects = FunctionEffectSpecifiersSyntax(asyncSpecifier: .keyword(.async, trailingTrivia: .space))
       }
 
       var newSignature = funcDecl.signature

--- a/Examples/Tests/MacroExamples/Implementation/Expression/AddBlockerTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/Expression/AddBlockerTests.swift
@@ -39,6 +39,33 @@ final class AddBlockerTests: XCTestCase {
     )
   }
 
+  func testExpansionWithSubtractionAppliesFixIt() {
+    assertMacroExpansion(
+      """
+      #addBlocker(x * y + z)
+      """,
+      expandedSource: """
+        x * y - z
+        """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "blocked an add; did you mean to subtract?",
+          line: 1,
+          column: 19,
+          severity: .warning,
+          fixIts: [FixItSpec(message: "use '-'")]
+        )
+      ],
+      macros: macros,
+      applyFixIts: ["use '-'"],
+      fixedSource:
+        """
+        #addBlocker(x * y - z)
+        """,
+      indentationWidth: .spaces(2)
+    )
+  }
+
   func testExpansionPreservesSubtraction() {
     assertMacroExpansion(
       """

--- a/Examples/Tests/MacroExamples/Implementation/Peer/AddCompletionHandlerMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/Peer/AddCompletionHandlerMacroTests.swift
@@ -98,4 +98,44 @@ final class AddCompletionHandlerMacroTests: XCTestCase {
       indentationWidth: .spaces(2)
     )
   }
+
+  func testExpansionOnNonAsyncFunctionAppliesFixIt() {
+    assertMacroExpansion(
+      """
+      struct Test {
+        @AddCompletionHandler
+        func fetchData() -> String {
+          return "Hello, World!"
+        }
+      }
+      """,
+      expandedSource: """
+        struct Test {
+          func fetchData() -> String {
+            return "Hello, World!"
+          }
+        }
+        """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "can only add a completion-handler variant to an 'async' function",
+          line: 3,
+          column: 3,
+          severity: .error,
+          fixIts: [FixItSpec(message: "add 'async'")]
+        )
+      ],
+      macros: macros,
+      applyFixIts: ["add 'async'"],
+      fixedSource: """
+        struct Test {
+          @AddCompletionHandler
+          func fetchData() async -> String {
+            return "Hello, World!"
+          }
+        }
+        """,
+      indentationWidth: .spaces(2)
+    )
+  }
 }


### PR DESCRIPTION
It introduces an enhancement to our macro expansion functionality with the addition of fix-it tests.

In `AddBlockerTests`, a new test case has been added to validate the scenario where an addition operation should be a subtraction, including a diagnostic message and the application of the suggested fix-it.

Similarly, `AddCompletionHandlerMacroTests` is now equipped with a test case that applies a fix-it for adding the 'async' keyword to functions that are missing it but have the `@AddCompletionHandler` attribute.