### PR TITLE
Enhance assertMacroExpansion to Validate Post-Fix-It Macro Expansions

### DIFF
--- a/Examples/Tests/MacroExamples/Implementation/Expression/AddBlockerTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/Expression/AddBlockerTests.swift
@@ -58,9 +58,11 @@ final class AddBlockerTests: XCTestCase {
       ],
       macros: macros,
       applyFixIts: ["use '-'"],
-      fixedSource:
-        """
+      fixedSource: """
         #addBlocker(x * y - z)
+        """,
+      expandedFixedSource: """
+        x * y - z
         """,
       indentationWidth: .spaces(2)
     )

--- a/Examples/Tests/MacroExamples/Implementation/Peer/AddCompletionHandlerMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/Peer/AddCompletionHandlerMacroTests.swift
@@ -135,6 +135,19 @@ final class AddCompletionHandlerMacroTests: XCTestCase {
           }
         }
         """,
+      expandedFixedSource: """
+        struct Test {
+          func fetchData() async -> String {
+            return "Hello, World!"
+          }
+
+          func fetchData(completionHandler: @escaping (String) -> Void) {
+            Task {
+              completionHandler(await fetchData())
+            }
+          }
+        }
+        """,
       indentationWidth: .spaces(2)
     )
   }


### PR DESCRIPTION
This PR introduces an enhancement to the `assertMacroExpansion` function in SwiftSyntax's testing suite. The key addition is the capability to validate macro expansions on source code after the application of Fix-Its. This change ensures a more robust and comprehensive testing process, particularly for macros that propose fix-its for diagnostics.

Modifications include:
- Addition of a new parameter `expandedFixedSource` in test assertions. This parameter allows users to assert against the expanded source code after applying Fix-Its.
- Update of `assertMacroExpansion` to handle the new testing workflow. It now performs macro expansion tests on both the original and the fixed source code, ensuring that both the pre-fix and post-fix states are correctly validated.
- Refinement of the internal logic for applying Fix-Its and conducting macro expansion tests, ensuring accuracy and efficiency in the testing process.
- Update of test cases in `AddBlockerTests.swift` and `AddCompletionHandlerMacroTests.swift` to demonstrate and validate the new functionality.

Resolves: https://github.com/apple/swift-syntax/issues/2333