### PR TITLE
Correctly skip arguments to `@convention` attribute

### DIFF
--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -162,14 +162,11 @@ extension Parser.Lookahead {
     if let (attr, handle) = self.at(anyIn: TypeAttribute.self) {
       // Ok, it is a valid attribute, eat it, and then process it.
       self.eat(handle)
-      if case .convention = attr {
-        guard
-          self.consume(if: .leftParen) != nil,
-          self.consume(if: .identifier) != nil,
-          self.consume(if: .rightParen) != nil
-        else {
-          return
-        }
+      switch attr {
+      case .convention:
+        self.skipSingle()
+      default:
+        break
       }
       return
     }

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -886,4 +886,25 @@ final class AttributeTests: ParserTestCase {
       """
     )
   }
+
+  func testConventionAttributeInArrayType() {
+    assertParse(
+      """
+      _ = [@convention(c, cType: "int (*)(int)") (Int32) -> Int32]()
+      """,
+      substructure: ConventionAttributeArgumentsSyntax(
+        conventionLabel: .identifier("c"),
+        comma: .commaToken(),
+        cTypeLabel: .keyword(.cType),
+        colon: .colonToken(),
+        cTypeString: StringLiteralExprSyntax(
+          openingQuote: .stringQuoteToken(),
+          segments: StringLiteralSegmentListSyntax([
+            StringLiteralSegmentListSyntax.Element(StringSegmentSyntax(content: .stringSegment("int (*)(int)")))
+          ]),
+          closingQuote: .stringQuoteToken()
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Fixes #2474
rdar://122358055