### PR TITLE
[SwiftSyntax] Refine several aspects of BumpPtrAllocator.

### DIFF
--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -30,7 +30,7 @@ extension Lexer {
     ///
     /// The memory footprint of not freeing past lexer states is negligible. It's
     /// usually less than 0.1% of the memory allocated by the syntax arena.
-    var lexerStateAllocator = BumpPtrAllocator(slabSize: 256)
+    var lexerStateAllocator = BumpPtrAllocator(initialSlabSize: 256)
 
     /// The offset of the trailing trivia end of `nextToken` relative to the source buffer’s start.
     var offsetToNextTokenEnd: Int {

--- a/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
+++ b/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
@@ -79,7 +79,7 @@ extension StringSegmentSyntax {
       // defensive as it's currently not used by `lexCharacterInStringLiteral`.
       let state = Lexer.Cursor.State.inStringLiteral(kind: stringLiteralKind, delimiterLength: delimiterLength)
       let transition = Lexer.StateTransition.push(newState: state)
-      cursor.perform(stateTransition: transition, stateAllocator: BumpPtrAllocator(slabSize: 256))
+      cursor.perform(stateTransition: transition, stateAllocator: BumpPtrAllocator(initialSlabSize: 256))
 
       while true {
         let lex = cursor.lexCharacterInStringLiteral(

--- a/Sources/SwiftSyntax/BumpPtrAllocator.swift
+++ b/Sources/SwiftSyntax/BumpPtrAllocator.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A ``BumpPtrAllocator`` that allocates `slabSize` at a time.
+/// `slabSize` initiates with `initialSlabSize` and doubles periodically as allocations occur.
 /// Once all memory in a slab has been used, it allocates a new slab and no
 /// memory allocations are necessary until that slab is completely filled up.
 @_spi(BumpPtrAllocator) @_spi(Testing)
@@ -20,8 +21,7 @@ public class BumpPtrAllocator {
   static private let GROWTH_DELAY: Int = 128
   static private let SLAB_ALIGNMENT: Int = 8
 
-  /// Initial slab size.
-  private var slabSize: Int
+  private let initialSlabSize: Int
 
   private var slabs: [Slab]
   /// Pair of pointers in the current slab.
@@ -38,8 +38,8 @@ public class BumpPtrAllocator {
   private var _totalBytesAllocated: Int
 
   /// Construct a new ``BumpPtrAllocator``.
-  public init(slabSize: Int) {
-    self.slabSize = slabSize
+  public init(initialSlabSize: Int) {
+    self.initialSlabSize = initialSlabSize
     slabs = []
     current = nil
     customSizeSlabs = []
@@ -61,7 +61,7 @@ public class BumpPtrAllocator {
   /// Calculate the size of the slab at the index.
   private func slabSize(at index: Int) -> Int {
     // Double the slab size every 'GROWTH_DELAY' slabs.
-    return self.slabSize * (1 << min(30, index / Self.GROWTH_DELAY))
+    return self.initialSlabSize * (1 << min(30, index / Self.GROWTH_DELAY))
   }
 
   private func startNewSlab() {
@@ -114,7 +114,7 @@ public class BumpPtrAllocator {
     }
 
     // If the size is too big, allocate a dedicated slab for it.
-    if byteCount >= self.slabSize {
+    if byteCount >= self.initialSlabSize {
       let customSlab = Slab.allocate(
         byteCount: byteCount,
         alignment: alignment

--- a/Sources/SwiftSyntax/BumpPtrAllocator.swift
+++ b/Sources/SwiftSyntax/BumpPtrAllocator.swift
@@ -48,8 +48,6 @@ public class BumpPtrAllocator {
 
   deinit {
     /// Deallocate all memory.
-    _totalBytesAllocated = 0
-    current = nil
     while let slab = slabs.popLast() {
       slab.deallocate()
     }

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -61,7 +61,7 @@ public class SyntaxArena {
   }
 
   fileprivate init(slabSize: Int) {
-    self.allocator = BumpPtrAllocator(slabSize: slabSize)
+    self.allocator = BumpPtrAllocator(initialSlabSize: slabSize)
     self.childRefs = []
     #if DEBUG || SWIFTSYNTAX_ENABLE_ASSERTIONS
     self.hasParent = false

--- a/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
+++ b/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
@@ -16,7 +16,7 @@ import XCTest
 final class BumpPtrAllocatorTests: XCTestCase {
 
   func testBasic() {
-    let allocator = BumpPtrAllocator(slabSize: 4096)
+    let allocator = BumpPtrAllocator(initialSlabSize: 4096)
 
     let byteBuffer = allocator.allocate(byteCount: 42, alignment: 4)
     XCTAssertNotNil(byteBuffer.baseAddress)


### PR DESCRIPTION
While skimming the `BumpPtrAllocator` class, I identified areas for improvement.
- Rename `slapSize` to `initialSlapSize` :  The variable name `slabSize` is quite confusing because it accidently implies that the allocated amount at a time is fixed, which is not the case. `BumpPtrAllocator` calculates the next size to be allocated based on the current index of the slabs array. So, I think we should clarify that it's only used initially.
- Remove unnecessary cleanup : Removed some unnecessary cleanup in the deinitializer of `BumpPtrAllocator`.
- Clarify the conditions for allocating a custom slab : We should check it based on the `slabSize`, not the `initialSlabSize`.