### PR TITLE
[Parser] Handle `deinit` and `subscript` as declaration name references

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -932,6 +932,8 @@ public let EXPR_NODES: [Node] = [
           .keyword(.self),
           .keyword(.Self),
           .keyword(.`init`),
+          .keyword(.`deinit`),
+          .keyword(.`subscript`),
           .token(.dollarIdentifier),
           .token(.binaryOperator),
           .token(.integerLiteral),

--- a/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
@@ -57,7 +57,15 @@ public let PATTERN_NODES: [Node] = [
     children: [
       Child(
         name: "identifier",
-        kind: .token(choices: [.token(.identifier), .keyword(.self), .keyword(.`init`)])
+        kind: .token(
+          choices: [
+            .token(.identifier),
+            .keyword(.self),
+            .keyword(.`init`),
+            .keyword(.`deinit`),
+            .keyword(.`subscript`),
+          ]
+        )
       )
     ]
   ),

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1120,7 +1120,7 @@ extension Parser {
           arena: self.arena
         )
       )
-    case (.identifier, let handle)?, (.self, let handle)?, (.`init`, let handle)?:
+    case (.identifier, let handle)?, (.self, let handle)?, (.`init`, let handle)?, (.`deinit`, let handle)?, (.`subscript`, let handle)?:
       // If we have "case let x" followed by ".", "(", "[", or a generic
       // argument list, we parse x as a normal name, not a binding, because it
       // is the start of an enum or expr pattern.

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -66,7 +66,7 @@ extension Parser {
   mutating func parseDeclReferenceExpr(_ flags: DeclNameOptions = []) -> RawDeclReferenceExprSyntax {
     // Consume the base name.
     let base: RawTokenSyntax
-    if let identOrSelf = self.consume(if: .identifier, .keyword(.self), .keyword(.Self)) ?? self.consume(if: .keyword(.`init`)) {
+    if let identOrSelf = self.consume(if: .identifier, .keyword(.self), .keyword(.Self)) ?? self.consume(if: .keyword(.`init`)) ?? self.consume(if: .keyword(.`deinit`)) ?? self.consume(if: .keyword(.`subscript`)) {
       base = identOrSelf
     } else if flags.contains(.operators), let (_, _) = self.at(anyIn: Operator.self) {
       base = self.consumeAnyToken(remapping: .binaryOperator)

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -66,7 +66,9 @@ extension Parser {
   mutating func parseDeclReferenceExpr(_ flags: DeclNameOptions = []) -> RawDeclReferenceExprSyntax {
     // Consume the base name.
     let base: RawTokenSyntax
-    if let identOrSelf = self.consume(if: .identifier, .keyword(.self), .keyword(.Self)) ?? self.consume(if: .keyword(.`init`)) ?? self.consume(if: .keyword(.`deinit`)) ?? self.consume(if: .keyword(.`subscript`)) {
+    if let identOrSelf = self.consume(if: .identifier, .keyword(.self), .keyword(.Self)) ?? self.consume(if: .keyword(.`init`)) ?? self.consume(
+      if: .keyword(.`deinit`)
+    ) ?? self.consume(if: .keyword(.`subscript`)) {
       base = identOrSelf
     } else if flags.contains(.operators), let (_, _) = self.at(anyIn: Operator.self) {
       base = self.consumeAnyToken(remapping: .binaryOperator)

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -869,6 +869,7 @@ enum PrimaryExpressionStart: TokenSpecSet {
   case `Any`
   case atSign  // For recovery
   case `Self`
+  case `deinit`
   case dollarIdentifier
   case `false`
   case floatLiteral
@@ -886,6 +887,7 @@ enum PrimaryExpressionStart: TokenSpecSet {
   case regexSlash
   case extendedRegexDelimiter
   case `self`
+  case `subscript`
   case `super`
   case `true`
   case wildcard
@@ -899,6 +901,7 @@ enum PrimaryExpressionStart: TokenSpecSet {
     case TokenSpec(.Any): self = .Any
     case TokenSpec(.atSign): self = .atSign
     case TokenSpec(.Self): self = .Self
+    case TokenSpec(.deinit): self = .`deinit`
     case TokenSpec(.dollarIdentifier): self = .dollarIdentifier
     case TokenSpec(.false): self = .false
     case TokenSpec(.floatLiteral): self = .floatLiteral
@@ -916,6 +919,7 @@ enum PrimaryExpressionStart: TokenSpecSet {
     case TokenSpec(.regexSlash): self = .regexSlash
     case TokenSpec(.regexPoundDelimiter): self = .extendedRegexDelimiter
     case TokenSpec(.self): self = .self
+    case TokenSpec(.subscript): self = .`subscript`
     case TokenSpec(.super): self = .super
     case TokenSpec(.true): self = .true
     case TokenSpec(.wildcard): self = .wildcard
@@ -932,6 +936,7 @@ enum PrimaryExpressionStart: TokenSpecSet {
     case .Any: return .keyword(.Any)
     case .atSign: return .atSign
     case .Self: return .keyword(.Self)
+    case .`deinit`: return .keyword(.`deinit`)
     case .dollarIdentifier: return .dollarIdentifier
     case .false: return .keyword(.false)
     case .floatLiteral: return .floatLiteral
@@ -949,6 +954,7 @@ enum PrimaryExpressionStart: TokenSpecSet {
     case .regexSlash: return .regexSlash
     case .extendedRegexDelimiter: return .regexPoundDelimiter
     case .self: return .keyword(.self)
+    case .`subscript`: return .keyword(.subscript)
     case .super: return .keyword(.super)
     case .true: return .keyword(.true)
     case .wildcard: return .wildcard

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -991,6 +991,8 @@ extension DeclReferenceExprSyntax {
     case `self`
     case `Self`
     case `init`
+    case `deinit`
+    case `subscript`
     case dollarIdentifier
     case binaryOperator
     case integerLiteral
@@ -1005,6 +1007,10 @@ extension DeclReferenceExprSyntax {
         self = .Self
       case TokenSpec(.`init`):
         self = .`init`
+      case TokenSpec(.deinit):
+        self = .deinit
+      case TokenSpec(.subscript):
+        self = .subscript
       case TokenSpec(.dollarIdentifier):
         self = .dollarIdentifier
       case TokenSpec(.binaryOperator):
@@ -1026,6 +1032,10 @@ extension DeclReferenceExprSyntax {
         return .keyword(.Self)
       case .`init`:
         return .keyword(.`init`)
+      case .deinit:
+        return .keyword(.deinit)
+      case .subscript:
+        return .keyword(.subscript)
       case .dollarIdentifier:
         return .dollarIdentifier
       case .binaryOperator:
@@ -1049,6 +1059,10 @@ extension DeclReferenceExprSyntax {
         return .keyword(.Self)
       case .`init`:
         return .keyword(.`init`)
+      case .deinit:
+        return .keyword(.deinit)
+      case .subscript:
+        return .keyword(.subscript)
       case .dollarIdentifier:
         return .dollarIdentifier("")
       case .binaryOperator:

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -1518,6 +1518,8 @@ extension IdentifierPatternSyntax {
     case identifier
     case `self`
     case `init`
+    case `deinit`
+    case `subscript`
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
@@ -1527,6 +1529,10 @@ extension IdentifierPatternSyntax {
         self = .self
       case TokenSpec(.`init`):
         self = .`init`
+      case TokenSpec(.deinit):
+        self = .deinit
+      case TokenSpec(.subscript):
+        self = .subscript
       default:
         return nil
       }
@@ -1540,6 +1546,10 @@ extension IdentifierPatternSyntax {
         return .keyword(.self)
       case .`init`:
         return .keyword(.`init`)
+      case .deinit:
+        return .keyword(.deinit)
+      case .subscript:
+        return .keyword(.subscript)
       }
     }
     
@@ -1555,6 +1565,10 @@ extension IdentifierPatternSyntax {
         return .keyword(.self)
       case .`init`:
         return .keyword(.`init`)
+      case .deinit:
+        return .keyword(.deinit)
+      case .subscript:
+        return .keyword(.subscript)
       }
     }
   }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -842,6 +842,8 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("self"), 
             .keyword("Self"), 
             .keyword("init"), 
+            .keyword("deinit"), 
+            .keyword("subscript"), 
             .tokenKind(.dollarIdentifier), 
             .tokenKind(.binaryOperator), 
             .tokenKind(.integerLiteral)

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1420,7 +1420,13 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .identifierPattern:
     assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier), .keyword("self"), .keyword("init")]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
+            .tokenKind(.identifier), 
+            .keyword("self"), 
+            .keyword("init"), 
+            .keyword("deinit"), 
+            .keyword("subscript")
+          ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
   case .identifierType:
     assert(layout.count == 5)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesD.swift
@@ -624,7 +624,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 
 /// ### Children
 /// 
-///  - `baseName`: (`<identifier>` | `self` | `Self` | `init` | `<dollarIdentifier>` | `<binaryOperator>` | `<integerLiteral>`)
+///  - `baseName`: (`<identifier>` | `self` | `Self` | `init` | `deinit` | `subscript` | `<dollarIdentifier>` | `<binaryOperator>` | `<integerLiteral>`)
 ///  - `argumentNames`: ``DeclNameArgumentsSyntax``?
 ///
 /// ### Contained in
@@ -701,6 +701,8 @@ public struct DeclReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _Leaf
   ///  - `self`
   ///  - `Self`
   ///  - `init`
+  ///  - `deinit`
+  ///  - `subscript`
   ///  - `<dollarIdentifier>`
   ///  - `<binaryOperator>`
   ///  - `<integerLiteral>`

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesGHI.swift
@@ -1534,7 +1534,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable, _LeafStmtSynt
 ///
 /// ### Children
 /// 
-///  - `identifier`: (`<identifier>` | `self` | `init`)
+///  - `identifier`: (`<identifier>` | `self` | `init` | `deinit` | `subscript`)
 public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
   
@@ -1587,6 +1587,8 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _L
   ///  - `<identifier>`
   ///  - `self`
   ///  - `init`
+  ///  - `deinit`
+  ///  - `subscript`
   public var identifier: TokenSyntax {
     get {
       return Syntax(self).child(at: 1)!.cast(TokenSyntax.self)

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -689,6 +689,43 @@ final class AttributeTests: ParserTestCase {
     )
   }
 
+  func testAttachedNames() {
+    assertParse(
+      """
+      @attached(member, names: named(deinit))
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @attached(member, names: named(init))
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @attached(member, names: named(init(a:b:)))
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @attached(member, names: named(subscript))
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @attached(member, names: named(subscript(a:b:)))
+      macro m()
+      """
+    )
+  }
+
   func testAttachedExtensionAttribute() {
     assertParse(
       """


### PR DESCRIPTION
Treat `deinit` and `subscript` the same way we treat `init` when parsing an expression, treating it as a declaration reference expression.

Fixes rdar://121687968.