### PR TITLE
[NFC] Minor annotations to minimize diagnostics under strict concurrency checking.

### DIFF
--- a/Sources/SwiftSyntax/BumpPtrAllocator.swift
+++ b/Sources/SwiftSyntax/BumpPtrAllocator.swift
@@ -17,8 +17,8 @@
 public class BumpPtrAllocator {
   typealias Slab = UnsafeMutableRawBufferPointer
 
-  static private var GROWTH_DELAY: Int = 128
-  static private var SLAB_ALIGNMENT: Int = 8
+  static private let GROWTH_DELAY: Int = 128
+  static private let SLAB_ALIGNMENT: Int = 8
 
   /// Initial slab size.
   private var slabSize: Int

--- a/Sources/SwiftSyntax/MemoryLayout.swift
+++ b/Sources/SwiftSyntax/MemoryLayout.swift
@@ -12,7 +12,7 @@
 
 // See `MemoryLayoutTest.swift`.
 @_spi(Testing) public enum SyntaxMemoryLayout {
-  public struct Value: Equatable {
+  public struct Value: Equatable, Sendable {
     var size: Int
     var stride: Int
     var alignment: Int

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -945,7 +945,7 @@ extension RawSyntax: Identifiable {
 }
 
 /// See `SyntaxMemoryLayout`.
-var RawSyntaxDataMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
+let RawSyntaxDataMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
   "RawSyntaxData": .init(RawSyntaxData.self),
   "RawSyntaxData.Layout": .init(RawSyntaxData.Layout.self),
   "RawSyntaxData.ParsedToken": .init(RawSyntaxData.ParsedToken.self),

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -309,7 +309,7 @@ extension Syntax {
 public struct SyntaxNode {}
 
 /// See `SyntaxMemoryLayout`.
-var SyntaxMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
+let SyntaxMemoryLayouts: [String: SyntaxMemoryLayout.Value] = [
   "Syntax": .init(Syntax.self),
   "Syntax.Info": .init(Syntax.Info.self),
   "Syntax.Info.Root": .init(Syntax.Info.Root.self),

--- a/Sources/SwiftSyntax/SyntaxIdentifier.swift
+++ b/Sources/SwiftSyntax/SyntaxIdentifier.swift
@@ -15,7 +15,7 @@
 public struct SyntaxIndexInTree: Comparable, Hashable, Sendable {
   let indexInTree: UInt32
 
-  static var zero: SyntaxIndexInTree = SyntaxIndexInTree(indexInTree: 0)
+  static let zero: SyntaxIndexInTree = SyntaxIndexInTree(indexInTree: 0)
 
   /// Assuming that this index points to the start of ``Raw``, so that it points
   /// to the next sibling of ``Raw``.


### PR DESCRIPTION
I tried building SwiftSyntax with `.enableExperimentalFeature("StrictConcurrency")`, and there were only a handful of warnings. Most of them were about accessing mutable global/static variables, which I've changed to `let`s because they weren't mutated anyway. For global variables to be concurrency-safe without isolation, they need to be immutable and `Sendable`, so I also annotated `SyntaxMemoryLayout.Value` as `Sendable` (which is trivial, but conformance synthesis is suppressed because the type is `public`).

The only remaining strict concurrency warning in SwiftSyntax itself after this change is here:

```swift
fileprivate struct SourceLocationDirectiveArguments {
  enum Error: Swift.Error, CustomStringConvertible {
    case nonDecimalLineNumber(TokenSyntax)
    case stringInterpolationInFileName(SimpleStringLiteralExprSyntax)

    var description: String {
      switch self {
      case .nonDecimalLineNumber(let token):
        return "'\(token.text)' is not a decimal integer"
      case .stringInterpolationInFileName(let stringLiteral):
        return "The string literal '\(stringLiteral)' contains string interpolation, which is not allowed"
      }
    }
  }

...
```

because `Error`-conforming types must conform to `Sendable`, but `TokenSyntax` and `SimpleStringLiteralExprSyntax` are not `Sendable`. There are also a handful of warnings in `MultithreadingTests.swift` for similar reasons.