### PR TITLE
Rename NonesapableTypes feature

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -17,7 +17,7 @@ public enum ExperimentalFeature: String, CaseIterable {
   case thenStatements
   case typedThrows
   case doExpressions
-  case nonEscapableTypes
+  case nonescapableTypes
 
   /// The name of the feature, which is used in the doc comment.
   public var featureName: String {
@@ -30,7 +30,7 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "typed throws"
     case .doExpressions:
       return "'do' expressions"
-    case .nonEscapableTypes:
+    case .nonescapableTypes:
       return "NonEscableTypes"
     }
   }

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -619,9 +619,9 @@ public enum Keyword: CaseIterable {
     case .required:
       return KeywordSpec("required")
     case ._resultDependsOn:
-      return KeywordSpec("_resultDependsOn", experimentalFeature: .nonEscapableTypes)
+      return KeywordSpec("_resultDependsOn", experimentalFeature: .nonescapableTypes)
     case ._resultDependsOnSelf:
-      return KeywordSpec("_resultDependsOnSelf", experimentalFeature: .nonEscapableTypes)
+      return KeywordSpec("_resultDependsOnSelf", experimentalFeature: .nonescapableTypes)
     case .rethrows:
       return KeywordSpec("rethrows", isLexerClassified: true)
     case .retroactive:

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -86,7 +86,7 @@ extension Parser {
         (.declarationModifier(._local), let handle)?,
         (.declarationModifier(.__setter_access), let handle)?,
         (.declarationModifier(.reasync), let handle)?,
-        (.declarationModifier(._resultDependsOnSelf), let handle)? where experimentalFeatures.contains(.nonEscapableTypes):
+        (.declarationModifier(._resultDependsOnSelf), let handle)? where experimentalFeatures.contains(.nonescapableTypes):
         let (unexpectedBeforeKeyword, keyword) = self.eat(handle)
         elements.append(RawDeclModifierSyntax(unexpectedBeforeKeyword, name: keyword, detail: nil, arena: self.arena))
       case (.declarationModifier(.rethrows), _)?:

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -353,7 +353,7 @@ extension Parser.Lookahead {
         && !self.at(.keyword(.__owned))
         && !self.at(.keyword(.borrowing))
         && !self.at(.keyword(.consuming))
-        && !(experimentalFeatures.contains(.nonEscapableTypes) && self.at(.keyword(._resultDependsOn)))
+        && !(experimentalFeatures.contains(.nonescapableTypes) && self.at(.keyword(._resultDependsOn)))
       {
         return true
       }

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -416,8 +416,8 @@ enum DeclarationModifier: TokenSpecSet {
     case TokenSpec(.static): self = .static
     case TokenSpec(.unowned): self = .unowned
     case TokenSpec(.weak): self = .weak
-    case TokenSpec(._resultDependsOn) where experimentalFeatures.contains(.nonEscapableTypes): self = ._resultDependsOn
-    case TokenSpec(._resultDependsOnSelf) where experimentalFeatures.contains(.nonEscapableTypes): self = ._resultDependsOnSelf
+    case TokenSpec(._resultDependsOn) where experimentalFeatures.contains(.nonescapableTypes): self = ._resultDependsOn
+    case TokenSpec(._resultDependsOnSelf) where experimentalFeatures.contains(.nonescapableTypes): self = ._resultDependsOnSelf
     default: return nil
     }
   }

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -37,5 +37,5 @@ extension Parser.ExperimentalFeatures {
   public static let doExpressions = Self (rawValue: 1 << 3)
   
   /// Whether to enable the parsing of NonEscableTypes.
-  public static let nonEscapableTypes = Self (rawValue: 1 << 4)
+  public static let nonescapableTypes = Self (rawValue: 1 << 4)
 }

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -202,7 +202,7 @@ extension AttributedTypeSyntax {
         self = .borrowing
       case TokenSpec(.consuming):
         self = .consuming
-      case TokenSpec(._resultDependsOn) where experimentalFeatures.contains(.nonEscapableTypes):
+      case TokenSpec(._resultDependsOn) where experimentalFeatures.contains(.nonescapableTypes):
         self = ._resultDependsOn
       default:
         return nil
@@ -793,7 +793,7 @@ extension DeclModifierSyntax {
         self = .public
       case TokenSpec(.reasync):
         self = .reasync
-      case TokenSpec(._resultDependsOnSelf) where experimentalFeatures.contains(.nonEscapableTypes):
+      case TokenSpec(._resultDependsOnSelf) where experimentalFeatures.contains(.nonescapableTypes):
         self = ._resultDependsOnSelf
       case TokenSpec(.required):
         self = .required

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3105,7 +3105,7 @@ final class DeclarationTests: ParserTestCase {
          }
        }
       """,
-      experimentalFeatures: .nonEscapableTypes
+      experimentalFeatures: .nonescapableTypes
     )
 
     assertParse(
@@ -3116,7 +3116,7 @@ final class DeclarationTests: ParserTestCase {
            }
          }
       """,
-      experimentalFeatures: .nonEscapableTypes
+      experimentalFeatures: .nonescapableTypes
     )
   }
 
@@ -3128,7 +3128,7 @@ final class DeclarationTests: ParserTestCase {
           return Builtin.unsafeCastToNativeObject(x)
         }
       """,
-      experimentalFeatures: .nonEscapableTypes
+      experimentalFeatures: .nonescapableTypes
     )
 
     assertParse(
@@ -3138,7 +3138,7 @@ final class DeclarationTests: ParserTestCase {
           return (Builtin.unsafeCastToNativeObject(x), Builtin.unsafeCastToNativeObject(x))
         }
       """,
-      experimentalFeatures: .nonEscapableTypes
+      experimentalFeatures: .nonescapableTypes
     )
   }
 }


### PR DESCRIPTION
Follow the feature flag convention for capitalization and be consistent with the related NoncopyableGenerics feature.

Corresponding swift commit 2a7c21f33be88ebb0329a9f1d7ee9a1b36c7e8ff