### PR TITLE
[Macros] Checking expression macro as caller-side default argument

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/CMakeLists.txt
+++ b/Sources/SwiftSyntaxMacroExpansion/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_syntax_library(SwiftSyntaxMacroExpansion
   BasicMacroExpansionContext.swift
   FunctionParameterUtils.swift
   IndentationUtils.swift
+  MacroArgument.swift
   MacroExpansion.swift
   MacroExpansionDiagnosticMessages.swift
   MacroReplacement.swift

--- a/Sources/SwiftSyntaxMacroExpansion/MacroArgument.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroArgument.swift
@@ -1,0 +1,138 @@
+import SwiftDiagnostics
+import SwiftSyntax
+
+enum DeclReferenceError: DiagnosticMessage {
+  case nonLiteral
+
+  var message: String {
+    switch self {
+    case .nonLiteral:
+      return "only literals are permitted"
+    }
+  }
+
+  var diagnosticID: MessageID {
+    .init(domain: "SwiftMacros", id: "\(self)")
+  }
+
+  var severity: DiagnosticSeverity {
+    .error
+  }
+}
+
+class CheckDeclReferenceVisitor: SyntaxAnyVisitor {
+  var diagnostics: [Diagnostic] = []
+
+  init() {
+    super.init(viewMode: .fixedUp)
+  }
+
+  // Integer literals
+  override func visit(_ node: IntegerLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // Floating point literals
+  override func visit(_ node: FloatLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // Negative numbers
+  override func visit(_ node: PrefixOperatorExprSyntax) -> SyntaxVisitorContinueKind {
+    switch node.operator.tokenKind {
+    case .prefixOperator("-")
+      // only allow negation on numbers, not other literal types
+      where node.expression.is(IntegerLiteralExprSyntax.self)
+      || node.expression.is(FloatLiteralExprSyntax.self):
+      return .visitChildren
+    default:
+      return diagnoseNonLiteral(node)
+    }
+  }
+
+  // Bool literals
+  override func visit(_ node: BooleanLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // nil literals
+  override func visit(_ node: NilLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // String literals
+  override func visit(_ node: StringLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // String interpolation
+  override func visit(_ node: StringLiteralSegmentListSyntax) -> SyntaxVisitorContinueKind {
+    guard node.count == 1,
+          case .stringSegment = node.first! else {
+      return diagnoseNonLiteral(node)
+    }
+    return .visitChildren
+  }
+
+  // Array literals
+  override func visit(_ node: ArrayExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // Dictionary literals
+  override func visit(_ node: DictionaryExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // Tuple literals
+  override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // Regex literals
+  override func visit(_ node: RegexLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // Macro uses.
+  override func visit(_ node: MacroExpansionExprSyntax) -> SyntaxVisitorContinueKind {
+    .visitChildren
+  }
+
+  // References to declarations.
+  override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+    return diagnoseNonLiteral(node)
+  }
+
+  override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+    if node.is(ExprSyntax.self) {
+      // We have an expression that is not one of the allowed forms, so
+      // diagnose it.
+      return diagnoseNonLiteral(node)
+    }
+
+    return .visitChildren
+  }
+
+  func diagnoseNonLiteral(_ node: some SyntaxProtocol) -> SyntaxVisitorContinueKind {
+    diagnostics.append(
+      Diagnostic(
+        node: node,
+        message: DeclReferenceError.nonLiteral
+      )
+    )
+
+    return .skipChildren
+  }
+}
+
+extension MacroExpansionExprSyntax {
+  public func checkDefaultArgumentMacroExpression() throws {
+    let visitor = CheckDeclReferenceVisitor()
+    visitor.walk(arguments)
+
+    if !visitor.diagnostics.isEmpty {
+      throw DiagnosticsError(diagnostics: visitor.diagnostics)
+    }
+  }
+}

--- a/Sources/SwiftSyntaxMacroExpansion/MacroArgument.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroArgument.swift
@@ -55,8 +55,8 @@ class OnlyLiteralExprChecker: SyntaxAnyVisitor {
   override func visit(_ node: PrefixOperatorExprSyntax) -> SyntaxVisitorContinueKind {
     switch node.operator.tokenKind {
     case .prefixOperator("-")
-      // only allow negation on numbers, not other literal types
-      where node.expression.is(IntegerLiteralExprSyntax.self)
+    // only allow negation on numbers, not other literal types
+    where node.expression.is(IntegerLiteralExprSyntax.self)
       || node.expression.is(FloatLiteralExprSyntax.self):
       return .visitChildren
     default:
@@ -82,7 +82,8 @@ class OnlyLiteralExprChecker: SyntaxAnyVisitor {
   // String interpolation
   override func visit(_ node: StringLiteralSegmentListSyntax) -> SyntaxVisitorContinueKind {
     guard node.count == 1,
-          case .stringSegment = node.first! else {
+      case .stringSegment = node.first!
+    else {
       return diagnoseNonLiteral(node)
     }
     return .visitChildren

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -19,7 +19,7 @@ enum MacroExpanderError: DiagnosticMessage {
   case definitionNotMacroExpansion
   case nonParameterReference(TokenSyntax)
   case nonTypeReference(TokenSyntax)
-  case nonLiteralOrParameter(ExprSyntax)
+  case nonLiteralOrParameter
 
   var message: String {
     switch self {
@@ -93,55 +93,14 @@ extension MacroDefinition {
   }
 }
 
-fileprivate class ParameterReplacementVisitor: SyntaxAnyVisitor {
+fileprivate class ParameterReplacementVisitor: CheckDeclReferenceVisitor {
   let macro: MacroDeclSyntax
   var replacements: [MacroDefinition.Replacement] = []
   var genericReplacements: [MacroDefinition.GenericArgumentReplacement] = []
-  var diagnostics: [Diagnostic] = []
 
   init(macro: MacroDeclSyntax) {
     self.macro = macro
-    super.init(viewMode: .fixedUp)
-  }
-
-  // Integer literals
-  override func visit(_ node: IntegerLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-    .visitChildren
-  }
-
-  // Floating point literals
-  override func visit(_ node: FloatLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-    .visitChildren
-  }
-
-  // nil literals
-  override func visit(_ node: NilLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-    .visitChildren
-  }
-
-  // String literals
-  override func visit(_ node: StringLiteralExprSyntax) -> SyntaxVisitorContinueKind {
-    .visitChildren
-  }
-
-  // Array literals
-  override func visit(_ node: ArrayExprSyntax) -> SyntaxVisitorContinueKind {
-    .visitChildren
-  }
-
-  // Dictionary literals
-  override func visit(_ node: DictionaryExprSyntax) -> SyntaxVisitorContinueKind {
-    .visitChildren
-  }
-
-  // Tuple literals
-  override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
-    .visitChildren
-  }
-
-  // Macro uses.
-  override func visit(_ node: MacroExpansionExprSyntax) -> SyntaxVisitorContinueKind {
-    .visitChildren
+    super.init()
   }
 
   // References to declarations. Only accept those that refer to a parameter
@@ -216,23 +175,16 @@ fileprivate class ParameterReplacementVisitor: SyntaxAnyVisitor {
     return .visitChildren
   }
 
-  override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
-    if let expr = node.as(ExprSyntax.self) {
-      // We have an expression that is not one of the allowed forms, so
-      // diagnose it.
-      diagnostics.append(
-        Diagnostic(
-          node: node,
-          message: MacroExpanderError.nonLiteralOrParameter(expr)
-        )
+  override func diagnoseNonLiteral(_ node: some SyntaxProtocol) -> SyntaxVisitorContinueKind {
+    diagnostics.append(
+      Diagnostic(
+        node: node,
+        message: MacroExpanderError.nonLiteralOrParameter
       )
+    )
 
-      return .skipChildren
-    }
-
-    return .visitChildren
+    return .skipChildren
   }
-
 }
 
 extension MacroDeclSyntax {

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -93,7 +93,7 @@ extension MacroDefinition {
   }
 }
 
-fileprivate class ParameterReplacementVisitor: CheckDeclReferenceVisitor {
+fileprivate class ParameterReplacementVisitor: OnlyLiteralExprChecker {
   let macro: MacroDeclSyntax
   var replacements: [MacroDefinition.Replacement] = []
   var genericReplacements: [MacroDefinition.GenericArgumentReplacement] = []

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroArgumentTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroArgumentTests.swift
@@ -13,7 +13,7 @@
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftSyntaxMacroExpansion
+@_spi(Compiler) import SwiftSyntaxMacroExpansion
 import XCTest
 import _SwiftSyntaxTestSupport
 
@@ -34,22 +34,21 @@ final class MacroArgumentTests: XCTestCase {
       #otherMacro(first: b, second: "\(false)", third: 1 + 2)
       """#
 
-    let diags: [Diagnostic]
-    do {
-      try macro.as(MacroExpansionExprSyntax.self)!
-        .checkDefaultArgumentMacroExpression()
-      XCTFail("should have failed with an error")
-      fatalError()
-    } catch let diagError as DiagnosticsError {
-      diags = diagError.diagnostics
-    }
+    XCTAssertThrowsError(try macro.as(MacroExpansionExprSyntax.self)!
+      .checkDefaultArgumentMacroExpression()) { error in
+        guard let diagError = error as? DiagnosticsError else {
+          XCTFail("should have failed with a diagnostics error")
+          return
+        }
+        let diags = diagError.diagnostics
 
-    XCTAssertEqual(diags.count, 3)
-    for diag in diags {
-      XCTAssertEqual(
-        diag.diagMessage.message,
-        "only literals are permitted"
-      )
-    }
+        XCTAssertEqual(diags.count, 3)
+        for diag in diags {
+          XCTAssertEqual(
+            diag.diagMessage.message,
+            "only literals are permitted"
+          )
+        }
+      }
   }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroArgumentTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroArgumentTests.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacroExpansion
+import XCTest
+import _SwiftSyntaxTestSupport
+
+final class MacroArgumentTests: XCTestCase {
+  func testDefaultArgumentMacroExprGood() throws {
+    let macro: ExprSyntax =
+      """
+      #otherMacro(first: (/foo/, 0x42), second: ["a": nil], third: [3.14159, -2.71828], fourth: true)
+      """
+
+    XCTAssertNoThrow(try macro.as(MacroExpansionExprSyntax.self)!
+      .checkDefaultArgumentMacroExpression())
+  }
+
+  func testDefaultArgumentMacroExprNonLiteral() throws {
+    let macro: ExprSyntax =
+      #"""
+      #otherMacro(first: b, second: "\(false)", third: 1 + 2)
+      """#
+
+    let diags: [Diagnostic]
+    do {
+      try macro.as(MacroExpansionExprSyntax.self)!
+        .checkDefaultArgumentMacroExpression()
+      XCTFail("should have failed with an error")
+      fatalError()
+    } catch let diagError as DiagnosticsError {
+      diags = diagError.diagnostics
+    }
+
+    XCTAssertEqual(diags.count, 3)
+    for diag in diags {
+      XCTAssertEqual(
+        diag.diagMessage.message,
+        "only literals are permitted"
+      )
+    }
+  }
+}

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroArgumentTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroArgumentTests.swift
@@ -24,8 +24,10 @@ final class MacroArgumentTests: XCTestCase {
       #otherMacro(first: (/foo/, 0x42), second: ["a": nil], third: [3.14159, -2.71828], fourth: true)
       """
 
-    XCTAssertNoThrow(try macro.as(MacroExpansionExprSyntax.self)!
-      .checkDefaultArgumentMacroExpression())
+    XCTAssertNoThrow(
+      try macro.as(MacroExpansionExprSyntax.self)!
+        .checkDefaultArgumentMacroExpression()
+    )
   }
 
   func testDefaultArgumentMacroExprNonLiteral() throws {
@@ -34,21 +36,23 @@ final class MacroArgumentTests: XCTestCase {
       #otherMacro(first: b, second: "\(false)", third: 1 + 2)
       """#
 
-    XCTAssertThrowsError(try macro.as(MacroExpansionExprSyntax.self)!
-      .checkDefaultArgumentMacroExpression()) { error in
-        guard let diagError = error as? DiagnosticsError else {
-          XCTFail("should have failed with a diagnostics error")
-          return
-        }
-        let diags = diagError.diagnostics
-
-        XCTAssertEqual(diags.count, 3)
-        for diag in diags {
-          XCTAssertEqual(
-            diag.diagMessage.message,
-            "only literals are permitted"
-          )
-        }
+    XCTAssertThrowsError(
+      try macro.as(MacroExpansionExprSyntax.self)!
+        .checkDefaultArgumentMacroExpression()
+    ) { error in
+      guard let diagError = error as? DiagnosticsError else {
+        XCTFail("should have failed with a diagnostics error")
+        return
       }
+      let diags = diagError.diagnostics
+
+      XCTAssertEqual(diags.count, 3)
+      for diag in diags {
+        XCTAssertEqual(
+          diag.diagMessage.message,
+          "only literals are permitted"
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
Companion for https://github.com/apple/swift/pull/70602 to allow only literals as arguments in a macro expression used as a default argument

## Note

This also impact accepted literals as mentioned in SE-0382 that

- Negative numbers are now accepted
- String interpolations are no longer accepted, even if all the interpolated expressions are literals or parameter references