### PR TITLE
protocol ListBuilder

### DIFF
--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -146,10 +146,6 @@ public struct SyntaxBuildableType: Hashable {
     }
   }
 
-  public var parameterType: TypeSyntax {
-    return optionalWrapped(type: parameterBaseType)
-  }
-
   /// Assuming that this is a collection type, the non-optional type of the result builder
   /// that can be used to build the collection.
   public var resultBuilderType: TypeSyntax {
@@ -159,11 +155,6 @@ public struct SyntaxBuildableType: Hashable {
     case .token:
       preconditionFailure("Tokens cannot be constructed using result builders")
     }
-  }
-
-  /// Whether this type has the `WithTrailingComma` trait.
-  public var hasWithTrailingCommaTrait: Bool {
-    SYNTAX_NODES.compactMap(\.layoutNode).contains { $0.type == self && $0.traits.contains("WithTrailingComma") }
   }
 
   /// If this type is not a base kind, its base type (see `SyntaxBuildableNode.base_type()`),

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
@@ -20,57 +20,20 @@ let resultBuildersFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
   for node in SYNTAX_NODES.compactMap(\.collectionNode) {
     let type = SyntaxBuildableType(kind: .node(kind: node.kind))
-    let elementType = node.collectionElementType
-    let expressionType: TypeSyntax = node.elementChoices.count == 1 ? elementType.parameterType : TypeSyntax("\(type.buildable).Element")
 
     try! StructDeclSyntax(
       """
+
+      // MARK: - \(type.resultBuilderType)
+
       @resultBuilder
       \(node.node.apiAttributes())\
-      public struct \(type.resultBuilderType)
+      public struct \(type.resultBuilderType): ListBuilder
       """
     ) {
       DeclSyntax(
         """
-        /// The type of individual statement expressions in the transformed function,
-        /// which defaults to Component if buildExpression() is not provided.
-        public typealias Expression = \(expressionType)
-        """
-      )
-
-      DeclSyntax(
-        """
-        /// The type of a partial result, which will be carried through all of the
-        /// build methods.
-        public typealias Component = [Expression]
-        """
-      )
-
-      DeclSyntax(
-        """
-        /// The type of the final returned result, which defaults to Component if
-        /// buildFinalResult() is not provided.
-        public typealias FinalResult = \(type.buildable)
-        """
-      )
-
-      DeclSyntax(
-        """
-        /// Required by every result builder to build combined results from
-        /// statement blocks.
-        public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-          return components.flatMap { $0 }
-        }
-        """
-      )
-
-      DeclSyntax(
-        """
-        /// If declared, provides contextual type information for statement
-        /// expressions to translate them into partial results.
-        public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-          return [expression]
-        }
+        public typealias FinalResult = \(type.syntaxBaseName)
         """
       )
 
@@ -78,101 +41,11 @@ let resultBuildersFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         for elementChoice in node.elementChoices {
           DeclSyntax(
             """
-            /// If declared, provides contextual type information for statement
-            /// expressions to translate them into partial results.
-            public static func buildExpression(_ expression: \(elementChoice.syntaxType)) -> Self.Component {
-              return buildExpression(.init(expression))
+            public static func buildExpression(_ expression: \(elementChoice.syntaxType)) -> Component {
+              buildExpression(.init(expression))
             }
             """
           )
-        }
-      }
-
-      DeclSyntax(
-        """
-        /// Add all the elements of `expression` to this result builder, effectively flattening them.
-        ///
-        /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-        ///   the elements are expressible by string interpolation. In that case we favor creating a
-        ///   single element from the string literal.
-        @_disfavoredOverload
-        public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-          return expression.map { $0 }
-        }
-        """
-      )
-
-      DeclSyntax(
-        """
-        /// Enables support for `if` statements that do not have an `else`.
-        public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-          return component ?? []
-        }
-        """
-      )
-
-      DeclSyntax(
-        """
-        /// With buildEither(second:), enables support for 'if-else' and 'switch'
-        /// statements by folding conditional results into a single result.
-        public static func buildEither(first component: Self.Component) -> Self.Component {
-          return component
-        }
-        """
-      )
-
-      DeclSyntax(
-        """
-        /// With buildEither(first:), enables support for 'if-else' and 'switch'
-        /// statements by folding conditional results into a single result.
-        public static func buildEither(second component: Self.Component) -> Self.Component {
-          return component
-        }
-        """
-      )
-
-      DeclSyntax(
-        """
-        /// Enables support for 'for..in' loops by combining the
-        /// results of all iterations into a single result.
-        public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-          return components.flatMap { $0 }
-        }
-        """
-      )
-
-      DeclSyntax(
-        """
-        /// If declared, this will be called on the partial result of an 'if'
-        /// #available' block to allow the result builder to erase type
-        /// information.
-        public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-          return component
-        }
-        """
-      )
-
-      try FunctionDeclSyntax(
-        """
-        /// If declared, this will be called on the partial result from the outermost
-        /// block statement to produce the final returned result.
-        public static func buildFinalResult(_ component: Component) -> FinalResult
-        """
-      ) {
-        if elementType.isToken {
-          StmtSyntax("return .init(component)")
-        } else if elementType.hasWithTrailingCommaTrait {
-          DeclSyntax("let lastIndex = component.count - 1")
-
-          StmtSyntax(
-            """
-            return .init(component.enumerated().map { index, source in
-              return index < lastIndex ? source.ensuringTrailingComma() : source
-            })
-            """
-          )
-        } else {
-          StmtSyntax("return .init(component)")
         }
       }
     }

--- a/Sources/SwiftSyntaxBuilder/CMakeLists.txt
+++ b/Sources/SwiftSyntaxBuilder/CMakeLists.txt
@@ -10,6 +10,7 @@ add_swift_syntax_library(SwiftSyntaxBuilder
   ConvenienceInitializers.swift
   DeclSyntaxParseable.swift
   Indenter.swift
+  ListBuilder.swift
   ResultBuilderExtensions.swift
   SwiftSyntaxBuilderCompatibility.swift
   Syntax+StringInterpolation.swift

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -13,7 +13,7 @@
 @_spi(RawSyntax) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
 
-// MARK: - ArrayElementList
+// MARK: - ArrayElementListSyntax
 
 extension ArrayElementListSyntax {
   public init(expressions: [ExprSyntax]) {
@@ -30,7 +30,7 @@ extension ArrayElementListSyntax {
   }
 }
 
-// MARK: - ArrayExpr
+// MARK: - ArrayExprSyntax
 
 extension ArrayExprSyntax {
   public init(expressions: [ExprSyntax]) {
@@ -38,7 +38,7 @@ extension ArrayExprSyntax {
   }
 }
 
-// MARK: - CustomAttribute
+// MARK: - AttributeSyntax
 
 extension AttributeSyntax {
   /// A convenience initializer that allows passing in arguments using a result builder
@@ -58,7 +58,7 @@ extension AttributeSyntax {
   }
 }
 
-// MARK: - BinaryOperatorExpr
+// MARK: - BinaryOperatorExprSyntax
 
 extension BinaryOperatorExprSyntax {
   public init(text: String) {
@@ -66,7 +66,7 @@ extension BinaryOperatorExprSyntax {
   }
 }
 
-// MARK: - BooleanLiteralExpr
+// MARK: - BooleanLiteralExprSyntax
 
 extension BooleanLiteralExprSyntax: ExpressibleByBooleanLiteral {
   public init(_ value: Bool) {
@@ -78,7 +78,7 @@ extension BooleanLiteralExprSyntax: ExpressibleByBooleanLiteral {
   }
 }
 
-// MARK: - CatchClause
+// MARK: - CatchClauseSyntax
 
 extension CatchClauseSyntax {
   /// A convenience initializer that calculates spacing around the `catch` keyword.
@@ -96,7 +96,7 @@ extension CatchClauseSyntax {
   }
 }
 
-// MARK: - DictionaryExpr
+// MARK: - DictionaryExprSyntax
 
 extension DictionaryExprSyntax {
   /// A convenience initializer that allows passing in members using a result builder
@@ -115,7 +115,15 @@ extension DictionaryExprSyntax {
   }
 }
 
-// MARK: - Expr
+// MARK: - ExprListSyntax
+
+extension ExprListSyntax {
+  public init(_ elements: [ExprSyntaxProtocol]) {
+    self.init(elements.map { ExprSyntax(fromProtocol: $0) } as [ExprSyntax])
+  }
+}
+
+// MARK: - ExprSyntax
 
 extension ExprSyntax {
   /// Returns a syntax tree for an expression that represents the value of the
@@ -163,7 +171,7 @@ extension FloatLiteralExprSyntax: ExpressibleByFloatLiteral {
   }
 }
 
-// MARK: - FunctionCallExpr
+// MARK: - FunctionCallExprSyntax
 
 extension FunctionCallExprSyntax {
   /// A convenience initializer that allows passing in arguments using a result builder
@@ -188,7 +196,7 @@ extension FunctionCallExprSyntax {
   }
 }
 
-// MARK: - IntegerLiteralExpr
+// MARK: - IntegerLiteralExprSyntax
 
 extension IntegerLiteralExprSyntax: ExpressibleByIntegerLiteral {
   public init(_ value: Int) {
@@ -200,7 +208,21 @@ extension IntegerLiteralExprSyntax: ExpressibleByIntegerLiteral {
   }
 }
 
-// MARK: - StringLiteralExpr
+// MARK: - LabeledExprSyntax
+
+extension LabeledExprSyntax {
+  /// A convenience initializer that allows passing in label as an optional string.
+  /// The presence of the colon will be inferred based on the presence of the label.
+  public init(label: String? = nil, expression: some ExprSyntaxProtocol) {
+    self.init(
+      label: label.map { .identifier($0) },
+      colon: label == nil ? nil : .colonToken(trailingTrivia: .space),
+      expression: expression
+    )
+  }
+}
+
+// MARK: - StringLiteralExprSyntax
 
 extension String {
   /// Replace literal newlines with "\r", "\n", "\u{2028}", and ASCII control characters with "\0", "\u{7}"
@@ -338,21 +360,15 @@ extension StringLiteralExprSyntax {
   }
 }
 
-// MARK: - TupleExprElement
+// MARK: - UnexpectedNodesSyntax
 
-extension LabeledExprSyntax {
-  /// A convenience initializer that allows passing in label as an optional string.
-  /// The presence of the colon will be inferred based on the presence of the label.
-  public init(label: String? = nil, expression: some ExprSyntaxProtocol) {
-    self.init(
-      label: label.map { .identifier($0) },
-      colon: label == nil ? nil : .colonToken(trailingTrivia: .space),
-      expression: expression
-    )
+extension UnexpectedNodesSyntax {
+  public init(_ elements: [SyntaxProtocol]) {
+    self.init(elements.map { Syntax(fromProtocol: $0) } as [Syntax])
   }
 }
 
-// MARK: - VariableDecl
+// MARK: - VariableDeclSyntax
 
 extension VariableDeclSyntax {
   /// Creates an optionally initialized property.

--- a/Sources/SwiftSyntaxBuilder/ListBuilder.swift
+++ b/Sources/SwiftSyntaxBuilder/ListBuilder.swift
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public protocol ListBuilder {
+  /// The type of the final returned result, which defaults to Component if
+  /// buildFinalResult() is not provided.
+  associatedtype FinalResult: SyntaxCollection
+
+  /// The type of individual statement expressions in the transformed function,
+  /// which defaults to Component if buildExpression() is not provided.
+  typealias Expression = FinalResult.Element
+
+  /// The type of a partial result, which will be carried through all of the
+  /// build methods.
+  typealias Component = [Expression]
+
+  /// Required by every result builder to build combined results from
+  /// statement blocks.
+  static func buildBlock(_ components: Component...) -> Component
+
+  /// Provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  static func buildExpression(_ expression: Expression) -> Component
+
+  /// Add all the elements of `expression` to this result builder, effectively flattening them.
+  ///
+  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
+  ///   the elements are expressible by string interpolation. In that case we favor creating a
+  ///   single element from the string literal.
+  @_disfavoredOverload
+  static func buildExpression(_ expression: FinalResult) -> Component
+
+  /// Enables support for `if` statements that do not have an `else`.
+  static func buildOptional(_ component: Component?) -> Component
+
+  /// With buildEither(second:), enables support for 'if-else' and 'switch'
+  /// statements by folding conditional results into a single result.
+  static func buildEither(first component: Component) -> Component
+
+  /// With buildEither(first:), enables support for 'if-else' and 'switch'
+  /// statements by folding conditional results into a single result.
+  static func buildEither(second component: Component) -> Component
+
+  /// Enables support for 'for..in' loops by combining the
+  /// results of all iterations into a single result.
+  static func buildArray(_ components: [Component]) -> Component
+
+  /// This will be called on the partial result of an 'if'
+  /// #available' block to allow the result builder to erase type
+  /// information.
+  static func buildLimitedAvailability(_ component: Component) -> Component
+
+  /// This will be called on the partial result from the outermost
+  /// block statement to produce the final returned result.
+  static func buildFinalResult(_ component: Component) -> FinalResult
+}
+
+public extension ListBuilder {
+  static func buildBlock(_ components: Component...) -> Component {
+    components.flatMap { $0 }
+  }
+  static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+  @_disfavoredOverload
+  static func buildExpression(_ expression: FinalResult) -> Component {
+    expression.map { $0 }
+  }
+  static func buildOptional(_ component: Component?) -> Component {
+    component ?? []
+  }
+  static func buildEither(first component: Component) -> Component {
+    component
+  }
+  static func buildEither(second component: Component) -> Component {
+    component
+  }
+  static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+  static func buildLimitedAvailability(_ component: Component) -> Component {
+    component
+  }
+  static func buildFinalResult(_ component: Component) -> FinalResult {
+    .init(component)
+  }
+}
+
+public extension ListBuilder where Expression: WithTrailingCommaSyntax {
+  static func buildFinalResult(_ component: Component) -> FinalResult {
+    .init(
+      component.enumerated().map { index, expression in
+        index < component.endIndex - 1 ? expression.ensuringTrailingComma() : expression
+      }
+    )
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
+++ b/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
@@ -50,20 +50,14 @@ extension MemberBlockItemListBuilder {
   }
 }
 
-// MARK: Initializing collections from protocols
-// These initializers allow the creation of syntax collections that have a base
-// node as their element from the corresponding protocol type.
-// These are used by the result builders.
-// Since we only have two of these, it doesn’t make sense to generate them.
-
-extension ExprListSyntax {
-  init(_ elements: [ExprSyntaxProtocol]) {
-    self = ExprListSyntax(elements.map { ExprSyntax(fromProtocol: $0) } as [ExprSyntax])
+extension ExprListBuilder {
+  public static func buildExpression(_ expression: some ExprSyntaxProtocol) -> Component {
+    return buildExpression(ExprSyntax(fromProtocol: expression))
   }
 }
 
-extension UnexpectedNodesSyntax {
-  public init(_ elements: [SyntaxProtocol]) {
-    self = UnexpectedNodesSyntax(elements.map { Syntax(fromProtocol: $0) } as [Syntax])
+extension UnexpectedNodesBuilder {
+  public static func buildExpression(_ expression: some SyntaxProtocol) -> Component {
+    return buildExpression(Syntax(fromProtocol: expression))
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -14,83 +14,11 @@
 
 import SwiftSyntax
 
+// MARK: - AccessorDeclListBuilder
+
 @resultBuilder
-public struct AccessorDeclListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = AccessorDeclSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct AccessorDeclListBuilder: ListBuilder {
   public typealias FinalResult = AccessorDeclListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension AccessorDeclListSyntax {
@@ -99,86 +27,11 @@ public extension AccessorDeclListSyntax {
   }
 }
 
+// MARK: - ArrayElementListBuilder
+
 @resultBuilder
-public struct ArrayElementListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = ArrayElementSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct ArrayElementListBuilder: ListBuilder {
   public typealias FinalResult = ArrayElementListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension ArrayElementListSyntax {
@@ -187,94 +40,18 @@ public extension ArrayElementListSyntax {
   }
 }
 
+// MARK: - AttributeListBuilder
+
 @resultBuilder
-public struct AttributeListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = AttributeListSyntax.Element
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct AttributeListBuilder: ListBuilder {
   public typealias FinalResult = AttributeListSyntax
   
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
+  public static func buildExpression(_ expression: AttributeSyntax) -> Component {
+    buildExpression(.init(expression))
   }
   
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: AttributeSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: IfConfigDeclSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+  public static func buildExpression(_ expression: IfConfigDeclSyntax) -> Component {
+    buildExpression(.init(expression))
   }
 }
 
@@ -284,86 +61,11 @@ public extension AttributeListSyntax {
   }
 }
 
+// MARK: - AvailabilityArgumentListBuilder
+
 @resultBuilder
-public struct AvailabilityArgumentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = AvailabilityArgumentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct AvailabilityArgumentListBuilder: ListBuilder {
   public typealias FinalResult = AvailabilityArgumentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension AvailabilityArgumentListSyntax {
@@ -372,83 +74,11 @@ public extension AvailabilityArgumentListSyntax {
   }
 }
 
+// MARK: - CatchClauseListBuilder
+
 @resultBuilder
-public struct CatchClauseListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = CatchClauseSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct CatchClauseListBuilder: ListBuilder {
   public typealias FinalResult = CatchClauseListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension CatchClauseListSyntax {
@@ -457,86 +87,11 @@ public extension CatchClauseListSyntax {
   }
 }
 
+// MARK: - CatchItemListBuilder
+
 @resultBuilder
-public struct CatchItemListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = CatchItemSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct CatchItemListBuilder: ListBuilder {
   public typealias FinalResult = CatchItemListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension CatchItemListSyntax {
@@ -545,86 +100,11 @@ public extension CatchItemListSyntax {
   }
 }
 
+// MARK: - ClosureCaptureListBuilder
+
 @resultBuilder
-public struct ClosureCaptureListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = ClosureCaptureSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct ClosureCaptureListBuilder: ListBuilder {
   public typealias FinalResult = ClosureCaptureListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension ClosureCaptureListSyntax {
@@ -633,86 +113,11 @@ public extension ClosureCaptureListSyntax {
   }
 }
 
+// MARK: - ClosureParameterListBuilder
+
 @resultBuilder
-public struct ClosureParameterListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = ClosureParameterSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct ClosureParameterListBuilder: ListBuilder {
   public typealias FinalResult = ClosureParameterListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension ClosureParameterListSyntax {
@@ -721,86 +126,11 @@ public extension ClosureParameterListSyntax {
   }
 }
 
+// MARK: - ClosureShorthandParameterListBuilder
+
 @resultBuilder
-public struct ClosureShorthandParameterListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = ClosureShorthandParameterSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct ClosureShorthandParameterListBuilder: ListBuilder {
   public typealias FinalResult = ClosureShorthandParameterListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension ClosureShorthandParameterListSyntax {
@@ -809,83 +139,11 @@ public extension ClosureShorthandParameterListSyntax {
   }
 }
 
+// MARK: - CodeBlockItemListBuilder
+
 @resultBuilder
-public struct CodeBlockItemListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = CodeBlockItemSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct CodeBlockItemListBuilder: ListBuilder {
   public typealias FinalResult = CodeBlockItemListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension CodeBlockItemListSyntax {
@@ -894,83 +152,11 @@ public extension CodeBlockItemListSyntax {
   }
 }
 
+// MARK: - CompositionTypeElementListBuilder
+
 @resultBuilder
-public struct CompositionTypeElementListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = CompositionTypeElementSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct CompositionTypeElementListBuilder: ListBuilder {
   public typealias FinalResult = CompositionTypeElementListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension CompositionTypeElementListSyntax {
@@ -979,86 +165,11 @@ public extension CompositionTypeElementListSyntax {
   }
 }
 
+// MARK: - ConditionElementListBuilder
+
 @resultBuilder
-public struct ConditionElementListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = ConditionElementSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct ConditionElementListBuilder: ListBuilder {
   public typealias FinalResult = ConditionElementListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension ConditionElementListSyntax {
@@ -1067,83 +178,11 @@ public extension ConditionElementListSyntax {
   }
 }
 
+// MARK: - DeclModifierListBuilder
+
 @resultBuilder
-public struct DeclModifierListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = DeclModifierSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct DeclModifierListBuilder: ListBuilder {
   public typealias FinalResult = DeclModifierListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension DeclModifierListSyntax {
@@ -1152,83 +191,11 @@ public extension DeclModifierListSyntax {
   }
 }
 
+// MARK: - DeclNameArgumentListBuilder
+
 @resultBuilder
-public struct DeclNameArgumentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = DeclNameArgumentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct DeclNameArgumentListBuilder: ListBuilder {
   public typealias FinalResult = DeclNameArgumentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension DeclNameArgumentListSyntax {
@@ -1237,83 +204,11 @@ public extension DeclNameArgumentListSyntax {
   }
 }
 
+// MARK: - DesignatedTypeListBuilder
+
 @resultBuilder
-public struct DesignatedTypeListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = DesignatedTypeSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct DesignatedTypeListBuilder: ListBuilder {
   public typealias FinalResult = DesignatedTypeListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension DesignatedTypeListSyntax {
@@ -1322,86 +217,11 @@ public extension DesignatedTypeListSyntax {
   }
 }
 
+// MARK: - DictionaryElementListBuilder
+
 @resultBuilder
-public struct DictionaryElementListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = DictionaryElementSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct DictionaryElementListBuilder: ListBuilder {
   public typealias FinalResult = DictionaryElementListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension DictionaryElementListSyntax {
@@ -1410,86 +230,11 @@ public extension DictionaryElementListSyntax {
   }
 }
 
+// MARK: - DifferentiabilityArgumentListBuilder
+
 @resultBuilder
-public struct DifferentiabilityArgumentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = DifferentiabilityArgumentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct DifferentiabilityArgumentListBuilder: ListBuilder {
   public typealias FinalResult = DifferentiabilityArgumentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension DifferentiabilityArgumentListSyntax {
@@ -1498,86 +243,11 @@ public extension DifferentiabilityArgumentListSyntax {
   }
 }
 
+// MARK: - DocumentationAttributeArgumentListBuilder
+
 @resultBuilder
-public struct DocumentationAttributeArgumentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = DocumentationAttributeArgumentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct DocumentationAttributeArgumentListBuilder: ListBuilder {
   public typealias FinalResult = DocumentationAttributeArgumentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension DocumentationAttributeArgumentListSyntax {
@@ -1586,83 +256,11 @@ public extension DocumentationAttributeArgumentListSyntax {
   }
 }
 
+// MARK: - EffectsAttributeArgumentListBuilder
+
 @resultBuilder
-public struct EffectsAttributeArgumentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = TokenSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct EffectsAttributeArgumentListBuilder: ListBuilder {
   public typealias FinalResult = EffectsAttributeArgumentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension EffectsAttributeArgumentListSyntax {
@@ -1671,86 +269,11 @@ public extension EffectsAttributeArgumentListSyntax {
   }
 }
 
+// MARK: - EnumCaseElementListBuilder
+
 @resultBuilder
-public struct EnumCaseElementListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = EnumCaseElementSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct EnumCaseElementListBuilder: ListBuilder {
   public typealias FinalResult = EnumCaseElementListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension EnumCaseElementListSyntax {
@@ -1759,86 +282,11 @@ public extension EnumCaseElementListSyntax {
   }
 }
 
+// MARK: - EnumCaseParameterListBuilder
+
 @resultBuilder
-public struct EnumCaseParameterListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = EnumCaseParameterSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct EnumCaseParameterListBuilder: ListBuilder {
   public typealias FinalResult = EnumCaseParameterListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension EnumCaseParameterListSyntax {
@@ -1847,83 +295,11 @@ public extension EnumCaseParameterListSyntax {
   }
 }
 
+// MARK: - ExprListBuilder
+
 @resultBuilder
-public struct ExprListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = ExprSyntaxProtocol
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct ExprListBuilder: ListBuilder {
   public typealias FinalResult = ExprListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension ExprListSyntax {
@@ -1932,86 +308,11 @@ public extension ExprListSyntax {
   }
 }
 
+// MARK: - FunctionParameterListBuilder
+
 @resultBuilder
-public struct FunctionParameterListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = FunctionParameterSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct FunctionParameterListBuilder: ListBuilder {
   public typealias FinalResult = FunctionParameterListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension FunctionParameterListSyntax {
@@ -2020,86 +321,11 @@ public extension FunctionParameterListSyntax {
   }
 }
 
+// MARK: - GenericArgumentListBuilder
+
 @resultBuilder
-public struct GenericArgumentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = GenericArgumentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct GenericArgumentListBuilder: ListBuilder {
   public typealias FinalResult = GenericArgumentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension GenericArgumentListSyntax {
@@ -2108,86 +334,11 @@ public extension GenericArgumentListSyntax {
   }
 }
 
+// MARK: - GenericParameterListBuilder
+
 @resultBuilder
-public struct GenericParameterListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = GenericParameterSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct GenericParameterListBuilder: ListBuilder {
   public typealias FinalResult = GenericParameterListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension GenericParameterListSyntax {
@@ -2196,86 +347,11 @@ public extension GenericParameterListSyntax {
   }
 }
 
+// MARK: - GenericRequirementListBuilder
+
 @resultBuilder
-public struct GenericRequirementListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = GenericRequirementSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct GenericRequirementListBuilder: ListBuilder {
   public typealias FinalResult = GenericRequirementListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension GenericRequirementListSyntax {
@@ -2284,83 +360,11 @@ public extension GenericRequirementListSyntax {
   }
 }
 
+// MARK: - IfConfigClauseListBuilder
+
 @resultBuilder
-public struct IfConfigClauseListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = IfConfigClauseSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct IfConfigClauseListBuilder: ListBuilder {
   public typealias FinalResult = IfConfigClauseListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension IfConfigClauseListSyntax {
@@ -2369,83 +373,11 @@ public extension IfConfigClauseListSyntax {
   }
 }
 
+// MARK: - ImportPathComponentListBuilder
+
 @resultBuilder
-public struct ImportPathComponentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = ImportPathComponentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct ImportPathComponentListBuilder: ListBuilder {
   public typealias FinalResult = ImportPathComponentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension ImportPathComponentListSyntax {
@@ -2454,86 +386,11 @@ public extension ImportPathComponentListSyntax {
   }
 }
 
+// MARK: - InheritedTypeListBuilder
+
 @resultBuilder
-public struct InheritedTypeListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = InheritedTypeSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct InheritedTypeListBuilder: ListBuilder {
   public typealias FinalResult = InheritedTypeListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension InheritedTypeListSyntax {
@@ -2542,83 +399,11 @@ public extension InheritedTypeListSyntax {
   }
 }
 
+// MARK: - KeyPathComponentListBuilder
+
 @resultBuilder
-public struct KeyPathComponentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = KeyPathComponentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct KeyPathComponentListBuilder: ListBuilder {
   public typealias FinalResult = KeyPathComponentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension KeyPathComponentListSyntax {
@@ -2627,86 +412,11 @@ public extension KeyPathComponentListSyntax {
   }
 }
 
+// MARK: - LabeledExprListBuilder
+
 @resultBuilder
-public struct LabeledExprListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = LabeledExprSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct LabeledExprListBuilder: ListBuilder {
   public typealias FinalResult = LabeledExprListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension LabeledExprListSyntax {
@@ -2715,83 +425,11 @@ public extension LabeledExprListSyntax {
   }
 }
 
+// MARK: - MemberBlockItemListBuilder
+
 @resultBuilder
-public struct MemberBlockItemListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = MemberBlockItemSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct MemberBlockItemListBuilder: ListBuilder {
   public typealias FinalResult = MemberBlockItemListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension MemberBlockItemListSyntax {
@@ -2800,83 +438,11 @@ public extension MemberBlockItemListSyntax {
   }
 }
 
+// MARK: - MultipleTrailingClosureElementListBuilder
+
 @resultBuilder
-public struct MultipleTrailingClosureElementListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = MultipleTrailingClosureElementSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct MultipleTrailingClosureElementListBuilder: ListBuilder {
   public typealias FinalResult = MultipleTrailingClosureElementListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension MultipleTrailingClosureElementListSyntax {
@@ -2885,83 +451,11 @@ public extension MultipleTrailingClosureElementListSyntax {
   }
 }
 
+// MARK: - ObjCSelectorPieceListBuilder
+
 @resultBuilder
-public struct ObjCSelectorPieceListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = ObjCSelectorPieceSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct ObjCSelectorPieceListBuilder: ListBuilder {
   public typealias FinalResult = ObjCSelectorPieceListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension ObjCSelectorPieceListSyntax {
@@ -2970,86 +464,11 @@ public extension ObjCSelectorPieceListSyntax {
   }
 }
 
+// MARK: - PatternBindingListBuilder
+
 @resultBuilder
-public struct PatternBindingListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = PatternBindingSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct PatternBindingListBuilder: ListBuilder {
   public typealias FinalResult = PatternBindingListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension PatternBindingListSyntax {
@@ -3058,86 +477,11 @@ public extension PatternBindingListSyntax {
   }
 }
 
+// MARK: - PlatformVersionItemListBuilder
+
 @resultBuilder
-public struct PlatformVersionItemListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = PlatformVersionItemSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct PlatformVersionItemListBuilder: ListBuilder {
   public typealias FinalResult = PlatformVersionItemListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension PlatformVersionItemListSyntax {
@@ -3146,100 +490,22 @@ public extension PlatformVersionItemListSyntax {
   }
 }
 
+// MARK: - PrecedenceGroupAttributeListBuilder
+
 @resultBuilder
-public struct PrecedenceGroupAttributeListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = PrecedenceGroupAttributeListSyntax.Element
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct PrecedenceGroupAttributeListBuilder: ListBuilder {
   public typealias FinalResult = PrecedenceGroupAttributeListSyntax
   
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
+  public static func buildExpression(_ expression: PrecedenceGroupRelationSyntax) -> Component {
+    buildExpression(.init(expression))
   }
   
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
+  public static func buildExpression(_ expression: PrecedenceGroupAssignmentSyntax) -> Component {
+    buildExpression(.init(expression))
   }
   
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: PrecedenceGroupRelationSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: PrecedenceGroupAssignmentSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: PrecedenceGroupAssociativitySyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+  public static func buildExpression(_ expression: PrecedenceGroupAssociativitySyntax) -> Component {
+    buildExpression(.init(expression))
   }
 }
 
@@ -3249,86 +515,11 @@ public extension PrecedenceGroupAttributeListSyntax {
   }
 }
 
+// MARK: - PrecedenceGroupNameListBuilder
+
 @resultBuilder
-public struct PrecedenceGroupNameListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = PrecedenceGroupNameSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct PrecedenceGroupNameListBuilder: ListBuilder {
   public typealias FinalResult = PrecedenceGroupNameListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension PrecedenceGroupNameListSyntax {
@@ -3337,86 +528,11 @@ public extension PrecedenceGroupNameListSyntax {
   }
 }
 
+// MARK: - PrimaryAssociatedTypeListBuilder
+
 @resultBuilder
-public struct PrimaryAssociatedTypeListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = PrimaryAssociatedTypeSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct PrimaryAssociatedTypeListBuilder: ListBuilder {
   public typealias FinalResult = PrimaryAssociatedTypeListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension PrimaryAssociatedTypeListSyntax {
@@ -3425,83 +541,11 @@ public extension PrimaryAssociatedTypeListSyntax {
   }
 }
 
+// MARK: - SimpleStringLiteralSegmentListBuilder
+
 @resultBuilder
-public struct SimpleStringLiteralSegmentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = StringSegmentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct SimpleStringLiteralSegmentListBuilder: ListBuilder {
   public typealias FinalResult = SimpleStringLiteralSegmentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension SimpleStringLiteralSegmentListSyntax {
@@ -3510,106 +554,26 @@ public extension SimpleStringLiteralSegmentListSyntax {
   }
 }
 
+// MARK: - SpecializeAttributeArgumentListBuilder
+
 @resultBuilder
-public struct SpecializeAttributeArgumentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = SpecializeAttributeArgumentListSyntax.Element
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct SpecializeAttributeArgumentListBuilder: ListBuilder {
   public typealias FinalResult = SpecializeAttributeArgumentListSyntax
   
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
+  public static func buildExpression(_ expression: LabeledSpecializeArgumentSyntax) -> Component {
+    buildExpression(.init(expression))
   }
   
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
+  public static func buildExpression(_ expression: SpecializeAvailabilityArgumentSyntax) -> Component {
+    buildExpression(.init(expression))
   }
   
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: LabeledSpecializeArgumentSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
+  public static func buildExpression(_ expression: SpecializeTargetFunctionArgumentSyntax) -> Component {
+    buildExpression(.init(expression))
   }
   
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: SpecializeAvailabilityArgumentSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: SpecializeTargetFunctionArgumentSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: GenericWhereClauseSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+  public static func buildExpression(_ expression: GenericWhereClauseSyntax) -> Component {
+    buildExpression(.init(expression))
   }
 }
 
@@ -3619,94 +583,18 @@ public extension SpecializeAttributeArgumentListSyntax {
   }
 }
 
+// MARK: - StringLiteralSegmentListBuilder
+
 @resultBuilder
-public struct StringLiteralSegmentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = StringLiteralSegmentListSyntax.Element
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct StringLiteralSegmentListBuilder: ListBuilder {
   public typealias FinalResult = StringLiteralSegmentListSyntax
   
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
+  public static func buildExpression(_ expression: StringSegmentSyntax) -> Component {
+    buildExpression(.init(expression))
   }
   
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: StringSegmentSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: ExpressionSegmentSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+  public static func buildExpression(_ expression: ExpressionSegmentSyntax) -> Component {
+    buildExpression(.init(expression))
   }
 }
 
@@ -3716,86 +604,11 @@ public extension StringLiteralSegmentListSyntax {
   }
 }
 
+// MARK: - SwitchCaseItemListBuilder
+
 @resultBuilder
-public struct SwitchCaseItemListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = SwitchCaseItemSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct SwitchCaseItemListBuilder: ListBuilder {
   public typealias FinalResult = SwitchCaseItemListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension SwitchCaseItemListSyntax {
@@ -3804,94 +617,18 @@ public extension SwitchCaseItemListSyntax {
   }
 }
 
+// MARK: - SwitchCaseListBuilder
+
 @resultBuilder
-public struct SwitchCaseListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = SwitchCaseListSyntax.Element
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct SwitchCaseListBuilder: ListBuilder {
   public typealias FinalResult = SwitchCaseListSyntax
   
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
+  public static func buildExpression(_ expression: SwitchCaseSyntax) -> Component {
+    buildExpression(.init(expression))
   }
   
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: SwitchCaseSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: IfConfigDeclSyntax) -> Self.Component {
-    return buildExpression(.init(expression))
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+  public static func buildExpression(_ expression: IfConfigDeclSyntax) -> Component {
+    buildExpression(.init(expression))
   }
 }
 
@@ -3901,86 +638,11 @@ public extension SwitchCaseListSyntax {
   }
 }
 
+// MARK: - TuplePatternElementListBuilder
+
 @resultBuilder
-public struct TuplePatternElementListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = TuplePatternElementSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct TuplePatternElementListBuilder: ListBuilder {
   public typealias FinalResult = TuplePatternElementListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension TuplePatternElementListSyntax {
@@ -3989,86 +651,11 @@ public extension TuplePatternElementListSyntax {
   }
 }
 
+// MARK: - TupleTypeElementListBuilder
+
 @resultBuilder
-public struct TupleTypeElementListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = TupleTypeElementSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct TupleTypeElementListBuilder: ListBuilder {
   public typealias FinalResult = TupleTypeElementListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    let lastIndex = component.count - 1
-    return .init(component.enumerated().map { index, source in
-      return index < lastIndex ? source.ensuringTrailingComma() : source
-      })
-  }
 }
 
 public extension TupleTypeElementListSyntax {
@@ -4077,83 +664,11 @@ public extension TupleTypeElementListSyntax {
   }
 }
 
+// MARK: - UnexpectedNodesBuilder
+
 @resultBuilder
-public struct UnexpectedNodesBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = SyntaxProtocol
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct UnexpectedNodesBuilder: ListBuilder {
   public typealias FinalResult = UnexpectedNodesSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension UnexpectedNodesSyntax {
@@ -4162,83 +677,11 @@ public extension UnexpectedNodesSyntax {
   }
 }
 
+// MARK: - VersionComponentListBuilder
+
 @resultBuilder
-public struct VersionComponentListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = VersionComponentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct VersionComponentListBuilder: ListBuilder {
   public typealias FinalResult = VersionComponentListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension VersionComponentListSyntax {
@@ -4247,83 +690,11 @@ public extension VersionComponentListSyntax {
   }
 }
 
+// MARK: - YieldedExpressionListBuilder
+
 @resultBuilder
-public struct YieldedExpressionListBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = YieldedExpressionSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
+public struct YieldedExpressionListBuilder: ListBuilder {
   public typealias FinalResult = YieldedExpressionListSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  ///
-  /// - Note: This overload is disfavored to resolve an ambiguity when both the final result and
-  ///   the elements are expressible by string interpolation. In that case we favor creating a
-  ///   single element from the string literal.
-  @_disfavoredOverload
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
 }
 
 public extension YieldedExpressionListSyntax {

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1246,7 +1246,8 @@ final class DeclarationTests: ParserTestCase {
           ])
         ),
         UnexpectedNodesSyntax([
-          TokenSyntax.identifier("bogus"), TokenSyntax.keyword(.rethrows),
+          TokenSyntax.identifier("bogus"),
+          TokenSyntax.keyword(.rethrows),
           TokenSyntax.identifier("set"),
         ])
       ),
@@ -1352,7 +1353,10 @@ final class DeclarationTests: ParserTestCase {
       substructure: FunctionParameterSyntax(
         firstName: .identifier("first"),
         secondName: .identifier("second"),
-        UnexpectedNodesSyntax([TokenSyntax.identifier("third"), TokenSyntax.identifier("fourth")]),
+        UnexpectedNodesSyntax([
+          TokenSyntax.identifier("third"),
+          TokenSyntax.identifier("fourth"),
+        ]),
         colon: .colonToken(),
         type: IdentifierTypeSyntax(name: .identifier("Int"))
       ),
@@ -2879,9 +2883,7 @@ final class DeclarationTests: ParserTestCase {
       substructure: FunctionDeclSyntax(
         funcKeyword: .keyword(.func),
         name: .identifier("test"),
-        UnexpectedNodesSyntax([
-          TokenSyntax.identifier("<#name#>")
-        ]),
+        UnexpectedNodesSyntax([TokenSyntax.identifier("<#name#>")]),
         signature: FunctionSignatureSyntax(
           parameterClause: FunctionParameterClauseSyntax(
             parameters: FunctionParameterListSyntax([])


### PR DESCRIPTION
Introducing the `ListBuilder` protocol with a default function implementation can significantly reduce the amount of generated code in the `Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift` file. Additionally, it makes the codebase more comprehensible by emphasizing similarities among all the result builders and highlighting differences between them.

Apart from this, the PR addresses another issue that requires detailed explanation. Two generated result builders (`ExprListBuilder` and `UnexpectedNodesBuilder`) stood out from the others. They were "special" because their `Expression` was not a concrete type; instead, it was a protocol (`ExprSyntaxProtocol` and `SyntaxProtocol` respectively). So we were dealing with existentials here, which are not very good. Furthermore, we had to create additional extensions dedicated to these two result builders, located at the bottom of the `Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift` file, accompanied by a lengthy comment.

The key point is that these two result builders don't need to be treated as special cases, and they don't have to involve existentials. They can conform to the `ListBuilder` protocol, just like all the other builders do. Despite this, we can still make them work with protocols just as before, maintaining the same approach used for some other result builders in the same file (`Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift`). This eliminates the need for special treatment and enhances codebase consistency.

In summary, this PR represents a refactoring. All the functionality remains unchanged. However, the refactoring is significant, making the code more structured, consistent, and efficient.