### PR TITLE
[509] Add `conformingTo` parameter to `MemberMacro.expansion` function

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -236,6 +236,7 @@ public func expandAttachedMacroWithoutCollapsing<Context: MacroExpansionContext>
       let members = try attachedMacro.expansion(
         of: attributeNode,
         providingMembersOf: declGroup,
+        conformingTo: conformanceList?.map(\.type) ?? [],
         in: context
       )
 

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
@@ -23,7 +23,9 @@ public protocol MemberMacro: AttachedMacro {
   ///
   /// - Returns: the set of member declarations introduced by this macro, which
   /// are nested inside the `attachedTo` declaration.
-  @available(*, deprecated, message: "Use expansion(of:providingMembersOf:conformingTo:in:")
+  ///
+  /// - Warning: This is the legacy `expansion` function of `MemberMacro` that is provided for backwards-compatiblity.
+  ///   Use ``expansion(of:providingMembersOf:conformingTo:in:)-1sxoe`` instead.
   static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
@@ -54,6 +56,16 @@ public protocol MemberMacro: AttachedMacro {
   ) throws -> [DeclSyntax]
 }
 
+private struct UnimplementedExpansionMethodError: Error, CustomStringConvertible {
+  var description: String {
+    """
+    Types conforming to `MemberMacro` must implement either \
+    expansion(of:providingMembersOf:in:) or \
+    expansion(of:providingMembersOf:conformingTo:in:)
+    """
+  }
+}
+
 public extension MemberMacro {
   /// Default implementation supplies no conformances.
   static func expansion(
@@ -61,7 +73,7 @@ public extension MemberMacro {
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    return try expansion(of: node, providingMembersOf: declaration, conformingTo: [], in: context)
+    throw UnimplementedExpansionMethodError()
   }
 
   /// Default implementation that ignores the unhandled conformances.

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
@@ -23,9 +23,54 @@ public protocol MemberMacro: AttachedMacro {
   ///
   /// - Returns: the set of member declarations introduced by this macro, which
   /// are nested inside the `attachedTo` declaration.
+  @available(*, deprecated, message: "Use expansion(of:providingMembersOf:conformingTo:in:")
   static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax]
+
+  /// Expand an attached declaration macro to produce a set of members.
+  ///
+  /// - Parameters:
+  ///   - node: The custom attribute describing the attached macro.
+  ///   - declaration: The declaration the macro attribute is attached to.
+  ///   - conformingTo: The set of protocols that were declared
+  ///     in the set of conformances for the macro and to which the declaration
+  ///     does not explicitly conform. The member macro itself cannot declare
+  ///     conformances to these protocols (only an extension macro can do that),
+  ///     but can provide supporting declarations, such as a required
+  ///     initializer or stored property, that cannot be written in an
+  ///     extension.
+  ///   - context: The context in which to perform the macro expansion.
+  ///
+  /// - Returns: the set of member declarations introduced by this macro, which
+  /// are nested inside the `attachedTo` declaration.
+  static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax]
+}
+
+public extension MemberMacro {
+  /// Default implementation supplies no conformances.
+  static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return try expansion(of: node, providingMembersOf: declaration, conformingTo: [], in: context)
+  }
+
+  /// Default implementation that ignores the unhandled conformances.
+  static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return try expansion(of: node, providingMembersOf: declaration, in: context)
+  }
 }


### PR DESCRIPTION
* **Explanation**: [SE-0407](https://github.com/apple/swift-evolution/blob/main/proposals/0407-member-macro-conformances.md) was implemented in 5.9.2. swift-syntax needs to be changed to to access the conformances from a macro. Add a new defaulted version of the `expansion` function in `MemberMacro` that receives the `conformingTo` parameter. Cherry-picks 746fab8 and 32f57055bdc19ec353fc2ced84a2f21818155b2c
* **Scope**: Expansion function of the `MemberMacro` protocol.
* **Risk**: Low
* **Testing**: Manually tested that a member macro gets passed the conformances list with this PR.
* **Issue**: https://forums.swift.org/t/member-macro-conformances-release-for-swiftsyntax/69333/1
* **Reviewer**:  @bnbarham @DougGregor 