### PR TITLE
Make CodeGeneration depend on swift-syntax 509

### DIFF
--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -12,17 +12,8 @@ let package = Package(
     .executable(name: "generate-swift-syntax", targets: ["generate-swift-syntax"])
   ],
   dependencies: [
-    // This directory is a standalone package that uses swift-syntax from the
-    // outer directory.
-    // If you are making significant changs to `CodeGeneration` locally and want
-    // to avoid breaking the build of `CodeGeneration` itself by generating new
-    // files in the parent swift-syntax package, it is encouraged to change the
-    // dependency to the following. That way `CodeGeneration` has its own
-    // checkout of swift-syntax that is unaffected by the newly generated files.
-    // Be sure to revert the change before committing your changes.
-    //
-    // .package(url: "https://github.com/apple/swift-syntax", branch: "main")
-    .package(path: "..")
+    .package(url: "https://github.com/apple/swift-syntax", from: "509.0.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
   ],
   targets: [
     .executableTarget(
@@ -63,14 +54,3 @@ let package = Package(
     ),
   ]
 )
-
-if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
-  // Building standalone.
-  package.dependencies += [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2")
-  ]
-} else {
-  package.dependencies += [
-    .package(path: "../../swift-argument-parser")
-  ]
-}

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -25,14 +25,14 @@ extension Parser {
 
 extension Parser.ExperimentalFeatures {
   /// Whether to enable the parsing of reference bindings.
-  public static let referenceBindings = Self(rawValue: 1 << 0)
+  public static let referenceBindings = Self (rawValue: 1 << 0)
   
   /// Whether to enable the parsing of 'then' statements.
-  public static let thenStatements = Self(rawValue: 1 << 1)
+  public static let thenStatements = Self (rawValue: 1 << 1)
   
   /// Whether to enable the parsing of typed throws.
-  public static let typedThrows = Self(rawValue: 1 << 2)
+  public static let typedThrows = Self (rawValue: 1 << 2)
   
   /// Whether to enable the parsing of 'do' expressions.
-  public static let doExpressions = Self(rawValue: 1 << 3)
+  public static let doExpressions = Self (rawValue: 1 << 3)
 }


### PR DESCRIPTION
https://github.com/apple/swift-syntax/pull/2239 was meant to make Generation depend on swift-syntax 509 but it didn’t actually flip the switch. Do so now.