### PR TITLE
Address review comments for API compatibility of `ThrowsClauseSyntax`

### DIFF
--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -84,6 +84,12 @@
   - The new classification case covers the first names of parameters in function-like declarations and the label of arguments in function-like calls.
   - Pull request: https://github.com/apple/swift-syntax/pull/2375
   - Migration steps: In exhaustive switches over `SyntaxClassification`, cover the new case.
+  
+- `SyntaxEnum` and `SyntaxKind` gained new cases: `throwsClause`
+  - The new cases cover the newly introduced `ThrowsClauseSyntax`
+  - Pull request: https://github.com/apple/swift-syntax/pull/2379
+  - Migration steps: In exhaustive switches over `SyntaxEnum` and `SyntaxKind`, cover the new case.
+  
 
 ## Template
 

--- a/Sources/SwiftParser/Specifiers.swift
+++ b/Sources/SwiftParser/Specifiers.swift
@@ -584,7 +584,7 @@ extension TokenConsumer {
 extension Parser {
   /// Parse a throws clause after we've already parsed the 'throws' keyword to introduce it.
   mutating func parseThrowsClause(after throwsKeyword: RawTokenSyntax) -> RawThrowsClauseSyntax {
-    guard self.at(.leftParen) && experimentalFeatures.contains(.typedThrows) else {
+    guard experimentalFeatures.contains(.typedThrows), let leftParen = self.consume(if: .leftParen) else {
       return RawThrowsClauseSyntax(
         throwsSpecifier: throwsKeyword,
         leftParen: nil,
@@ -594,12 +594,10 @@ extension Parser {
       )
     }
 
-    let (unexpectedBetweenThrowsSpecifierAndLeftParen, leftParen) = self.expect(.leftParen)
     let type = self.parseType()
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     return RawThrowsClauseSyntax(
       throwsSpecifier: throwsKeyword,
-      unexpectedBetweenThrowsSpecifierAndLeftParen,
       leftParen: leftParen,
       type: type,
       unexpectedBeforeRightParen,

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -14,17 +14,24 @@
 // All users of the declarations in this file should transition away from them ASAP.
 
 public extension AccessorEffectSpecifiersSyntax {
+  @_disfavoredOverload
   @available(*, deprecated, message: "use throwsClause instead of throwsSpecifier")
   init(
     leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeAsyncSpecifier: UnexpectedNodesSyntax? = nil,
     asyncSpecifier: TokenSyntax? = nil,
+    _ unexpectedBetweenAsyncSpecifierAndThrowsSpecifier: UnexpectedNodesSyntax? = nil,
     throwsSpecifier: TokenSyntax? = nil,
+    _ unexpectedAfterThrowsSpecifier: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
     self.init(
       leadingTrivia: leadingTrivia,
+      unexpectedBeforeAsyncSpecifier,
       asyncSpecifier: asyncSpecifier,
+      unexpectedBetweenAsyncSpecifierAndThrowsSpecifier,
       throwsClause: throwsSpecifier.map { ThrowsClauseSyntax(throwsSpecifier: $0) },
+      unexpectedAfterThrowsSpecifier,
       trailingTrivia: trailingTrivia
     )
   }
@@ -68,6 +75,12 @@ public extension DeclGroupSyntax {
 }
 
 public extension EffectSpecifiersSyntax {
+  @available(*, deprecated, renamed: "unexpectedBetweenAsyncSpecifierAndThrowsClause")
+  var unexpectedBetweenAsyncSpecifierAndThrowsSpecifier: UnexpectedNodesSyntax? {
+    get { unexpectedBetweenAsyncSpecifierAndThrowsClause }
+    set { unexpectedBetweenAsyncSpecifierAndThrowsClause = newValue }
+  }
+
   @available(*, deprecated, message: "use throwsClause.throwsSpecifier")
   var throwsSpecifier: TokenSyntax? {
     get { throwsClause?.throwsSpecifier }
@@ -85,20 +98,33 @@ public extension EffectSpecifiersSyntax {
       }
     }
   }
+
+  @available(*, deprecated, renamed: "unexpectedAfterThrowsClause")
+  var unexpectedAfterThrowsSpecifier: UnexpectedNodesSyntax? {
+    get { unexpectedAfterThrowsClause }
+    set { unexpectedAfterThrowsClause = newValue }
+  }
 }
 
 public extension FunctionEffectSpecifiersSyntax {
+  @_disfavoredOverload
   @available(*, deprecated, message: "use throwsClause instead of throwsSpecifier")
   init(
     leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeAsyncSpecifier: UnexpectedNodesSyntax? = nil,
     asyncSpecifier: TokenSyntax? = nil,
+    _ unexpectedBetweenAsyncSpecifierAndThrowsSpecifier: UnexpectedNodesSyntax? = nil,
     throwsSpecifier: TokenSyntax? = nil,
+    _ unexpectedAfterThrowsSpecifier: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
     self.init(
       leadingTrivia: leadingTrivia,
+      unexpectedBeforeAsyncSpecifier,
       asyncSpecifier: asyncSpecifier,
+      unexpectedBetweenAsyncSpecifierAndThrowsSpecifier,
       throwsClause: throwsSpecifier.map { ThrowsClauseSyntax(throwsSpecifier: $0) },
+      unexpectedAfterThrowsSpecifier,
       trailingTrivia: trailingTrivia
     )
   }
@@ -496,14 +522,20 @@ public extension TypeEffectSpecifiersSyntax {
   @available(*, deprecated, message: "use throwsClause instead of throwsSpecifier")
   init(
     leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeAsyncSpecifier: UnexpectedNodesSyntax? = nil,
     asyncSpecifier: TokenSyntax? = nil,
+    _ unexpectedBetweenAsyncSpecifierAndThrowsSpecifier: UnexpectedNodesSyntax? = nil,
     throwsSpecifier: TokenSyntax? = nil,
+    _ unexpectedAfterThrowsSpecifier: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
     self.init(
       leadingTrivia: leadingTrivia,
+      unexpectedBeforeAsyncSpecifier,
       asyncSpecifier: asyncSpecifier,
+      unexpectedBetweenAsyncSpecifierAndThrowsSpecifier,
       throwsClause: throwsSpecifier.map { ThrowsClauseSyntax(throwsSpecifier: $0) },
+      unexpectedAfterThrowsSpecifier,
       trailingTrivia: trailingTrivia
     )
   }


### PR DESCRIPTION
This adds a release notes entry for the addition of cases to `SyntaxKind` and `SyntaxEnum` and compatibility layers for the _unexpected_ fields in the effect specifiers syntax nodes.