### PR TITLE
Make CodeBlockSyntax parseable  @DougGregor

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/CommonNodes.swift
@@ -56,6 +56,7 @@ public let COMMON_NODES: [Node] = [
     kind: .codeBlock,
     base: .syntax,
     nameForDiagnostics: "code block",
+    parserFunction: "parseCodeBlock",
     traits: [
       "Braced",
       "WithStatements",

--- a/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
+++ b/Sources/SwiftParser/generated/LayoutNodes+Parsable.swift
@@ -126,6 +126,24 @@ extension CodeBlockItemSyntax: SyntaxParseable {
   }
 }
 
+extension CodeBlockSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    // Keep the parser alive so that the arena in which `raw` is allocated
+    // doesn’t get deallocated before we have a chance to create a syntax node
+    // from it. We can’t use `parser.arena` as the parameter to
+    // `Syntax(raw:arena:)` because the node might have been re-used during an
+    // incremental parse and would then live in a different arena than
+    // `parser.arena`.
+    defer {
+      withExtendedLifetime(parser) {
+      }
+    }
+    let node = parser.parseCodeBlock()
+    let raw = RawSyntax(parser.parseRemainder(into: node))
+    return Syntax(raw: raw, rawNodeArena: raw.arena).cast(Self.self)
+  }
+}
+
 extension DeclSyntax: SyntaxParseable {
   public static func parse(from parser: inout Parser) -> Self {
     // Keep the parser alive so that the arena in which `raw` is allocated

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -26,6 +26,8 @@ extension ClosureParameterSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension CodeBlockItemSyntax: SyntaxExpressibleByStringInterpolation {}
 
+extension CodeBlockSyntax: SyntaxExpressibleByStringInterpolation {}
+
 extension DeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension EnumCaseParameterSyntax: SyntaxExpressibleByStringInterpolation {}


### PR DESCRIPTION
This is useful when working with function body macros