### PR TITLE
[5.10] Revert "guard nonisolated(unsafe) by experimental feature"

### DIFF
--- a/Sources/SwiftParser/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/ExperimentalFeatures.swift
@@ -26,7 +26,4 @@ extension Parser.ExperimentalFeatures {
 
   /// Whether to enable the parsing of 'then' statements.
   public static let thenStatements = Self(rawValue: 1 << 1)
-
-  /// Whether to enable the parsing of strict concurrency for globals.
-  public static let globalConcurrency = Self(rawValue: 1 << 2)
 }

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -61,12 +61,7 @@ extension Parser {
       case (.declarationModifier(.unowned), let handle)?:
         elements.append(self.parseUnownedModifier(handle))
       case (.declarationModifier(.nonisolated), let handle)?:
-        if experimentalFeatures.contains(.globalConcurrency) {
-          elements.append(parseNonisolatedModifier(handle))
-        } else {
-          let (unexpectedBeforeKeyword, keyword) = self.eat(handle)
-          elements.append(RawDeclModifierSyntax(unexpectedBeforeKeyword, name: keyword, detail: nil, arena: self.arena))
-        }
+        elements.append(parseNonisolatedModifier(handle))
       case (.declarationModifier(.final), let handle)?,
         (.declarationModifier(.required), let handle)?,
         (.declarationModifier(.optional), let handle)?,

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -210,8 +210,7 @@ final class DeclarationTests: ParserTestCase {
           nonisolated(unsafe) var c: Int { 0 }
           nonisolated(unsafe) let d = 0
         }
-        """,
-      experimentalFeatures: [.globalConcurrency]
+        """
     )
   }
 


### PR DESCRIPTION
This reverts commit b57568f4cb2593b170bf87fb912ce0683a941277.

`nonisolated(unsafe)` is being enabled in Swift 5.10 in https://github.com/apple/swift/pull/70750