### PR TITLE
Implement `NameMatcher` in Swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -159,7 +159,7 @@ let package = Package(
 
     .target(
       name: "SwiftIDEUtils",
-      dependencies: ["SwiftSyntax"],
+      dependencies: ["SwiftSyntax", "SwiftParser"],
       exclude: ["CMakeLists.txt"]
     ),
 

--- a/Sources/SwiftIDEUtils/CMakeLists.txt
+++ b/Sources/SwiftIDEUtils/CMakeLists.txt
@@ -7,6 +7,8 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_syntax_library(SwiftIDEUtils
+  DeclNameLocation.swift
+  NameMatcher.swift
   SwiftIDEUtilsCompatibility.swift
   Syntax+Classifications.swift
   SyntaxClassification.swift
@@ -14,4 +16,5 @@ add_swift_syntax_library(SwiftIDEUtils
 )
 
 target_link_swift_syntax_libraries(SwiftIDEUtils PUBLIC
+  SwiftParser
   SwiftSyntax)

--- a/Sources/SwiftIDEUtils/DeclNameLocation.swift
+++ b/Sources/SwiftIDEUtils/DeclNameLocation.swift
@@ -1,0 +1,130 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// The location of a declaration name, resolved by ``NameMatcher`` and that can
+/// be used to rename the declaration name and, if it is a function, its
+/// argument labels.
+@_spi(Compiler)
+public struct DeclNameLocation: Equatable {
+  /// A single argument inside a ``DeclNameLocation``.
+  public enum Argument: Equatable {
+    /// The argument has an explicit label.
+    ///
+    /// The ranges are the ranges of the first name and second name, both without trivia.
+    ///
+    /// ## Examples
+    /// - `a` in `func foo(a: Int) {}`
+    /// - `a` and `b` in `func foo(a b: Int) {}`
+    case labeled(firstName: Range<AbsolutePosition>, secondName: Range<AbsolutePosition>?)
+
+    /// The argument of a call.
+    ///
+    /// The range of the label does not include trivia. The range of the colon *does* include trivia.
+    ///
+    /// ## Examples
+    /// - `a` and `:` in `foo(a: 1)`
+    case labeledCall(label: Range<AbsolutePosition>, colon: Range<AbsolutePosition>)
+
+    /// The argument is unlabeled (like `foo(1)`).
+    ///
+    /// The position points to the position of the argument after skipping leading trivia.
+    case unlabeled(argumentPosition: AbsolutePosition)
+
+    static func labeled(firstName: TokenSyntax, secondName: TokenSyntax?) -> Argument {
+      return .labeled(firstName: firstName.rangeWithoutTrivia, secondName: secondName?.rangeWithoutTrivia)
+    }
+
+    static func labeledCall(label: TokenSyntax, colon: TokenSyntax) -> Argument {
+      // FIXME: (NameMatcher) The `labeledCall` case is problematic for two reasons
+      // 1. The fact that `colon` includes trivia is inconsistent with the associated values in `label` and `labeledCall`
+      // 2. If `colon` didn't need to contain trivia, we wouldn't need the `labeledCall` case at all.
+      // See if we can unify `labeledCall` and `labeled`.
+      return .labeledCall(label: label.rangeWithoutTrivia, colon: colon.position..<colon.endPosition)
+    }
+
+    static func unlabeled(argument: some SyntaxProtocol) -> Argument {
+      return .unlabeled(argumentPosition: argument.positionAfterSkippingLeadingTrivia)
+    }
+
+    public var range: Range<AbsolutePosition> {
+      switch self {
+      case .labeled(let firstName, let secondName):
+        let endPosition = secondName?.upperBound ?? firstName.upperBound
+        return firstName.lowerBound..<endPosition
+      case .labeledCall(label: let label, colon: let colon):
+        return label.lowerBound..<colon.upperBound
+      case .unlabeled(argumentPosition: let argumentPosition):
+        return argumentPosition..<argumentPosition
+      }
+    }
+  }
+
+  /// The arguments of a ``DeclNameLocation``.
+  public enum Arguments: Equatable {
+    /// The location doesn't have any arguments
+    case noArguments
+
+    /// A function call, like `foo(a: 2)`
+    ///
+    /// If the call contains a trailing closure, `firstTrailingClosureIndex` is the index to the first argument that
+    /// is a trailing closure, otherwise `firstTrailingClosureIndex` is `nil`.
+    case call([Argument], firstTrailingClosureIndex: Int?)
+
+    /// The parameter of a function declaration, like `func foo(a b: Int)`
+    case parameters([Argument])
+
+    /// Same as `param` but the parameters can't be collapsed if they are the same. This is the case for subscript
+    /// declarations.
+    ///
+    /// For example, `subscript(a a: Int)` requires both the first and the second parameter label.
+    case noncollapsibleParameters([Argument])
+
+    /// The argument label to disambiguate multiple functions with the same base name, like `foo(a:)`.
+    case selector([Argument])
+  }
+
+  public enum Context {
+    /// The name occurs anywhere in normal Swift code.
+    case `default`
+
+    /// The name occurs inside a `#selector`.
+    case selector
+
+    /// The name occurs inside a comment.
+    case comment
+
+    /// The name occurs inside a string literal.
+    case stringLiteral
+  }
+
+  /// The range of the base name, without trivia.
+  ///
+  /// ## Examples
+  /// - For `foo(a: 1)`, the range of `foo`.
+  /// - For `myArray[1]`, the base name range is `[`.
+  /// - For a variable that is a closure, and a call `closure(1)`, the call has the base name `(`.
+  public let baseNameRange: Range<AbsolutePosition>
+
+  public let arguments: Arguments
+
+  /// The context in which the name occurs, eg. in code, a comment or a string
+  /// literal.
+  public let context: Context
+
+  /// If the name occurs in an inactive `#if` region, `false`, otherwise `true`.
+  ///
+  /// - Note: Currently `NameMatcher` does not evaluate `#if` conditions and all
+  ///   occurances within `#if`, `#elseif` or `#else` blocks are considered inactive.
+  public let isActive: Bool
+}

--- a/Sources/SwiftIDEUtils/NameMatcher.swift
+++ b/Sources/SwiftIDEUtils/NameMatcher.swift
@@ -1,0 +1,407 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftParser
+import SwiftSyntax
+
+/// Given a set of positions in a source file, resolve the names of the
+/// declarations that are referenced at these locations and, if they refer to
+/// functions, their argument labels.
+@_spi(Compiler)
+public class NameMatcher: SyntaxAnyVisitor {
+  /// The positions that still need to be resolved.
+  ///
+  /// Elements are removed from this set when they are resoled.
+  private var positionsToResolve: [AbsolutePosition]
+
+  /// The locations that we have already resolved.
+  ///
+  /// - Note: These are not guaranteed to be in source order since we might eg. generate an entry for a subscript call
+  ///   at `[` when visiting the `SubscriptCallExprSyntax` before resolving the base name at `foo[1]`.
+  private var resolvedLocs: [DeclNameLocation] = []
+
+  /// The topmost element of this stack always represents the context of newly resolved locations.
+  ///
+  /// As we walk into syntax nodes that contribute context to any locations resolved within them, an entry is pushed to
+  /// this stack. Elements are popped of the stack when the syntax node with the context is left.
+  private var contextStack: [DeclNameLocation.Context] = [.default] {
+    didSet {
+      precondition(!contextStack.isEmpty)
+    }
+  }
+  /// The topmost element of this stack always represents whether newly resolved locations are active or inactive.
+  ///
+  /// As we walk into `#if` regions, an element is pushed to this stack depending on whether the region is active. As
+  /// the region is left, values are popped.
+  private var isActiveStack: [Bool] = [true] {
+    didSet {
+      precondition(!isActiveStack.isEmpty)
+    }
+  }
+
+  private init(baseNamePositions: some Sequence<AbsolutePosition>) {
+    self.positionsToResolve = baseNamePositions.sorted()
+    super.init(viewMode: .sourceAccurate)
+  }
+
+  // MARK: - Public entry
+
+  public static func resolve(baseNamePositions: some Sequence<AbsolutePosition>, in sourceFile: SourceFileSyntax) -> [DeclNameLocation] {
+    let matcher = NameMatcher(baseNamePositions: baseNamePositions)
+    matcher.walk(sourceFile)
+    return matcher.resolvedLocs
+  }
+
+  // MARK: - Utilities
+
+  /// Checks if the `position` is in `positionsToResolve`. If so, remove it from `positionsToResolve` and return `true`.
+  /// Otherwise, return `false`.
+  private func removePositionToResolveIfExists(at position: AbsolutePosition) -> Bool {
+    for (index, positionToResolve) in positionsToResolve.enumerated() {
+      if positionToResolve > position {
+        // positionToResolve is sorted. If we're already past the position we are looking for, we won't find anything
+        // later.
+        return false
+      }
+      if positionToResolve == position {
+        positionsToResolve.remove(at: index)
+        return true
+      }
+    }
+    return false
+  }
+
+  /// If there is a position to resolve inside `range` return it, otherwise return `nil`.
+  private func firstPositionToResolve(in range: Range<AbsolutePosition>) -> AbsolutePosition? {
+    for positionToResolve in positionsToResolve {
+      if positionToResolve > range.upperBound {
+        // positionToResolve is sorted. If we're already past the range we are looking for, we won't find anything later
+        return nil
+      }
+      if range.contains(positionToResolve) {
+        return positionToResolve
+      }
+    }
+    return nil
+  }
+
+  // MARK: - addResolvedLocIfRequested overloads
+
+  /// If a position should be resolved at at the start of `baseNameRange`, create a new `DeclNameLocation` to
+  /// `resolvedLocs`, otherwise a no-op.
+  private func addResolvedLocIfRequested(
+    baseNameRange: Range<AbsolutePosition>,
+    argumentLabels: DeclNameLocation.Arguments,
+    context: DeclNameLocation.Context? = nil
+  ) {
+    guard removePositionToResolveIfExists(at: baseNameRange.lowerBound) else {
+      return
+    }
+    resolvedLocs.append(
+      DeclNameLocation(
+        baseNameRange: baseNameRange,
+        arguments: argumentLabels,
+        context: context ?? contextStack.last!,
+        isActive: isActiveStack.last!
+      )
+    )
+  }
+
+  /// Try resolving `baseName` with the given argument labels.
+  ///
+  /// This adds a resolved location if the start of `baseName` is in `positionsToResolve` and if the base name starts
+  /// with `$` or `_` and `positionsToResolve` contains the position after the `$` or `_`. This ensures that we can
+  /// rename the underlying properties referenced by property wrappers.
+  private func addResolvedLocIfRequested(
+    baseName: TokenSyntax,
+    argumentLabels: DeclNameLocation.Arguments
+  ) {
+    addResolvedLocIfRequested(
+      baseNameRange: baseName.rangeWithoutTrivia,
+      argumentLabels: argumentLabels
+    )
+    if baseName.text.first == "$" || baseName.text.first == "_" {
+      let range = baseName.positionAfterSkippingLeadingTrivia.advanced(by: 1)..<baseName.endPositionBeforeTrailingTrivia
+      addResolvedLocIfRequested(
+        baseNameRange: range,
+        argumentLabels: argumentLabels
+      )
+    }
+  }
+
+  /// Try resolving a function-style call at `baseName`.
+  ///
+  /// This computes the argument labels from the passed arguments and trailing closures.
+  private func addResolvedLocIfRequested(
+    baseName: TokenSyntax,
+    arguments: LabeledExprListSyntax,
+    trailingClosure: ClosureExprSyntax? = nil,
+    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? = nil
+  ) {
+    var firstTrailingClosureIndex: Int? = nil
+    var argumentLabels = arguments.map { (argument) -> DeclNameLocation.Argument in
+      if let label = argument.label, let colon = argument.colon {
+        return .labeledCall(label: label, colon: colon)
+      } else {
+        return .unlabeled(argument: Syntax(argument.colon) ?? Syntax(argument.expression))
+      }
+    }
+    if let trailingClosure {
+      firstTrailingClosureIndex = argumentLabels.count
+      argumentLabels.append(.unlabeled(argument: trailingClosure))
+    }
+    if let additionalTrailingClosures {
+      argumentLabels += additionalTrailingClosures.map { (additionalTrailingClosure) -> DeclNameLocation.Argument in
+        // FIXME: (NameMatcher) This really should be callLabel but the old NameMatcher also reported this as labeled
+        return .labeled(firstName: additionalTrailingClosure.label, secondName: nil)
+      }
+    }
+    addResolvedLocIfRequested(baseName: baseName, argumentLabels: .call(argumentLabels, firstTrailingClosureIndex: firstTrailingClosureIndex))
+  }
+
+  /// Try resolving a function-style declaration at `baseName`.
+  ///
+  /// This computes the argument labels from the passed function signature.
+  private func addResolvedLocIfRequested(
+    baseName: TokenSyntax,
+    signature: FunctionSignatureSyntax
+  ) {
+    let argumentLabels = signature.parameterClause.parameters.map { (argument) -> DeclNameLocation.Argument in
+      return .labeled(firstName: argument.firstName, secondName: argument.secondName)
+    }
+    addResolvedLocIfRequested(baseName: baseName, argumentLabels: .parameters(argumentLabels))
+  }
+
+  // MARK: - Visit functions
+
+  public override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+    if firstPositionToResolve(in: node.position..<node.endPosition) == nil {
+      return .skipChildren
+    } else {
+      return .visitChildren
+    }
+  }
+
+  public override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    while let baseNamePosition = firstPositionToResolve(in: token.leadingTriviaRange) ?? firstPositionToResolve(in: token.trailingTriviaRange) {
+      let positionOffsetInToken = baseNamePosition.utf8Offset - token.position.utf8Offset
+      guard let tokenLength = getFirstTokenLength(in: token.syntaxTextBytes[positionOffsetInToken...]) else {
+        continue
+      }
+      // FIXME: (NameMatcher) We could also resolve argument labels inside comments if we are parsing anyway.
+      addResolvedLocIfRequested(
+        baseNameRange: baseNamePosition..<baseNamePosition.advanced(by: tokenLength.utf8Length),
+        argumentLabels: .noArguments,
+        context: .comment
+      )
+    }
+
+    if case .stringSegment = token.tokenKind {
+      while let baseNamePosition = positionsToResolve.first(where: { token.rangeWithoutTrivia.contains($0) }) {
+        let positionOffsetInStringSegment = baseNamePosition.utf8Offset - token.position.utf8Offset
+        guard let tokenLength = getFirstTokenLength(in: token.syntaxTextBytes[positionOffsetInStringSegment...]) else {
+          continue
+        }
+        addResolvedLocIfRequested(
+          baseNameRange: baseNamePosition..<baseNamePosition.advanced(by: tokenLength.utf8Length),
+          argumentLabels: .noArguments,
+          context: .stringLiteral
+        )
+      }
+    }
+    addResolvedLocIfRequested(baseName: token, argumentLabels: .noArguments)
+    return .skipChildren
+  }
+
+  public override func visit(_ node: AttributeSyntax) -> SyntaxVisitorContinueKind {
+    let attributeName: TokenSyntax
+    if let name = node.attributeName.as(IdentifierTypeSyntax.self) {
+      attributeName = name.name
+    } else if let name = node.attributeName.as(MemberTypeSyntax.self) {
+      attributeName = name.name
+    } else {
+      return .visitChildren
+    }
+
+    if node.arguments == nil {
+      addResolvedLocIfRequested(baseName: attributeName, argumentLabels: .noArguments)
+    } else if case .argumentList(let argumentList) = node.arguments {
+      addResolvedLocIfRequested(baseName: attributeName, arguments: argumentList)
+    }
+    return .visitChildren
+  }
+
+  public override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+    if let argumentNames = node.argumentNames {
+      addResolvedLocIfRequested(
+        baseName: node.baseName,
+        argumentLabels: .selector(argumentNames.arguments.map { .labeled(firstName: $0.name, secondName: nil) })
+      )
+    } else if let functionCall = node.parentFunctionCall {
+      addResolvedLocIfRequested(
+        baseName: node.baseName,
+        arguments: functionCall.arguments,
+        trailingClosure: functionCall.trailingClosure,
+        additionalTrailingClosures: functionCall.additionalTrailingClosures
+      )
+    }
+    return .visitChildren
+  }
+
+  public override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
+    if let parameterClause = node.parameterClause {
+      let argumentLabels = parameterClause.parameters.map { (argument) -> DeclNameLocation.Argument in
+        if let firstName = argument.firstName {
+          return .labeled(firstName: firstName, secondName: argument.secondName)
+        } else {
+          return .unlabeled(argument: Syntax(argument.secondName) ?? Syntax(argument.colon) ?? Syntax(argument.type))
+        }
+      }
+      addResolvedLocIfRequested(baseName: node.name, argumentLabels: .parameters(argumentLabels))
+    }
+    return .visitChildren
+  }
+
+  public override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+    // Calls to closures are represented by a location to resolve at the opening `(`. We need to match that.
+    // Renames of the function name are handled by `visit(_:DeclReferenceExprSyntax)`.
+    if let leftParen = node.leftParen {
+      addResolvedLocIfRequested(
+        baseName: leftParen,
+        arguments: node.arguments,
+        trailingClosure: node.trailingClosure,
+        additionalTrailingClosures: node.additionalTrailingClosures
+      )
+    }
+    return .visitChildren
+  }
+
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    addResolvedLocIfRequested(baseName: node.name, signature: node.signature)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
+    isActiveStack.append(false)
+    return .visitChildren
+  }
+
+  public override func visitPost(_ node: IfConfigDeclSyntax) {
+    isActiveStack.removeLast()
+  }
+
+  public override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+    addResolvedLocIfRequested(baseName: node.initKeyword, signature: node.signature)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: MacroDeclSyntax) -> SyntaxVisitorContinueKind {
+    addResolvedLocIfRequested(baseName: node.name, signature: node.signature)
+    return .visitChildren
+  }
+
+  public override func visit(_ node: MacroExpansionDeclSyntax) -> SyntaxVisitorContinueKind {
+    if node.macroName.text == "selector" {
+      contextStack.append(.selector)
+    }
+    addResolvedLocIfRequested(
+      baseName: node.macroName,
+      arguments: node.arguments,
+      trailingClosure: node.trailingClosure,
+      additionalTrailingClosures: node.additionalTrailingClosures
+    )
+    return .visitChildren
+  }
+
+  public override func visitPost(_ node: MacroExpansionDeclSyntax) {
+    if node.macroName.text == "selector" {
+      contextStack.removeLast()
+    }
+  }
+
+  public override func visit(_ node: MacroExpansionExprSyntax) -> SyntaxVisitorContinueKind {
+    if node.macroName.text == "selector" {
+      contextStack.append(.selector)
+    }
+    addResolvedLocIfRequested(
+      baseName: node.macroName,
+      arguments: node.arguments,
+      trailingClosure: node.trailingClosure,
+      additionalTrailingClosures: node.additionalTrailingClosures
+    )
+    return .visitChildren
+  }
+
+  public override func visitPost(_ node: MacroExpansionExprSyntax) {
+    if node.macroName.text == "selector" {
+      contextStack.removeLast()
+    }
+  }
+
+  public override func visit(_ node: SubscriptCallExprSyntax) -> SyntaxVisitorContinueKind {
+    addResolvedLocIfRequested(
+      baseName: node.leftSquare,
+      arguments: node.arguments,
+      trailingClosure: node.trailingClosure,
+      additionalTrailingClosures: node.additionalTrailingClosures
+    )
+    return .visitChildren
+  }
+
+  public override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
+    let argumentLabels = node.parameterClause.parameters.map { (argument) -> DeclNameLocation.Argument in
+      return .labeled(firstName: argument.firstName, secondName: argument.secondName)
+    }
+    addResolvedLocIfRequested(baseName: node.subscriptKeyword, argumentLabels: .noncollapsibleParameters(argumentLabels))
+    return .visitChildren
+  }
+}
+
+extension TokenSyntax {
+  var rangeWithoutTrivia: Range<AbsolutePosition> {
+    return positionAfterSkippingLeadingTrivia..<endPositionBeforeTrailingTrivia
+  }
+  var leadingTriviaRange: Range<AbsolutePosition> {
+    return position..<positionAfterSkippingLeadingTrivia
+  }
+  var trailingTriviaRange: Range<AbsolutePosition> {
+    return endPositionBeforeTrailingTrivia..<endPosition
+  }
+}
+
+extension DeclReferenceExprSyntax {
+  var parentFunctionCall: FunctionCallExprSyntax? {
+    if let functionCall = self.parent?.as(FunctionCallExprSyntax.self) {
+      // E.g `foo(a: 1)`
+      return functionCall
+    } else if let memberAccess = self.parent?.as(MemberAccessExprSyntax.self),
+      memberAccess.declName == self,
+      let functionCall = memberAccess.parent?.as(FunctionCallExprSyntax.self)
+    {
+      // E.g. `foo.bar(a: 1)``
+      return functionCall
+    } else {
+      return nil
+    }
+  }
+}
+
+private func getFirstTokenLength(in text: ArraySlice<UInt8>) -> SourceLength? {
+  return text.withUnsafeBufferPointer { (buffer) -> SourceLength? in
+    // We can force-unwrap the first token because there must be at least the EOF token in the source file.
+    let firstToken = Parser.parse(source: buffer).firstToken(viewMode: .sourceAccurate)!
+    guard firstToken.leadingTriviaLength == .zero else {
+      return nil
+    }
+    return firstToken.trimmedLength
+  }
+}

--- a/Tests/SwiftIDEUtilsTest/NameMatcherTests.swift
+++ b/Tests/SwiftIDEUtilsTest/NameMatcherTests.swift
@@ -1,0 +1,300 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Compiler) import SwiftIDEUtils
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import XCTest
+import _SwiftSyntaxTestSupport
+
+fileprivate extension String {
+  subscript(_ range: Range<AbsolutePosition>) -> String? {
+    let startIndex = self.utf8.index(self.utf8.startIndex, offsetBy: range.lowerBound.utf8Offset)
+    let endIndex = self.utf8.index(self.utf8.startIndex, offsetBy: range.upperBound.utf8Offset)
+    return String(self.utf8[startIndex..<endIndex])
+  }
+}
+
+private func assertNameMatcherResult(
+  _ markedText: String,
+  expected: [DeclNameLocationSpec],
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  let (markers, input) = extractMarkers(markedText)
+  let tree = Parser.parse(source: input)
+  let positions = markers.values.map { AbsolutePosition(utf8Offset: $0) }
+  let resolvedLocations = NameMatcher.resolve(baseNamePositions: Set(positions), in: tree)
+  guard resolvedLocations.count == expected.count else {
+    XCTFail("Expected \(expected.count) resolved locations but got \(resolvedLocations.count)", file: file, line: line)
+    return
+  }
+  for (actual, expected) in zip(resolvedLocations, expected) {
+    guard let actualBaseName = input[actual.baseNameRange] else {
+      XCTFail("Base name range returned by NameMatcher covers invalid UTF-8", file: file, line: expected.originatorLine)
+      continue
+    }
+    XCTAssertEqual(actualBaseName, expected.baseName, file: file, line: expected.originatorLine)
+
+    let argumentLabels: [DeclNameLocation.Argument] =
+      switch actual.arguments {
+      case .noArguments: []
+      case .call(let labels, _): labels
+      case .parameters(let labels): labels
+      case .noncollapsibleParameters(let labels): labels
+      case .selector(let labels): labels
+      }
+
+    let actualArgumentLabels = argumentLabels.map { input[$0.range] }
+    XCTAssertEqual(actualArgumentLabels, expected.arguments, file: file, line: expected.originatorLine)
+
+    XCTAssertEqual(DeclNameLocationSpec.ArgumentsType(actual.arguments), expected.type, file: file, line: expected.originatorLine)
+    XCTAssertEqual(actual.isActive, expected.isActive, file: file, line: expected.originatorLine)
+    XCTAssertEqual(actual.context, expected.context, file: file, line: expected.originatorLine)
+  }
+}
+
+private struct DeclNameLocationSpec {
+  /// Mirror of `DeclNameLocation.Arguments` without associated values.
+  enum ArgumentsType {
+    case noArguments
+    case call
+    case parameters
+    case noncollapsibleParameters
+    case selector
+
+    init(_ arguments: DeclNameLocation.Arguments) {
+      switch arguments {
+      case .noArguments: self = .noArguments
+      case .call: self = .call
+      case .parameters: self = .parameters
+      case .noncollapsibleParameters: self = .noncollapsibleParameters
+      case .selector: self = .selector
+      }
+    }
+  }
+
+  let baseName: String
+  let arguments: [String]
+  let type: ArgumentsType
+  let isActive: Bool
+  let context: DeclNameLocation.Context
+  let originatorLine: UInt
+
+  init(
+    baseName: String,
+    argumentLabels: [String],
+    type: ArgumentsType = .call,
+    isActive: Bool = true,
+    context: DeclNameLocation.Context = .default,
+    originatorLine: UInt = #line
+  ) {
+    self.baseName = baseName
+    self.arguments = argumentLabels
+    self.type = type
+    self.isActive = isActive
+    self.context = context
+    self.originatorLine = originatorLine
+  }
+
+  init(
+    baseName: String,
+    isActive: Bool = true,
+    context: DeclNameLocation.Context = .default,
+    originatorLine: UInt = #line
+  ) {
+    self.baseName = baseName
+    self.arguments = []
+    self.type = .noArguments
+    self.isActive = isActive
+    self.context = context
+    self.originatorLine = originatorLine
+  }
+}
+
+public class NameMatcherTests: XCTestCase {
+  func testMemberCall() {
+    assertNameMatcherResult(
+      "Foo.1️⃣first(associated: 1)",
+      expected: [
+        DeclNameLocationSpec(baseName: "first", argumentLabels: ["associated: "])
+      ]
+    )
+  }
+
+  func testStringLiteral() {
+    assertNameMatcherResult(
+      """
+      "hello 1️⃣world 2️⃣world"
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "world", context: .stringLiteral),
+        DeclNameLocationSpec(baseName: "world", context: .stringLiteral),
+      ]
+    )
+  }
+
+  func testWildcardParameter() {
+    assertNameMatcherResult(
+      "func 0️⃣foo1(_ x: Int) {}",
+      expected: [
+        DeclNameLocationSpec(baseName: "foo1", argumentLabels: ["_ x"], type: .parameters)
+      ]
+    )
+  }
+
+  func testMatchInComment() {
+    assertNameMatcherResult(
+      """
+      /// 1️⃣foo
+      func foo() {}
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "foo", context: .comment)
+      ]
+    )
+
+    assertNameMatcherResult(
+      """
+      /*
+          /*foo:unknown*/1️⃣foo() is not /*foo:unknown*/2️⃣foo(first:)
+      */
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "foo", context: .comment),
+        DeclNameLocationSpec(baseName: "foo", context: .comment),
+      ]
+    )
+  }
+
+  func testSubscript() {
+    assertNameMatcherResult(
+      """
+      test1️⃣[x: 10]
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "[", argumentLabels: ["x: "])
+      ]
+    )
+  }
+
+  func testSubscriptWithBacktickedLabel() {
+    assertNameMatcherResult(
+      """
+      test1️⃣[`x`: 10]
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "[", argumentLabels: ["`x`: "])
+      ]
+    )
+  }
+
+  func testFunctionCallOnParenthesis() {
+    assertNameMatcherResult(
+      "foo1️⃣(1)",
+      expected: [
+        DeclNameLocationSpec(baseName: "(", argumentLabels: [""])
+      ]
+    )
+  }
+
+  func testMatchUnderscoreOrDollarInToken() {
+    assertNameMatcherResult(
+      "_1️⃣foo",
+      expected: [
+        DeclNameLocationSpec(baseName: "foo")
+      ]
+    )
+
+    assertNameMatcherResult(
+      "$1️⃣foo",
+      expected: [
+        DeclNameLocationSpec(baseName: "foo")
+      ]
+    )
+
+    assertNameMatcherResult(
+      "_1️⃣foo(x: 1)",
+      expected: [
+        DeclNameLocationSpec(baseName: "foo", argumentLabels: ["x: "])
+      ]
+    )
+  }
+
+  func testQualifiedAttribute() {
+    assertNameMatcherResult(
+      """
+      @Outer.1️⃣Inner(x: 1)
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "Inner", argumentLabels: ["x: "])
+      ]
+    )
+  }
+
+  func testSelector() {
+    assertNameMatcherResult(
+      "#selector(foo.1️⃣bar)",
+      expected: [
+        DeclNameLocationSpec(baseName: "bar", context: .selector)
+      ]
+    )
+
+    assertNameMatcherResult(
+      "#selector(foo.1️⃣bar(a:))",
+      expected: [
+        DeclNameLocationSpec(baseName: "bar", argumentLabels: ["a"], type: .selector, context: .selector)
+      ]
+    )
+  }
+
+  func testIsActive() {
+    assertNameMatcherResult(
+      """
+      #if true
+      1️⃣foo
+      #endif
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "foo", isActive: false)
+      ]
+    )
+  }
+
+  func testBaseOfMemberAccess() {
+    assertNameMatcherResult(
+      "1️⃣Foo.bar(a: 1, b: 2)",
+      expected: [
+        DeclNameLocationSpec(baseName: "Foo")
+      ]
+    )
+  }
+
+  func testOperatorDeclaration() {
+    assertNameMatcherResult(
+      "func 1️⃣+(x: Int, y: Int) {}",
+      expected: [
+        DeclNameLocationSpec(baseName: "+", argumentLabels: ["x", "y"], type: .parameters)
+      ]
+    )
+  }
+
+  func testCallQualifiedDeclName() {
+    assertNameMatcherResult(
+      "1️⃣fn(x:)(1)",
+      expected: [
+        DeclNameLocationSpec(baseName: "fn", argumentLabels: ["x"], type: .selector)
+      ]
+    )
+  }
+}


### PR DESCRIPTION
Companion of https://github.com/apple/swift/pull/70008

---

This implements the C++ `NameMatcher` in swift-syntax, which simplifies its implementation.