### PR TITLE
[macros] prepare generic arguments for replacement in macros

### DIFF
--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -35,6 +35,11 @@
 - `String.isValidIdentifier(for:)`
   - Description: `SwiftParser` adds an extension on `String` to check if it can be used as an identifier in a given context.
   - Pull Request: https://github.com/apple/swift-syntax/pull/2434
+    
+- `MacroDeclSyntax.expand`
+  - the `expand(argumentList:definition:replacements:)` method gains a new parameter 'genericReplacements:' that is defaulted to an empty array.
+  - The method's signature is now `expand(argumentList:definition:replacements:genericReplacements:)`
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2450
 
 - `SyntaxProtocol.asMacroLexicalContext()` and `allMacroLexicalContexts(enclosingSyntax:)`
   - Description: Produce the lexical context for a given syntax node (if it has one), or the entire stack of lexical contexts enclosing a syntax node, for use in macro expansion.

--- a/Release Notes/511.md
+++ b/Release Notes/511.md
@@ -67,6 +67,11 @@
 
 ## API-Incompatible Changes
 
+- `MacroDefinition` used for expanding macros:
+  - Description: The `MacroDefinition/expansion` enum case used to have two values (`(MacroExpansionExprSyntax, replacements: [Replacement])`), has now gained another value in order to support generic argument replacements in macro expansions: `(MacroExpansionExprSyntax, replacements: [Replacement], genericReplacements: [GenericArgumentReplacement])`
+  - Pull request: https://github.com/apple/swift-syntax/pull/2450
+  - Migration steps: Code which exhaustively checked over the enum should be changed to `case .expansion(let node, let replacements, let genericReplacements):`. Creating the `.extension` gained a compatibility shim, retaining the previous syntax source compatible (`return .expansion(node, replacements: [])`).
+
 - Effect specifiers:
   - Description: The `unexpectedAfterThrowsSpecifier` node of the various effect specifiers has been removed.
   - Pull request: https://github.com/apple/swift-syntax/pull/2219

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -331,6 +331,10 @@ private final class MacroExpansionRewriter: SyntaxRewriter {
       return super.visit(node)
     }
 
+    guard parameterIndex < genericArguments.count else {
+      return super.visit(node)
+    }
+
     // Swap in the argument for type parameter
     return GenericArgumentSyntax(
       leadingTrivia: node.leadingTrivia,
@@ -339,9 +343,9 @@ private final class MacroExpansionRewriter: SyntaxRewriter {
       node.unexpectedBetweenArgumentAndTrailingComma,
       trailingComma: node.trailingComma,
       node.unexpectedAfterTrailingComma
-      // TODO: seems we're getting spurious trailing " " here,
-      //  skipping trailing trivia for now
-      // trailingTrivia: node.trailingTrivia
+        // TODO: seems we're getting spurious trailing " " here,
+        //  skipping trailing trivia for now
+        // trailingTrivia: node.trailingTrivia
     )
   }
 }
@@ -359,15 +363,14 @@ extension MacroDeclSyntax {
     // FIXME: Do real call-argument matching between the argument list and the
     // macro parameter list, porting over from the compiler.
     let parameterReplacements = Dictionary(
-        uniqueKeysWithValues: replacements.map { replacement in
-          (replacement.reference, replacement.parameterIndex)
-        }
-      )
+      uniqueKeysWithValues: replacements.map { replacement in
+        (replacement.reference, replacement.parameterIndex)
+      }
+    )
     let arguments: [ExprSyntax] =
       argumentList?.map { element in
         element.expression
       } ?? []
-
 
     let genericReplacements = Dictionary(
       uniqueKeysWithValues: genericReplacements.map { replacement in
@@ -375,10 +378,9 @@ extension MacroDeclSyntax {
       }
     )
     let genericArguments: [TypeSyntax] =
-      genericArgumentList?.arguments.map { element in 
+      genericArgumentList?.arguments.map { element in
         element.argument
       } ?? []
-
 
     let rewriter: MacroExpansionRewriter = MacroExpansionRewriter(
       parameterReplacements: parameterReplacements,

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -398,7 +398,7 @@ extension MacroDeclSyntax {
     _ node: some FreestandingMacroExpansionSyntax,
     definition: MacroExpansionExprSyntax,
     replacements: [MacroDefinition.Replacement],
-    genericReplacements: [MacroDefinition.GenericArgumentReplacement]
+    genericReplacements: [MacroDefinition.GenericArgumentReplacement] = []
   ) -> ExprSyntax {
     return expand(
       argumentList: node.arguments,

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -363,9 +363,10 @@ extension MacroDeclSyntax {
     // FIXME: Do real call-argument matching between the argument list and the
     // macro parameter list, porting over from the compiler.
     let parameterReplacements = Dictionary(
-      uniqueKeysWithValues: replacements.map { replacement in
+      replacements.map { replacement in
         (replacement.reference, replacement.parameterIndex)
-      }
+      },
+      uniquingKeysWith: { l, r in l }
     )
     let arguments: [ExprSyntax] =
       argumentList?.map { element in
@@ -373,9 +374,10 @@ extension MacroDeclSyntax {
       } ?? []
 
     let genericReplacements = Dictionary(
-      uniqueKeysWithValues: genericReplacements.map { replacement in
+      genericReplacements.map { replacement in
         (replacement.reference, replacement.parameterIndex)
-      }
+      },
+      uniquingKeysWith: { l, r in l }
     )
     let genericArguments: [TypeSyntax] =
       genericArgumentList?.arguments.map { element in

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -67,6 +67,7 @@ public enum MacroDefinition {
 
 extension MacroDefinition {
   /// Best effort compatibility shim, the case has gained additional parameters.
+  @available(*, deprecated, message: "Use the expansion case with three associated values instead")
   public func expansion(_ node: MacroExpansionExprSyntax, replacements: [Replacement]) -> Self {
     .expansion(node, replacements: replacements, genericReplacements: [])
   }
@@ -191,7 +192,7 @@ fileprivate class ParameterReplacementVisitor: SyntaxAnyVisitor {
       return .skipChildren
     }
 
-    let matchedParameter = genericParameterClause.parameters.enumerated().first { (index, parameter) in
+    let parameterIndex = genericParameterClause.parameters.firstIndex { (index, parameter) in
       return parameter.name.text == "\(baseName)"
     }
 
@@ -371,7 +372,7 @@ extension MacroDeclSyntax {
     _ node: AttributeSyntax,
     definition: MacroExpansionExprSyntax,
     replacements: [MacroDefinition.Replacement],
-    genericReplacements: [MacroDefinition.GenericArgumentReplacement]
+    genericReplacements: [MacroDefinition.GenericArgumentReplacement] = []
   ) -> ExprSyntax {
     // Dig out the argument list.
     let argumentList: LabeledExprListSyntax?

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -202,12 +202,12 @@ fileprivate class ParameterReplacementVisitor: SyntaxAnyVisitor {
 
     guard let (parameterIndex, _) = matchedParameter else {
       // We have a reference to something that isn't a parameter of the macro.
-     diagnostics.append(
-       Diagnostic(
-         node: Syntax(baseName),
-         message: MacroExpanderError.nonTypeReference(baseName)
-       )
-     )
+      diagnostics.append(
+        Diagnostic(
+          node: Syntax(baseName),
+          message: MacroExpanderError.nonTypeReference(baseName)
+        )
+      )
 
       return .visitChildren
     }
@@ -302,9 +302,11 @@ private final class MacroExpansionRewriter: SyntaxRewriter {
   let genericParameterReplacements: [DeclReferenceExprSyntax: Int]
   let arguments: [ExprSyntax]
 
-  init(parameterReplacements: [DeclReferenceExprSyntax: Int],
-       genericReplacements: [DeclReferenceExprSyntax: Int],
-       arguments: [ExprSyntax]) {
+  init(
+    parameterReplacements: [DeclReferenceExprSyntax: Int],
+    genericReplacements: [DeclReferenceExprSyntax: Int],
+    arguments: [ExprSyntax]
+  ) {
     self.parameterReplacements = parameterReplacements
     self.genericParameterReplacements = genericReplacements
     self.arguments = arguments

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
@@ -24,7 +24,7 @@ final class MacroReplacementTests: XCTestCase {
       macro expand1(a: Int, b: Int) = #otherMacro(first: b, second: ["a": a], third: [3.14159, 2.71828], fourth: 4)
       """
 
-    let definition = try macro.as(MacroDeclSyntax.self)!.checkDefinition()
+    let definition = try macro.cast(MacroDeclSyntax.self).checkDefinition()
     guard case let .expansion(_, replacements, _) = definition else {
       XCTFail("not an expansion definition")
       fatalError()
@@ -43,7 +43,7 @@ final class MacroReplacementTests: XCTestCase {
 
     let diags: [Diagnostic]
     do {
-      _ = try macro.as(MacroDeclSyntax.self)!.checkDefinition()
+      _ = try macro.cast(MacroDeclSyntax.self).checkDefinition()
       XCTFail("should have failed with an error")
       fatalError()
     } catch let diagError as DiagnosticsError {
@@ -69,7 +69,7 @@ final class MacroReplacementTests: XCTestCase {
 
     let diags: [Diagnostic]
     do {
-      _ = try macro.as(MacroDeclSyntax.self)!.checkDefinition()
+      _ = try macro.cast(MacroDeclSyntax.self).checkDefinition()
       XCTFail("should have failed with an error")
       fatalError()
     } catch let diagError as DiagnosticsError {
@@ -94,7 +94,7 @@ final class MacroReplacementTests: XCTestCase {
       #expand1(a: 5, b: 17)
       """
 
-    let macroDecl = macro.as(MacroDeclSyntax.self)!
+    let macroDecl = macro.cast(MacroDeclSyntax.self)
     let definition = try macroDecl.checkDefinition()
     guard case let .expansion(expansion, replacements, genericReplacements) = definition else {
       XCTFail("not a normal expansion")
@@ -115,7 +115,7 @@ final class MacroReplacementTests: XCTestCase {
     )
   }
 
-  func testMacroGenericArgumentExpansion_base() throws {
+  func testMacroGenericArgumentExpansionBase() throws {
     let macro: DeclSyntax =
       """
       macro gen<A, B>(a: A, b: B) = #otherMacro<A, B>(first: a, second: b)
@@ -126,7 +126,7 @@ final class MacroReplacementTests: XCTestCase {
       #gen<Int, String>(a: 5, b: "Hello")
       """
 
-    let macroDecl = macro.as(MacroDeclSyntax.self)!
+    let macroDecl = macro.cast(MacroDeclSyntax.self)
     let definition = try macroDecl.checkDefinition()
     guard case let .expansion(expansion, replacements, genericReplacements) = definition else {
       XCTFail("not a normal expansion")
@@ -158,7 +158,7 @@ final class MacroReplacementTests: XCTestCase {
     )
   }
 
-  func testMacroGenericArgumentExpansion_ignoreTrivia() throws {
+  func testMacroGenericArgumentExpansionIgnoreTrivia() throws {
     let macro: DeclSyntax =
       """
       macro gen<A, B /* some comment */>(a: A, b: B) = #otherMacro<A, B>(first: a, second: b)
@@ -169,7 +169,7 @@ final class MacroReplacementTests: XCTestCase {
       #gen<Int, String>(a: 5, b: "Hello")
       """
 
-    let macroDecl = macro.as(MacroDeclSyntax.self)!
+    let macroDecl = macro.cast(MacroDeclSyntax.self)
     let definition = try macroDecl.checkDefinition()
     guard case let .expansion(expansion, replacements, genericReplacements) = definition else {
       XCTFail("not a normal expansion")
@@ -200,7 +200,7 @@ final class MacroReplacementTests: XCTestCase {
     )
   }
 
-  func testMacroGenericArgumentExpansion_notVisitGenericParameterArguments() throws {
+  func testMacroGenericArgumentExpansionNotVisitGenericParameterArguments() throws {
     let macro: DeclSyntax =
       """
       macro gen(a: Array<Int>) = #otherMacro(first: a)
@@ -211,7 +211,7 @@ final class MacroReplacementTests: XCTestCase {
       #gen(a: [1, 2, 3])
       """
 
-    let macroDecl = macro.as(MacroDeclSyntax.self)!
+    let macroDecl = macro.cast(MacroDeclSyntax.self)
     let definition = try macroDecl.checkDefinition()
     guard case let .expansion(expansion, replacements, genericReplacements) = definition else {
       XCTFail("not a normal expansion")
@@ -234,7 +234,7 @@ final class MacroReplacementTests: XCTestCase {
     )
   }
 
-  func testMacroGenericArgumentExpansion_replaceInner() throws {
+  func testMacroGenericArgumentExpansionReplaceInner() throws {
     let macro: DeclSyntax =
       """
       macro gen<A>(a: Array<A>) = #reduce<A>(first: a)
@@ -245,7 +245,7 @@ final class MacroReplacementTests: XCTestCase {
       #gen<Int>(a: [1, 2, 3])
       """
 
-    let macroDecl = macro.as(MacroDeclSyntax.self)!
+    let macroDecl = macro.cast(MacroDeclSyntax.self)
     let definition = try macroDecl.checkDefinition()
     guard case let .expansion(expansion, replacements, genericReplacements) = definition else {
       XCTFail("not a normal expansion")
@@ -268,7 +268,7 @@ final class MacroReplacementTests: XCTestCase {
     )
   }
 
-  func testMacroGenericArgumentExpansion_array() throws {
+  func testMacroGenericArgumentExpansionArray() throws {
     let macro: DeclSyntax =
       """
       macro gen(a: Array<Int>) = #other<A>(first: a)
@@ -276,10 +276,10 @@ final class MacroReplacementTests: XCTestCase {
 
     let use: ExprSyntax =
       """
-      #otheren<Int>(a: [1, 2, 3])
+      #gen<Int>(a: [1, 2, 3])
       """
 
-    let macroDecl = macro.as(MacroDeclSyntax.self)!
+    let macroDecl = macro.cast(MacroDeclSyntax.self)
     let definition = try macroDecl.checkDefinition()
     guard case let .expansion(expansion, replacements, genericReplacements) = definition else {
       XCTFail("not a normal expansion")
@@ -302,7 +302,7 @@ final class MacroReplacementTests: XCTestCase {
     )
   }
 
-  func testMacroExpansion_dontCrashOnDuplicates() throws {
+  func testMacroExpansionDontCrashOnDuplicates() throws {
     let macro: DeclSyntax =
       """
       macro gen(a: Array<Int>) = #other<A>(first: a)
@@ -310,10 +310,10 @@ final class MacroReplacementTests: XCTestCase {
 
     let use: ExprSyntax =
       """
-      #otheren<Int>(a: [1, 2, 3])
+      #gen<Int>(a: [1, 2, 3])
       """
 
-    let macroDecl = macro.as(MacroDeclSyntax.self)!
+    let macroDecl = macro.cast(MacroDeclSyntax.self)
     let definition = try macroDecl.checkDefinition()
     guard case let .expansion(expansion, replacements, genericReplacements) = definition else {
       XCTFail("not a normal expansion")

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
@@ -132,7 +132,7 @@ final class MacroReplacementTests: XCTestCase {
       XCTFail("not a normal expansion")
       return
     }
-    
+
     let replacementA = try XCTUnwrap(genericReplacements.first)
     let replacementB = try XCTUnwrap(genericReplacements.dropFirst().first)
 
@@ -237,12 +237,12 @@ final class MacroReplacementTests: XCTestCase {
   func testMacroGenericArgumentExpansion_replaceInner() throws {
     let macro: DeclSyntax =
       """
-      macro gen<A>(a: Array<A>) = #otherMacro(first: a)
+      macro gen<A>(a: Array<A>) = #reduce<A>(first: a)
       """
 
     let use: ExprSyntax =
       """
-      #gen(a: [1, 2, 3])
+      #gen<Int>(a: [1, 2, 3])
       """
 
     let macroDecl = macro.as(MacroDeclSyntax.self)!
@@ -252,7 +252,7 @@ final class MacroReplacementTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(genericReplacements.count, 0)
+    XCTAssertEqual(genericReplacements.count, 1)
 
     let expandedSyntax = macroDecl.expand(
       use.as(MacroExpansionExprSyntax.self)!,
@@ -263,7 +263,7 @@ final class MacroReplacementTests: XCTestCase {
     assertStringsEqualWithDiff(
       expandedSyntax.description,
       """
-      #otherMacro(first: [1, 2, 3])
+      #reduce<Int>(first: [1, 2, 3])
       """
     )
   }

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
@@ -140,7 +140,7 @@ final class MacroReplacementTests: XCTestCase {
     guard let replacementB = genericReplacements.dropFirst().first else {
       XCTFail("Expected generic replacement for B")
       return
-    } 
+    }
     XCTAssertEqual(genericReplacements.count, 2)
 
     XCTAssertEqual(replacementA.parameterIndex, 0)

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
@@ -267,4 +267,38 @@ final class MacroReplacementTests: XCTestCase {
       """
     )
   }
+
+  func testMacroGenericArgumentExpansion_array() throws {
+    let macro: DeclSyntax =
+      """
+      macro gen(a: Array<Int>) = #other<A>(first: a)
+      """
+
+    let use: ExprSyntax =
+      """
+      #otheren<Int>(a: [1, 2, 3])
+      """
+
+    let macroDecl = macro.as(MacroDeclSyntax.self)!
+    let definition = try macroDecl.checkDefinition()
+    guard case let .expansion(expansion, replacements, genericReplacements) = definition else {
+      XCTFail("not a normal expansion")
+      return
+    }
+
+    XCTAssertEqual(genericReplacements.count, 0)
+
+    let expandedSyntax = macroDecl.expand(
+      use.as(MacroExpansionExprSyntax.self)!,
+      definition: expansion,
+      replacements: replacements,
+      genericReplacements: genericReplacements
+    )
+    assertStringsEqualWithDiff(
+      expandedSyntax.description,
+      """
+      #other<A>(first: [1, 2, 3])
+      """
+    )
+  }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/MacroReplacementTests.swift
@@ -133,10 +133,7 @@ final class MacroReplacementTests: XCTestCase {
       fatalError()
     }
 
-    guard let replacementA = genericReplacements.first else {
-      XCTFail("Expected generic replacement for A")
-      fatalError()
-    }
+    let replacementA = try XCTUnwrap(genericReplacements.first)
     guard let replacementB = genericReplacements.dropFirst().first else {
       XCTFail("Expected generic replacement for A")
       fatalError()


### PR DESCRIPTION
Swift-syntax changes necessary of allowing the following code:

```swift
@freestanding(expression)
public macro checkGeneric_root<DAS>() = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")

@freestanding(expression)
public macro checkGeneric<DAS>() = #checkGeneric_root<DAS>()
```

I didn't quite implement it entirely right and need to add a test here as well.

Resolves rdar://122004157