### PR TITLE
[region-isolation] Add support for parsing transferring.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -467,6 +467,7 @@ public let DECL_NODES: [Node] = [
           .keyword(._resultDependsOnSelf),
           .keyword(.required),
           .keyword(.static),
+          .keyword(.transferring),
           .keyword(.unowned),
           .keyword(.weak),
         ])

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -267,6 +267,7 @@ public enum Keyword: CaseIterable {
   case then
   case `throw`
   case `throws`
+  case transferring
   case transpose
   case `true`
   case `try`
@@ -670,6 +671,11 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("throw", isLexerClassified: true)
     case .throws:
       return KeywordSpec("throws", isLexerClassified: true)
+    case .transferring:
+      return KeywordSpec(
+        "transferring",
+        experimentalFeature: .transferringArgsAndResults
+      )
     case .transpose:
       return KeywordSpec("transpose")
     case .true:

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -52,6 +52,7 @@ public let TYPE_NODES: [Node] = [
           .keyword(._const),
           .keyword(.borrowing),
           .keyword(.consuming),
+          .keyword(.transferring),
           .keyword(._resultDependsOn),
         ]),
         isOptional: true

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -19,7 +19,7 @@ extension DeclarationModifier {
       .borrowing, .class, .consuming, .convenience, .distributed, .dynamic,
       .final, .indirect, .infix, .isolated, .lazy, .mutating, .nonmutating,
       .optional, .override, .postfix, .prefix, .reasync, ._resultDependsOn, ._resultDependsOnSelf, .required,
-      .rethrows, .static, .weak:
+      .rethrows, .static, .weak, .transferring:
       return false
     case .fileprivate, .internal, .nonisolated, .package, .open, .private,
       .public, .unowned:

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -353,6 +353,7 @@ extension Parser.Lookahead {
         && !self.at(.keyword(.__owned))
         && !self.at(.keyword(.borrowing))
         && !self.at(.keyword(.consuming))
+        && !(experimentalFeatures.contains(.transferringArgsAndResults) && self.at(.keyword(.transferring)))
         && !(experimentalFeatures.contains(.nonescapableTypes) && self.at(.keyword(._resultDependsOn)))
       {
         return true

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -231,6 +231,7 @@ enum TokenPrecedence: Comparable {
       .__consuming, .final, .required, .optional, .lazy, .dynamic, .infix, .postfix, .prefix, .mutating, .nonmutating, .convenience, .override, .package, .open,
       .__setter_access, .indirect, .isolated, .nonisolated, .distributed, ._local,
       .inout, ._mutating, ._borrow, ._borrowing, .borrowing, ._consuming, .consuming, .consume, ._resultDependsOnSelf, ._resultDependsOn,
+      .transferring,
       // Accessors
       .get, .set, .didSet, .willSet, .unsafeAddress, .addressWithOwner, .addressWithNativeOwner, .unsafeMutableAddress,
       .mutableAddressWithOwner, .mutableAddressWithNativeOwner, ._read, ._modify,

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -374,6 +374,7 @@ enum DeclarationModifier: TokenSpecSet {
   case required
   case `rethrows`
   case `static`
+  case transferring
   case unowned
   case weak
   case _resultDependsOn
@@ -414,6 +415,7 @@ enum DeclarationModifier: TokenSpecSet {
     case TokenSpec(.required): self = .required
     case TokenSpec(.rethrows): self = .rethrows
     case TokenSpec(.static): self = .static
+    case TokenSpec(.transferring): self = .transferring
     case TokenSpec(.unowned): self = .unowned
     case TokenSpec(.weak): self = .weak
     case TokenSpec(._resultDependsOn) where experimentalFeatures.contains(.nonescapableTypes): self = ._resultDependsOn
@@ -457,6 +459,7 @@ enum DeclarationModifier: TokenSpecSet {
     case .required: return .keyword(.required)
     case .rethrows: return TokenSpec(.rethrows, recoveryPrecedence: .declKeyword)
     case .static: return .keyword(.static)
+    case .transferring: return .keyword(.transferring)
     case .unowned: return TokenSpec(.unowned, recoveryPrecedence: .declKeyword)
     case .weak: return TokenSpec(.weak, recoveryPrecedence: .declKeyword)
     case ._resultDependsOn: return TokenSpec(._resultDependsOn, recoveryPrecedence: .declKeyword)
@@ -685,6 +688,7 @@ public enum TypeSpecifier: TokenSpecSet {
   case shared
   case borrowing
   case consuming
+  case transferring
 
   init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
     switch PrepareForKeywordMatch(lexeme) {
@@ -693,6 +697,7 @@ public enum TypeSpecifier: TokenSpecSet {
     case TokenSpec(.__shared): self = .shared
     case TokenSpec(.consuming): self = .consuming
     case TokenSpec(.borrowing): self = .borrowing
+    case TokenSpec(.transferring): self = .transferring
     default: return nil
     }
   }
@@ -705,6 +710,7 @@ public enum TypeSpecifier: TokenSpecSet {
     case TokenSpec(.__shared): self = .shared
     case TokenSpec(.consuming): self = .shared
     case TokenSpec(.borrowing): self = .shared
+    case TokenSpec(.transferring): self = .transferring
     default: return nil
     }
   }
@@ -716,6 +722,7 @@ public enum TypeSpecifier: TokenSpecSet {
     case .shared: return .keyword(.__shared)
     case .borrowing: return .keyword(.borrowing)
     case .consuming: return .keyword(.consuming)
+    case .transferring: return .keyword(.transferring)
     }
   }
 }

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -184,6 +184,8 @@ extension AttributedTypeSyntax {
     case borrowing
     case consuming
     @_spi(ExperimentalLanguageFeatures)
+    case transferring
+    @_spi(ExperimentalLanguageFeatures)
     case _resultDependsOn
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
@@ -202,6 +204,8 @@ extension AttributedTypeSyntax {
         self = .borrowing
       case TokenSpec(.consuming):
         self = .consuming
+      case TokenSpec(.transferring) where experimentalFeatures.contains(.transferringArgsAndResults):
+        self = .transferring
       case TokenSpec(._resultDependsOn) where experimentalFeatures.contains(.nonescapableTypes):
         self = ._resultDependsOn
       default:
@@ -225,6 +229,8 @@ extension AttributedTypeSyntax {
         return .keyword(.borrowing)
       case .consuming:
         return .keyword(.consuming)
+      case .transferring:
+        return .keyword(.transferring)
       case ._resultDependsOn:
         return .keyword(._resultDependsOn)
       }
@@ -250,6 +256,8 @@ extension AttributedTypeSyntax {
         return .keyword(.borrowing)
       case .consuming:
         return .keyword(.consuming)
+      case .transferring:
+        return .keyword(.transferring)
       case ._resultDependsOn:
         return .keyword(._resultDependsOn)
       }
@@ -726,6 +734,8 @@ extension DeclModifierSyntax {
     case _resultDependsOnSelf
     case required
     case `static`
+    @_spi(ExperimentalLanguageFeatures)
+    case transferring
     case unowned
     case weak
     
@@ -799,6 +809,8 @@ extension DeclModifierSyntax {
         self = .required
       case TokenSpec(.static):
         self = .static
+      case TokenSpec(.transferring) where experimentalFeatures.contains(.transferringArgsAndResults):
+        self = .transferring
       case TokenSpec(.unowned):
         self = .unowned
       case TokenSpec(.weak):
@@ -878,6 +890,8 @@ extension DeclModifierSyntax {
         return .keyword(.required)
       case .static:
         return .keyword(.static)
+      case .transferring:
+        return .keyword(.transferring)
       case .unowned:
         return .keyword(.unowned)
       case .weak:
@@ -959,6 +973,8 @@ extension DeclModifierSyntax {
         return .keyword(.required)
       case .static:
         return .keyword(.static)
+      case .transferring:
+        return .keyword(.transferring)
       case .unowned:
         return .keyword(.unowned)
       case .weak:

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -211,6 +211,8 @@ public enum Keyword: UInt8, Hashable {
   case then
   case `throw`
   case `throws`
+  @_spi(ExperimentalLanguageFeatures)
+  case transferring
   case transpose
   case `true`
   case `try`
@@ -646,6 +648,8 @@ public enum Keyword: UInt8, Hashable {
         self = .backDeployed
       case "noDerivative":
         self = .noDerivative
+      case "transferring":
+        self = .transferring
       default:
         return nil
       }
@@ -984,6 +988,7 @@ public enum Keyword: UInt8, Hashable {
       "then", 
       "throw", 
       "throws", 
+      "transferring", 
       "transpose", 
       "true", 
       "try", 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -387,6 +387,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("_const"), 
             .keyword("borrowing"), 
             .keyword("consuming"), 
+            .keyword("transferring"), 
             .keyword("_resultDependsOn")
           ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
@@ -806,6 +807,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("_resultDependsOnSelf"), 
             .keyword("required"), 
             .keyword("static"), 
+            .keyword("transferring"), 
             .keyword("unowned"), 
             .keyword("weak")
           ]))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesAB.swift
@@ -3257,7 +3257,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNodePr
 
 /// ### Children
 /// 
-///  - `specifier`: (`inout` | `__shared` | `__owned` | `isolated` | `_const` | `borrowing` | `consuming` | `_resultDependsOn`)?
+///  - `specifier`: (`inout` | `__shared` | `__owned` | `isolated` | `_const` | `borrowing` | `consuming` | `transferring` | `_resultDependsOn`)?
 ///  - `attributes`: ``AttributeListSyntax``
 ///  - `baseType`: ``TypeSyntax``
 public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTypeSyntaxNodeProtocol {
@@ -3336,6 +3336,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable, _LeafTyp
   ///  - `_const`
   ///  - `borrowing`
   ///  - `consuming`
+  ///  - `transferring`
   ///  - `_resultDependsOn`
   public var specifier: TokenSyntax? {
     get {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -169,7 +169,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyn
 
 /// ### Children
 /// 
-///  - `name`: (`__consuming` | `__setter_access` | `_const` | `_local` | `actor` | `async` | `borrowing` | `class` | `consuming` | `convenience` | `distributed` | `dynamic` | `fileprivate` | `final` | `indirect` | `infix` | `internal` | `isolated` | `lazy` | `mutating` | `nonisolated` | `nonmutating` | `open` | `optional` | `override` | `package` | `postfix` | `prefix` | `private` | `public` | `reasync` | `_resultDependsOnSelf` | `required` | `static` | `unowned` | `weak`)
+///  - `name`: (`__consuming` | `__setter_access` | `_const` | `_local` | `actor` | `async` | `borrowing` | `class` | `consuming` | `convenience` | `distributed` | `dynamic` | `fileprivate` | `final` | `indirect` | `infix` | `internal` | `isolated` | `lazy` | `mutating` | `nonisolated` | `nonmutating` | `open` | `optional` | `override` | `package` | `postfix` | `prefix` | `private` | `public` | `reasync` | `_resultDependsOnSelf` | `required` | `static` | `transferring` | `unowned` | `weak`)
 ///  - `detail`: ``DeclModifierDetailSyntax``?
 ///
 /// ### Contained in
@@ -273,6 +273,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNod
   ///  - `_resultDependsOnSelf`
   ///  - `required`
   ///  - `static`
+  ///  - `transferring`
   ///  - `unowned`
   ///  - `weak`
   public var name: TokenSyntax {

--- a/Tests/SwiftParserTest/TransferringTest.swift
+++ b/Tests/SwiftParserTest/TransferringTest.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(ExperimentalLanguageFeatures) import SwiftParser
+import XCTest
+
+final class TransferringTests: ParserTestCase {
+  func testTransferingArg1() {
+    assertParse(
+      """
+      class Klass {}
+      func transferMain(_ x: transferring Klass) -> ()
+      """,
+      experimentalFeatures: .transferringArgsAndResults
+    )
+  }
+
+  func testTransferingArgMiddle() {
+    assertParse(
+      """
+      class Klass {}
+      func transferMain(_ y: Klass, _ x: transferring Klass, _ z: Klass) -> ()
+      """,
+      experimentalFeatures: .transferringArgsAndResults
+    )
+  }
+}


### PR DESCRIPTION
This PR contains the swift-syntax part of allowing for transferring arguments and results.