### PR TITLE
Revert "guard nonisolated(unsafe) by experimental feature"

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -18,7 +18,6 @@ public enum ExperimentalFeature: String, CaseIterable {
   case typedThrows
   case doExpressions
   case nonEscapableTypes
-  case globalConcurrency
 
   /// The name of the feature, which is used in the doc comment.
   public var featureName: String {
@@ -33,8 +32,6 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "'do' expressions"
     case .nonEscapableTypes:
       return "NonEscableTypes"
-    case .globalConcurrency:
-      return "strict concurrency for globals"
     }
   }
 

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -61,12 +61,7 @@ extension Parser {
       case (.declarationModifier(.unowned), let handle)?:
         elements.append(self.parseUnownedModifier(handle))
       case (.declarationModifier(.nonisolated), let handle)?:
-        if experimentalFeatures.contains(.globalConcurrency) {
-          elements.append(parseNonisolatedModifier(handle))
-        } else {
-          let (unexpectedBeforeKeyword, keyword) = self.eat(handle)
-          elements.append(RawDeclModifierSyntax(unexpectedBeforeKeyword, name: keyword, detail: nil, arena: self.arena))
-        }
+        elements.append(parseNonisolatedModifier(handle))
       case (.declarationModifier(.final), let handle)?,
         (.declarationModifier(.required), let handle)?,
         (.declarationModifier(.optional), let handle)?,

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -38,7 +38,4 @@ extension Parser.ExperimentalFeatures {
   
   /// Whether to enable the parsing of NonEscableTypes.
   public static let nonEscapableTypes = Self (rawValue: 1 << 4)
-  
-  /// Whether to enable the parsing of strict concurrency for globals.
-  public static let globalConcurrency = Self (rawValue: 1 << 5)
 }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -265,8 +265,7 @@ final class DeclarationTests: ParserTestCase {
           nonisolated(unsafe) var c: Int { 0 }
           nonisolated(unsafe) let d = 0
         }
-        """,
-      experimentalFeatures: [.globalConcurrency]
+        """
     )
   }
 


### PR DESCRIPTION
This attribute `nonisolated(unsafe)` should no longer be guarded by the broader GlobalConcurrency experimental feature flag.