### PR TITLE
Remove ability to parse `available` in `@_specialize`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AttributeNodes.swift
@@ -629,7 +629,6 @@ public let ATTRIBUTE_NODES: [Node] = [
           .keyword(.kind),
           .keyword(.spi),
           .keyword(.spiModule),
-          .keyword(.available),
         ]),
         nameForDiagnostics: "label",
         documentation: "The label of the argument"

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -689,25 +689,6 @@ extension Parser {
             )
           )
         )
-      case (.available, let handle)?:
-        let label = self.eat(handle)
-        let (unexpectedBeforeColon, colon) = self.expect(.colon)
-        // FIXME: I have no idea what this is supposed to be, but the Syntax
-        // tree only allows us to insert a token so we'll take anything.
-        let available = self.consumeAnyToken()
-        let comma = self.consume(if: .comma)
-        elements.append(
-          .labeledSpecializeArgument(
-            RawLabeledSpecializeArgumentSyntax(
-              label: label,
-              unexpectedBeforeColon,
-              colon: colon,
-              value: available,
-              trailingComma: comma,
-              arena: self.arena
-            )
-          )
-        )
       case (.exported, let handle)?:
         let label = self.eat(handle)
         let (unexpectedBeforeColon, colon) = self.expect(.colon)

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -1910,7 +1910,6 @@ extension LabeledSpecializeArgumentSyntax {
     case kind
     case spi
     case spiModule
-    case available
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
@@ -1926,8 +1925,6 @@ extension LabeledSpecializeArgumentSyntax {
         self = .spi
       case TokenSpec(.spiModule):
         self = .spiModule
-      case TokenSpec(.available):
-        self = .available
       default:
         return nil
       }
@@ -1947,8 +1944,6 @@ extension LabeledSpecializeArgumentSyntax {
         return .keyword(.spi)
       case .spiModule:
         return .keyword(.spiModule)
-      case .available:
-        return .keyword(.available)
       }
     }
     
@@ -1970,8 +1965,6 @@ extension LabeledSpecializeArgumentSyntax {
         return .keyword(.spi)
       case .spiModule:
         return .keyword(.spiModule)
-      case .available:
-        return .keyword(.available)
       }
     }
   }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1667,8 +1667,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("exported"), 
             .keyword("kind"), 
             .keyword("spi"), 
-            .keyword("spiModule"), 
-            .keyword("available")
+            .keyword("spiModule")
           ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.colon)]))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -1004,7 +1004,7 @@ public struct LabeledExprSyntax: SyntaxProtocol, SyntaxHashable, _LeafSyntaxNode
 ///
 /// ### Children
 /// 
-///  - `label`: (`target` | `availability` | `exported` | `kind` | `spi` | `spiModule` | `available`)
+///  - `label`: (`target` | `availability` | `exported` | `kind` | `spi` | `spiModule`)
 ///  - `colon`: `:`
 ///  - `value`: ``TokenSyntax``
 ///  - `trailingComma`: `,`?
@@ -1099,7 +1099,6 @@ public struct LabeledSpecializeArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
   ///  - `kind`
   ///  - `spi`
   ///  - `spiModule`
-  ///  - `available`
   public var label: TokenSyntax {
     get {
       return Syntax(self).child(at: 1)!.cast(TokenSyntax.self)


### PR DESCRIPTION
The `available` argument to `@_specialize` is only supported in SIL, which SwiftSyntax doesn’t parse.