### PR TITLE
Only parse subscript and deinit as declaration references within macro role attributes

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -185,6 +185,7 @@ public enum Keyword: CaseIterable {
   case discard
   case forward
   case `func`
+  case freestanding
   case get
   case `guard`
   case higherThan
@@ -508,6 +509,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("forward")
     case .func:
       return KeywordSpec("func", isLexerClassified: true)
+    case .freestanding:
+      return KeywordSpec("freestanding")
     case .get:
       return KeywordSpec("get")
     case .guard:

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -376,7 +376,7 @@ extension Parser {
       trailingComma: roleTrailingComma,
       arena: self.arena
     )
-    let additionalArgs = self.parseArgumentListElements(pattern: .none, flavor: .attributeArgument)
+    let additionalArgs = self.parseArgumentListElements(pattern: .none, flavor: .attributeArguments)
     return [roleElement] + additionalArgs
   }
 }

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -60,6 +60,7 @@ extension Parser {
     case derivative
     case differentiable
     case exclusivity
+    case freestanding
     case inline
     case objc
     case Sendable
@@ -96,6 +97,7 @@ extension Parser {
       case TokenSpec(.derivative): self = .derivative
       case TokenSpec(.differentiable): self = .differentiable
       case TokenSpec(.exclusivity): self = .exclusivity
+      case TokenSpec(.freestanding): self = .freestanding
       case TokenSpec(.inline): self = .inline
       case TokenSpec(.objc): self = .objc
       case TokenSpec(.Sendable): self = .Sendable
@@ -136,6 +138,7 @@ extension Parser {
       case .derivative: return .keyword(.derivative)
       case .differentiable: return .keyword(.differentiable)
       case .exclusivity: return .keyword(.exclusivity)
+      case .freestanding: return .keyword(.freestanding)
       case .inline: return .keyword(.inline)
       case .objc: return .keyword(.objc)
       case .Sendable: return .keyword(.Sendable)
@@ -322,9 +325,9 @@ extension Parser {
       return parseAttribute(argumentMode: .optional) { parser in
         return .unavailableFromAsyncArguments(parser.parseUnavailableFromAsyncAttributeArguments())
       }
-    case .attached:
+    case .attached, .freestanding:
       return parseAttribute(argumentMode: .customAttribute) { parser in
-        let arguments = parser.parseAttachedArguments()
+        let arguments = parser.parseMacroRoleArguments()
         return .argumentList(RawLabeledExprListSyntax(elements: arguments, arena: parser.arena))
       }
     case .rethrows:
@@ -356,7 +359,7 @@ extension Parser {
 }
 
 extension Parser {
-  mutating func parseAttachedArguments() -> [RawLabeledExprSyntax] {
+  mutating func parseMacroRoleArguments() -> [RawLabeledExprSyntax] {
     let (unexpectedBeforeRole, role) = self.expect(.identifier, TokenSpec(.extension, remapping: .identifier), default: .identifier)
     let roleTrailingComma = self.consume(if: .comma)
     let roleElement = RawLabeledExprSyntax(
@@ -373,7 +376,7 @@ extension Parser {
       trailingComma: roleTrailingComma,
       arena: self.arena
     )
-    let additionalArgs = self.parseArgumentListElements(pattern: .none)
+    let additionalArgs = self.parseArgumentListElements(pattern: .none, flavor: .attributeArgument)
     return [roleElement] + additionalArgs
   }
 }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -79,9 +79,9 @@ extension Parser {
     /// We don't allow allow newlines here.
     case poundIfDirective
 
-    /// Parsing an attribute argument, which can contain declaration references
-    /// like `subscript` or `deinit`.
-    case attributeArgument
+    /// Parsing an attribute's arguments, which can contain declaration
+    /// references like `subscript` or `deinit`.
+    case attributeArguments
   }
 
   enum PatternContext {
@@ -1245,7 +1245,7 @@ extension Parser {
     var options: DeclNameOptions = .compoundNames
     switch flavor {
     case .basic, .poundIfDirective, .stmtCondition: break
-    case .attributeArgument: options.insert(.keywords)
+    case .attributeArguments: options.insert(.keywordsUsingSpecialNames)
     }
 
     let declName = self.parseDeclReferenceExpr(options)
@@ -2565,7 +2565,7 @@ private extension Parser.ExprFlavor {
   var callArgumentFlavor: Parser.ExprFlavor {
     switch self {
     case .basic, .poundIfDirective, .stmtCondition: return .basic
-    case .attributeArgument: return .attributeArgument
+    case .attributeArguments: return .attributeArguments
     }
   }
 }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -78,6 +78,10 @@ extension Parser {
     ///
     /// We don't allow allow newlines here.
     case poundIfDirective
+
+    /// Parsing an attribute argument, which can contain declaration references
+    /// like `subscript` or `deinit`.
+    case attributeArgument
   }
 
   enum PatternContext {
@@ -725,7 +729,7 @@ extension Parser {
 
       // If there is an expr-call-suffix, parse it and form a call.
       if let lparen = self.consume(if: TokenSpec(.leftParen, allowAtStartOfLine: false)) {
-        let args = self.parseArgumentListElements(pattern: pattern)
+        let args = self.parseArgumentListElements(pattern: pattern, flavor: flavor.callArgumentFlavor)
         let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
 
         // If we can parse trailing closures, do so.
@@ -1135,9 +1139,9 @@ extension Parser {
         return RawExprSyntax(RawPatternExprSyntax(pattern: pattern, arena: self.arena))
       }
 
-      return RawExprSyntax(self.parseIdentifierExpression())
+      return RawExprSyntax(self.parseIdentifierExpression(flavor: flavor))
     case (.Self, _)?:  // Self
-      return RawExprSyntax(self.parseIdentifierExpression())
+      return RawExprSyntax(self.parseIdentifierExpression(flavor: flavor))
     case (.Any, _)?:  // Any
       let anyType = RawTypeSyntax(self.parseAnyType())
       return RawExprSyntax(RawTypeExprSyntax(type: anyType, arena: self.arena))
@@ -1237,8 +1241,14 @@ extension Parser {
 
 extension Parser {
   /// Parse an identifier as an expression.
-  mutating func parseIdentifierExpression() -> RawExprSyntax {
-    let declName = self.parseDeclReferenceExpr(.compoundNames)
+  mutating func parseIdentifierExpression(flavor: ExprFlavor) -> RawExprSyntax {
+    var options: DeclNameOptions = .compoundNames
+    switch flavor {
+    case .basic, .poundIfDirective, .stmtCondition: break
+    case .attributeArgument: options.insert(.keywords)
+    }
+
+    let declName = self.parseDeclReferenceExpr(options)
     guard self.withLookahead({ $0.canParseAsGenericArgumentList() }) else {
       return RawExprSyntax(declName)
     }
@@ -1689,7 +1699,7 @@ extension Parser {
             name = nil
             unexpectedBeforeEqual = nil
             equal = nil
-            expression = RawExprSyntax(self.parseIdentifierExpression())
+            expression = RawExprSyntax(self.parseIdentifierExpression(flavor: .basic))
           }
 
           keepGoing = self.consume(if: .comma)
@@ -1833,7 +1843,7 @@ extension Parser {
   ///
   /// This is currently the same as parsing a tuple expression. In the future,
   /// this will be a dedicated argument list type.
-  mutating func parseArgumentListElements(pattern: PatternContext) -> [RawLabeledExprSyntax] {
+  mutating func parseArgumentListElements(pattern: PatternContext, flavor: ExprFlavor = .basic) -> [RawLabeledExprSyntax] {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return [
         RawLabeledExprSyntax(
@@ -1878,7 +1888,7 @@ extension Parser {
       if self.at(.binaryOperator) && self.peek(isAt: .comma, .rightParen, .rightSquare) {
         expr = RawExprSyntax(self.parseDeclReferenceExpr(.operators))
       } else {
-        expr = self.parseExpression(flavor: .basic, pattern: pattern)
+        expr = self.parseExpression(flavor: flavor, pattern: pattern)
       }
       keepGoing = self.consume(if: .comma)
       result.append(
@@ -2545,6 +2555,17 @@ extension SyntaxKind {
       return true
     default:
       return false
+    }
+  }
+}
+
+private extension Parser.ExprFlavor {
+  /// The expression flavor used for the argument of a call that occurs
+  /// within a particularly-flavored expression.
+  var callArgumentFlavor: Parser.ExprFlavor {
+    switch self {
+    case .basic, .poundIfDirective, .stmtCondition: return .basic
+    case .attributeArgument: return .attributeArgument
     }
   }
 }

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -66,12 +66,13 @@ extension Parser {
   mutating func parseDeclReferenceExpr(_ flags: DeclNameOptions = []) -> RawDeclReferenceExprSyntax {
     // Consume the base name.
     let base: RawTokenSyntax
-    if let identOrSelf = self.consume(if: .identifier, .keyword(.self), .keyword(.Self)) ?? self.consume(if: .keyword(.`init`)) ?? self.consume(
-      if: .keyword(.`deinit`)
-    ) ?? self.consume(if: .keyword(.`subscript`)) {
+    if let identOrSelf = self.consume(if: .identifier, .keyword(.self), .keyword(.Self)) ?? self.consume(if: .keyword(.`init`)) {
       base = identOrSelf
     } else if flags.contains(.operators), let (_, _) = self.at(anyIn: Operator.self) {
       base = self.consumeAnyToken(remapping: .binaryOperator)
+    } else if flags.contains(.keywordsUsingSpecialNames),
+              let special = self.consume(if: .keyword(.`deinit`), .keyword(.`subscript`)) {
+      base = special
     } else if flags.contains(.keywords) && self.currentToken.isLexerClassifiedKeyword {
       base = self.consumeAnyToken(remapping: .identifier)
     } else {

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -71,7 +71,8 @@ extension Parser {
     } else if flags.contains(.operators), let (_, _) = self.at(anyIn: Operator.self) {
       base = self.consumeAnyToken(remapping: .binaryOperator)
     } else if flags.contains(.keywordsUsingSpecialNames),
-              let special = self.consume(if: .keyword(.`deinit`), .keyword(.`subscript`)) {
+      let special = self.consume(if: .keyword(.`deinit`), .keyword(.`subscript`))
+    {
       base = special
     } else if flags.contains(.keywords) && self.currentToken.isLexerClassifiedKeyword {
       base = self.consumeAnyToken(remapping: .identifier)

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -282,6 +282,7 @@ enum TokenPrecedence: Comparable {
       .backDeployed,
       .derivative,
       .exclusivity,
+      .freestanding,
       .inline,
       .objc,
       .transpose:

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -127,6 +127,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case discard
   case forward
   case `func`
+  case freestanding
   case get
   case `guard`
   case higherThan
@@ -647,6 +648,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .availability
       case "backDeployed":
         self = .backDeployed
+      case "freestanding":
+        self = .freestanding
       case "noDerivative":
         self = .noDerivative
       case "transferring":
@@ -909,6 +912,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "discard", 
       "forward", 
       "func", 
+      "freestanding", 
       "get", 
       "guard", 
       "higherThan", 

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -692,72 +692,182 @@ final class AttributeTests: ParserTestCase {
   func testMacroRoleNames() {
     assertParse(
       """
-      @attached(member, names: named(deinit))
+      @attached(member, names: named(1️⃣deinit))
       macro m()
-      """
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .keyword(.`deinit`)),
+      substructureAfterMarker: "1️⃣"
     )
 
     assertParse(
       """
-      @attached(member, names: named(init))
+      @attached(member, names: named(1️⃣init))
       macro m()
-      """
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .keyword(.`init`)),
+      substructureAfterMarker: "1️⃣"
     )
 
     assertParse(
       """
-      @attached(member, names: named(init(a:b:)))
+      @attached(member, names: named(1️⃣init(a:b:)))
       macro m()
-      """
+      """,
+      substructure: DeclReferenceExprSyntax(
+        baseName: .keyword(.`init`),
+        argumentNames: DeclNameArgumentsSyntax(
+          arguments: [
+            DeclNameArgumentSyntax(name: .identifier("a")),
+            DeclNameArgumentSyntax(name: .identifier("b")),
+          ]
+        )
+      ),
+      substructureAfterMarker: "1️⃣"
     )
 
     assertParse(
       """
-      @attached(member, names: named(subscript))
+      @attached(member, names: named(1️⃣subscript))
       macro m()
-      """
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .keyword(.`subscript`)),
+      substructureAfterMarker: "1️⃣"
     )
 
     assertParse(
       """
-      @attached(declaration, names: named(subscript(a:b:)))
+      @attached(declaration, names: named(1️⃣subscript(a:b:)))
       macro m()
-      """
+      """,
+      substructure: DeclReferenceExprSyntax(
+        baseName: .keyword(.`subscript`),
+        argumentNames: DeclNameArgumentsSyntax(
+          arguments: [
+            DeclNameArgumentSyntax(name: .identifier("a")),
+            DeclNameArgumentSyntax(name: .identifier("b")),
+          ]
+        )
+      ),
+      substructureAfterMarker: "1️⃣"
     )
 
     assertParse(
       """
-      @freestanding(declaration, names: named(deinit))
+      @freestanding(declaration, names: named(1️⃣deinit))
       macro m()
-      """
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .keyword(.`deinit`)),
+      substructureAfterMarker: "1️⃣"
     )
 
     assertParse(
       """
-      @freestanding(declaration, names: named(init))
+      @freestanding(declaration, names: named(1️⃣init))
       macro m()
-      """
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .keyword(.`init`)),
+      substructureAfterMarker: "1️⃣"
     )
 
     assertParse(
       """
-      @freestanding(declaration, names: named(init(a:b:)))
+      @freestanding(declaration, names: named(1️⃣init(a:b:)))
       macro m()
-      """
+      """,
+      substructure: DeclReferenceExprSyntax(
+        baseName: .keyword(.`init`),
+        argumentNames: DeclNameArgumentsSyntax(
+          arguments: [
+            DeclNameArgumentSyntax(name: .identifier("a")),
+            DeclNameArgumentSyntax(name: .identifier("b")),
+          ]
+        )
+      ),
+      substructureAfterMarker: "1️⃣"
     )
 
     assertParse(
       """
-      @freestanding(member, names: named(subscript))
+      @freestanding(member, names: named(1️⃣subscript))
       macro m()
-      """
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .keyword(.`subscript`)),
+      substructureAfterMarker: "1️⃣"
     )
 
     assertParse(
       """
-      @freestanding(member, names: named(subscript(a:b:)))
+      @freestanding(member, names: named(1️⃣subscript(a:b:)))
       macro m()
+      """,
+      substructure: DeclReferenceExprSyntax(
+        baseName: .keyword(.`subscript`),
+        argumentNames: DeclNameArgumentsSyntax(
+          arguments: [
+            DeclNameArgumentSyntax(name: .identifier("a")),
+            DeclNameArgumentSyntax(name: .identifier("b")),
+          ]
+        )
+      ),
+      substructureAfterMarker: "1️⃣"
+    )
+
+    assertParse(
       """
+      @attached(member, names: named(1️⃣`class`))
+      macro m()
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("`class`")),
+      substructureAfterMarker: "1️⃣"
+    )
+
+    assertParse(
+      """
+      @attached4️⃣(member, names: named(1️⃣class2️⃣))
+      macro m()3️⃣
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected value and ')' to end function call",
+          fixIts: ["insert value and ')'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "expected ')' to end attribute",
+          notes: [
+            NoteSpec(
+              locationMarker: "4️⃣",
+              message: "to match this opening '('"
+            )
+          ],
+          fixIts: ["insert ')'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "expected identifier in class",
+          fixIts: ["insert identifier"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "expected '{' in class",
+          fixIts: ["insert '{'"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "unexpected code '))' before macro"
+        ),
+        DiagnosticSpec(
+          locationMarker: "3️⃣",
+          message: "expected '}' to end class",
+          fixIts: ["insert '}'"]
+        ),
+      ],
+      fixedSource: """
+        @attached(member, names: named(<#expression#>)) class <#identifier#> {))
+        macro m()
+        }
+        """
     )
   }
 

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -689,7 +689,7 @@ final class AttributeTests: ParserTestCase {
     )
   }
 
-  func testAttachedNames() {
+  func testMacroRoleNames() {
     assertParse(
       """
       @attached(member, names: named(deinit))
@@ -720,7 +720,42 @@ final class AttributeTests: ParserTestCase {
 
     assertParse(
       """
-      @attached(member, names: named(subscript(a:b:)))
+      @attached(declaration, names: named(subscript(a:b:)))
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @freestanding(declaration, names: named(deinit))
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @freestanding(declaration, names: named(init))
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @freestanding(declaration, names: named(init(a:b:)))
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @freestanding(member, names: named(subscript))
+      macro m()
+      """
+    )
+
+    assertParse(
+      """
+      @freestanding(member, names: named(subscript(a:b:)))
       macro m()
       """
     )

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -3005,5 +3005,21 @@ final class StatementExpressionTests: ParserTestCase {
       """,
       substructure: DeclReferenceExprSyntax(baseName: .identifier("subscript"))
     )
+
+    assertParse(
+      """
+      x.1️⃣deinit
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("deinit")),
+      substructureAfterMarker: "1️⃣"
+    )
+
+    assertParse(
+      """
+      x.1️⃣subscript
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("subscript")),
+      substructureAfterMarker: "1️⃣"
+    )
   }
 }

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2990,4 +2990,20 @@ final class StatementExpressionTests: ParserTestCase {
       fixedSource: "foo(<#identifier#>: 1)"
     )
   }
+
+  func testSubscriptDeinitMembers() {
+    assertParse(
+      """
+      .deinit
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("deinit"))
+    )
+
+    assertParse(
+      """
+      .subscript
+      """,
+      substructure: DeclReferenceExprSyntax(baseName: .identifier("subscript"))
+    )
+  }
 }


### PR DESCRIPTION
The macro role attributes require us to parse `subscript` and `deinit` is
normal member references. Thread an `ExprFlavor` through to make this happen,
and do so for both `@attached` and `@freestanding`.