### PR TITLE
build: clean up `Package.swift` slightly

### DIFF
--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -48,11 +48,6 @@ let package = Package(
       ],
       path: "Tests/MacroExamples/Implementation"
     ),
-  ]
-)
-
-package.targets.append(
-  contentsOf: [
     .target(
       name: "MacroExamplesInterface",
       dependencies: [


### PR DESCRIPTION
Now that macros are enabled on all the platforms we currently support (Windows, Linux, Apple), the optional addition of the macro targets was removed.  Clean up the structure of the file as the initial changes were done quickly to enable testing on all platforms.