### PR TITLE
Make `SyntaxArena.hasParent` an atomic boolean

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,5 +88,9 @@ if (SWIFTSYNTAX_ENABLE_ASSERTIONS)
   )
 endif()
 
+add_compile_definitions(
+  $<$<COMPILE_LANGUAGE:Swift>:SWIFT_SYNTAX_BUILD_USING_CMAKE>
+)
+
 add_subdirectory(Sources)
 add_subdirectory(cmake/modules)

--- a/Package.swift
+++ b/Package.swift
@@ -88,6 +88,10 @@ let package = Package(
     // MARK: - Internal helper targets
 
     .target(
+      name: "_AtomicBool"
+    ),
+
+    .target(
       name: "_InstructionCounter"
     ),
 
@@ -172,7 +176,7 @@ let package = Package(
 
     .target(
       name: "SwiftSyntax",
-      dependencies: ["SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax511"],
+      dependencies: ["_AtomicBool", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax511"],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
     ),

--- a/Sources/_AtomicBool/include/AtomicBool.h
+++ b/Sources/_AtomicBool/include/AtomicBool.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdbool.h>
+
+typedef struct {
+  _Atomic(bool) value;
+} AtomicBool;
+
+__attribute__((swift_name("AtomicBool.init(initialValue:)")))
+AtomicBool atomic_bool_create(bool initialValue);
+
+__attribute__((swift_name("getter:AtomicBool.value(self:)")))
+bool atomic_bool_get(AtomicBool *atomic);
+
+__attribute__((swift_name("setter:AtomicBool.value(self:_:)")))
+void atomic_bool_set(AtomicBool *atomic, bool newValue);

--- a/Sources/_AtomicBool/src/AtomicBool.c
+++ b/Sources/_AtomicBool/src/AtomicBool.c
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "AtomicBool.h"
+
+AtomicBool atomic_bool_create(bool initialValue) {
+  AtomicBool atomic;
+  atomic.value = initialValue;
+  return atomic;
+}
+
+bool atomic_bool_get(AtomicBool *atomic) {
+  return atomic->value;
+}
+
+void atomic_bool_set(AtomicBool *atomic, bool newValue) {
+  atomic->value = newValue;
+}


### PR DESCRIPTION
This fixes a concurrency issue in `SyntaxArena`.

Building `_AtomicBool` using CMake is more tricky because the CMake infrastructure in swift-syntax doesn’t know how to build C modules. Since the compiler is only single-threaded race conditions are impossible, so we fake `AtomicBool` for now in CMake builds.

rdar://121324116