### PR TITLE
`TokenSyntax.rawText` to get raw token text as `SyntaxText`

### DIFF
--- a/Sources/SwiftSyntax/TokenSyntax.swift
+++ b/Sources/SwiftSyntax/TokenSyntax.swift
@@ -75,6 +75,11 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     return tokenKind.text
   }
 
+  @_spi(RawSyntax)
+  public var rawText: SyntaxText {
+    return tokenView.rawText
+  }
+
   /// The leading trivia (spaces, newlines, etc.) associated with this token.
   public var leadingTrivia: Trivia {
     get {


### PR DESCRIPTION
Declare `SyntaxText` as a SPI. and expose `RawSyntax.tokenView.rawText` as `TokenSyntax.rawText`.

`SyntaxText` is a byte sequence conforming to `RandomAccessCollection` and has basic query methods e.g. `==`, `hasPrefix(_:)`, `contains(_:)`. It is useful for performance critical logic because `TokenSyntax.rawText` is faster than `TokenSytnax.text` which requies intantiating `TokenKind` often with `Swift.String`.