### PR TITLE
Don't add a space between literals and period in BasicFormat

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -331,8 +331,11 @@ open class BasicFormat: SyntaxRewriter {
       (.rawStringPoundDelimiter, .multilineStringQuote),  // opening raw string delimiter should never be separate by a space
       (.rawStringPoundDelimiter, .singleQuote),  // opening raw string delimiter should never be separate by a space
       (.rawStringPoundDelimiter, .stringQuote),  // opening raw string delimiter should never be separate by a space
+      (.rawStringPoundDelimiter, .period),  // opening raw string delimiter should never be separate by a space
       (.regexLiteralPattern, _),
+      (.regexPoundDelimiter, .period),  // #/myRegex/#.someMember
       (.regexSlash, .regexPoundDelimiter),  // closing extended regex delimiter should never be separate by a space
+      (.regexSlash, .period),  // /myRegex/.someMember
       (.rightAngle, .leftParen),  // func foo<T>(x: T)
       (.rightAngle, .period),  // Foo<T>.bar
       (.rightBrace, .leftParen),  // { return 1 }()
@@ -341,6 +344,7 @@ open class BasicFormat: SyntaxRewriter {
       (.rightSquare, .period),  // myArray[1].someProperty
       (.singleQuote, .rawStringPoundDelimiter),  // closing raw string delimiter should never be separate by a space
       (.stringQuote, .rawStringPoundDelimiter),  // closing raw string delimiter should never be separate by a space
+      (.stringQuote, .period),  // "test".lowercased
       (.stringSegment, _),
       (_, .comma),
       (_, .ellipsis),

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -538,4 +538,32 @@ final class BasicFormatTest: XCTestCase {
       expected: "Foo<T>.bar"
     )
   }
+
+  func testPeriodAfterStringLiteral() {
+    let source = """
+      "test".lowercased()
+      """
+    assertFormatted(source: source, expected: source)
+  }
+
+  func testPeriodAfterRawStringLiteral() {
+    let source = """
+      #"test"#.lowercased()
+      """
+    assertFormatted(source: source, expected: source)
+  }
+
+  func testPeriodAfterRegexLiteral() {
+    let source = """
+      /test/.something
+      """
+    assertFormatted(source: source, expected: source)
+  }
+
+  func testPeriodAfterRawRegexLiteral() {
+    let source = """
+      /test/.something
+      """
+    assertFormatted(source: source, expected: source)
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/apple/swift-syntax/issues/2344 
rdar://118176218