### PR TITLE
Add syntax highlighting for parameter labels

### DIFF
--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -72,6 +72,11 @@
   - Pull request: https://github.com/apple/swift-syntax/pull/2272
   - Migration steps: If necessary, change type annotations from the tuple to the `IncrementalParseResult` type.
 
+- `SyntaxClassification` gained a new case: `argumentLabel`
+  - The new classification case covers the first names of parameters in function-like declarations and the label of arguments in function-like calls.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2375
+  - Migration steps: In exhaustive switches over `SyntaxClassification`, cover the new case.
+
 ## Template
 
 - *Affected API or two word description*

--- a/Sources/SwiftIDEUtils/SyntaxClassification.swift
+++ b/Sources/SwiftIDEUtils/SyntaxClassification.swift
@@ -47,6 +47,8 @@ public enum SyntaxClassification {
   case stringLiteral
   /// An identifier referring to a type.
   case type
+  /// The label of a function parameter or a function call argument.
+  case argumentLabel
 }
 
 extension SyntaxClassification {
@@ -83,6 +85,10 @@ extension SyntaxClassification {
       return (.keyword, false)
     case \SimpleTypeIdentifierSyntax.name:
       return (.type, false)
+    case \FunctionParameterSyntax.firstName:
+      return (.argumentLabel, false)
+    case \LabeledExprSyntax.label:
+      return (.argumentLabel, false)
     default:
       return nil
     }

--- a/Tests/SwiftIDEUtilsTest/ClassificationTests.swift
+++ b/Tests/SwiftIDEUtilsTest/ClassificationTests.swift
@@ -130,9 +130,9 @@ public class ClassificationTests: XCTestCase {
       expected: [
         ClassificationSpec(source: "func", kind: .keyword),
         ClassificationSpec(source: "foo", kind: .identifier),
-        ClassificationSpec(source: "x", kind: .identifier),
+        ClassificationSpec(source: "x", kind: .argumentLabel),
         ClassificationSpec(source: "Int", kind: .type),
-        ClassificationSpec(source: "y", kind: .identifier),
+        ClassificationSpec(source: "y", kind: .argumentLabel),
         ClassificationSpec(source: "Int", kind: .type),
         ClassificationSpec(source: "Int", kind: .type),
         ClassificationSpec(source: "return", kind: .keyword),
@@ -283,13 +283,13 @@ public class ClassificationTests: XCTestCase {
       "#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)",
       expected: [
         ClassificationSpec(source: "colorLiteral", kind: .identifier),
-        ClassificationSpec(source: "red", kind: .identifier),
+        ClassificationSpec(source: "red", kind: .argumentLabel),
         ClassificationSpec(source: "0", kind: .integerLiteral),
-        ClassificationSpec(source: "green", kind: .identifier),
+        ClassificationSpec(source: "green", kind: .argumentLabel),
         ClassificationSpec(source: "0", kind: .integerLiteral),
-        ClassificationSpec(source: "blue", kind: .identifier),
+        ClassificationSpec(source: "blue", kind: .argumentLabel),
         ClassificationSpec(source: "0", kind: .integerLiteral),
-        ClassificationSpec(source: "alpha", kind: .identifier),
+        ClassificationSpec(source: "alpha", kind: .argumentLabel),
         ClassificationSpec(source: "1", kind: .integerLiteral),
       ]
     )
@@ -300,7 +300,7 @@ public class ClassificationTests: XCTestCase {
       "#imageLiteral(resourceName: \"cloud.png\")",
       expected: [
         ClassificationSpec(source: "imageLiteral", kind: .identifier),
-        ClassificationSpec(source: "resourceName", kind: .identifier),
+        ClassificationSpec(source: "resourceName", kind: .argumentLabel),
         ClassificationSpec(source: "\"cloud.png\"", kind: .stringLiteral),
       ]
     )
@@ -311,7 +311,7 @@ public class ClassificationTests: XCTestCase {
       "#fileLiteral(resourceName: \"cloud.png\")",
       expected: [
         ClassificationSpec(source: "fileLiteral", kind: .identifier),
-        ClassificationSpec(source: "resourceName", kind: .identifier),
+        ClassificationSpec(source: "resourceName", kind: .argumentLabel),
         ClassificationSpec(source: "\"cloud.png\"", kind: .stringLiteral),
       ]
     )
@@ -530,10 +530,10 @@ public class ClassificationTests: XCTestCase {
         ClassificationSpec(source: "keywordInCaseAndLocalArgLabel", kind: .identifier),
         ClassificationSpec(source: "for", kind: .identifier),
         ClassificationSpec(source: "Int", kind: .type),
-        ClassificationSpec(source: "for", kind: .identifier),
+        ClassificationSpec(source: "for", kind: .argumentLabel),
         ClassificationSpec(source: "in", kind: .identifier),
         ClassificationSpec(source: "Int", kind: .type),
-        ClassificationSpec(source: "class", kind: .identifier),
+        ClassificationSpec(source: "class", kind: .argumentLabel),
         ClassificationSpec(source: "Int", kind: .type),
       ]
     )
@@ -574,6 +574,31 @@ public class ClassificationTests: XCTestCase {
         ClassificationSpec(source: "// some comment", kind: .lineComment),
         ClassificationSpec(source: "func", kind: .keyword),
         ClassificationSpec(source: "foo", kind: .identifier),
+      ]
+    )
+  }
+
+  public func testargumentLabel() {
+    assertClassification(
+      """
+      func foo(arg: Int) {}
+      """,
+      expected: [
+        ClassificationSpec(source: "func", kind: .keyword),
+        ClassificationSpec(source: "foo", kind: .identifier),
+        ClassificationSpec(source: "arg", kind: .argumentLabel),
+        ClassificationSpec(source: "Int", kind: .type),
+      ]
+    )
+
+    assertClassification(
+      """
+      foo(arg: 1)
+      """,
+      expected: [
+        ClassificationSpec(source: "foo", kind: .identifier),
+        ClassificationSpec(source: "arg", kind: .argumentLabel),
+        ClassificationSpec(source: "1", kind: .integerLiteral),
       ]
     )
   }


### PR DESCRIPTION
Companion of https://github.com/apple/sourcekit-lsp/pull/983

---

This introduces a a new `SyntaxClassification` that is used for the first names of parameters in function-like declarations and the label of arguments in function-like calls.