### PR TITLE
Add a command to dev utils that run all other necessary scripts to submit a PR 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,17 @@ Alternatively, you can generate the files from the command line by running the f
 swift run --package-path CodeGeneration
 ```
 
+## Running Pre-PR Checks Script
+
+To ensure that your changes to the project are implemented correctly and do not introduce issues across the repository, a script has been provided to automate the necessary pre-PR checks. 
+
+```bash
+./swift-syntax-dev-utils local-pr-precheck
+```
+
+> [!NOTE]
+> Running the pre-PR checks script may take some time, so it's recommended to perform this final check before submitting a PR rather than after every change.
+
 ## Authoring commits
 
 Prefer to squash the commits of your PR (*pull request*) and avoid adding commits like “Address review comments”. This creates a clearer git history, which doesn’t need to record the history of how the PR evolved.

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/SwiftSyntaxDevUtils.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/SwiftSyntaxDevUtils.swift
@@ -28,6 +28,7 @@ struct SwiftSyntaxDevUtils: ParsableCommand {
       Build.self,
       Format.self,
       GenerateSourceCode.self,
+      LocalPrPrecheck.self,
       Test.self,
       VerifyDocumentation.self,
       VerifySourceCode.self,

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/LocalPrPrecheck.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/LocalPrPrecheck.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+
+struct LocalPrPrecheck: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    abstract: """
+      Ensure changes are fully tested, formatted, and validated before pull request submission.
+      """
+  )
+
+  @OptionGroup
+  var arguments: SourceCodeGeneratorArguments
+
+  func run() throws {
+    let executor = LocalPrPrecheckExecutor(
+      toolchain: try arguments.toolchain,
+      verbose: arguments.verbose
+    )
+    try executor.run()
+  }
+}
+
+struct LocalPrPrecheckExecutor {
+  private let formatExecutor: FormatExecutor
+  private let generateSourceCodeExecutor: GenerateSourceCodeExecutor
+  private let buildExecutor: BuildExecutor
+  private let testExecutor: TestExecutor
+
+  /// Creates an executor
+  /// - Parameters:
+  ///   - toolchain: The path to the toolchain that shall be used to build SwiftSyntax.
+  ///   - verbose: Enable verbose logging.
+  init(toolchain: URL, verbose: Bool = false) {
+    self.formatExecutor = FormatExecutor(update: false, verbose: verbose)
+    self.generateSourceCodeExecutor = GenerateSourceCodeExecutor(toolchain: toolchain, verbose: verbose)
+    self.buildExecutor = BuildExecutor(swiftPMBuilder: SwiftPMBuilder(toolchain: toolchain, useLocalDeps: false, verbose: verbose))
+    self.testExecutor = TestExecutor(swiftPMBuilder: SwiftPMBuilder(toolchain: toolchain, useLocalDeps: false, verbose: verbose))
+  }
+
+  func run() throws {
+    try formatExecutor.run()
+    try generateSourceCodeExecutor.run(sourceDir: Paths.sourcesDir)
+    try buildExecutor.run()
+    try testExecutor.run()
+  }
+}

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SwiftPMBuilder.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SwiftPMBuilder.swift
@@ -38,6 +38,9 @@ struct SwiftPMBuilder {
   /// no round-trip or assertion failures.
   let enableTestFuzzing: Bool
 
+  /// A flag indicating whether to use local dependencies during the build process.
+  let useLocalDeps: Bool
+
   /// Treat all warnings as errors.
   let warningsAsErrors: Bool
 
@@ -51,6 +54,7 @@ struct SwiftPMBuilder {
     release: Bool = false,
     enableRawSyntaxValidation: Bool = false,
     enableTestFuzzing: Bool = false,
+    useLocalDeps: Bool = true,
     warningsAsErrors: Bool = false,
     verbose: Bool = false
   ) {
@@ -60,6 +64,7 @@ struct SwiftPMBuilder {
     self.release = release
     self.enableRawSyntaxValidation = enableRawSyntaxValidation
     self.enableTestFuzzing = enableTestFuzzing
+    self.useLocalDeps = useLocalDeps
     self.warningsAsErrors = warningsAsErrors
     self.verbose = verbose
   }
@@ -139,8 +144,10 @@ struct SwiftPMBuilder {
       additionalEnvironment["SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION"] = "1"
     }
 
-    // Tell other projects in the unified build to use local dependencies
-    additionalEnvironment["SWIFTCI_USE_LOCAL_DEPS"] = "1"
+    if useLocalDeps {
+      // Tell other projects in the unified build to use local dependencies
+      additionalEnvironment["SWIFTCI_USE_LOCAL_DEPS"] = "1"
+    }
 
     return additionalEnvironment
   }


### PR DESCRIPTION
Add the script to the swift-syntax dev utils package to allow developers to run all necessary actions before submitting a PR

Resolves #2066