### PR TITLE
Add support for `@preconcurrency` type attribute

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -232,6 +232,7 @@ public enum Keyword: CaseIterable {
   case package
   case postfix
   case `precedencegroup`
+  case preconcurrency
   case prefix
   case `private`
   case `Protocol`
@@ -684,6 +685,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("unavailable")
     case .unchecked:
       return KeywordSpec("unchecked")
+    case .preconcurrency:
+      return KeywordSpec("preconcurrency")
     case .unowned:
       return KeywordSpec("unowned")
     case .unsafe:

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -247,6 +247,7 @@ enum TokenPrecedence: Comparable {
       .escaping,
       .noDerivative,
       .noescape,
+      .preconcurrency,
       .Sendable,
       .retroactive,
       .unchecked:

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -636,6 +636,7 @@ enum TypeAttribute: TokenSpecSet {
   case escaping
   case noDerivative
   case noescape
+  case preconcurrency
   case retroactive
   case Sendable
   case unchecked
@@ -652,6 +653,7 @@ enum TypeAttribute: TokenSpecSet {
     case TokenSpec(.escaping): self = .escaping
     case TokenSpec(.noDerivative): self = .noDerivative
     case TokenSpec(.noescape): self = .noescape
+    case TokenSpec(.preconcurrency): self = .preconcurrency
     case TokenSpec(.Sendable): self = .Sendable
     case TokenSpec(.retroactive): self = .retroactive
     case TokenSpec(.unchecked): self = .unchecked
@@ -671,6 +673,7 @@ enum TypeAttribute: TokenSpecSet {
     case .escaping: return .keyword(.escaping)
     case .noDerivative: return .keyword(.noDerivative)
     case .noescape: return .keyword(.noescape)
+    case .preconcurrency: return .keyword(.preconcurrency)
     case .retroactive: return .keyword(.retroactive)
     case .Sendable: return .keyword(.Sendable)
     case .unchecked: return .keyword(.unchecked)

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -924,7 +924,7 @@ extension Parser {
   mutating func parseTypeAttribute() -> RawAttributeListSyntax.Element {
     switch peek(isAtAnyIn: TypeAttribute.self) {
     case ._local, ._noMetadata, .async, .escaping, .noDerivative, .noescape,
-      .retroactive, .Sendable, .unchecked, .autoclosure:
+      .preconcurrency, .retroactive, .Sendable, .unchecked, .autoclosure:
       // Known type attribute that doesn't take any arguments
       return parseAttributeWithoutArguments()
     case .differentiable:

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -174,6 +174,7 @@ public enum Keyword: UInt8, Hashable {
   case package
   case postfix
   case `precedencegroup`
+  case preconcurrency
   case prefix
   case `private`
   case `Protocol`
@@ -676,6 +677,8 @@ public enum Keyword: UInt8, Hashable {
         self = .associatedtype
       case "differentiable":
         self = .differentiable
+      case "preconcurrency":
+        self = .preconcurrency
       case "witness_method":
         self = .witness_method
       default:
@@ -949,6 +952,7 @@ public enum Keyword: UInt8, Hashable {
       "package", 
       "postfix", 
       "precedencegroup", 
+      "preconcurrency", 
       "prefix", 
       "private", 
       "Protocol", 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -742,6 +742,20 @@ final class DeclarationTests: ParserTestCase {
     )
   }
 
+  func testParsePreconcurrency() {
+    assertParse(
+      """
+      struct MyValue: @preconcurrency P {}
+      """
+    )
+
+    assertParse(
+      """
+      extension MyValue: @preconcurrency P {}
+      """
+    )
+  }
+
   func testParseDynamicReplacement() {
     assertParse(
       """


### PR DESCRIPTION
Part of the `@preconcurrency` conformances feature. 
Swift Forums discussion - https://forums.swift.org/t/pitch-dynamic-actor-isolation-enforcement/68354