### PR TITLE
reject invalid arguments to nonisolated contextual keyword

### DIFF
--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -99,9 +99,9 @@ extension Parser {
 }
 
 extension Parser {
-  mutating func parseModifierDetail(_ keyword: Keyword) -> RawDeclModifierDetailSyntax {
+  mutating func parseModifierDetail() -> RawDeclModifierDetailSyntax {
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-    let (unexpectedBeforeDetailToken, detailToken) = self.expect(.identifier, TokenSpec(keyword, remapping: .identifier), default: .identifier)
+    let (unexpectedBeforeDetailToken, detailToken) = self.expect(.identifier, TokenSpec(.set, remapping: .identifier), default: .identifier)
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     return RawDeclModifierDetailSyntax(
       unexpectedBeforeLeftParen,
@@ -119,7 +119,7 @@ extension Parser {
 
     let detail: RawDeclModifierDetailSyntax?
     if self.at(.leftParen) {
-      detail = self.parseModifierDetail(.set)
+      detail = self.parseModifierDetail()
     } else {
       detail = nil
     }
@@ -224,7 +224,18 @@ extension Parser {
 
     let detail: RawDeclModifierDetailSyntax?
     if self.at(.leftParen) {
-      detail = self.parseModifierDetail(.unsafe)
+      let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
+      let (unexpectedBeforeDetailToken, detailToken) = self.expect(TokenSpec(.unsafe, remapping: .identifier))
+      let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
+      detail = RawDeclModifierDetailSyntax(
+        unexpectedBeforeLeftParen,
+        leftParen: leftParen,
+        unexpectedBeforeDetailToken,
+        detail: detailToken,
+        unexpectedBeforeRightParen,
+        rightParen: rightParen,
+        arena: self.arena
+      )
     } else {
       detail = nil
     }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -248,8 +248,24 @@ final class DeclarationTests: ParserTestCase {
       struct A {
         nonisolated(unsafe) let b = 0
         nonisolated(unsafe) var c: Int { 0 }
+        nonisolated(1️⃣safe) let d = 0
       }
-      """
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected 'unsafe' in modifier",
+          fixIts: ["replace 'safe' with 'unsafe'"]
+        )
+      ],
+      fixedSource: """
+        nonisolated(unsafe) let a = 0
+
+        struct A {
+          nonisolated(unsafe) let b = 0
+          nonisolated(unsafe) var c: Int { 0 }
+          nonisolated(unsafe) let d = 0
+        }
+        """
     )
   }
 


### PR DESCRIPTION
tidying and follow-up to https://github.com/apple/swift-syntax/pull/2306