### PR TITLE
Add missing dependency for SwiftSyntaxMacroExpansion

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/CMakeLists.txt
+++ b/Sources/SwiftSyntaxMacroExpansion/CMakeLists.txt
@@ -9,6 +9,10 @@ add_swift_syntax_library(SwiftSyntaxMacroExpansion
 )
 
 target_link_swift_syntax_libraries(SwiftSyntaxMacroExpansion PUBLIC
+  SwiftBasicFormat
+  SwiftDiagnostics
+  SwiftOperators
   SwiftSyntax
+  SwiftSyntaxBuilder
   SwiftSyntaxMacros
 )


### PR DESCRIPTION
SwiftSyntaxMacroExpansion imports SwiftOperators, add it as a CMake link dependency. Also add the transitive
dependencies while here.