### PR TITLE
Fix lookahead for effects specifiers in function types

### DIFF
--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -815,7 +815,6 @@ extension Parser.Lookahead {
       if peek(isAtAnyIn: EffectSpecifier.self) != nil {
         var backtrack = self.lookahead()
         backtrack.consumeAnyToken()
-        backtrack.consumeAnyToken()
         return backtrack.atFunctionTypeArrow()
       }
 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1048,6 +1048,15 @@ final class DeclarationTests: ParserTestCase {
       ],
       fixedSource: "func test() async throws(MyError){}"
     )
+
+    assertParse(
+      """
+      struct S<Element, Failure: Error> {
+        init(produce: @escaping () async throws(Failure) -> Element?) {
+        }
+      }
+      """
+    )
   }
 
   func testExtraneousRightBraceRecovery() {


### PR DESCRIPTION
We were failing to properly look past effect specifiers like `async throws(X)` in a function type starting with an attribute.