### PR TITLE
Clean up formatting of function body macros

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -453,6 +453,17 @@ public func collapse<Node: SyntaxProtocol>(
   var expansions = expansions
   var separator = "\n\n"
 
+  // Wrap the expansions in a set of braces.
+  func wrapInBraces() {
+    // Default to 4 spaces if no indentation was passed.
+    // In the future, we could consider inferring the indentation width from
+    // the expansions to collapse.
+    expansions = expansions.map({ $0.indented(by: indentationWidth ?? .spaces(4)) })
+    expansions[0] = "{\n" + expansions[0]
+    expansions[expansions.count - 1] += "\n}"
+    separator = "\n"
+  }
+
   switch role {
   case .accessor:
     let onDeclarationWithoutAccessor: Bool
@@ -469,16 +480,18 @@ public func collapse<Node: SyntaxProtocol>(
       onDeclarationWithoutAccessor = false
     }
     if onDeclarationWithoutAccessor {
-      // Default to 4 spaces if no indentation was passed.
-      // In the future, we could consider inferring the indentation width from
-      // the expansions to collapse.
-      expansions = expansions.map({ $0.indented(by: indentationWidth ?? .spaces(4)) })
-      expansions[0] = "{\n" + expansions[0]
-      expansions[expansions.count - 1] += "\n}"
-      separator = "\n"
+      wrapInBraces()
     }
   case .memberAttribute:
     separator = " "
+
+  case .body:
+    wrapInBraces()
+
+  case .preamble:
+    // Only place a single newline between statements.
+    separator = "\n"
+
   default:
     break
   }

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -379,7 +379,7 @@ private func expandPreambleMacro(
   // Match the indentation of the statements if we can, and put newlines around
   // the preamble to separate it from the rest of the body.
   let indentation = decl.body?.statements.indentationOfFirstLine ?? (decl.indentationOfFirstLine + indentationWidth)
-  let indentedSource = "\n" + expanded.indented(by: indentation) + "\n\n"
+  let indentedSource = "\n" + expanded.indented(by: indentation) + "\n"
   return "\(raw: indentedSource)"
 }
 
@@ -409,10 +409,13 @@ private func expandBodyMacro(
     return nil
   }
 
-  // Wrap the body in braces.
-  let beforeBody = decl.body == nil ? " " : "";
-  let indentedSource = beforeBody + "{\n" + expanded.indented(by: decl.indentationOfFirstLine + indentationWidth) + "\n}\n"
-  return "\(raw: indentedSource)" as CodeBlockSyntax
+  // `expandAttachedMacro` adds the `{` and `}` to wrap the accessor block and
+  // then indents it.
+  // Remove any indentaiton from the first line using `drop(while:)` and then
+  // prepend a space to separate it from the variable declaration
+  let leadingWhitespace = decl.body == nil ? " " : ""
+  let indentedSource = leadingWhitespace + expanded.indented(by: decl.indentationOfFirstLine).drop(while: { $0.isWhitespace })
+  return "\(raw: indentedSource)"
 }
 
 // MARK: - MacroSystem

--- a/Tests/SwiftSyntaxMacroExpansionTest/PreambleMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PreambleMacroTests.swift
@@ -80,7 +80,6 @@ final class PreambleMacroTests: XCTestCase {
 
         func doSomethingDangerous(operation: String) {
           log("Entering doSomethingDangerous(operation: \\(operation))")
-
           defer {
             log("Exiting doSomethingDangerous(operation:)")
           }
@@ -104,12 +103,10 @@ final class PreambleMacroTests: XCTestCase {
 
         func doSomethingDangerous(operation: String) {
           log("Entering doSomethingDangerous(operation: \\(operation))")
-
           defer {
             log("Exiting doSomethingDangerous(operation:)")
           }
           log("Entering doSomethingDangerous(operation: \\(operation))")
-
           defer {
             log("Exiting doSomethingDangerous(operation:)")
           }
@@ -131,7 +128,6 @@ final class PreambleMacroTests: XCTestCase {
 
         func f(a: Int, b: String) async throws -> String {
           log("Entering f(a: \\(a), b: \\(b))")
-
           defer {
             log("Exiting f(a:b:)")
           }


### PR DESCRIPTION
Two changes to the formatting of function body macros:
* Move the introduction of the braces for body macros into common code, so the macro expansion refactoring can use it as well
* Only put a single newline in between the code items in a preamble macro