### PR TITLE
[509] Don't add a space between literals and period in BasicFormat

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -307,8 +307,11 @@ open class BasicFormat: SyntaxRewriter {
       (.rawStringPoundDelimiter, .multilineStringQuote),  // opening raw string delimiter should never be separate by a space
       (.rawStringPoundDelimiter, .singleQuote),  // opening raw string delimiter should never be separate by a space
       (.rawStringPoundDelimiter, .stringQuote),  // opening raw string delimiter should never be separate by a space
+      (.rawStringPoundDelimiter, .period),  // opening raw string delimiter should never be separate by a space
       (.regexLiteralPattern, _),
+      (.regexPoundDelimiter, .period),  // #/myRegex/#.someMember
       (.regexSlash, .regexPoundDelimiter),  // closing extended regex delimiter should never be separate by a space
+      (.regexSlash, .period),  // /myRegex/.someMember
       (.rightAngle, .leftParen),  // func foo<T>(x: T)
       (.rightAngle, .period),  // Foo<T>.bar
       (.rightBrace, .leftParen),  // { return 1 }()
@@ -317,6 +320,7 @@ open class BasicFormat: SyntaxRewriter {
       (.rightSquare, .period),  // myArray[1].someProperty
       (.singleQuote, .rawStringPoundDelimiter),  // closing raw string delimiter should never be separate by a space
       (.stringQuote, .rawStringPoundDelimiter),  // closing raw string delimiter should never be separate by a space
+      (.stringQuote, .period),  // "test".lowercased
       (.stringSegment, _),
       (_, .comma),
       (_, .ellipsis),

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -505,10 +505,31 @@ final class BasicFormatTest: XCTestCase {
     }
   }
 
-  func testRightAnglePeriodNotFormatted() {
-    assertFormatted(
-      tree: ExprSyntax("Foo<T>.bar"),
-      expected: "Foo<T>.bar"
-    )
+  func testPeriodAfterStringLiteral() {
+    let source = """
+      "test".lowercased()
+      """
+    assertFormatted(source: source, expected: source)
+  }
+
+  func testPeriodAfterRawStringLiteral() {
+    let source = """
+      #"test"#.lowercased()
+      """
+    assertFormatted(source: source, expected: source)
+  }
+
+  func testPeriodAfterRegexLiteral() {
+    let source = """
+      /test/.something
+      """
+    assertFormatted(source: source, expected: source)
+  }
+
+  func testPeriodAfterRawRegexLiteral() {
+    let source = """
+      /test/.something
+      """
+    assertFormatted(source: source, expected: source)
   }
 }


### PR DESCRIPTION
* **Explanation**: `SwiftBasicFormat` was adding a space between string/regex literals and period. This caused macros to generate code like `"hello" .lowercased()`, which didn’t compile because the spaced on the left- and right-hand side of the period must be balanced
* **Risk**: Low
* **Testing**: Added new test cases
* **Issue**:  rdar://118176218 (#2344)
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/2345