### PR TITLE
Fix "escaped newline symbol" bug in `CodeGeneration` module

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Utils.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Utils.swift
@@ -42,35 +42,19 @@ public func lowercaseFirstWord(name: String) -> String {
 extension SwiftSyntax.Trivia {
   /// Make a new trivia from a (possibly multi-line) string, prepending `///`
   /// to each line and creating a `.docLineComment` trivia piece for each line.
-  public static func docCommentTrivia(from string: String?) -> SwiftSyntax.Trivia {
-    guard let string else {
-      return []
-    }
-
-    let lines = string.split(separator: "\n", omittingEmptySubsequences: false)
-    let pieces = lines.enumerated().map { (index, line) in
-      var line = line
-      if index != lines.count - 1 {
-        line = "\(line)\n"
-      }
-      return SwiftSyntax.TriviaPiece.docLineComment("/// \(line)")
-    }
-    return SwiftSyntax.Trivia(pieces: pieces)
+  public static func docCommentTrivia(from string: String?) -> Self {
+    guard let string else { return [] }
+    let lines = string.split(separator: "\n", omittingEmptySubsequences: false).map { "/// \($0)" }
+    return .init(pieces: lines.flatMap { [.docLineComment($0), .newlines(1)] })
   }
 
   /// Make a new trivia by joining together ``SwiftSyntax/TriviaPiece``s from `joining`,
   /// and gluing them together with pieces from `separator`.
   public init(
     joining items: [SwiftSyntax.Trivia],
-    separator: SwiftSyntax.Trivia = SwiftSyntax.Trivia(pieces: [TriviaPiece.newlines(1), TriviaPiece.docLineComment("///"), TriviaPiece.newlines(1)])
+    separator: SwiftSyntax.Trivia = .init(pieces: [.docLineComment("///"), .newlines(1)])
   ) {
-
-    self.init(
-      pieces:
-        items
-        .filter { !$0.isEmpty }
-        .joined(separator: separator)
-    )
+    self.init(pieces: items.filter { !$0.isEmpty }.joined(separator: separator))
   }
 }
 

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -173,7 +173,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     try! StructDeclSyntax(
       """
-      \(documentation)
+      \(documentation)\
       \(node.apiAttributes())\
       public struct \(node.kind.syntaxType): \(node.kind.protocolType), SyntaxHashable
       """

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -26,7 +26,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     try! StructDeclSyntax(
       """
-      \(documentation)
+      \(documentation)\
       \(node.node.apiAttributes())\
       public struct \(node.kind.syntaxType): SyntaxCollection, SyntaxHashable
       """

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxNodesFile.swift
@@ -27,7 +27,7 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
         """
         // MARK: - \(node.kind.syntaxType)
 
-        \(SwiftSyntax.Trivia(joining: [node.documentation, node.experimentalDocNote, node.grammar, node.containedIn]))
+        \(SwiftSyntax.Trivia(joining: [node.documentation, node.experimentalDocNote, node.grammar, node.containedIn]))\
         \(node.node.apiAttributes())\
         public struct \(node.kind.syntaxType): \(node.baseType.syntaxBaseName)Protocol, SyntaxHashable, \(node.base.leafProtocolType)
         """
@@ -55,7 +55,7 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
 
         try! InitializerDeclSyntax(
           """
-          \(node.generateInitializerDocComment())
+          \(node.generateInitializerDocComment())\
           \(node.generateInitializerDeclHeader())
           """
         ) {
@@ -137,7 +137,7 @@ func syntaxNode(nodesStartingWith: [Character]) -> SourceFileSyntax {
 
           try! VariableDeclSyntax(
             """
-            \(child.documentation)
+            \(child.documentation)\
             \(child.apiAttributes)public var \(child.varOrCaseName.backtickedIfNeeded): \(type)
             """
           ) {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -21,11 +21,9 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       // MARK: - \(trait.protocolName)
 
-      \(trait.documentation)
+      \(trait.documentation)\
       public protocol \(trait.protocolName): SyntaxProtocol\(raw:
-        trait.baseKind != nil
-          ? ", \(trait.baseKind!.protocolType)"
-          : ""
+        trait.baseKind == nil ? "" : ", \(trait.baseKind!.protocolType)"
       )
       """
     ) {
@@ -34,7 +32,7 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
         DeclSyntax(
           """
-          \(child.documentation)
+          \(child.documentation)\
           \(child.apiAttributes)var \(child.varOrCaseName): \(child.syntaxNodeKind.syntaxType)\(raw: questionMark) { get set }
           """
         )

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
@@ -23,7 +23,6 @@ let resultBuildersFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     try! StructDeclSyntax(
       """
-
       // MARK: - \(type.resultBuilderType)
 
       @resultBuilder

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -14,7 +14,6 @@
 
 // MARK: - BracedSyntax
 
-
 public protocol BracedSyntax: SyntaxProtocol {
   /// ### Tokens
   /// 
@@ -61,7 +60,6 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - DeclGroupSyntax
-
 
 public protocol DeclGroupSyntax: SyntaxProtocol, DeclSyntaxProtocol {
   var attributes: AttributeListSyntax {
@@ -119,7 +117,6 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - EffectSpecifiersSyntax
-
 
 public protocol EffectSpecifiersSyntax: SyntaxProtocol {
   var unexpectedBeforeAsyncSpecifier: UnexpectedNodesSyntax? {
@@ -181,7 +178,6 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - FreestandingMacroExpansionSyntax
-
 
 public protocol FreestandingMacroExpansionSyntax: SyntaxProtocol {
   /// ### Tokens
@@ -266,7 +262,6 @@ public extension SyntaxProtocol {
 
 // MARK: - NamedDeclSyntax
 
-
 public protocol NamedDeclSyntax: SyntaxProtocol {
   /// ### Tokens
   /// 
@@ -350,7 +345,6 @@ public extension SyntaxProtocol {
 
 // MARK: - ParenthesizedSyntax
 
-
 public protocol ParenthesizedSyntax: SyntaxProtocol {
   /// ### Tokens
   /// 
@@ -398,7 +392,6 @@ public extension SyntaxProtocol {
 
 // MARK: - WithAttributesSyntax
 
-
 public protocol WithAttributesSyntax: SyntaxProtocol {
   var attributes: AttributeListSyntax {
     get
@@ -434,7 +427,6 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - WithCodeBlockSyntax
-
 
 public protocol WithCodeBlockSyntax: SyntaxProtocol {
   var body: CodeBlockSyntax {
@@ -518,7 +510,6 @@ public extension SyntaxProtocol {
 
 // MARK: - WithModifiersSyntax
 
-
 public protocol WithModifiersSyntax: SyntaxProtocol {
   var modifiers: DeclModifierListSyntax {
     get
@@ -554,7 +545,6 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - WithOptionalCodeBlockSyntax
-
 
 public protocol WithOptionalCodeBlockSyntax: SyntaxProtocol {
   var body: CodeBlockSyntax? {
@@ -592,7 +582,6 @@ public extension SyntaxProtocol {
 
 // MARK: - WithStatementsSyntax
 
-
 public protocol WithStatementsSyntax: SyntaxProtocol {
   var statements: CodeBlockItemListSyntax {
     get
@@ -628,7 +617,6 @@ public extension SyntaxProtocol {
 }
 
 // MARK: - WithTrailingCommaSyntax
-
 
 public protocol WithTrailingCommaSyntax: SyntaxProtocol {
   /// ### Tokens


### PR DESCRIPTION
I stumbled upon a small bug by accident, and upon investigation, it appeared to have deep roots. Eventually, it warranted its own PR. The bug involved duplicating empty lines in the generated `SyntaxTraits` file after every `// MARK: -` without documentation text.

The file is generated based on `SyntaxTraitsFile` file of `CodeGeneration` module:
```
      // MARK: - \(trait.protocolName)

      \(trait.documentation)
      public protocol \(trait.protocolName): SyntaxProtocol\(raw:
```

In other parts of the module, similar situations are addressed using the "escaped newline" symbol: "\". For instance, in the `ResultBuilderFile` file:
```
      // MARK: - \(type.resultBuilderType)

      @resultBuilder
      \(node.node.apiAttributes())\
      public struct \(type.resultBuilderType): ListBuilder
```

So in this PR, I resolve the bug by employing the same approach. This not only enhances the consistency of the codebase but also serves as an elegant solution to the problem itself. 
All the changes are confined to the `CodeGeneration` module and have no impact on the rest of the `SwiftSyntax` library, making them safe to merge.