### PR TITLE
Disallow whitespace between `@`, attribute name and `(`

### DIFF
--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -30,8 +30,9 @@ add_swift_syntax_library(SwiftParser
   Recovery.swift
   Specifiers.swift
   Statements.swift
-  StringLiterals.swift
   StringLiteralRepresentedLiteralValue.swift
+  StringLiterals.swift
+  SwiftVersion.swift
   SyntaxUtils.swift
   TokenConsumer.swift
   TokenPrecedence.swift

--- a/Sources/SwiftParser/Lexer/Lexeme.swift
+++ b/Sources/SwiftParser/Lexer/Lexeme.swift
@@ -102,7 +102,8 @@ extension Lexer {
       SyntaxText(baseAddress: start, count: byteLength)
     }
 
-    var textRange: Range<SyntaxText.Index> {
+    @_spi(Testing)
+    public var textRange: Range<SyntaxText.Index> {
       leadingTriviaByteLength..<leadingTriviaByteLength + textByteLength
     }
 

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -27,6 +27,9 @@ extension Parser {
     /// i.e. how far it looked ahead.
     var tokensConsumed: Int = 0
 
+    /// The Swift version as which this source file should be parsed.
+    let swiftVersion: SwiftVersion
+
     /// The experimental features that have been enabled in the underlying
     /// parser.
     let experimentalFeatures: ExperimentalFeatures
@@ -34,10 +37,12 @@ extension Parser {
     private init(
       lexemes: Lexer.LexemeSequence,
       currentToken: Lexer.Lexeme,
+      swiftVersion: SwiftVersion,
       experimentalFeatures: ExperimentalFeatures
     ) {
       self.lexemes = lexemes
       self.currentToken = currentToken
+      self.swiftVersion = swiftVersion
       self.experimentalFeatures = experimentalFeatures
     }
 
@@ -45,6 +50,7 @@ extension Parser {
       self.init(
         lexemes: other.lexemes,
         currentToken: other.currentToken,
+        swiftVersion: other.swiftVersion,
         experimentalFeatures: other.experimentalFeatures
       )
     }
@@ -55,6 +61,7 @@ extension Parser {
       return Lookahead(
         lexemes: self.lexemes,
         currentToken: self.currentToken,
+        swiftVersion: self.swiftVersion,
         experimentalFeatures: self.experimentalFeatures
       )
     }

--- a/Sources/SwiftParser/ParseSourceFile.swift
+++ b/Sources/SwiftParser/ParseSourceFile.swift
@@ -26,9 +26,10 @@ extension Parser {
   @_spi(ExperimentalLanguageFeatures)
   public static func parse(
     source: UnsafeBufferPointer<UInt8>,
+    swiftVersion: SwiftVersion? = nil,
     experimentalFeatures: ExperimentalFeatures
   ) -> SourceFileSyntax {
-    var parser = Parser(source, experimentalFeatures: experimentalFeatures)
+    var parser = Parser(source, swiftVersion: swiftVersion, experimentalFeatures: experimentalFeatures)
     return SourceFileSyntax.parse(from: &parser)
   }
 
@@ -36,9 +37,10 @@ extension Parser {
   /// `Parser.init` for more details.
   public static func parse(
     source: UnsafeBufferPointer<UInt8>,
-    maximumNestingLevel: Int? = nil
+    maximumNestingLevel: Int? = nil,
+    swiftVersion: SwiftVersion? = nil
   ) -> SourceFileSyntax {
-    var parser = Parser(source, maximumNestingLevel: maximumNestingLevel)
+    var parser = Parser(source, maximumNestingLevel: maximumNestingLevel, swiftVersion: swiftVersion)
     return SourceFileSyntax.parse(from: &parser)
   }
 

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -64,10 +64,11 @@ fileprivate class StringLiteralExpressionIndentationChecker {
       // error is fixed
       return nil
     }
-    return token.tokenView.withTokenDiagnostic(
+    let tokenWithDiagnostic = token.tokenView.withTokenDiagnostic(
       tokenDiagnostic: TokenDiagnostic(.insufficientIndentationInMultilineStringLiteral, byteOffset: 0),
       arena: arena
     )
+    return RawSyntax(tokenWithDiagnostic)
   }
 
   private func visitLayoutNode(node: RawSyntax) -> RawSyntax? {

--- a/Sources/SwiftParser/SwiftVersion.swift
+++ b/Sources/SwiftParser/SwiftVersion.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Parser {
+  /// A Swift language version.
+  public enum SwiftVersion: Comparable {
+    case v4
+    case v5
+    case v6
+  }
+}

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -18,6 +18,8 @@ protocol TokenConsumer {
   /// The current token syntax being examined by the consumer
   var currentToken: Lexer.Lexeme { get }
 
+  var swiftVersion: Parser.SwiftVersion { get }
+
   /// The experimental features that have been enabled.
   var experimentalFeatures: Parser.ExperimentalFeatures { get }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -281,28 +281,28 @@ public struct RawSyntaxTokenView: Sendable {
   }
 
   @_spi(RawSyntax)
-  public func withTokenDiagnostic(tokenDiagnostic: TokenDiagnostic?, arena: SyntaxArena) -> RawSyntax {
+  public func withTokenDiagnostic(tokenDiagnostic: TokenDiagnostic?, arena: SyntaxArena) -> RawTokenSyntax {
     arena.addChild(self.raw.arenaReference)
     switch raw.rawData.payload {
     case .parsedToken(var dat):
       if arena == self.raw.arenaReference {
         dat.tokenDiagnostic = tokenDiagnostic
-        return RawSyntax(arena: arena, payload: .parsedToken(dat))
+        return RawSyntax(arena: arena, payload: .parsedToken(dat)).cast(RawTokenSyntax.self)
       }
       // If the modified token is allocated in a different arena, it might have
       // a different or no `parseTrivia` function. We thus cannot use a
       // `parsedToken` anymore.
-      return .makeMaterializedToken(
+      return RawSyntax.makeMaterializedToken(
         kind: formKind(),
         leadingTrivia: formLeadingTrivia(),
         trailingTrivia: formTrailingTrivia(),
         presence: presence,
         tokenDiagnostic: tokenDiagnostic,
         arena: arena
-      )
+      ).cast(RawTokenSyntax.self)
     case .materializedToken(var dat):
       dat.tokenDiagnostic = tokenDiagnostic
-      return RawSyntax(arena: arena, payload: .materializedToken(dat))
+      return RawSyntax(arena: arena, payload: .materializedToken(dat)).cast(RawTokenSyntax.self)
     default:
       preconditionFailure("'withTokenDiagnostic' is not available for non-token node")
     }

--- a/Sources/SwiftSyntax/TokenDiagnostic.swift
+++ b/Sources/SwiftSyntax/TokenDiagnostic.swift
@@ -30,6 +30,10 @@ public struct TokenDiagnostic: Hashable, Sendable {
     case expectedDigitInFloatLiteral
     case expectedHexCodeInUnicodeEscape
     case expectedHexDigitInHexLiteral
+    case extraneousLeadingWhitespaceError
+    case extraneousLeadingWhitespaceWarning
+    case extraneousTrailingWhitespaceError
+    case extraneousTrailingWhitespaceWarning
     case insufficientIndentationInMultilineStringLiteral
     case invalidBinaryDigitInIntegerLiteral
     case invalidCharacter
@@ -65,6 +69,10 @@ public struct TokenDiagnostic: Hashable, Sendable {
       case .expectedDigitInFloatLiteral: return .error
       case .expectedHexCodeInUnicodeEscape: return .error
       case .expectedHexDigitInHexLiteral: return .error
+      case .extraneousLeadingWhitespaceError: return .error
+      case .extraneousLeadingWhitespaceWarning: return .warning
+      case .extraneousTrailingWhitespaceError: return .error
+      case .extraneousTrailingWhitespaceWarning: return .warning
       case .insufficientIndentationInMultilineStringLiteral: return .error
       case .invalidBinaryDigitInIntegerLiteral: return .error
       case .invalidCharacter: return .error

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -947,4 +947,71 @@ final class AttributeTests: ParserTestCase {
       """
     )
   }
+
+  func testSpaceBetweenAtAndAttribute() {
+    assertParse(
+      "@1️⃣ custom func foo() {}",
+      diagnostics: [
+        DiagnosticSpec(message: "extraneous whitespace after '@' is not permitted", fixIts: ["remove whitespace"])
+      ],
+      fixedSource: "@custom func foo() {}"
+    )
+
+    assertParse(
+      "@1️⃣ custom func foo() {}",
+      diagnostics: [
+        DiagnosticSpec(
+          message: "extraneous whitespace after '@' is not permitted; this is an error in Swift 6",
+          severity: .warning,
+          fixIts: ["remove whitespace"]
+        )
+      ],
+      fixedSource: "@custom func foo() {}",
+      swiftVersion: .v5
+    )
+
+    assertParse(
+      """
+      @1️⃣
+      custom func foo() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "extraneous whitespace after '@' is not permitted", fixIts: ["remove whitespace"])
+      ],
+      fixedSource: "@custom func foo() {}"
+    )
+  }
+
+  func testSpaceBetweenAttributeNameAndLeftParen() {
+    assertParse(
+      "@custom1️⃣ (1) func foo() {}",
+      diagnostics: [
+        DiagnosticSpec(message: "extraneous whitespace before '(' is not permitted", fixIts: ["remove whitespace"])
+      ],
+      fixedSource: "@custom(1) func foo() {}"
+    )
+
+    assertParse(
+      "@custom1️⃣ (1) func foo() {}",
+      diagnostics: [
+        DiagnosticSpec(
+          message: "extraneous whitespace before '(' is not permitted; this is an error in Swift 6",
+          severity: .warning,
+          fixIts: ["remove whitespace"]
+        )
+      ],
+      fixedSource: "@custom(1) func foo() {}",
+      swiftVersion: .v5
+    )
+
+    assertParse(
+      """
+      @custom
+      1️⃣(1) func foo() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "unexpected code '(1)' in function")
+      ]
+    )
+  }
 }


### PR DESCRIPTION
SwiftParser equivalent of https://github.com/apple/swift/pull/71237.

Add a Swift version parameter to parser. When parsing in Swift 6 mode, disallow whitespace between `@`, the attribute’s name and `(`. In Swift 5 warn.

Use this opportunity to refactor how we diagnose extraneous whitespace.

rdar://121668395