### PR TITLE
Update DeclGroupSyntax to refine DeclSyntaxProtocol

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -14,14 +14,19 @@ import SwiftSyntax
 
 public class Trait {
   public let traitName: String
-  public let syntaxBaseName: TokenSyntax?
+  /// The kind of syntax the trait refines.
+  ///
+  /// Base kind _must_ be a base syntax node, e.g. `.decl`, `.expr` , or
+  /// others. See ``SyntaxNodeKind/isBase`` for more details.
+  public let baseKind: SyntaxNodeKind?
   public let protocolName: TokenSyntax
   public let documentation: SwiftSyntax.Trivia
   public let children: [Child]
 
-  init(traitName: String, syntaxBaseName: String?, documentation: String? = nil, children: [Child]) {
+  init(traitName: String, baseKind: SyntaxNodeKind? = nil, documentation: String? = nil, children: [Child]) {
+    precondition(baseKind?.isBase != false, "`baseKind` must be a base syntax node kind")
     self.traitName = traitName
-    self.syntaxBaseName = syntaxBaseName.map { .identifier("\($0)Protocol") }
+    self.baseKind = baseKind
     self.protocolName = .identifier("\(traitName)Syntax")
     self.documentation = SwiftSyntax.Trivia.docCommentTrivia(from: documentation)
     self.children = children
@@ -31,7 +36,6 @@ public class Trait {
 public let TRAITS: [Trait] = [
   Trait(
     traitName: "Braced",
-    syntaxBaseName: nil,
     children: [
       Child(name: "leftBrace", kind: .token(choices: [.token(.leftBrace)])),
       Child(name: "rightBrace", kind: .token(choices: [.token(.rightBrace)])),
@@ -39,7 +43,7 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "DeclGroup",
-    syntaxBaseName: "DeclSyntax",
+    baseKind: .decl,
     children: [
       Child(name: "attributes", kind: .node(kind: .attributeList)),
       Child(name: "modifiers", kind: .node(kind: .declModifierList)),
@@ -55,7 +59,6 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "EffectSpecifiers",
-    syntaxBaseName: nil,
     children: [
       Child(name: "unexpectedBeforeAsyncSpecifier", kind: .node(kind: .unexpectedNodes), isOptional: true),
       Child(name: "asyncSpecifier", kind: .token(choices: [.keyword(.async), .keyword(.reasync)]), isOptional: true),
@@ -74,7 +77,6 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "FreestandingMacroExpansion",
-    syntaxBaseName: nil,
     children: [
       Child(name: "pound", deprecatedName: "poundToken", kind: .token(choices: [.token(.pound)])),
       Child(name: "macroName", deprecatedName: "macro", kind: .token(choices: [.token(.identifier)])),
@@ -88,14 +90,12 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "NamedDecl",
-    syntaxBaseName: nil,
     children: [
       Child(name: "name", kind: .token(choices: [.token(.identifier)]))
     ]
   ),
   Trait(
     traitName: "MissingNode",
-    syntaxBaseName: nil,
     documentation: """
       Represents a layout node that is missing in the source file.
 
@@ -113,7 +113,6 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "Parenthesized",
-    syntaxBaseName: nil,
     children: [
       Child(name: "leftParen", kind: .token(choices: [.token(.leftParen)])),
       Child(name: "rightParen", kind: .token(choices: [.token(.rightParen)])),
@@ -121,21 +120,18 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "WithAttributes",
-    syntaxBaseName: nil,
     children: [
       Child(name: "attributes", kind: .node(kind: .attributeList))
     ]
   ),
   Trait(
     traitName: "WithCodeBlock",
-    syntaxBaseName: nil,
     children: [
       Child(name: "body", kind: .node(kind: .codeBlock))
     ]
   ),
   Trait(
     traitName: "WithGenericParameters",
-    syntaxBaseName: nil,
     documentation: """
       Syntax nodes that have generic parameters.
 
@@ -159,7 +155,6 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "WithModifiers",
-    syntaxBaseName: nil,
     children: [
       Child(name: "modifiers", kind: .node(kind: .declModifierList))
     ]
@@ -172,14 +167,12 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "WithStatements",
-    syntaxBaseName: nil,
     children: [
       Child(name: "statements", kind: .node(kind: .codeBlockItemList))
     ]
   ),
   Trait(
     traitName: "WithTrailingComma",
-    syntaxBaseName: nil,
     children: [
       Child(name: "trailingComma", kind: .token(choices: [.token(.comma)]), isOptional: true)
     ]

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -14,12 +14,14 @@ import SwiftSyntax
 
 public class Trait {
   public let traitName: String
+  public let syntaxBaseName: TokenSyntax?
   public let protocolName: TokenSyntax
   public let documentation: SwiftSyntax.Trivia
   public let children: [Child]
 
-  init(traitName: String, documentation: String? = nil, children: [Child]) {
+  init(traitName: String, syntaxBaseName: String?, documentation: String? = nil, children: [Child]) {
     self.traitName = traitName
+    self.syntaxBaseName = syntaxBaseName.map { .identifier("\($0)Protocol") }
     self.protocolName = .identifier("\(traitName)Syntax")
     self.documentation = SwiftSyntax.Trivia.docCommentTrivia(from: documentation)
     self.children = children
@@ -29,6 +31,7 @@ public class Trait {
 public let TRAITS: [Trait] = [
   Trait(
     traitName: "Braced",
+    syntaxBaseName: nil,
     children: [
       Child(name: "leftBrace", kind: .token(choices: [.token(.leftBrace)])),
       Child(name: "rightBrace", kind: .token(choices: [.token(.rightBrace)])),
@@ -36,6 +39,7 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "DeclGroup",
+    syntaxBaseName: "DeclSyntax",
     children: [
       Child(name: "attributes", kind: .node(kind: .attributeList)),
       Child(name: "modifiers", kind: .node(kind: .declModifierList)),
@@ -51,6 +55,7 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "EffectSpecifiers",
+    syntaxBaseName: nil,
     children: [
       Child(name: "unexpectedBeforeAsyncSpecifier", kind: .node(kind: .unexpectedNodes), isOptional: true),
       Child(name: "asyncSpecifier", kind: .token(choices: [.keyword(.async), .keyword(.reasync)]), isOptional: true),
@@ -69,6 +74,7 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "FreestandingMacroExpansion",
+    syntaxBaseName: nil,
     children: [
       Child(name: "pound", deprecatedName: "poundToken", kind: .token(choices: [.token(.pound)])),
       Child(name: "macroName", deprecatedName: "macro", kind: .token(choices: [.token(.identifier)])),
@@ -82,12 +88,14 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "NamedDecl",
+    syntaxBaseName: nil,
     children: [
       Child(name: "name", kind: .token(choices: [.token(.identifier)]))
     ]
   ),
   Trait(
     traitName: "MissingNode",
+    syntaxBaseName: nil,
     documentation: """
       Represents a layout node that is missing in the source file.
 
@@ -105,6 +113,7 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "Parenthesized",
+    syntaxBaseName: nil,
     children: [
       Child(name: "leftParen", kind: .token(choices: [.token(.leftParen)])),
       Child(name: "rightParen", kind: .token(choices: [.token(.rightParen)])),
@@ -112,18 +121,21 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "WithAttributes",
+    syntaxBaseName: nil,
     children: [
       Child(name: "attributes", kind: .node(kind: .attributeList))
     ]
   ),
   Trait(
     traitName: "WithCodeBlock",
+    syntaxBaseName: nil,
     children: [
       Child(name: "body", kind: .node(kind: .codeBlock))
     ]
   ),
   Trait(
     traitName: "WithGenericParameters",
+    syntaxBaseName: nil,
     documentation: """
       Syntax nodes that have generic parameters.
 
@@ -147,6 +159,7 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "WithModifiers",
+    syntaxBaseName: nil,
     children: [
       Child(name: "modifiers", kind: .node(kind: .declModifierList))
     ]
@@ -159,12 +172,14 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "WithStatements",
+    syntaxBaseName: nil,
     children: [
       Child(name: "statements", kind: .node(kind: .codeBlockItemList))
     ]
   ),
   Trait(
     traitName: "WithTrailingComma",
+    syntaxBaseName: nil,
     children: [
       Child(name: "trailingComma", kind: .token(choices: [.token(.comma)]), isOptional: true)
     ]

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -22,7 +22,11 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       // MARK: - \(trait.protocolName)
 
       \(trait.documentation)
-      public protocol \(trait.protocolName): SyntaxProtocol
+      public protocol \(trait.protocolName): SyntaxProtocol\(raw:
+        trait.syntaxBaseName != nil
+          ? ", \(trait.syntaxBaseName!)"
+          : ""
+      )
       """
     ) {
       for child in trait.children {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -23,8 +23,8 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
       \(trait.documentation)
       public protocol \(trait.protocolName): SyntaxProtocol\(raw:
-        trait.syntaxBaseName != nil
-          ? ", \(trait.syntaxBaseName!)"
+        trait.baseKind != nil
+          ? ", \(trait.baseKind!.protocolType)"
           : ""
       )
       """

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -63,7 +63,7 @@ public extension SyntaxProtocol {
 // MARK: - DeclGroupSyntax
 
 
-public protocol DeclGroupSyntax: SyntaxProtocol {
+public protocol DeclGroupSyntax: SyntaxProtocol, DeclSyntaxProtocol {
   var attributes: AttributeListSyntax {
     get
     set


### PR DESCRIPTION
Updates the swift-syntax code generator to support traits refining a syntax base type. Uses this new code generator feature to change DeclGroupSyntax to refine DeclSyntaxProtocol.

Fixes #2365