### PR TITLE
Add a bash script to simplify calling `swift-syntax-dev-utils`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ swift-syntax is formatted using [swift-format](http://github.com/apple/swift-for
 
 To format your changes run the formatter using the following command
 ```bash
-swift run --package-path SwiftSyntaxDevUtils/ swift-syntax-dev-utils format
+./swift-syntax-dev-utils format
 ```
 It will build a local copy of swift-format from the `main` branch and format the repository. Since it is building a release version of `swift-format`, the first run will take few minutes. Subsequent runs take less than 2 seconds.
 
@@ -36,7 +36,7 @@ Generated source code is not formatted to make it easier to spot changes when re
 > #!/usr/bin/env bash
 > set -e
 > SOURCE_DIR=$(realpath "$(dirname $0)/../..")
-> swift run --package-path "$SOURCE_DIR/SwiftSyntaxDevUtils" swift-syntax-dev-utils format --lint
+> swift "$SOURCE_DIR/swift-syntax-dev-utils" format --lint
 > ```
 > 2. Mark the file as executable: `chmod a+x swift-syntax/.git/hooks/pre-commit`
 > 3. If you have global git hooks installed, be sure to call them at the end of the script with `path/to/global/hooks/pre-commit "$@"` 

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Format.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Format.swift
@@ -82,15 +82,15 @@ struct FormatExecutor {
 
           Run the following command to format swift-syntax
 
-            swift run --package-path SwiftSyntaxDevUtils/ swift-syntax-dev-utils format
+            ./swift-syntax-dev-utils format
 
           If the issue persists, try updating swift-format by running
 
-            swift run --package-path SwiftSyntaxDevUtils/ swift-syntax-dev-utils format --update
+            ./swift-syntax-dev-utils format --update
 
           Should that still fail, fix any remaining issues manually and verify they match the swift-format style using
 
-            swift run --package-path SwiftSyntaxDevUtils/ swift-syntax-dev-utils format --lint
+            ./swift-syntax-dev-utils format --lint
           """
       }
     }

--- a/swift-syntax-dev-utils
+++ b/swift-syntax-dev-utils
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+swift run --package-path "$(dirname $0)/SwiftSyntaxDevUtils" swift-syntax-dev-utils "$@"


### PR DESCRIPTION
Calling `swift-syntax-dev-utils` has always been a little bit cumbersome. Add a `swift-syntax-dev-utils` script that expands to `swift run --package-path SwiftSyntaxDevUtils/` to make it simpler.

rdar://118137372
Fixes #2341