### PR TITLE
Parse `_borrowing x` contextually as a pattern binding when `.borrowingSwitch` feature is enabled.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExperimentalFeatures.swift
@@ -18,6 +18,7 @@ public enum ExperimentalFeature: String, CaseIterable {
   case doExpressions
   case nonescapableTypes
   case transferringArgsAndResults
+  case borrowingSwitch
 
   /// The name of the feature, which is used in the doc comment.
   public var featureName: String {
@@ -32,6 +33,8 @@ public enum ExperimentalFeature: String, CaseIterable {
       return "NonEscableTypes"
     case .transferringArgsAndResults:
       return "TransferringArgsAndResults"
+    case .borrowingSwitch:
+      return "borrowing pattern matching"
     }
   }
 

--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -19,6 +19,7 @@ public struct KeywordSpec {
   /// The experimental feature the keyword is part of, or `nil` if this isn't
   /// for an experimental feature.
   public let experimentalFeature: ExperimentalFeature?
+  public let experimentalFeature2: ExperimentalFeature?
 
   /// Indicates if the token kind is switched from being an identifier to a keyword in the lexer.
   public let isLexerClassified: Bool
@@ -59,6 +60,26 @@ public struct KeywordSpec {
   ) {
     self.name = name
     self.experimentalFeature = experimentalFeature
+    self.experimentalFeature2 = nil
+    self.isLexerClassified = isLexerClassified
+  }
+
+  /// Initializes a new `KeywordSpec` instance.
+  ///
+  /// - Parameters:
+  ///   - name: A name of the keyword.
+  ///   - experimentalFeature: The experimental feature the keyword is part of, or `nil` if this isn't for an experimental feature.
+  ///   - or: A second experimental feature the keyword is also part of, or `nil` if this isn't for an experimental feature.
+  ///   - isLexerClassified: Indicates if the token kind is switched from being an identifier to a keyword in the lexer.
+  init(
+    _ name: String,
+    experimentalFeature: ExperimentalFeature,
+    or experimentalFeature2: ExperimentalFeature,
+    isLexerClassified: Bool = false
+  ) {
+    self.name = name
+    self.experimentalFeature = experimentalFeature
+    self.experimentalFeature2 = experimentalFeature2
     self.isLexerClassified = isLexerClassified
   }
 }
@@ -720,7 +741,7 @@ public enum Keyword: CaseIterable {
     case .yield:
       return KeywordSpec("yield")
     case ._borrowing:
-      return KeywordSpec("_borrowing", experimentalFeature: .referenceBindings)
+      return KeywordSpec("_borrowing", experimentalFeature: .referenceBindings, or: .borrowingSwitch)
     case ._consuming:
       return KeywordSpec("_consuming", experimentalFeature: .referenceBindings)
     case ._mutating:

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ParserTokenSpecSetFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ParserTokenSpecSetFile.swift
@@ -15,11 +15,14 @@ import SwiftSyntaxBuilder
 import SyntaxSupport
 import Utils
 
-func tokenCaseMatch(_ caseName: TokenSyntax, experimentalFeature: ExperimentalFeature?) -> SwitchCaseSyntax {
-  let whereClause =
-    experimentalFeature.map {
-      "where experimentalFeatures.contains(.\($0.token))"
-    } ?? ""
+func tokenCaseMatch(_ caseName: TokenSyntax, experimentalFeature: ExperimentalFeature?, experimentalFeature2: ExperimentalFeature?) -> SwitchCaseSyntax {
+  var whereClause = ""
+  if let feature = experimentalFeature {
+    whereClause += "where experimentalFeatures.contains(.\(feature.token))"
+    if let feature2 = experimentalFeature2 {
+      whereClause += " || experimentalFeatures.contains(.\(feature2.token))"
+    }
+  }
   return "case TokenSpec(.\(caseName))\(raw: whereClause): self = .\(caseName)"
 }
 
@@ -57,12 +60,14 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                   case .keyword(let keyword):
                     tokenCaseMatch(
                       keyword.spec.varOrCaseName,
-                      experimentalFeature: keyword.spec.experimentalFeature
+                      experimentalFeature: keyword.spec.experimentalFeature,
+                      experimentalFeature2: keyword.spec.experimentalFeature2
                     )
                   case .token(let token):
                     tokenCaseMatch(
                       token.spec.varOrCaseName,
-                      experimentalFeature: token.spec.experimentalFeature
+                      experimentalFeature: token.spec.experimentalFeature,
+                      experimentalFeature2: nil
                     )
                   }
                 }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -118,9 +118,21 @@ extension Parser {
     //
     // Only do this if we're parsing a pattern, to improve QoI on malformed
     // expressions followed by (e.g.) let/var decls.
-    if pattern != .none, self.at(anyIn: MatchingPatternStart.self) != nil {
-      let pattern = self.parseMatchingPattern(context: .matching)
-      return RawExprSyntax(RawPatternExprSyntax(pattern: pattern, arena: self.arena))
+    if pattern != .none {
+      switch self.at(anyIn: MatchingPatternStart.self) {
+      case (spec: .rhs(let bindingIntroducer), handle: _)? where self.withLookahead { $0.shouldParsePatternBinding(introducer: bindingIntroducer) }:
+        fallthrough
+      case (spec: .lhs(_), handle: _)?:
+        let pattern = self.parseMatchingPattern(context: .matching)
+        return RawExprSyntax(RawPatternExprSyntax(pattern: pattern, arena: self.arena))
+
+      // If the token can't start a pattern, or contextually isn't parsed as a
+      // binding introducer, handle as the start of a normal expression.
+      case (spec: .rhs(_), handle: _)?,
+        nil:
+        // Not a pattern. Break out to parse as a normal expression below.
+        break
+      }
     }
     return RawExprSyntax(self.parseSequenceExpression(flavor: flavor, pattern: pattern))
   }

--- a/Sources/SwiftParser/generated/ExperimentalFeatures.swift
+++ b/Sources/SwiftParser/generated/ExperimentalFeatures.swift
@@ -38,4 +38,7 @@ extension Parser.ExperimentalFeatures {
   
   /// Whether to enable the parsing of TransferringArgsAndResults.
   public static let transferringArgsAndResults = Self (rawValue: 1 << 4)
+  
+  /// Whether to enable the parsing of borrowing pattern matching.
+  public static let borrowingSwitch = Self (rawValue: 1 << 5)
 }

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -2318,7 +2318,7 @@ extension OptionalBindingConditionSyntax {
         self = .inout
       case TokenSpec(._mutating) where experimentalFeatures.contains(.referenceBindings):
         self = ._mutating
-      case TokenSpec(._borrowing) where experimentalFeatures.contains(.referenceBindings):
+      case TokenSpec(._borrowing) where experimentalFeatures.contains(.referenceBindings) || experimentalFeatures.contains(.borrowingSwitch):
         self = ._borrowing
       case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
         self = ._consuming
@@ -2992,7 +2992,7 @@ extension ValueBindingPatternSyntax {
         self = .inout
       case TokenSpec(._mutating) where experimentalFeatures.contains(.referenceBindings):
         self = ._mutating
-      case TokenSpec(._borrowing) where experimentalFeatures.contains(.referenceBindings):
+      case TokenSpec(._borrowing) where experimentalFeatures.contains(.referenceBindings) || experimentalFeatures.contains(.borrowingSwitch):
         self = ._borrowing
       case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
         self = ._consuming
@@ -3064,7 +3064,7 @@ extension VariableDeclSyntax {
         self = .inout
       case TokenSpec(._mutating) where experimentalFeatures.contains(.referenceBindings):
         self = ._mutating
-      case TokenSpec(._borrowing) where experimentalFeatures.contains(.referenceBindings):
+      case TokenSpec(._borrowing) where experimentalFeatures.contains(.referenceBindings) || experimentalFeatures.contains(.borrowingSwitch):
         self = ._borrowing
       case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
         self = ._consuming


### PR DESCRIPTION
The existing parsing under `.referenceBindings` parses this (along with `_mutating` and `_consuming`) as unconditional keywords, which would be a source break we can't ship. Narrow the behavior so that `_borrowing` is only parsed immediately before an identifier in a pattern.