### PR TITLE
[Parser] Correct the start byte range for UTF8 characters.

### DIFF
--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -1504,4 +1504,23 @@ public class LexerTests: ParserTestCase {
       ]
     )
   }
+
+  func testUnicodeContainTheEdgeContinuationByte() {
+    // A continuation byte must be in the range greater than or
+    // equal to 0x80 and less than or equal to 0xBF
+
+    // À(0xC3 0x80), 㗀(0xE3 0x97 0x80), 🀀(0xF0 0x9F 0x80 0x80),
+    // ÿ(0xC3 0xBF), 俿(0xE4 0xBF 0xBF), 𐐿(0xF0 0x90 0x90 0xBF)
+    assertLexemes(
+      "À 㗀 🀀 ÿ 俿 𐐿",
+      lexemes: [
+        LexemeSpec(.identifier, text: "À", trailing: " "),
+        LexemeSpec(.identifier, text: "㗀", trailing: " "),
+        LexemeSpec(.identifier, text: "🀀", trailing: " "),
+        LexemeSpec(.identifier, text: "ÿ", trailing: " "),
+        LexemeSpec(.identifier, text: "俿", trailing: " "),
+        LexemeSpec(.identifier, text: "𐐿"),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
This PR is nearly identical to [the fix in the compiler's lexer](https://github.com/apple/swift/pull/70763), addressing the correction of the UTF-8 start byte range.
- '0x80' is not a valid byte for the start of a UTF8 character; it's a continuation byte.(RFC 3629)

But while examining the SwiftSyntax version, I found an additional semantic error in the start byte validation. 
Existing computed property __isStartOfUTF8Character__ is extented on Unicode.Scalar type, which is very confusing because a value of Unicode.Scalar represents a valid decoded unicode value, not a single UTF-8 byte. 
For example, Unicode.Scalar(0x80) consists of 2 UTF-8 bytes, and it doesn't make sense semantically to check whether it's within the range of the UTF-8 start byte.
So let's check this instead with UInt8 type.