### PR TITLE
Remove `@_implementationOnly` annotations

### DIFF
--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -12,12 +12,22 @@
 // NOTE: This basic plugin mechanism is mostly copied from
 // https://github.com/apple/swift-package-manager/blob/main/Sources/PackagePlugin/Plugin.swift
 
-@_implementationOnly import Foundation
-@_implementationOnly import SwiftCompilerPluginMessageHandling
 import SwiftSyntaxMacros
 
+#if swift(>=5.11)
+private import Foundation
+private import SwiftCompilerPluginMessageHandling
+#else
+import Foundation
+import SwiftCompilerPluginMessageHandling
+#endif
+
 #if os(Windows)
-@_implementationOnly import ucrt
+#if swift(>=5.11)
+private import ucrt
+#else
+import ucrt
+#endif
 #endif
 
 //
@@ -167,8 +177,8 @@ extension CompilerPlugin {
 }
 
 internal struct PluginHostConnection: MessageConnection {
-  let inputStream: FileHandle
-  let outputStream: FileHandle
+  fileprivate let inputStream: FileHandle
+  fileprivate let outputStream: FileHandle
 
   func sendMessage<TX: Encodable>(_ message: TX) throws {
     // Encode the message as JSON.

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -10,12 +10,22 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.11)
 #if canImport(Darwin)
-@_implementationOnly import Darwin
+private import Darwin
 #elseif canImport(Glibc)
-@_implementationOnly import Glibc
+private import Glibc
 #elseif canImport(Musl)
-@_implementationOnly import Musl
+private import Musl
+#endif
+#else
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 #endif
 
 /// Represent a string.

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -17,8 +17,13 @@ import SwiftParserDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
-import XCTest
 import _SwiftSyntaxTestSupport
+
+#if swift(>=5.11)
+private import XCTest
+#else
+import XCTest
+#endif
 
 // MARK: - Note
 


### PR DESCRIPTION
These annotations produce warnings when compiling swift-syntax without library evolution using Swift ≥5.10.

Replace them by `private import` when compiling using Swift ≥5.11.

Also mark the import of XCTest from `SwiftSyntaxMacrosTestSupport` as `private`, fixing rdar://119517162.

Fixes https://github.com/apple/swift-syntax/issues/2228
rdar://119517162
rdar://115910675