### PR TITLE
Move `MacroExpansion{Error|Warning|FixIt}Message` to the `SwiftSyntaxMacros` module

### DIFF
--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -21,6 +21,11 @@
   - Issue: https://github.com/apple/swift-syntax/issues/2267
   - Pull request: https://github.com/apple/swift-syntax/pull/2272
 
+- `MacroExpansion{Error|Warning|FixIt}Message` moved to the `SwiftSyntaxMacros` module
+  - Description: Move the `MacroExpansion{Error|Warning|FixIt}Message` types from the `SwiftSyntaxMacroExpansion` module to `SwiftSyntaxMacros`. Deprecated typealiases in `SwiftSyntaxMacroExpansion` forward to `SwiftSyntaxMacros`.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2338
+  - Notes: The expansion diagnostic messages were defined in `SwiftSyntaxMacroExpansion`, which is intended as an implementation detail of the plugin server and should not need to be imported by macros.  
+
 ## API-Incompatible Changes
 
 - Effect specifiers:

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansionDiagnosticMessages.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansionDiagnosticMessages.swift
@@ -10,59 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftDiagnostics
+import SwiftSyntaxMacros
 
-/// An error during macro expansion that is described by its message.
-///
-/// This type allows macro authors to quickly generate error messages based on a
-/// string. For any non-trivial error messages, it is encouraged to define a
-/// custom type that conforms to `DiagnosticMessage`.
-public struct MacroExpansionErrorMessage: Error, DiagnosticMessage {
-  public let message: String
+@available(*, deprecated, message: "MacroExpansionErrorMessage has been moved to the SwiftSyntaxMacros module")
+public typealias MacroExpansionErrorMessage = SwiftSyntaxMacros.MacroExpansionErrorMessage
 
-  public var severity: SwiftDiagnostics.DiagnosticSeverity { .error }
+@available(*, deprecated, message: "MacroExpansionWarningMessage has been moved to the SwiftSyntaxMacros module")
+public typealias MacroExpansionWarningMessage = SwiftSyntaxMacros.MacroExpansionWarningMessage
 
-  public var diagnosticID: SwiftDiagnostics.MessageID {
-    .init(domain: diagnosticDomain, id: "\(Self.self)")
-  }
-
-  public init(_ message: String) {
-    self.message = message
-  }
-}
-
-/// An warning during macro expansion that is described by its message.
-///
-/// This type allows macro authors to quickly generate warning messages based on
-/// a string. For any non-trivial warning messages, it is encouraged to define a
-/// custom type that conforms to `DiagnosticMessage`.
-public struct MacroExpansionWarningMessage: DiagnosticMessage {
-  public let message: String
-
-  public var severity: SwiftDiagnostics.DiagnosticSeverity { .warning }
-
-  public var diagnosticID: SwiftDiagnostics.MessageID {
-    .init(domain: diagnosticDomain, id: "\(Self.self)")
-  }
-
-  public init(_ message: String) {
-    self.message = message
-  }
-}
-
-/// The message of a Fix-It that is specified by a string literal
-///
-/// This type allows macro authors to quickly generate Fix-It messages based on
-/// a string. For any non-trivial Fix-It messages, it is encouraged to define a
-/// custom type that conforms to `FixItMessage`.
-public struct MacroExpansionFixItMessage: FixItMessage {
-  public var message: String
-
-  public var fixItID: SwiftDiagnostics.MessageID {
-    .init(domain: diagnosticDomain, id: "\(Self.self)")
-  }
-
-  public init(_ message: String) {
-    self.message = message
-  }
-}
+@available(*, deprecated, message: "MacroExpansionFixItMessage has been moved to the SwiftSyntaxMacros module")
+public typealias MacroExpansionFixItMessage = SwiftSyntaxMacros.MacroExpansionFixItMessage

--- a/Sources/SwiftSyntaxMacros/CMakeLists.txt
+++ b/Sources/SwiftSyntaxMacros/CMakeLists.txt
@@ -22,6 +22,7 @@ add_swift_syntax_library(SwiftSyntaxMacros
 
   AbstractSourceLocation.swift
   MacroExpansionContext.swift
+  MacroExpansionDiagnosticMessages.swift
 )
 
 target_link_swift_syntax_libraries(SwiftSyntaxMacros PUBLIC

--- a/Sources/SwiftSyntaxMacros/MacroExpansionDiagnosticMessages.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionDiagnosticMessages.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+
+fileprivate let diagnosticDomain: String = "SwiftSyntaxMacros"
+
+/// An error during macro expansion that is described by its message.
+///
+/// This type allows macro authors to quickly generate error messages based on a
+/// string. For any non-trivial error messages, it is encouraged to define a
+/// custom type that conforms to `DiagnosticMessage`.
+public struct MacroExpansionErrorMessage: Error, DiagnosticMessage {
+  public let message: String
+
+  public var severity: SwiftDiagnostics.DiagnosticSeverity { .error }
+
+  public var diagnosticID: SwiftDiagnostics.MessageID {
+    .init(domain: diagnosticDomain, id: "\(Self.self)")
+  }
+
+  public init(_ message: String) {
+    self.message = message
+  }
+}
+
+/// An warning during macro expansion that is described by its message.
+///
+/// This type allows macro authors to quickly generate warning messages based on
+/// a string. For any non-trivial warning messages, it is encouraged to define a
+/// custom type that conforms to `DiagnosticMessage`.
+public struct MacroExpansionWarningMessage: DiagnosticMessage {
+  public let message: String
+
+  public var severity: SwiftDiagnostics.DiagnosticSeverity { .warning }
+
+  public var diagnosticID: SwiftDiagnostics.MessageID {
+    .init(domain: diagnosticDomain, id: "\(Self.self)")
+  }
+
+  public init(_ message: String) {
+    self.message = message
+  }
+}
+
+/// The message of a Fix-It that is specified by a string literal
+///
+/// This type allows macro authors to quickly generate Fix-It messages based on
+/// a string. For any non-trivial Fix-It messages, it is encouraged to define a
+/// custom type that conforms to `FixItMessage`.
+public struct MacroExpansionFixItMessage: FixItMessage {
+  public var message: String
+
+  public var fixItID: SwiftDiagnostics.MessageID {
+    .init(domain: diagnosticDomain, id: "\(Self.self)")
+  }
+
+  public init(_ message: String) {
+    self.message = message
+  }
+}


### PR DESCRIPTION
The expansion diagnostic messages were defined in `SwiftSyntaxMacroExpansion`, which is intended as an implementation detail of the plugin server and should not need to be imported by macros. Move them to the `SwiftSyntaxMacros` module where they belong.