### PR TITLE
Move note about changes to `assertMacroExpansion` function from 511 to 510

### DIFF
--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -21,6 +21,11 @@
   - Description: Remarks are used by the Swift compiler and other tools to describe some aspect of translation that doesn't reflect correctness, but may be useful for the user. Remarks have been added to the diagnostic severity enums to align with the Swift compiler.
   - Pull Request: https://github.com/apple/swift-syntax/pull/2143
 
+- `assertMacroExpansion` now have new parameters named `applyFixIts` and `fixedSource`
+  - Description: `applyFixIts` and `fixedSource` are used to assert so ensure that the source code after applying Fix-Its matches this string.
+  - Issue: https://github.com/apple/swift-syntax/issues/2015
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2021
+
 ## API Behavior Changes
 
 ## Deprecations

--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -11,11 +11,6 @@
   - Issue: https://github.com/apple/sourcekit-lsp/issues/909
   - Pull Request: https://github.com/apple/swift-syntax/pull/2314
 
-- `assertMacroExpansion` now have new parameters named `applyFixIts` and `fixedSource`
-  - Description: `applyFixIts` and `fixedSource` are used to assert so ensure that the source code after applying Fix-Its matches this string.
-  - Issue: https://github.com/apple/swift-syntax/issues/2015
-  - Pull Request: https://github.com/apple/swift-syntax/pull/2021
-
 - `DeclSyntaxEnum`, `StmtSyntaxEnum`, `ExprSyntaxEnum`, `TypeSyntaxEnum`, and `PatternSyntaxEnum`
   - Description: Enum to exhaustively switch over all different syntax nodes of each base type.
   - Pull Request: https://github.com/apple/swift-syntax/pull/2351


### PR DESCRIPTION
In a follow-up PR, we will cherry-pick this and those: #2226, #2021 changes to `release/5.10`.