### PR TITLE
Add _BridgeObject and _TrivialStride layouts

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/GenericNodes.swift
@@ -205,6 +205,8 @@ public let GENERIC_NODES: [Node] = [
           .keyword(._NativeRefCountedObject),
           .keyword(._Class),
           .keyword(._NativeClass),
+          .keyword(._BridgeObject),
+          .keyword(._TrivialStride),
         ])
       ),
       Child(

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -82,6 +82,7 @@ public enum Keyword: CaseIterable {
   case _backDeploy
   case _borrow
   case _borrowing
+  case _BridgeObject
   case _cdecl
   case _Class
   case _compilerInitialized
@@ -119,6 +120,7 @@ public enum Keyword: CaseIterable {
   case _swift_native_objc_runtime_base
   case _Trivial
   case _TrivialAtMost
+  case _TrivialStride
   case _typeEraser
   case _unavailableFromAsync
   case _underlyingVersion
@@ -301,6 +303,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("_backDeploy")
     case ._borrow:
       return KeywordSpec("_borrow")
+    case ._BridgeObject:
+      return KeywordSpec("_BridgeObject")
     case ._cdecl:
       return KeywordSpec("_cdecl")
     case ._Class:
@@ -371,6 +375,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("_Trivial")
     case ._TrivialAtMost:
       return KeywordSpec("_TrivialAtMost")
+    case ._TrivialStride:
+      return KeywordSpec("_TrivialStride")
     case ._typeEraser:
       return KeywordSpec("_typeEraser")
     case ._unavailableFromAsync:

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -579,14 +579,16 @@ extension Parser {
             var hasArguments: Bool {
               switch layoutSpecifier {
               case ._Trivial,
-                ._TrivialAtMost:
+                ._TrivialAtMost,
+                ._TrivialStride:
                 return true
 
               case ._UnknownLayout,
                 ._RefCountedObject,
                 ._NativeRefCountedObject,
                 ._Class,
-                ._NativeClass:
+                ._NativeClass,
+                ._BridgeObject:
                 return false
               }
             }

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -288,6 +288,7 @@ enum TokenPrecedence: Comparable {
     case  // Treat all other keywords as expression keywords in the absence of any better information.
     .__owned,
       .__shared,
+      ._BridgeObject,
       ._Class,
       ._compilerInitialized,
       ._const,
@@ -300,6 +301,7 @@ enum TokenPrecedence: Comparable {
       ._RefCountedObject,
       ._Trivial,
       ._TrivialAtMost,
+      ._TrivialStride,
       ._underlyingVersion,
       ._UnknownLayout,
       ._version,

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -1979,6 +1979,8 @@ extension LayoutRequirementSyntax {
     case _NativeRefCountedObject
     case _Class
     case _NativeClass
+    case _BridgeObject
+    case _TrivialStride
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
@@ -1996,6 +1998,10 @@ extension LayoutRequirementSyntax {
         self = ._Class
       case TokenSpec(._NativeClass):
         self = ._NativeClass
+      case TokenSpec(._BridgeObject):
+        self = ._BridgeObject
+      case TokenSpec(._TrivialStride):
+        self = ._TrivialStride
       default:
         return nil
       }
@@ -2017,6 +2023,10 @@ extension LayoutRequirementSyntax {
         return .keyword(._Class)
       case ._NativeClass:
         return .keyword(._NativeClass)
+      case ._BridgeObject:
+        return .keyword(._BridgeObject)
+      case ._TrivialStride:
+        return .keyword(._TrivialStride)
       }
     }
     
@@ -2040,6 +2050,10 @@ extension LayoutRequirementSyntax {
         return .keyword(._Class)
       case ._NativeClass:
         return .keyword(._NativeClass)
+      case ._BridgeObject:
+        return .keyword(._BridgeObject)
+      case ._TrivialStride:
+        return .keyword(._TrivialStride)
       }
     }
   }

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -22,6 +22,7 @@ public enum Keyword: UInt8, Hashable {
   case _borrow
   @_spi(ExperimentalLanguageFeatures)
   case _borrowing
+  case _BridgeObject
   case _cdecl
   case _Class
   case _compilerInitialized
@@ -61,6 +62,7 @@ public enum Keyword: UInt8, Hashable {
   case _swift_native_objc_runtime_base
   case _Trivial
   case _TrivialAtMost
+  case _TrivialStride
   case _typeEraser
   case _unavailableFromAsync
   case _underlyingVersion
@@ -647,6 +649,8 @@ public enum Keyword: UInt8, Hashable {
       }
     case 13:
       switch text {
+      case "_BridgeObject":
+        self = ._BridgeObject
       case "associativity":
         self = .associativity
       case "unsafeAddress":
@@ -662,6 +666,8 @@ public enum Keyword: UInt8, Hashable {
         self = ._spi_available
       case "_TrivialAtMost":
         self = ._TrivialAtMost
+      case "_TrivialStride":
+        self = ._TrivialStride
       case "_UnknownLayout":
         self = ._UnknownLayout
       case "associatedtype":
@@ -789,6 +795,7 @@ public enum Keyword: UInt8, Hashable {
       "_backDeploy", 
       "_borrow", 
       "_borrowing", 
+      "_BridgeObject", 
       "_cdecl", 
       "_Class", 
       "_compilerInitialized", 
@@ -826,6 +833,7 @@ public enum Keyword: UInt8, Hashable {
       "_swift_native_objc_runtime_base", 
       "_Trivial", 
       "_TrivialAtMost", 
+      "_TrivialStride", 
       "_typeEraser", 
       "_unavailableFromAsync", 
       "_underlyingVersion", 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1699,7 +1699,9 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("_RefCountedObject"), 
             .keyword("_NativeRefCountedObject"), 
             .keyword("_Class"), 
-            .keyword("_NativeClass")
+            .keyword("_NativeClass"), 
+            .keyword("_BridgeObject"), 
+            .keyword("_TrivialStride")
           ]))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.leftParen)]))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -1350,7 +1350,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSy
 /// 
 ///  - `type`: ``TypeSyntax``
 ///  - `colon`: `:`
-///  - `layoutSpecifier`: (`_Trivial` | `_TrivialAtMost` | `_UnknownLayout` | `_RefCountedObject` | `_NativeRefCountedObject` | `_Class` | `_NativeClass`)
+///  - `layoutSpecifier`: (`_Trivial` | `_TrivialAtMost` | `_UnknownLayout` | `_RefCountedObject` | `_NativeRefCountedObject` | `_Class` | `_NativeClass` | `_BridgeObject` | `_TrivialStride`)
 ///  - `leftParen`: `(`?
 ///  - `size`: `<integerLiteral>`?
 ///  - `comma`: `,`?
@@ -1505,6 +1505,8 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
   ///  - `_NativeRefCountedObject`
   ///  - `_Class`
   ///  - `_NativeClass`
+  ///  - `_BridgeObject`
+  ///  - `_TrivialStride`
   public var layoutSpecifier: TokenSyntax {
     get {
       return Syntax(self).child(at: 5)!.cast(TokenSyntax.self)

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -75,13 +75,15 @@ final class AttributeTests: ParserTestCase {
       """
       @_specialize(where @_noMetdata T : _BridgeObject)
       func foo(_ t: T) {}
-      """)
+      """
+    )
 
     assertParse(
       """
       @_specialize(where @_noMetdata T : _TrivialStride(64))
       func foo(_ t: T) {}
-      """)
+      """
+    )
   }
 
   func testMissingClosingParenToAttribute() {

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -70,6 +70,20 @@ final class AttributeTests: ParserTestCase {
     )
   }
 
+  func testSpecializeAttribute() {
+    assertParse(
+      """
+      @_specialize(where @_noMetdata T : _BridgeObject)
+      func foo(_ t: T) {}
+      """)
+
+    assertParse(
+      """
+      @_specialize(where @_noMetdata T : _TrivialStride(64))
+      func foo(_ t: T) {}
+      """)
+  }
+
   func testMissingClosingParenToAttribute() {
     assertParse(
       """


### PR DESCRIPTION
Both layout kinds are useful for pre-specializations of commonly emitted generic function specializations.