### PR TITLE
[5.10] update decl group syntax to refine decl syntax protocol

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -14,12 +14,19 @@ import SwiftSyntax
 
 public class Trait {
   public let traitName: String
+  /// The kind of syntax the trait refines.
+  ///
+  /// Base kind _must_ be a base syntax node, e.g. `.decl`, `.expr` , or
+  /// others. See ``SyntaxNodeKind/isBase`` for more details.
+  public let baseKind: SyntaxNodeKind?
   public let protocolName: TokenSyntax
   public let documentation: SwiftSyntax.Trivia
   public let children: [Child]
 
-  init(traitName: String, documentation: String? = nil, children: [Child]) {
+  init(traitName: String, baseKind: SyntaxNodeKind? = nil, documentation: String? = nil, children: [Child]) {
+    precondition(baseKind?.isBase != false, "`baseKind` must be a base syntax node kind")
     self.traitName = traitName
+    self.baseKind = baseKind
     self.protocolName = .identifier("\(traitName)Syntax")
     self.documentation = docCommentTrivia(from: documentation)
     self.children = children
@@ -36,6 +43,7 @@ public let TRAITS: [Trait] = [
   ),
   Trait(
     traitName: "DeclGroup",
+    baseKind: .decl,
     children: [
       Child(name: "attributes", kind: .node(kind: .attributeList)),
       Child(name: "modifiers", kind: .node(kind: .declModifierList)),

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -22,7 +22,11 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       // MARK: - \(trait.protocolName)
 
       \(trait.documentation)
-      public protocol \(trait.protocolName): SyntaxProtocol
+      public protocol \(trait.protocolName): SyntaxProtocol\(raw:
+        trait.baseKind != nil
+          ? ", \(trait.baseKind!.protocolType)"
+          : ""
+      )
       """
     ) {
       for child in trait.children {

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -57,7 +57,7 @@ public extension SyntaxProtocol {
 // MARK: - DeclGroupSyntax
 
 
-public protocol DeclGroupSyntax: SyntaxProtocol {
+public protocol DeclGroupSyntax: SyntaxProtocol, DeclSyntaxProtocol {
   var attributes: AttributeListSyntax {
     get
     set


### PR DESCRIPTION
Updates the swift-syntax code generator to support traits refining a syntax base type. Uses this new code generator feature to change DeclGroupSyntax to refine DeclSyntaxProtocol.