### PR TITLE
Move `FixItApplier` to `SwiftIDEUtils` so that SourceKit-LSP can use it

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,7 @@ let package = Package(
 
     .target(
       name: "SwiftIDEUtils",
-      dependencies: ["SwiftSyntax", "SwiftParser"],
+      dependencies: ["SwiftSyntax", "SwiftDiagnostics", "SwiftParser"],
       exclude: ["CMakeLists.txt"]
     ),
 
@@ -191,7 +191,7 @@ let package = Package(
 
     .target(
       name: "SwiftSyntaxMacrosTestSupport",
-      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics", "SwiftParser", "SwiftSyntaxMacros", "SwiftSyntaxMacroExpansion"]
+      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics", "SwiftIDEUtils", "SwiftParser", "SwiftSyntaxMacros", "SwiftSyntaxMacroExpansion"]
     ),
 
     .testTarget(
@@ -211,7 +211,7 @@ let package = Package(
 
     .testTarget(
       name: "SwiftParserTest",
-      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics", "SwiftOperators", "SwiftParser", "SwiftSyntaxBuilder"],
+      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics", "SwiftIDEUtils", "SwiftOperators", "SwiftParser", "SwiftSyntaxBuilder"],
       swiftSettings: swiftParserSwiftSettings
     ),
 

--- a/Sources/SwiftIDEUtils/FixItApplier.swift
+++ b/Sources/SwiftIDEUtils/FixItApplier.swift
@@ -12,8 +12,8 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacroExpansion
 
+@_spi(FixItApplier)
 public enum FixItApplier {
   /// Applies selected or all Fix-Its from the provided diagnostics to a given syntax tree.
   ///

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -12,6 +12,7 @@
 
 import SwiftBasicFormat
 import SwiftDiagnostics
+@_spi(FixItApplier) import SwiftIDEUtils
 import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
+@_spi(FixItApplier) import SwiftIDEUtils
 @_spi(Testing) @_spi(RawSyntax) @_spi(AlternateTokenIntrospection) @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(RawSyntax) import SwiftParserDiagnostics
 @_spi(RawSyntax) import SwiftSyntax


### PR DESCRIPTION
SourceKit-LSP currently contains a copy of FixItApplier. We should be able to use the version from SwiftSyntax.