### PR TITLE
UnicodeScalar operators.

### DIFF
--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -97,21 +97,8 @@ extension Unicode.Scalar {
     // ASCII operator chars.
     if self.value < 0x80 {
       switch UInt8(self.value) {
-      case UInt8(ascii: "/"),
-        UInt8(ascii: "="),
-        UInt8(ascii: "-"),
-        UInt8(ascii: "+"),
-        UInt8(ascii: "*"),
-        UInt8(ascii: "%"),
-        UInt8(ascii: "<"),
-        UInt8(ascii: ">"),
-        UInt8(ascii: "!"),
-        UInt8(ascii: "&"),
-        UInt8(ascii: "|"),
-        UInt8(ascii: "^"),
-        UInt8(ascii: "~"),
-        UInt8(ascii: "."),
-        UInt8(ascii: "?"):
+      case "/", "=", "-", "+", "*", "%", "<",
+        ">", "!", "&", "|", "^", "~", ".", "?":
         return true
       default:
         return false
@@ -257,5 +244,42 @@ extension UInt8 {
     // RFC 2279: The octet values FE and FF never appear.
     // RFC 3629: The octet values C0, C1, F5 to FF never appear.
     return self < 0x80 || (self >= 0xC2 && self < 0xF5)
+  }
+}
+
+/// Allows direct comparisons between UInt8 and double quoted literals.
+extension UInt8 {
+  /// Equality operator
+  @_transparent
+  static func == (i: Self, s: Unicode.Scalar) -> Bool {
+    return i == UInt8(ascii: s)
+  }
+  /// Inequality operator
+  @_transparent
+  static func != (i: Self, s: Unicode.Scalar) -> Bool {
+    return i != UInt8(ascii: s)
+  }
+  /// Used in switch statements
+  @_transparent
+  static func ~= (s: Unicode.Scalar, i: Self) -> Bool {
+    return i == UInt8(ascii: s)
+  }
+}
+
+extension UInt8? {
+  /// Equality operator
+  @_transparent
+  static func == (i: Self, s: Unicode.Scalar) -> Bool {
+    return i == UInt8(ascii: s)
+  }
+  /// Inequality operator
+  @_transparent
+  static func != (i: Self, s: Unicode.Scalar) -> Bool {
+    return i != UInt8(ascii: s)
+  }
+  /// Used in switch statements
+  @_transparent
+  static func ~= (s: Unicode.Scalar, i: Self) -> Bool {
+    return i == UInt8(ascii: s)
   }
 }


### PR DESCRIPTION
Hi Apple,

Some ideas being explored on [this thread](https://forums.swift.org/t/single-quoted-character-literals-why-yes-again/61898/88) in Swift evolution trying to validate the use of a protocol extension for avoiding having to use `UInt8(ascii:)` all the time for low level code. The TL;DR is that this change tidies up the new Lexer code in `Cursor.swift` considerably but I've not been able  to quantify any performance regression for a `Release` build. For details on how it was benchmarked see the remainder of the [character-literals](https://github.com/johnno1962/swift-syntax/pull/1/files) branch.

Cheers