### PR TITLE
Don't declare attribute names as keywords

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -78,22 +78,14 @@ public enum Keyword: CaseIterable {
   case __owned
   case __setter_access
   case __shared
-  case _alignment
-  case _backDeploy
   case _borrow
   case _borrowing
   case _BridgeObject
-  case _cdecl
   case _Class
   case _compilerInitialized
   case _const
   case _consuming
-  case _documentation
-  case _dynamicReplacement
-  case _effects
-  case _expose
   case _forward
-  case _implements
   case _linear
   case _local
   case _modify
@@ -101,28 +93,12 @@ public enum Keyword: CaseIterable {
   case _mutating
   case _NativeClass
   case _NativeRefCountedObject
-  case _noMetadata
-  case _nonSendable
-  case _objcImplementation
-  case _objcRuntimeName
-  case _opaqueReturnTypeOf
-  case _optimize
-  case _originallyDefinedIn
   case _PackageDescription
-  case _private
-  case _projectedValueProperty
   case _read
   case _RefCountedObject
-  case _semantics
-  case _specialize
-  case _spi
-  case _spi_available
-  case _swift_native_objc_runtime_base
   case _Trivial
   case _TrivialAtMost
   case _TrivialStride
-  case _typeEraser
-  case _unavailableFromAsync
   case _underlyingVersion
   case _UnknownLayout
   case _version
@@ -137,12 +113,8 @@ public enum Keyword: CaseIterable {
   case `associatedtype`
   case associativity
   case async
-  case attached
-  case autoclosure
   case availability
-  case available
   case await
-  case backDeployed
   case before
   case block
   case borrowing
@@ -157,23 +129,18 @@ public enum Keyword: CaseIterable {
   case consuming
   case `continue`
   case convenience
-  case convention
   case cType
   case `default`
   case `defer`
   case `deinit`
   case deprecated
-  case derivative
   case didSet
-  case differentiable
   case distributed
   case `do`
   case dynamic
   case each
   case `else`
   case `enum`
-  case escaping
-  case exclusivity
   case exported
   case `extension`
   case `fallthrough`
@@ -185,7 +152,6 @@ public enum Keyword: CaseIterable {
   case discard
   case forward
   case `func`
-  case freestanding
   case get
   case `guard`
   case higherThan
@@ -196,7 +162,6 @@ public enum Keyword: CaseIterable {
   case infix
   case `init`
   case initializes
-  case inline
   case `inout`
   case `internal`
   case introduced
@@ -218,12 +183,9 @@ public enum Keyword: CaseIterable {
   case mutating
   case `nil`
   case noasync
-  case noDerivative
-  case noescape
   case none
   case nonisolated
   case nonmutating
-  case objc
   case obsoleted
   case of
   case open
@@ -233,7 +195,6 @@ public enum Keyword: CaseIterable {
   case package
   case postfix
   case `precedencegroup`
-  case preconcurrency
   case prefix
   case `private`
   case `Protocol`
@@ -246,14 +207,12 @@ public enum Keyword: CaseIterable {
   case _resultDependsOn
   case _resultDependsOnSelf
   case `rethrows`
-  case retroactive
   case `return`
   case reverse
   case right
   case safe
   case `self`
   case `Self`
-  case Sendable
   case set
   case some
   case sourceFile
@@ -270,13 +229,11 @@ public enum Keyword: CaseIterable {
   case `throw`
   case `throws`
   case transferring
-  case transpose
   case `true`
   case `try`
   case `Type`
   case `typealias`
   case unavailable
-  case unchecked
   case unowned
   case unsafe
   case unsafeAddress
@@ -301,34 +258,18 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("__setter_access")
     case .__shared:
       return KeywordSpec("__shared")
-    case ._alignment:
-      return KeywordSpec("_alignment")
-    case ._backDeploy:
-      return KeywordSpec("_backDeploy")
     case ._borrow:
       return KeywordSpec("_borrow")
     case ._BridgeObject:
       return KeywordSpec("_BridgeObject")
-    case ._cdecl:
-      return KeywordSpec("_cdecl")
     case ._Class:
       return KeywordSpec("_Class")
     case ._compilerInitialized:
       return KeywordSpec("_compilerInitialized")
     case ._const:
       return KeywordSpec("_const")
-    case ._documentation:
-      return KeywordSpec("_documentation")
-    case ._dynamicReplacement:
-      return KeywordSpec("_dynamicReplacement")
-    case ._effects:
-      return KeywordSpec("_effects")
-    case ._expose:
-      return KeywordSpec("_expose")
     case ._forward:
       return KeywordSpec("_forward")
-    case ._implements:
-      return KeywordSpec("_implements")
     case ._linear:
       return KeywordSpec("_linear")
     case ._local:
@@ -341,50 +282,18 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("_NativeClass")
     case ._NativeRefCountedObject:
       return KeywordSpec("_NativeRefCountedObject")
-    case ._noMetadata:
-      return KeywordSpec("_noMetadata")
-    case ._nonSendable:
-      return KeywordSpec("_nonSendable")
-    case ._objcImplementation:
-      return KeywordSpec("_objcImplementation")
-    case ._objcRuntimeName:
-      return KeywordSpec("_objcRuntimeName")
-    case ._opaqueReturnTypeOf:
-      return KeywordSpec("_opaqueReturnTypeOf")
-    case ._optimize:
-      return KeywordSpec("_optimize")
-    case ._originallyDefinedIn:
-      return KeywordSpec("_originallyDefinedIn")
     case ._PackageDescription:
       return KeywordSpec("_PackageDescription")
-    case ._private:
-      return KeywordSpec("_private")
-    case ._projectedValueProperty:
-      return KeywordSpec("_projectedValueProperty")
     case ._read:
       return KeywordSpec("_read")
     case ._RefCountedObject:
       return KeywordSpec("_RefCountedObject")
-    case ._semantics:
-      return KeywordSpec("_semantics")
-    case ._specialize:
-      return KeywordSpec("_specialize")
-    case ._spi:
-      return KeywordSpec("_spi")
-    case ._spi_available:
-      return KeywordSpec("_spi_available")
-    case ._swift_native_objc_runtime_base:
-      return KeywordSpec("_swift_native_objc_runtime_base")
     case ._Trivial:
       return KeywordSpec("_Trivial")
     case ._TrivialAtMost:
       return KeywordSpec("_TrivialAtMost")
     case ._TrivialStride:
       return KeywordSpec("_TrivialStride")
-    case ._typeEraser:
-      return KeywordSpec("_typeEraser")
-    case ._unavailableFromAsync:
-      return KeywordSpec("_unavailableFromAsync")
     case ._underlyingVersion:
       return KeywordSpec("_underlyingVersion")
     case ._UnknownLayout:
@@ -413,18 +322,10 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("associativity")
     case .async:
       return KeywordSpec("async")
-    case .attached:
-      return KeywordSpec("attached")
-    case .autoclosure:
-      return KeywordSpec("autoclosure")
     case .availability:
       return KeywordSpec("availability")
-    case .available:
-      return KeywordSpec("available")
     case .await:
       return KeywordSpec("await")
-    case .backDeployed:
-      return KeywordSpec("backDeployed")
     case .before:
       return KeywordSpec("before")
     case .block:
@@ -453,8 +354,6 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("continue", isLexerClassified: true)
     case .convenience:
       return KeywordSpec("convenience")
-    case .convention:
-      return KeywordSpec("convention")
     case .cType:
       return KeywordSpec("cType")
     case .default:
@@ -465,12 +364,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("deinit", isLexerClassified: true)
     case .deprecated:
       return KeywordSpec("deprecated")
-    case .derivative:
-      return KeywordSpec("derivative")
     case .didSet:
       return KeywordSpec("didSet")
-    case .differentiable:
-      return KeywordSpec("differentiable")
     case .distributed:
       return KeywordSpec("distributed")
     case .do:
@@ -483,10 +378,6 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("else", isLexerClassified: true)
     case .enum:
       return KeywordSpec("enum", isLexerClassified: true)
-    case .escaping:
-      return KeywordSpec("escaping")
-    case .exclusivity:
-      return KeywordSpec("exclusivity")
     case .exported:
       return KeywordSpec("exported")
     case .extension:
@@ -509,8 +400,6 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("forward")
     case .func:
       return KeywordSpec("func", isLexerClassified: true)
-    case .freestanding:
-      return KeywordSpec("freestanding")
     case .get:
       return KeywordSpec("get")
     case .guard:
@@ -531,8 +420,6 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("init", isLexerClassified: true)
     case .initializes:
       return KeywordSpec("initializes")
-    case .inline:
-      return KeywordSpec("inline")
     case .inout:
       return KeywordSpec("inout", isLexerClassified: true)
     case .internal:
@@ -575,18 +462,12 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("nil", isLexerClassified: true)
     case .noasync:
       return KeywordSpec("noasync")
-    case .noDerivative:
-      return KeywordSpec("noDerivative")
-    case .noescape:
-      return KeywordSpec("noescape")
     case .none:
       return KeywordSpec("none")
     case .nonisolated:
       return KeywordSpec("nonisolated")
     case .nonmutating:
       return KeywordSpec("nonmutating")
-    case .objc:
-      return KeywordSpec("objc")
     case .obsoleted:
       return KeywordSpec("obsoleted")
     case .of:
@@ -629,8 +510,6 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("_resultDependsOnSelf", experimentalFeature: .nonescapableTypes)
     case .rethrows:
       return KeywordSpec("rethrows", isLexerClassified: true)
-    case .retroactive:
-      return KeywordSpec("retroactive")
     case .return:
       return KeywordSpec("return", isLexerClassified: true)
     case .reverse:
@@ -643,8 +522,6 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("self", isLexerClassified: true)
     case .Self:
       return KeywordSpec("Self", isLexerClassified: true)
-    case .Sendable:
-      return KeywordSpec("Sendable")
     case .set:
       return KeywordSpec("set")
     case .some:
@@ -680,8 +557,6 @@ public enum Keyword: CaseIterable {
         "transferring",
         experimentalFeature: .transferringArgsAndResults
       )
-    case .transpose:
-      return KeywordSpec("transpose")
     case .true:
       return KeywordSpec("true", isLexerClassified: true)
     case .try:
@@ -692,10 +567,6 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("typealias", isLexerClassified: true)
     case .unavailable:
       return KeywordSpec("unavailable")
-    case .unchecked:
-      return KeywordSpec("unchecked")
-    case .preconcurrency:
-      return KeywordSpec("preconcurrency")
     case .unowned:
       return KeywordSpec("unowned")
     case .unsafe:

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -67,41 +67,52 @@ extension Parser {
     case transpose
 
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
-      switch PrepareForKeywordMatch(lexeme) {
-      case TokenSpec(._alignment): self = ._alignment
-      case TokenSpec(._backDeploy): self = ._backDeploy
-      case TokenSpec(._cdecl): self = ._cdecl
-      case TokenSpec(._documentation): self = ._documentation
-      case TokenSpec(._dynamicReplacement): self = ._dynamicReplacement
-      case TokenSpec(._effects): self = ._effects
-      case TokenSpec(._expose): self = ._expose
-      case TokenSpec(._implements): self = ._implements
-      case TokenSpec(._nonSendable): self = ._nonSendable
-      case TokenSpec(._objcImplementation): self = ._objcImplementation
-      case TokenSpec(._objcRuntimeName): self = ._objcRuntimeName
-      case TokenSpec(._optimize): self = ._optimize
-      case TokenSpec(._originallyDefinedIn): self = ._originallyDefinedIn
-      case TokenSpec(._private): self = ._private
-      case TokenSpec(._projectedValueProperty): self = ._projectedValueProperty
-      case TokenSpec(._semantics): self = ._semantics
-      case TokenSpec(._specialize): self = ._specialize
-      case TokenSpec(._spi): self = ._spi
-      case TokenSpec(._spi_available): self = ._spi_available
-      case TokenSpec(._swift_native_objc_runtime_base): self = ._swift_native_objc_runtime_base
-      case TokenSpec(._typeEraser): self = ._typeEraser
-      case TokenSpec(._unavailableFromAsync): self = ._unavailableFromAsync
-      case TokenSpec(.`rethrows`): self = .rethrows
-      case TokenSpec(.attached): self = .attached
-      case TokenSpec(.available): self = .available
-      case TokenSpec(.backDeployed): self = .backDeployed
-      case TokenSpec(.derivative): self = .derivative
-      case TokenSpec(.differentiable): self = .differentiable
-      case TokenSpec(.exclusivity): self = .exclusivity
-      case TokenSpec(.freestanding): self = .freestanding
-      case TokenSpec(.inline): self = .inline
-      case TokenSpec(.objc): self = .objc
-      case TokenSpec(.Sendable): self = .Sendable
-      case TokenSpec(.transpose): self = .transpose
+      switch lexeme.rawTokenKind {
+      case .keyword:
+        switch Keyword(lexeme.tokenText) {
+        case .rethrows: self = .rethrows
+        default:
+          return nil
+        }
+      case .identifier:
+        switch lexeme.tokenText {
+        case "_alignment": self = ._alignment
+        case "_backDeploy": self = ._backDeploy
+        case "_cdecl": self = ._cdecl
+        case "_documentation": self = ._documentation
+        case "_dynamicReplacement": self = ._dynamicReplacement
+        case "_effects": self = ._effects
+        case "_expose": self = ._expose
+        case "_implements": self = ._implements
+        case "_nonSendable": self = ._nonSendable
+        case "_objcImplementation": self = ._objcImplementation
+        case "_objcRuntimeName": self = ._objcRuntimeName
+        case "_optimize": self = ._optimize
+        case "_originallyDefinedIn": self = ._originallyDefinedIn
+        case "_private": self = ._private
+        case "_projectedValueProperty": self = ._projectedValueProperty
+        case "_semantics": self = ._semantics
+        case "_specialize": self = ._specialize
+        case "_spi": self = ._spi
+        case "_spi_available": self = ._spi_available
+        case "_swift_native_objc_runtime_base": self = ._swift_native_objc_runtime_base
+        case "_typeEraser": self = ._typeEraser
+        case "_unavailableFromAsync": self = ._unavailableFromAsync
+        case "rethrows": self = .rethrows
+        case "attached": self = .attached
+        case "backDeployed": self = .backDeployed
+        case "derivative": self = .derivative
+        case "differentiable": self = .differentiable
+        case "exclusivity": self = .exclusivity
+        case "freestanding": self = .freestanding
+        case "inline": self = .inline
+        case "objc": self = .objc
+        case "available": self = .available
+        case "Sendable": self = .Sendable
+        case "transpose": self = .transpose
+        default:
+          return nil
+        }
       default:
         return nil
       }
@@ -109,40 +120,8 @@ extension Parser {
 
     var spec: TokenSpec {
       switch self {
-      case ._alignment: return .keyword(._alignment)
-      case ._backDeploy: return .keyword(._backDeploy)
-      case ._cdecl: return .keyword(._cdecl)
-      case ._documentation: return .keyword(._documentation)
-      case ._dynamicReplacement: return .keyword(._dynamicReplacement)
-      case ._effects: return .keyword(._effects)
-      case ._expose: return .keyword(._expose)
-      case ._implements: return .keyword(._implements)
-      case ._nonSendable: return .keyword(._nonSendable)
-      case ._objcImplementation: return .keyword(._objcImplementation)
-      case ._objcRuntimeName: return .keyword(._objcRuntimeName)
-      case ._optimize: return .keyword(._optimize)
-      case ._originallyDefinedIn: return .keyword(._originallyDefinedIn)
-      case ._private: return .keyword(._private)
-      case ._projectedValueProperty: return .keyword(._projectedValueProperty)
-      case ._semantics: return .keyword(._semantics)
-      case ._specialize: return .keyword(._specialize)
-      case ._spi: return .keyword(._spi)
-      case ._spi_available: return .keyword(._spi_available)
-      case ._swift_native_objc_runtime_base: return .keyword(._swift_native_objc_runtime_base)
-      case ._typeEraser: return .keyword(._typeEraser)
-      case ._unavailableFromAsync: return .keyword(._unavailableFromAsync)
-      case .`rethrows`: return .keyword(.rethrows)
-      case .attached: return .keyword(.attached)
-      case .available: return .keyword(.available)
-      case .backDeployed: return .keyword(.backDeployed)
-      case .derivative: return .keyword(.derivative)
-      case .differentiable: return .keyword(.differentiable)
-      case .exclusivity: return .keyword(.exclusivity)
-      case .freestanding: return .keyword(.freestanding)
-      case .inline: return .keyword(.inline)
-      case .objc: return .keyword(.objc)
-      case .Sendable: return .keyword(.Sendable)
-      case .transpose: return .keyword(.transpose)
+      case .rethrows: return .keyword(.rethrows)
+      default: return .identifier
       }
     }
   }
@@ -401,28 +380,6 @@ extension Parser {
 }
 
 extension Parser {
-  mutating func parseDifferentiableAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
-    let (unexpectedBeforeDifferentiable, differentiable) = self.expect(TokenSpec(.differentiable, remapping: .identifier))
-    let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-
-    let argument = self.parseDifferentiableAttributeArguments()
-    let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
-
-    return RawAttributeSyntax(
-      unexpectedBeforeAtSign,
-      atSign: atSign,
-      unexpectedBeforeDifferentiable,
-      attributeName: RawTypeSyntax(RawIdentifierTypeSyntax(name: differentiable, genericArgumentClause: nil, arena: self.arena)),
-      unexpectedBeforeLeftParen,
-      leftParen: leftParen,
-      arguments: .differentiableArguments(argument),
-      unexpectedBeforeRightParen,
-      rightParen: rightParen,
-      arena: self.arena
-    )
-  }
-
   mutating func parseDifferentiableAttributeArguments() -> RawDifferentiableAttributeArgumentsSyntax {
     let kindSpecifier: RawTokenSyntax?
     let kindSpecifierComma: RawTokenSyntax?
@@ -543,50 +500,6 @@ extension Parser {
 }
 
 extension Parser {
-  mutating func parseDerivativeAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
-    let (unexpectedBeforeDerivative, derivative) = self.expect(TokenSpec(.derivative, remapping: .identifier))
-
-    let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-    let argument = self.parseDerivativeAttributeArguments()
-    let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
-
-    return RawAttributeSyntax(
-      unexpectedBeforeAtSign,
-      atSign: atSign,
-      unexpectedBeforeDerivative,
-      attributeName: RawTypeSyntax(RawIdentifierTypeSyntax(name: derivative, genericArgumentClause: nil, arena: self.arena)),
-      unexpectedBeforeLeftParen,
-      leftParen: leftParen,
-      arguments: .derivativeRegistrationArguments(argument),
-      unexpectedBeforeRightParen,
-      rightParen: rightParen,
-      arena: self.arena
-    )
-  }
-
-  mutating func parseTransposeAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
-    let (unexpectedBeforeTranspose, transpose) = self.expect(TokenSpec(.transpose, remapping: .identifier))
-
-    let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-    let argument = self.parseDerivativeAttributeArguments()
-    let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
-
-    return RawAttributeSyntax(
-      unexpectedBeforeAtSign,
-      atSign: atSign,
-      unexpectedBeforeTranspose,
-      attributeName: RawTypeSyntax(RawIdentifierTypeSyntax(name: transpose, genericArgumentClause: nil, arena: self.arena)),
-      unexpectedBeforeLeftParen,
-      leftParen: leftParen,
-      arguments: .derivativeRegistrationArguments(argument),
-      unexpectedBeforeRightParen,
-      rightParen: rightParen,
-      arena: self.arena
-    )
-  }
-
   mutating func parseDerivativeAttributeArguments() -> RawDerivativeAttributeArgumentsSyntax {
     let (unexpectedBeforeOfLabel, ofLabel) = self.expect(.keyword(.of))
     let (unexpectedBetweenOfLabelAndColon, colon) = self.expect(.colon)

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -239,56 +239,6 @@ enum TokenPrecedence: Comparable {
       .import:
       self = .declKeyword
 
-    case  // `TypeAttribute`
-    ._noMetadata,
-      ._opaqueReturnTypeOf,
-      .autoclosure,
-      .convention,
-      .differentiable,
-      .escaping,
-      .noDerivative,
-      .noescape,
-      .preconcurrency,
-      .Sendable,
-      .retroactive,
-      .unchecked:
-      // Note that .isolated is preferred as a decl keyword
-      self = .exprKeyword
-
-    case  // `DeclarationAttributeWithSpecialSyntax`
-    ._alignment,
-      ._backDeploy,
-      ._cdecl,
-      ._documentation,
-      ._dynamicReplacement,
-      ._effects,
-      ._expose,
-      ._implements,
-      ._nonSendable,
-      ._objcImplementation,
-      ._objcRuntimeName,
-      ._optimize,
-      ._originallyDefinedIn,
-      ._private,
-      ._projectedValueProperty,
-      ._semantics,
-      ._specialize,
-      ._spi,
-      ._spi_available,
-      ._swift_native_objc_runtime_base,
-      ._typeEraser,
-      ._unavailableFromAsync,
-      .attached,
-      .available,
-      .backDeployed,
-      .derivative,
-      .exclusivity,
-      .freestanding,
-      .inline,
-      .objc,
-      .transpose:
-      self = .exprKeyword
-
     case  // Treat all other keywords as expression keywords in the absence of any better information.
     .__owned,
       .__shared,

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -646,44 +646,31 @@ enum TypeAttribute: TokenSpecSet {
   case isolated
 
   init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
-    switch PrepareForKeywordMatch(lexeme) {
-    case TokenSpec(._local): self = ._local
-    case TokenSpec(._noMetadata): self = ._noMetadata
-    case TokenSpec(._opaqueReturnTypeOf): self = ._opaqueReturnTypeOf
-    case TokenSpec(.async): self = .async
-    case TokenSpec(.autoclosure): self = .autoclosure
-    case TokenSpec(.convention): self = .convention
-    case TokenSpec(.differentiable): self = .differentiable
-    case TokenSpec(.escaping): self = .escaping
-    case TokenSpec(.noDerivative): self = .noDerivative
-    case TokenSpec(.noescape): self = .noescape
-    case TokenSpec(.preconcurrency): self = .preconcurrency
-    case TokenSpec(.Sendable): self = .Sendable
-    case TokenSpec(.retroactive): self = .retroactive
-    case TokenSpec(.unchecked): self = .unchecked
-    case TokenSpec(.isolated): self = .isolated
+    guard lexeme.rawTokenKind == .identifier else {
+      return nil
+    }
+    switch lexeme.tokenText {
+    case "_local": self = ._local
+    case "_noMetadata": self = ._noMetadata
+    case "_opaqueReturnTypeOf": self = ._opaqueReturnTypeOf
+    case "async": self = .async
+    case "autoclosure": self = .autoclosure
+    case "convention": self = .convention
+    case "differentiable": self = .differentiable
+    case "escaping": self = .escaping
+    case "noDerivative": self = .noDerivative
+    case "noescape": self = .noescape
+    case "preconcurrency": self = .preconcurrency
+    case "Sendable": self = .Sendable
+    case "retroactive": self = .retroactive
+    case "unchecked": self = .unchecked
+    case "isolated": self = .isolated
     default: return nil
     }
   }
 
   var spec: TokenSpec {
-    switch self {
-    case ._local: return .keyword(._local)
-    case ._noMetadata: return .keyword(._noMetadata)
-    case ._opaqueReturnTypeOf: return .keyword(._opaqueReturnTypeOf)
-    case .async: return .keyword(.async)
-    case .autoclosure: return .keyword(.autoclosure)
-    case .convention: return .keyword(.convention)
-    case .differentiable: return .keyword(.differentiable)
-    case .escaping: return .keyword(.escaping)
-    case .noDerivative: return .keyword(.noDerivative)
-    case .noescape: return .keyword(.noescape)
-    case .preconcurrency: return .keyword(.preconcurrency)
-    case .retroactive: return .keyword(.retroactive)
-    case .Sendable: return .keyword(.Sendable)
-    case .unchecked: return .keyword(.unchecked)
-    case .isolated: return .keyword(.isolated)
-    }
+    return .identifier
   }
 }
 

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -938,7 +938,9 @@ extension Parser {
       // Known type attribute that doesn't take any arguments
       return parseAttributeWithoutArguments()
     case .differentiable:
-      return .attribute(self.parseDifferentiableAttribute())
+      return parseAttribute(argumentMode: .required) { parser in
+        return .differentiableArguments(parser.parseDifferentiableAttributeArguments())
+      }
 
     case .convention:
       return parseAttribute(argumentMode: .required) { parser in

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -17,24 +17,16 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case __owned
   case __setter_access
   case __shared
-  case _alignment
-  case _backDeploy
   case _borrow
   @_spi(ExperimentalLanguageFeatures)
   case _borrowing
   case _BridgeObject
-  case _cdecl
   case _Class
   case _compilerInitialized
   case _const
   @_spi(ExperimentalLanguageFeatures)
   case _consuming
-  case _documentation
-  case _dynamicReplacement
-  case _effects
-  case _expose
   case _forward
-  case _implements
   case _linear
   case _local
   case _modify
@@ -43,28 +35,12 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case _mutating
   case _NativeClass
   case _NativeRefCountedObject
-  case _noMetadata
-  case _nonSendable
-  case _objcImplementation
-  case _objcRuntimeName
-  case _opaqueReturnTypeOf
-  case _optimize
-  case _originallyDefinedIn
   case _PackageDescription
-  case _private
-  case _projectedValueProperty
   case _read
   case _RefCountedObject
-  case _semantics
-  case _specialize
-  case _spi
-  case _spi_available
-  case _swift_native_objc_runtime_base
   case _Trivial
   case _TrivialAtMost
   case _TrivialStride
-  case _typeEraser
-  case _unavailableFromAsync
   case _underlyingVersion
   case _UnknownLayout
   case _version
@@ -79,12 +55,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case `associatedtype`
   case associativity
   case async
-  case attached
-  case autoclosure
   case availability
-  case available
   case await
-  case backDeployed
   case before
   case block
   case borrowing
@@ -99,23 +71,18 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case consuming
   case `continue`
   case convenience
-  case convention
   case cType
   case `default`
   case `defer`
   case `deinit`
   case deprecated
-  case derivative
   case didSet
-  case differentiable
   case distributed
   case `do`
   case dynamic
   case each
   case `else`
   case `enum`
-  case escaping
-  case exclusivity
   case exported
   case `extension`
   case `fallthrough`
@@ -127,7 +94,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case discard
   case forward
   case `func`
-  case freestanding
   case get
   case `guard`
   case higherThan
@@ -138,7 +104,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case infix
   case `init`
   case initializes
-  case inline
   case `inout`
   case `internal`
   case introduced
@@ -160,12 +125,9 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case mutating
   case `nil`
   case noasync
-  case noDerivative
-  case noescape
   case none
   case nonisolated
   case nonmutating
-  case objc
   case obsoleted
   case of
   case open
@@ -175,7 +137,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case package
   case postfix
   case `precedencegroup`
-  case preconcurrency
   case prefix
   case `private`
   case `Protocol`
@@ -190,14 +151,12 @@ public enum Keyword: UInt8, Hashable, Sendable {
   @_spi(ExperimentalLanguageFeatures)
   case _resultDependsOnSelf
   case `rethrows`
-  case retroactive
   case `return`
   case reverse
   case right
   case safe
   case `self`
   case `Self`
-  case Sendable
   case set
   case some
   case sourceFile
@@ -215,13 +174,11 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case `throws`
   @_spi(ExperimentalLanguageFeatures)
   case transferring
-  case transpose
   case `true`
   case `try`
   case `Type`
   case `typealias`
   case unavailable
-  case unchecked
   case unowned
   case unsafe
   case unsafeAddress
@@ -284,8 +241,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       }
     case 4:
       switch text {
-      case "_spi":
-        self = ._spi
       case "case":
         self = .case
       case "copy":
@@ -312,8 +267,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .line
       case "none":
         self = .none
-      case "objc":
-        self = .objc
       case "open":
         self = .open
       case "safe":
@@ -390,8 +343,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       }
     case 6:
       switch text {
-      case "_cdecl":
-        self = ._cdecl
       case "_Class":
         self = ._Class
       case "_const":
@@ -406,8 +357,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .didSet
       case "import":
         self = .import
-      case "inline":
-        self = .inline
       case "linear":
         self = .linear
       case "module":
@@ -441,8 +390,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .__owned
       case "_borrow":
         self = ._borrow
-      case "_expose":
-        self = ._expose
       case "_linear":
         self = ._linear
       case "_modify":
@@ -484,26 +431,18 @@ public enum Keyword: UInt8, Hashable, Sendable {
       switch text {
       case "__shared":
         self = .__shared
-      case "_effects":
-        self = ._effects
       case "_forward":
         self = ._forward
-      case "_private":
-        self = ._private
       case "_Trivial":
         self = ._Trivial
       case "_version":
         self = ._version
       case "accesses":
         self = .accesses
-      case "attached":
-        self = .attached
       case "compiler":
         self = .compiler
       case "continue":
         self = .continue
-      case "escaping":
-        self = .escaping
       case "exported":
         self = .exported
       case "indirect":
@@ -516,8 +455,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .metadata
       case "mutating":
         self = .mutating
-      case "noescape":
-        self = .noescape
       case "operator":
         self = .operator
       case "optional":
@@ -532,8 +469,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .required
       case "rethrows":
         self = .rethrows
-      case "Sendable":
-        self = .Sendable
       default:
         return nil
       }
@@ -541,10 +476,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       switch text {
       case "_mutating":
         self = ._mutating
-      case "_optimize":
-        self = ._optimize
-      case "available":
-        self = .available
       case "borrowing":
         self = .borrowing
       case "canImport":
@@ -561,33 +492,21 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .spiModule
       case "subscript":
         self = .subscript
-      case "transpose":
-        self = .transpose
       case "typealias":
         self = .typealias
-      case "unchecked":
-        self = .unchecked
       default:
         return nil
       }
     case 10:
       switch text {
-      case "_alignment":
-        self = ._alignment
       case "_borrowing":
         self = ._borrowing
       case "_consuming":
         self = ._consuming
-      case "_semantics":
-        self = ._semantics
       case "assignment":
         self = .assignment
-      case "convention":
-        self = .convention
       case "deprecated":
         self = .deprecated
-      case "derivative":
-        self = .derivative
       case "higherThan":
         self = .higherThan
       case "introduced":
@@ -603,24 +522,10 @@ public enum Keyword: UInt8, Hashable, Sendable {
       switch text {
       case "__consuming":
         self = .__consuming
-      case "_backDeploy":
-        self = ._backDeploy
-      case "_implements":
-        self = ._implements
-      case "_noMetadata":
-        self = ._noMetadata
-      case "_specialize":
-        self = ._specialize
-      case "_typeEraser":
-        self = ._typeEraser
-      case "autoclosure":
-        self = .autoclosure
       case "convenience":
         self = .convenience
       case "distributed":
         self = .distributed
-      case "exclusivity":
-        self = .exclusivity
       case "fallthrough":
         self = .fallthrough
       case "fileprivate":
@@ -631,8 +536,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .nonisolated
       case "nonmutating":
         self = .nonmutating
-      case "retroactive":
-        self = .retroactive
       case "unavailable":
         self = .unavailable
       default:
@@ -642,16 +545,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
       switch text {
       case "_NativeClass":
         self = ._NativeClass
-      case "_nonSendable":
-        self = ._nonSendable
       case "availability":
         self = .availability
-      case "backDeployed":
-        self = .backDeployed
-      case "freestanding":
-        self = .freestanding
-      case "noDerivative":
-        self = .noDerivative
       case "transferring":
         self = .transferring
       default:
@@ -670,10 +565,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       }
     case 14:
       switch text {
-      case "_documentation":
-        self = ._documentation
-      case "_spi_available":
-        self = ._spi_available
       case "_TrivialAtMost":
         self = ._TrivialAtMost
       case "_TrivialStride":
@@ -682,10 +573,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = ._UnknownLayout
       case "associatedtype":
         self = .associatedtype
-      case "differentiable":
-        self = .differentiable
-      case "preconcurrency":
-        self = .preconcurrency
       case "witness_method":
         self = .witness_method
       default:
@@ -702,8 +589,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       }
     case 16:
       switch text {
-      case "_objcRuntimeName":
-        self = ._objcRuntimeName
       case "addressWithOwner":
         self = .addressWithOwner
       case "_resultDependsOn":
@@ -727,12 +612,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       }
     case 19:
       switch text {
-      case "_dynamicReplacement":
-        self = ._dynamicReplacement
-      case "_objcImplementation":
-        self = ._objcImplementation
-      case "_opaqueReturnTypeOf":
-        self = ._opaqueReturnTypeOf
       case "_PackageDescription":
         self = ._PackageDescription
       default:
@@ -742,19 +621,10 @@ public enum Keyword: UInt8, Hashable, Sendable {
       switch text {
       case "_compilerInitialized":
         self = ._compilerInitialized
-      case "_originallyDefinedIn":
-        self = ._originallyDefinedIn
       case "_resultDependsOnSelf":
         self = ._resultDependsOnSelf
       case "unsafeMutableAddress":
         self = .unsafeMutableAddress
-      default:
-        return nil
-      }
-    case 21:
-      switch text {
-      case "_unavailableFromAsync":
-        self = ._unavailableFromAsync
       default:
         return nil
       }
@@ -769,8 +639,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       switch text {
       case "_NativeRefCountedObject":
         self = ._NativeRefCountedObject
-      case "_projectedValueProperty":
-        self = ._projectedValueProperty
       case "mutableAddressWithOwner":
         self = .mutableAddressWithOwner
       default:
@@ -780,13 +648,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       switch text {
       case "mutableAddressWithNativeOwner":
         self = .mutableAddressWithNativeOwner
-      default:
-        return nil
-      }
-    case 31:
-      switch text {
-      case "_swift_native_objc_runtime_base":
-        self = ._swift_native_objc_runtime_base
       default:
         return nil
       }
@@ -805,22 +666,14 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "__owned", 
       "__setter_access", 
       "__shared", 
-      "_alignment", 
-      "_backDeploy", 
       "_borrow", 
       "_borrowing", 
       "_BridgeObject", 
-      "_cdecl", 
       "_Class", 
       "_compilerInitialized", 
       "_const", 
       "_consuming", 
-      "_documentation", 
-      "_dynamicReplacement", 
-      "_effects", 
-      "_expose", 
       "_forward", 
-      "_implements", 
       "_linear", 
       "_local", 
       "_modify", 
@@ -828,28 +681,12 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "_mutating", 
       "_NativeClass", 
       "_NativeRefCountedObject", 
-      "_noMetadata", 
-      "_nonSendable", 
-      "_objcImplementation", 
-      "_objcRuntimeName", 
-      "_opaqueReturnTypeOf", 
-      "_optimize", 
-      "_originallyDefinedIn", 
       "_PackageDescription", 
-      "_private", 
-      "_projectedValueProperty", 
       "_read", 
       "_RefCountedObject", 
-      "_semantics", 
-      "_specialize", 
-      "_spi", 
-      "_spi_available", 
-      "_swift_native_objc_runtime_base", 
       "_Trivial", 
       "_TrivialAtMost", 
       "_TrivialStride", 
-      "_typeEraser", 
-      "_unavailableFromAsync", 
       "_underlyingVersion", 
       "_UnknownLayout", 
       "_version", 
@@ -864,12 +701,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "associatedtype", 
       "associativity", 
       "async", 
-      "attached", 
-      "autoclosure", 
       "availability", 
-      "available", 
       "await", 
-      "backDeployed", 
       "before", 
       "block", 
       "borrowing", 
@@ -884,23 +717,18 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "consuming", 
       "continue", 
       "convenience", 
-      "convention", 
       "cType", 
       "default", 
       "defer", 
       "deinit", 
       "deprecated", 
-      "derivative", 
       "didSet", 
-      "differentiable", 
       "distributed", 
       "do", 
       "dynamic", 
       "each", 
       "else", 
       "enum", 
-      "escaping", 
-      "exclusivity", 
       "exported", 
       "extension", 
       "fallthrough", 
@@ -912,7 +740,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "discard", 
       "forward", 
       "func", 
-      "freestanding", 
       "get", 
       "guard", 
       "higherThan", 
@@ -923,7 +750,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "infix", 
       "init", 
       "initializes", 
-      "inline", 
       "inout", 
       "internal", 
       "introduced", 
@@ -945,12 +771,9 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "mutating", 
       "nil", 
       "noasync", 
-      "noDerivative", 
-      "noescape", 
       "none", 
       "nonisolated", 
       "nonmutating", 
-      "objc", 
       "obsoleted", 
       "of", 
       "open", 
@@ -960,7 +783,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "package", 
       "postfix", 
       "precedencegroup", 
-      "preconcurrency", 
       "prefix", 
       "private", 
       "Protocol", 
@@ -973,14 +795,12 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "_resultDependsOn", 
       "_resultDependsOnSelf", 
       "rethrows", 
-      "retroactive", 
       "return", 
       "reverse", 
       "right", 
       "safe", 
       "self", 
       "Self", 
-      "Sendable", 
       "set", 
       "some", 
       "sourceFile", 
@@ -997,13 +817,11 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "throw", 
       "throws", 
       "transferring", 
-      "transpose", 
       "true", 
       "try", 
       "Type", 
       "typealias", 
       "unavailable", 
-      "unchecked", 
       "unowned", 
       "unsafe", 
       "unsafeAddress", 


### PR DESCRIPTION
They were declared as `Keyword` only for `TokenSpecs` (DeclarationAttributeWithSpecialSyntax and TypeAttribute), the attribute names are always parsed as `TypeSyntax` so those keywords weren't even appear in the parsed syntax tree.

Instead, make those `TokenSpecSet` to accept `.identifier` lexemes.