### PR TITLE
Skip newlines for `weakBracketClose` precedence level

### DIFF
--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -100,10 +100,10 @@ enum TokenPrecedence: Comparable {
     return precedence(lhs) < precedence(rhs)
   }
 
-  /// When expecting a token with `stmtKeyword` precedence or higher, newlines may be skipped to find that token.
+  /// When expecting a token with `weakBracketClose` precedence or higher, newlines may be skipped to find that token.
   /// For lower precedence groups, we consider newlines the end of the lookahead scope.
   var shouldSkipOverNewlines: Bool {
-    return self >= .stmtKeyword
+    return self >= .weakBracketClose
   }
 
   init(_ lexeme: Lexer.Lexeme) {

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -487,12 +487,10 @@ final class DeclarationTests: ParserTestCase {
       ) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected 'set)' to end modifier", fixIts: ["insert 'set)'"]),
-        // FIXME: It should print `+` as detail of text.
-        DiagnosticSpec(message: "unexpected code in variable"),
+        DiagnosticSpec(message: "expected 'set' in modifier", fixIts: ["remove '+'"])
       ],
       fixedSource: """
-        private(set) +
+        private(
           set
         ) var a = 0
         """
@@ -1470,18 +1468,12 @@ final class DeclarationTests: ParserTestCase {
           fixIts: ["insert ':'"]
         ),
         DiagnosticSpec(
-          locationMarker: "2️⃣",
-          message: "expected ')' to end parameter clause",
-          notes: [NoteSpec(message: "to match this opening '('")],
-          fixIts: ["insert ')'"]
-        ),
-        DiagnosticSpec(
           locationMarker: "3️⃣",
-          message: "extraneous code ': Int) {}' at top level"
+          message: "unexpected code ': Int' in parameter clause"
         ),
       ],
       fixedSource: """
-        func foo(first second: third)
+        func foo(first second: third
         : Int) {}
         """
     )


### PR DESCRIPTION
This slightly improves recovery.