### PR TITLE
[5.10] Remove `WildcardPattern.typeAnnotation`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
@@ -173,12 +173,7 @@ public let PATTERN_NODES: [Node] = [
       Child(
         name: "wildcard",
         kind: .token(choices: [.token(.wildcard)])
-      ),
-      Child(
-        name: "typeAnnotation",
-        kind: .node(kind: .typeAnnotation),
-        isOptional: true
-      ),
+      )
     ]
   ),
 

--- a/Release Notes/510.md
+++ b/Release Notes/510.md
@@ -40,6 +40,10 @@
   - Issue: https://github.com/apple/swift-syntax/issues/2092
   - Pull Request: https://github.com/apple/swift-syntax/pull/2108
 
+- `WildcardPatternSyntax.typeAnnotation`
+  - Description: `typeAnnotation` on `WildcardPatternSyntax` was a mistake. Use `typeAnnotation` properties on the outer constructs instead. E.g. `PatternBindingListSyntax.typeAnnotation`
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2393
+
 ## API-Incompatible Changes
 
 - `NoteMessage.fixItID` renamed to `noteID`

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -64,7 +64,6 @@ extension Parser {
       return RawPatternSyntax(
         RawWildcardPatternSyntax(
           wildcard: wildcard,
-          typeAnnotation: nil,
           arena: self.arena
         )
       )

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -438,6 +438,45 @@ public extension TokenSyntax {
   }
 }
 
+public extension WildcardPatternSyntax {
+  @available(*, deprecated, message: "remove 'typeAnnotation'")
+  init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil,
+    wildcard: TokenSyntax = .wildcardToken(),
+    _ unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
+    typeAnnotation: TypeAnnotationSyntax? = nil,
+    _ unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeWildcard,
+      wildcard: wildcard,
+      unexpectedAfterTypeAnnotation,
+      trailingTrivia: trailingTrivia
+    );
+  }
+
+  @available(*, deprecated, message: "'unexpectedBetweenWildcardAndTypeAnnotation' was removed")
+  var unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? {
+    get { nil }
+    set {}
+  }
+
+  @available(*, deprecated, message: "'typeAnnotation' was removed")
+  var typeAnnotation: TypeAnnotationSyntax? {
+    get { nil }
+    set {}
+  }
+
+  @available(*, deprecated, renamed: "unexpectedAfterWildcard")
+  var unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? {
+    get { unexpectedAfterWildcard }
+    set { unexpectedAfterWildcard = newValue }
+  }
+}
+
 //==========================================================================//
 // IMPORTANT: If you are tempted to add a compatibility layer code here     //
 // please insert it in alphabetical order above                             //

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -3387,12 +3387,8 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "unexpectedBeforeWildcard"
   case \WildcardPatternSyntax.wildcard:
     return "wildcard"
-  case \WildcardPatternSyntax.unexpectedBetweenWildcardAndTypeAnnotation:
-    return "unexpectedBetweenWildcardAndTypeAnnotation"
-  case \WildcardPatternSyntax.typeAnnotation:
-    return "typeAnnotation"
-  case \WildcardPatternSyntax.unexpectedAfterTypeAnnotation:
-    return "unexpectedAfterTypeAnnotation"
+  case \WildcardPatternSyntax.unexpectedAfterWildcard:
+    return "unexpectedAfterWildcard"
   case \YieldStmtSyntax.unexpectedBeforeYieldKeyword:
     return "unexpectedBeforeYieldKeyword"
   case \YieldStmtSyntax.yieldKeyword:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesTUVWXYZ.swift
@@ -2298,19 +2298,15 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol {
   public init(
       _ unexpectedBeforeWildcard: RawUnexpectedNodesSyntax? = nil, 
       wildcard: RawTokenSyntax, 
-      _ unexpectedBetweenWildcardAndTypeAnnotation: RawUnexpectedNodesSyntax? = nil, 
-      typeAnnotation: RawTypeAnnotationSyntax?, 
-      _ unexpectedAfterTypeAnnotation: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedAfterWildcard: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .wildcardPattern, uninitializedCount: 5, arena: arena) { layout in
+      kind: .wildcardPattern, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWildcard?.raw
       layout[1] = wildcard.raw
-      layout[2] = unexpectedBetweenWildcardAndTypeAnnotation?.raw
-      layout[3] = typeAnnotation?.raw
-      layout[4] = unexpectedAfterTypeAnnotation?.raw
+      layout[2] = unexpectedAfterWildcard?.raw
     }
     self.init(unchecked: raw)
   }
@@ -2323,16 +2319,8 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenWildcardAndTypeAnnotation: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterWildcard: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var typeAnnotation: RawTypeAnnotationSyntax? {
-    layoutView.children[3].map(RawTypeAnnotationSyntax.init(raw:))
-  }
-  
-  public var unexpectedAfterTypeAnnotation: RawUnexpectedNodesSyntax? {
-    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2690,12 +2690,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 5, verify(layout[5], as: RawCodeBlockSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .wildcardPattern:
-    assert(layout.count == 5)
+    assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.wildcard)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawTypeAnnotationSyntax?.self))
-    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   case .yieldStmt:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -1823,7 +1823,6 @@ public struct TypeAliasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDecl
 ///  - ``MatchingPatternConditionSyntax``.``MatchingPatternConditionSyntax/typeAnnotation``
 ///  - ``OptionalBindingConditionSyntax``.``OptionalBindingConditionSyntax/typeAnnotation``
 ///  - ``PatternBindingSyntax``.``PatternBindingSyntax/typeAnnotation``
-///  - ``WildcardPatternSyntax``.``WildcardPatternSyntax/typeAnnotation``
 public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
@@ -3807,7 +3806,6 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
 /// ### Children
 /// 
 ///  - `wildcard`: `'_'`
-///  - `typeAnnotation`: ``TypeAnnotationSyntax``?
 public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
@@ -3825,28 +3823,14 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Lea
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil,
       wildcard: TokenSyntax = .wildcardToken(),
-      _ unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
-      typeAnnotation: TypeAnnotationSyntax? = nil,
-      _ unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? = nil,
+      _ unexpectedAfterWildcard: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
-    self = withExtendedLifetime((SyntaxArena(), (
-            unexpectedBeforeWildcard, 
-            wildcard, 
-            unexpectedBetweenWildcardAndTypeAnnotation, 
-            typeAnnotation, 
-            unexpectedAfterTypeAnnotation
-          ))) { (arena, _) in
-      let layout: [RawSyntax?] = [
-          unexpectedBeforeWildcard?.raw, 
-          wildcard.raw, 
-          unexpectedBetweenWildcardAndTypeAnnotation?.raw, 
-          typeAnnotation?.raw, 
-          unexpectedAfterTypeAnnotation?.raw
-        ]
+    self = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWildcard, wildcard, unexpectedAfterWildcard))) { (arena, _) in
+      let layout: [RawSyntax?] = [unexpectedBeforeWildcard?.raw, wildcard.raw, unexpectedAfterWildcard?.raw]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.wildcardPattern,
         from: layout,
@@ -3877,7 +3861,7 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public var unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? {
+  public var unexpectedAfterWildcard: UnexpectedNodesSyntax? {
     get {
       return Syntax(self).child(at: 2)?.cast(UnexpectedNodesSyntax.self)
     }
@@ -3886,32 +3870,8 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _Lea
     }
   }
   
-  public var typeAnnotation: TypeAnnotationSyntax? {
-    get {
-      return Syntax(self).child(at: 3)?.cast(TypeAnnotationSyntax.self)
-    }
-    set(value) {
-      self = Syntax(self).replacingChild(at: 3, with: Syntax(value), arena: SyntaxArena()).cast(WildcardPatternSyntax.self)
-    }
-  }
-  
-  public var unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? {
-    get {
-      return Syntax(self).child(at: 4)?.cast(UnexpectedNodesSyntax.self)
-    }
-    set(value) {
-      self = Syntax(self).replacingChild(at: 4, with: Syntax(value), arena: SyntaxArena()).cast(WildcardPatternSyntax.self)
-    }
-  }
-  
   public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeWildcard, 
-          \Self.wildcard, 
-          \Self.unexpectedBetweenWildcardAndTypeAnnotation, 
-          \Self.typeAnnotation, 
-          \Self.unexpectedAfterTypeAnnotation
-        ])
+    return .layout([\Self.unexpectedBeforeWildcard, \Self.wildcard, \Self.unexpectedAfterWildcard])
   }
 }
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-syntax/pull/2395 into release/5.10

* **Explanation**: `WildPatternSyntax.typeAnnotation` was added by accident. It should have never been a part of `WildcardPatternSyntax`.
* **Scope**: SwiftSyntax tree API
* **Risk**: Low. `SwiftParser` never set it.
* **Testing**: Passes the current test suite
* **Issues**: N/A
* **Reviewer**: Alex Hoppen (@ahoppen)