### PR TITLE
Tutorial updated to support Xcode15

### DIFF
--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step1.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,22 +6,17 @@ import PackageDescription
 let package = Package(
   name: "importformatter",
   products: [
-    // Products define the executables and libraries a package produces, and make them visible to other packages.
+    // Products define the executables and libraries a package produces, making them visible to other packages.
     .library(
       name: "importformatter",
       targets: ["importformatter"]
     )
   ],
-  dependencies: [
-    // Dependencies declare other packages that this package depends on.
-    // .package(url: /* package url */, from: "1.0.0"),
-  ],
   targets: [
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages this package depends on.
+    // Targets are the basic building blocks of a package, defining a module or a test suite.
+    // Targets can depend on other targets in this package and products from dependencies.
     .target(
-      name: "importformatter",
-      dependencies: []
+      name: "importformatter"
     ),
     .testTarget(
       name: "importformatterTests",

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step2.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,22 +6,17 @@ import PackageDescription
 let package = Package(
   name: "importformatter",
   products: [
-    // Products define the executables and libraries a package produces, and make them visible to other packages.
+    // Products define the executables and libraries a package produces, making them visible to other packages.
     .executable(
       name: "importformatter",
       targets: ["importformatter"]
     )
   ],
-  dependencies: [
-    // Dependencies declare other packages that this package depends on.
-    // .package(url: /* package url */, from: "1.0.0"),
-  ],
   targets: [
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages this package depends on.
+    // Targets are the basic building blocks of a package, defining a module or a test suite.
+    // Targets can depend on other targets in this package and products from dependencies.
     .executableTarget(
-      name: "importformatter",
-      dependencies: []
+      name: "importformatter"
     ),
     .testTarget(
       name: "importformatterTests",

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step3.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step3.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
   name: "importformatter",
   products: [
-    // Products define the executables and libraries a package produces, and make them visible to other packages.
+    // Products define the executables and libraries a package produces, making them visible to other packages.
     .executable(
       name: "importformatter",
       targets: ["importformatter"]
@@ -17,11 +17,10 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-syntax.git", branch: "main")
   ],
   targets: [
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages this package depends on.
+    // Targets are the basic building blocks of a package, defining a module or a test suite.
+    // Targets can depend on other targets in this package and products from dependencies.
     .executableTarget(
-      name: "importformatter",
-      dependencies: []
+      name: "importformatter"
     ),
     .testTarget(
       name: "importformatterTests",

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step4.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step4.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
   name: "importformatter",
   products: [
-    // Products define the executables and libraries a package produces, and make them visible to other packages.
+    // Products define the executables and libraries a package produces, making them visible to other packages.
     .executable(
       name: "importformatter",
       targets: ["importformatter"]
@@ -17,8 +17,8 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-syntax.git", branch: "main")
   ],
   targets: [
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages this package depends on.
+    // Targets are the basic building blocks of a package, defining a module or a test suite.
+    // Targets can depend on other targets in this package and products from dependencies.
     .executableTarget(
       name: "importformatter",
       dependencies: [

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step5.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Package.step5.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,7 +9,7 @@ let package = Package(
     .macOS(.v10_15)
   ],
   products: [
-    // Products define the executables and libraries a package produces, and make them visible to other packages.
+    // Products define the executables and libraries a package produces, making them visible to other packages.
     .executable(
       name: "importformatter",
       targets: ["importformatter"]
@@ -20,8 +20,8 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-syntax.git", branch: "main")
   ],
   targets: [
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages this package depends on.
+    // Targets are the basic building blocks of a package, defining a module or a test suite.
+    // Targets can depend on other targets in this package and products from dependencies.
     .executableTarget(
       name: "importformatter",
       dependencies: [

--- a/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
+++ b/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
@@ -52,7 +52,7 @@
     
     @Steps {
        @Step {
-        Configure your package. Continue to select the Package.swift file.
+        Open the `Package.swift` file created in the previous section.
             
         @Code(name: "Package.swift", file: Package.step2.swift)
       }

--- a/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
+++ b/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
@@ -51,6 +51,12 @@
     }
     
     @Steps {
+       @Step {
+        Configure your package. Continue to select the Package.swift file.
+            
+        @Code(name: "Package.swift", file: Package.step2.swift)
+      }
+        
       @Step {
         Add the `swift-syntax` package to the dependencies section of your 
         `Package.swift` file.


### PR DESCRIPTION
## Description
I've made revisions so that it resembles code similar to Xcode15.

Also, as it currently stands, Section2's Step1 makes it difficult to understand what has been edited. I believe that by adding another Step to show the differences, it will be easier to identify the changes, so I've edited it.

## Changes
- Package.step1 ~ 5
- add Step

## Expectations
- You won't be confused when using the latest Xcode15.
- Displaying the differences makes it easier for beginners to avoid getting lost.

| Before | 
| ---- | 
| <img src="https://github.com/apple/swift-syntax/assets/70003919/76518d70-f1ab-4a8b-bb2d-299c24226e73" width=100%> | 

| After |
| ---- |
| <img src="https://github.com/apple/swift-syntax/assets/70003919/ba50b292-1956-4c51-a483-a09c3119fdf0" width=100%> | 

<details>

<summary> Japanese </summary>

## 説明
Xcode15と同じようなコードになるように修正しました。

また、Section2 のStep1は現状だとどこを編集したか分かりにくい。もう1つStepを追加することで差分が表示され、変更箇所がわかりやすくなると思い、編集しました。

## 変更点
- Package.step1 ~ 5
- Step を追加

## 期待されること
- 最新のXcode15を使った時に戸惑わなくなります。
- 差分を表示することで、初心者が迷わなくなります。
</details>