### PR TITLE
[5.10] Cherry-pick a couple of macro system fixes for attached accessor macros

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -792,7 +792,7 @@ extension Parser {
       }
 
       // Check for a trailing closure, if allowed.
-      if self.at(.leftBrace) && self.withLookahead({ $0.atValidTrailingClosure(flavor: flavor) }) {
+      if self.at(.leftBrace) && !leadingExpr.raw.kind.isLiteral && self.withLookahead({ $0.atValidTrailingClosure(flavor: flavor) }) {
         // FIXME: if Result has a trailing closure, break out.
         // Add dummy blank argument list to the call expression syntax.
         let list = RawLabeledExprListSyntax(elements: [], arena: self.arena)
@@ -2515,6 +2515,17 @@ extension Parser.Lookahead {
       return false
     default:
       return true
+    }
+  }
+}
+
+extension SyntaxKind {
+  fileprivate var isLiteral: Bool {
+    switch self {
+    case .arrayExpr, .booleanLiteralExpr, .dictionaryExpr, .floatLiteralExpr, .integerLiteralExpr, .nilLiteralExpr, .regexLiteralExpr, .stringLiteralExpr:
+      return true
+    default:
+      return false
     }
   }
 }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1498,17 +1498,38 @@ extension Parser {
     var elements = [RawSyntax]()
     do {
       var collectionProgress = LoopProgressCondition()
-      COLLECTION_LOOP: while self.hasProgressed(&collectionProgress) {
+      var keepGoing: RawTokenSyntax?
+      COLLECTION_LOOP: repeat {
         elementKind = self.parseCollectionElement(elementKind)
 
+        /// Whether expression of an array element or the value of a dictionary
+        /// element is missing. If this is the case, we shouldn't recover from
+        /// a missing comma since most likely the closing `]` is missing.
+        var elementIsMissingExpression: Bool {
+          switch elementKind! {
+          case .dictionary(_, _, _, let value):
+            return value.is(RawMissingExprSyntax.self)
+          case .array(let rawExprSyntax):
+            return rawExprSyntax.is(RawMissingExprSyntax.self)
+          }
+        }
+
         // Parse the ',' if exists.
-        let comma = self.consume(if: .comma)
+        if let token = self.consume(if: .comma) {
+          keepGoing = token
+        } else if !self.at(.rightSquare, .endOfFile) && !self.atStartOfLine && !elementIsMissingExpression && !self.atStartOfDeclaration()
+          && !self.atStartOfStatement(preferExpr: false)
+        {
+          keepGoing = missingToken(.comma)
+        } else {
+          keepGoing = nil
+        }
 
         switch elementKind! {
         case .array(let el):
           let element = RawArrayElementSyntax(
             expression: el,
-            trailingComma: comma,
+            trailingComma: keepGoing,
             arena: self.arena
           )
           if element.isEmpty {
@@ -1522,7 +1543,7 @@ extension Parser {
             unexpectedBeforeColon,
             colon: colon,
             value: value,
-            trailingComma: comma,
+            trailingComma: keepGoing,
             arena: self.arena
           )
           if element.isEmpty {
@@ -1531,29 +1552,7 @@ extension Parser {
             elements.append(RawSyntax(element))
           }
         }
-
-        // If we saw a comma, that's a strong indicator we have more elements
-        // to process. If that's not the case, we have to do some legwork to
-        // determine if we should bail out.
-        guard comma == nil || self.at(.rightSquare, .endOfFile) else {
-          continue
-        }
-
-        // If we found EOF or the closing square bracket, bailout.
-        if self.at(.rightSquare, .endOfFile) {
-          break
-        }
-
-        // If the next token is at the beginning of a new line and can never start
-        // an element, break.
-        if self.atStartOfLine
-          && (self.at(.rightBrace, .poundEndif)
-            || self.atStartOfDeclaration()
-            || self.atStartOfStatement(preferExpr: false))
-        {
-          break
-        }
-      }
+      } while keepGoing != nil && self.hasProgressed(&collectionProgress)
     }
 
     let (unexpectedBeforeRSquare, rsquare) = self.expect(.rightSquare)

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -267,7 +267,8 @@ private func expandAccessorMacroWithoutExistingAccessors(
       conformanceList: nil,
       in: context,
       indentationWidth: indentationWidth
-    )
+    ),
+    !expanded.isEmpty
   else {
     return nil
   }

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -307,7 +307,7 @@ private func expandAccessorMacroWithExistingAccessors(
     return nil
   }
 
-  // Separate the accessor from any existing accessors by two spaces
+  // Separate the accessor from any existing accessors by an empty line
   let indentedSource = "\n" + expanded.indented(by: attachedTo.indentationOfFirstLine + indentationWidth)
   return "\(raw: indentedSource)"
 }
@@ -636,13 +636,26 @@ private class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
       context.addDiagnostics(from: MacroApplicationError.accessorMacroOnVariableWithMultipleBindings, node: node)
       return DeclSyntax(node)
     }
-    node.bindings[node.bindings.startIndex].accessorBlock = expandAccessors(of: node, existingAccessors: binding.accessorBlock)
+
+    let expansion = expandAccessors(of: node, existingAccessors: binding.accessorBlock)
+    if expansion.accessors != binding.accessorBlock {
+      if binding.initializer != nil, expansion.expandsGetSet {
+        // The accessor block will have a leading space, but there will already be a
+        // space between the variable and the to-be-removed initializer. Remove the
+        // leading trivia on the accessor block so we don't double up.
+        node.bindings[node.bindings.startIndex].accessorBlock = expansion.accessors?.with(\.leadingTrivia, [])
+        node.bindings[node.bindings.startIndex].initializer = nil
+      } else {
+        node.bindings[node.bindings.startIndex].accessorBlock = expansion.accessors
+      }
+    }
+
     return DeclSyntax(node)
   }
 
   override func visit(_ node: SubscriptDeclSyntax) -> DeclSyntax {
     var node = super.visit(node).cast(SubscriptDeclSyntax.self)
-    node.accessorBlock = expandAccessors(of: node, existingAccessors: node.accessorBlock)
+    node.accessorBlock = expandAccessors(of: node, existingAccessors: node.accessorBlock).accessors
     return DeclSyntax(node)
   }
 }
@@ -803,14 +816,23 @@ extension MacroApplication {
     }
   }
 
-  /// Expand all 'accessor' macros attached to `storage` and return the `storage`
-  /// node.
+  /// Expand all 'accessor' macros attached to `storage`.
   ///
-  /// - Returns: The storage node with all macro-synthesized accessors applied.
-  private func expandAccessors(of storage: some DeclSyntaxProtocol, existingAccessors: AccessorBlockSyntax?) -> AccessorBlockSyntax? {
+  /// - Returns: The final accessors block that includes both the existing
+  ///   and expanded accessors, as well as whether any `get`/`set` were
+  ///   expanded (in which case any initializer on `storage` should be
+  ///   removed).
+  private func expandAccessors(of storage: some DeclSyntaxProtocol, existingAccessors: AccessorBlockSyntax?) -> (
+    accessors: AccessorBlockSyntax?, expandsGetSet: Bool
+  ) {
     let accessorMacros = macroAttributes(attachedTo: DeclSyntax(storage), ofType: AccessorMacro.Type.self)
 
     var newAccessorsBlock = existingAccessors
+    var expandsGetSet = false
+    func checkExpansions(_ accessors: AccessorDeclListSyntax?) {
+      guard let accessors else { return }
+      expandsGetSet = expandsGetSet || accessors.contains(where: \.isGetOrSet)
+    }
 
     for macro in accessorMacros {
       do {
@@ -828,6 +850,8 @@ extension MacroApplication {
             in: context,
             indentationWidth: indentationWidth
           ) {
+            checkExpansions(newAccessors)
+
             // If existingAccessors is not `nil`, then we also set
             // `newAccessorBlock` above to a a non-nil value, so
             // `newAccessorsBlock` also isn’t `nil`.
@@ -836,31 +860,33 @@ extension MacroApplication {
               indentationWidth: self.indentationWidth
             )
           }
-        } else {
-          let newAccessors = try expandAccessorMacroWithoutExistingAccessors(
-            definition: macro.definition,
-            attributeNode: macro.attributeNode,
-            attachedTo: DeclSyntax(storage),
-            in: context,
-            indentationWidth: indentationWidth
-          )
-          if newAccessorsBlock == nil {
-            newAccessorsBlock = newAccessors
-          } else if let newAccessors = newAccessors {
-            guard case .accessors(let accessorList) = newAccessors.accessors else {
-              throw MacroApplicationError.malformedAccessor
-            }
-            newAccessorsBlock = newAccessorsBlock!.addingAccessors(
+        } else if let newAccessors = try expandAccessorMacroWithoutExistingAccessors(
+          definition: macro.definition,
+          attributeNode: macro.attributeNode,
+          attachedTo: DeclSyntax(storage),
+          in: context,
+          indentationWidth: indentationWidth
+        ) {
+          guard case .accessors(let accessorList) = newAccessors.accessors else {
+            throw MacroApplicationError.malformedAccessor
+          }
+
+          checkExpansions(accessorList)
+
+          if let oldBlock = newAccessorsBlock {
+            newAccessorsBlock = oldBlock.addingAccessors(
               from: accessorList,
               indentationWidth: self.indentationWidth
             )
+          } else {
+            newAccessorsBlock = newAccessors
           }
         }
       } catch {
         context.addDiagnostics(from: error, node: macro.attributeNode)
       }
     }
-    return newAccessorsBlock
+    return (newAccessorsBlock, expandsGetSet)
   }
 }
 
@@ -1062,5 +1088,11 @@ private extension AttributeSyntax {
     foldingWith operatorTable: OperatorTable?
   ) -> Self {
     return (detach(in: context, foldingWith: operatorTable) as Syntax).cast(Self.self)
+  }
+}
+
+private extension AccessorDeclSyntax {
+  var isGetOrSet: Bool {
+    return accessorSpecifier.tokenKind == .keyword(.get) || accessorSpecifier.tokenKind == .keyword(.set)
   }
 }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -2513,4 +2513,11 @@ final class DeclarationTests: ParserTestCase {
       """
     )
   }
+
+  func testLiteralInitializerWithTrailingClosure() {
+    assertParse(
+      "let foo = 1 { return 1 }",
+      substructure: AccessorBlockSyntax(accessors: .getter([CodeBlockItemSyntax("return 1")]))
+    )
+  }
 }

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -1463,12 +1463,86 @@ final class ExpressionTests: ParserTestCase {
     )
   }
 
-  func testNulCharacterInSourceFile() {
+  func testLiteralWithTrailingClosure() {
+    let expectedDiagnostics = [
+      DiagnosticSpec(
+        message: "consecutive statements on a line must be separated by newline or ';'",
+        fixIts: ["insert newline", "insert ';'"]
+      )
+    ]
+
     assertParse(
-      "let a = 1️⃣\u{0}1",
-      diagnostics: [
-        DiagnosticSpec(message: "nul character embedded in middle of file", severity: .warning)
-      ]
+      "_ = true1️⃣ { return true }",
+      diagnostics: expectedDiagnostics,
+      fixedSource: """
+        _ = true
+        { return true }
+        """
+    )
+    assertParse(
+      "_ = nil1️⃣ { return nil }",
+      diagnostics: expectedDiagnostics,
+      fixedSource: """
+        _ = nil
+        { return nil }
+        """
+    )
+    assertParse(
+      "_ = 11️⃣ { return 1 }",
+      diagnostics: expectedDiagnostics,
+      fixedSource: """
+        _ = 1
+        { return 1 }
+        """
+    )
+    assertParse(
+      "_ = 1.01️⃣ { return 1.0 }",
+      diagnostics: expectedDiagnostics,
+      fixedSource: """
+        _ = 1.0
+        { return 1.0 }
+        """
+    )
+    assertParse(
+      #"_ = "foo"1️⃣ { return "foo" }"#,
+      diagnostics: expectedDiagnostics,
+      fixedSource: """
+        _ = "foo"
+        { return "foo" }
+        """
+    )
+    assertParse(
+      "_ = /foo/1️⃣ { return /foo/ }",
+      diagnostics: expectedDiagnostics,
+      fixedSource: """
+        _ = /foo/
+        { return /foo/ }
+        """
+    )
+    assertParse(
+      "_ = [1]1️⃣ { return [1] }",
+      diagnostics: expectedDiagnostics,
+      fixedSource: """
+        _ = [1]
+        { return [1] }
+        """
+    )
+    assertParse(
+      "_ = [1: 1]1️⃣ { return [1: 1] }",
+      diagnostics: expectedDiagnostics,
+      fixedSource: """
+        _ = [1: 1]
+        { return [1: 1] }
+        """
+    )
+
+    assertParse(
+      "_ = 1 + 11️⃣ { return 1 }",
+      diagnostics: expectedDiagnostics,
+      fixedSource: """
+        _ = 1 + 1
+        { return 1 }
+        """
     )
   }
 }

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2742,4 +2742,65 @@ final class StatementExpressionTests: ParserTestCase {
       """
     )
   }
+
+  func testArrayExprWithNoCommas() {
+    assertParse("[() ()]")
+
+    assertParse(
+      "[1 1️⃣2]",
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected ',' in array element",
+          fixIts: ["insert ','"]
+        )
+      ],
+      fixedSource: "[1, 2]"
+    )
+
+    assertParse(
+      #"["hello" 1️⃣"world"]"#,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected ',' in array element",
+          fixIts: ["insert ','"]
+        )
+      ],
+      fixedSource: #"["hello", "world"]"#
+    )
+  }
+
+  func testDictionaryExprWithNoCommas() {
+    assertParse(
+      "[1: () 1️⃣2: ()]",
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected ',' in dictionary element",
+          fixIts: ["insert ','"]
+        )
+      ],
+      fixedSource: #"[1: (), 2: ()]"#
+    )
+
+    assertParse(
+      #"["foo": 1 1️⃣"bar": 2]"#,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected ',' in dictionary element",
+          fixIts: ["insert ','"]
+        )
+      ],
+      fixedSource: #"["foo": 1, "bar": 2]"#
+    )
+
+    assertParse(
+      #"[1: "hello" 1️⃣2: "world"]"#,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected ',' in dictionary element",
+          fixIts: ["insert ','"]
+        )
+      ],
+      fixedSource: #"[1: "hello", 2: "world"]"#
+    )
+  }
 }

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -1485,4 +1485,13 @@ public class LexerTests: ParserTestCase {
       ]
     )
   }
+
+  func testNulCharacterInSourceFile() {
+    assertParse(
+      "let a = 1️⃣\u{0}1",
+      diagnostics: [
+        DiagnosticSpec(message: "nul character embedded in middle of file", severity: .warning)
+      ]
+    )
+  }
 }

--- a/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
+++ b/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
@@ -18,13 +18,14 @@ final class ObjectLiteralsTests: ParserTestCase {
   func testObjectLiterals1a() {
     assertParse(
       """
-      let _ = [#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)#1️⃣]
+      let _ = [#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)1️⃣#2️⃣]
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"])
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ',' in array element", fixIts: ["insert ','"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"]),
       ],
       fixedSource: """
-        let _ = [#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)#<#identifier#>]
+        let _ = [#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha), #<#identifier#>]
         """
     )
   }
@@ -32,13 +33,14 @@ final class ObjectLiteralsTests: ParserTestCase {
   func testObjectLiterals1b() {
     assertParse(
       """
-      let _ = [#Image(imageLiteral: localResourceNameAsString)#1️⃣]
+      let _ = [#Image(imageLiteral: localResourceNameAsString)1️⃣#2️⃣]
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"])
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ',' in array element", fixIts: ["insert ','"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"]),
       ],
       fixedSource: """
-        let _ = [#Image(imageLiteral: localResourceNameAsString)#<#identifier#>]
+        let _ = [#Image(imageLiteral: localResourceNameAsString), #<#identifier#>]
         """
     )
   }
@@ -46,13 +48,14 @@ final class ObjectLiteralsTests: ParserTestCase {
   func testObjectLiterals1c() {
     assertParse(
       """
-      let _ = [#FileReference(fileReferenceLiteral: localResourceNameAsString)#1️⃣]
+      let _ = [#FileReference(fileReferenceLiteral: localResourceNameAsString)1️⃣#2️⃣]
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"])
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ',' in array element", fixIts: ["insert ','"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"]),
       ],
       fixedSource: """
-        let _ = [#FileReference(fileReferenceLiteral: localResourceNameAsString)#<#identifier#>]
+        let _ = [#FileReference(fileReferenceLiteral: localResourceNameAsString), #<#identifier#>]
         """
     )
   }
@@ -112,10 +115,11 @@ final class ObjectLiteralsTests: ParserTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"]),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ',' in array element", fixIts: ["insert ','"]),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"]),
       ],
       fixedSource: """
-        let _ = [#<#identifier#> #<#identifier#>]
+        let _ = [#<#identifier#>, #<#identifier#>]
         """
     )
   }
@@ -123,11 +127,10 @@ final class ObjectLiteralsTests: ParserTestCase {
   func testObjectLiterals5() {
     assertParse(
       """
-      let _ = ℹ️[#Color(_: 1, green: 1, 2)2️⃣
+      let _ = ℹ️[#Color(_: 1, green: 1, 2)1️⃣
       """,
       diagnostics: [
         DiagnosticSpec(
-          locationMarker: "2️⃣",
           message: "expected ']' to end array",
           notes: [NoteSpec(message: "to match this opening '['")],
           fixIts: ["insert ']'"]
@@ -142,23 +145,28 @@ final class ObjectLiteralsTests: ParserTestCase {
   func testObjectLiterals6() {
     assertParse(
       """
-      let _ = ℹ️[1️⃣#Color(red: 1, green: 1, blue: 1)#2️⃣3️⃣
+      let _ = ℹ️[#Color(red: 1, green: 1, blue: 1)1️⃣#2️⃣
       """,
       diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected ',' in array element",
+          fixIts: ["insert ','"]
+        ),
         DiagnosticSpec(
           locationMarker: "2️⃣",
           message: "expected identifier in macro expansion",
           fixIts: ["insert identifier"]
         ),
         DiagnosticSpec(
-          locationMarker: "3️⃣",
+          locationMarker: "2️⃣",
           message: "expected ']' to end array",
           notes: [NoteSpec(message: "to match this opening '['")],
           fixIts: ["insert ']'"]
         ),
       ],
       fixedSource: """
-        let _ = [#Color(red: 1, green: 1, blue: 1)#<#identifier#>]
+        let _ = [#Color(red: 1, green: 1, blue: 1), #<#identifier#>]
         """
     )
   }
@@ -166,13 +174,14 @@ final class ObjectLiteralsTests: ParserTestCase {
   func testObjectLiterals7() {
     assertParse(
       """
-      let _ = [#Color(withRed: 1, green: 1, whatever: 2)#1️⃣]
+      let _ = [#Color(withRed: 1, green: 1, whatever: 2)1️⃣#2️⃣]
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"])
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ',' in array element", fixIts: ["insert ','"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in macro expansion", fixIts: ["insert identifier"]),
       ],
       fixedSource: """
-        let _ = [#Color(withRed: 1, green: 1, whatever: 2)#<#identifier#>]
+        let _ = [#Color(withRed: 1, green: 1, whatever: 2), #<#identifier#>]
         """
     )
   }

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -1810,14 +1810,14 @@ final class RecoveryTests: ParserTestCase {
     assertParse(
       """
       struct ErrorInFunctionSignatureResultArrayType2 1️⃣{
-        func foo() -> Int2️⃣[0 {
+        func foo() -> Int2️⃣[0 3️⃣{
           return [0]
-        }3️⃣
-      4️⃣}
+        }4️⃣
+      5️⃣}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected ']' in array type
-        // TODO: Old parser expected note on line 2: to match this opening '['
+        // TODO: Old parser expected error to add `]` on line 2, but we should just recover to
+        //       `{` with `[0` becoming unexpected.
         DiagnosticSpec(
           locationMarker: "2️⃣",
           message: "expected '}' to end struct",
@@ -1826,19 +1826,24 @@ final class RecoveryTests: ParserTestCase {
         ),
         DiagnosticSpec(
           locationMarker: "3️⃣",
+          message: "expected ',' in array element",
+          fixIts: ["insert ','"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "4️⃣",
           message: "expected ']' to end array",
           notes: [NoteSpec(locationMarker: "2️⃣", message: "to match this opening '['")],
           fixIts: ["insert ']'"]
         ),
         DiagnosticSpec(
-          locationMarker: "4️⃣",
+          locationMarker: "5️⃣",
           message: "extraneous brace at top level"
         ),
       ],
       fixedSource: """
         struct ErrorInFunctionSignatureResultArrayType2 {
           func foo() -> Int
-        }[0 {
+        }[0, {
             return [0]
           }]
         }
@@ -1895,11 +1900,12 @@ final class RecoveryTests: ParserTestCase {
     assertParse(
       """
       struct ErrorInFunctionSignatureResultArrayType11 ℹ️{
-        func foo() -> Int1️⃣[(a){a++}] {
+        func foo() -> Int1️⃣[(a){a++}]2️⃣ {
         }
-      2️⃣}
+      3️⃣}
       """,
       diagnostics: [
+        // TODO: We should just recover to `{` with `[(a){a++}]` becoming unexpected.
         DiagnosticSpec(
           locationMarker: "1️⃣",
           message: "expected '}' to end struct",
@@ -1908,13 +1914,19 @@ final class RecoveryTests: ParserTestCase {
         ),
         DiagnosticSpec(
           locationMarker: "2️⃣",
+          message: "consecutive statements on a line must be separated by newline or ';'",
+          fixIts: ["insert newline", "insert ';'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "3️⃣",
           message: "extraneous brace at top level"
         ),
       ],
       fixedSource: """
         struct ErrorInFunctionSignatureResultArrayType11 {
           func foo() -> Int
-        }[(a){a++}] {
+        }[(a){a++}]
+          {
           }
         }
         """

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -2425,6 +2425,11 @@ final class RecoveryTests: ParserTestCase {
         ),
         DiagnosticSpec(
           locationMarker: "5️⃣",
+          message: "expected ',' in array element",
+          fixIts: ["insert ','"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "5️⃣",
           message: "expected ']' to end array",
           notes: [NoteSpec(locationMarker: "3️⃣", message: "to match this opening '['")],
           fixIts: ["insert ']'"]
@@ -2439,7 +2444,7 @@ final class RecoveryTests: ParserTestCase {
         struct Foo19605164 {
         func a(s: S)
         }[{{g) -> Int {}
-        }}]}
+        }},]}
         #endif
         """
     )

--- a/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/CodeItemMacroTests.swift
@@ -133,4 +133,23 @@ final class CodeItemMacroTests: XCTestCase {
       indentationWidth: indentationWidth
     )
   }
+
+  func testEmpty() {
+    struct TestMacro: CodeItemMacro {
+      static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+      ) throws -> [CodeBlockItemSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      "#test",
+      expandedSource: "",
+      macros: [
+        "test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/DeclarationMacroTests.swift
@@ -389,4 +389,22 @@ final class DeclarationMacroTests: XCTestCase {
     )
   }
 
+  func testEmpty() {
+    struct TestMacro: DeclarationMacro {
+      static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+      ) throws -> [DeclSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      "#test",
+      expandedSource: "",
+      macros: [
+        "test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/ExtensionMacroTests.swift
@@ -106,4 +106,26 @@ final class ExtensionMacroTests: XCTestCase {
       indentationWidth: indentationWidth
     )
   }
+
+  func testEmpty() {
+    struct TestMacro: ExtensionMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+      ) throws -> [ExtensionDeclSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      "@Test struct Foo {}",
+      expandedSource: "struct Foo {}",
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberAttributeMacroTests.swift
@@ -354,4 +354,48 @@ final class MemberAttributeMacroTests: XCTestCase {
     )
   }
 
+  func testEmpty() {
+    struct TestMacro: MemberAttributeMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingAttributesFor member: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+      ) throws -> [AttributeSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          var x: Int
+        }
+        """,
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+        }
+        """,
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MemberMacroTests.swift
@@ -255,4 +255,48 @@ final class MemberMacroTests: XCTestCase {
     )
   }
 
+  func testEmpty() {
+    struct TestMacro: MemberMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+      ) throws -> [DeclSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+        var x: Int
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+          var x: Int
+        }
+        """,
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+
+    assertMacroExpansion(
+      """
+      @Test
+      struct Foo {
+      }
+      """,
+      expandedSource: """
+        struct Foo {
+        }
+        """,
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
@@ -173,4 +173,24 @@ final class PeerMacroTests: XCTestCase {
       macros: ["Test": TestMacro.self]
     )
   }
+
+  func testEmpty() {
+    struct TestMacro: PeerMacro {
+      static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+      ) throws -> [DeclSyntax] {
+        return []
+      }
+    }
+
+    assertMacroExpansion(
+      "@Test var x: Int",
+      expandedSource: "var x: Int",
+      macros: [
+        "Test": TestMacro.self
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-syntax/pull/2187 and https://github.com/apple/swift-syntax/pull/2315 into release/5.10.

* **Explanation**: Couple fixes to `MacroSystem` - one to allow returning an empty list of accessors for an attached accessor macro and another to remove initializers if a getter/setter is returned.
* **Risk**: Low
* **Testing**: New test cases
* **Issues**:  rdar://117442713
* **Reviewer**: Alex Hoppen (@ahoppen)