### PR TITLE
[509] Add visionOS to the list of platforms that can't start a new process from swift-parser-cli

### DIFF
--- a/Sources/swift-parser-cli/Commands/Reduce.swift
+++ b/Sources/swift-parser-cli/Commands/Reduce.swift
@@ -66,7 +66,7 @@ struct Reduce: ParsableCommand {
   /// Invoke `swift-parser-cli verify-round-trip` with the same arguments as this `reduce` subcommand.
   /// Returns the exit code of the invocation.
   private func runVerifyRoundTripInSeparateProcess(source: [UInt8]) throws -> ProcessExit {
-    #if os(iOS) || os(tvOS) || os(watchOS)
+    #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     // We cannot launch a new process on iOS-like platforms.
     // Default to running verification in-process.
     // Honestly, this isn't very important because you can't launch swift-parser-cli


### PR DESCRIPTION
* **Explanation**: `Process` is not available on visionOS, causing a build failure of swift-syntax 509.x.x for that platform when building the `swift-parser-cli` command line test utility. We should use the same `#if` check that we have for iOS, tvOS and watchOS to also guard the process spawning code on visionOS.
* **Scope**: Building the swift-parser-cli target on visionOS. Building commonly used products like SwiftSyntax and SwiftParser is fine
* **Risk**: Very low, treat visionOS the same as iOS
* **Testing**: Tested that the swift-syntax package now builds for visionOS
* **Issue**: n/a
* **Reviewer**:  @bnbarham