### PR TITLE
Fix: Incorrect insertion location in fix-it for `)`

### DIFF
--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -198,12 +198,8 @@ extension FixIt.MultiNodeChange {
       }
     }
 
-    if let previousToken = node.previousToken(viewMode: .fixedUp),
-      previousToken.isPresent,
-      let firstToken = node.firstToken(viewMode: .all),
-      previousToken.trailingTrivia.allSatisfy({ $0.isWhitespace }),
-      !BasicFormat().requiresWhitespace(between: previousToken, and: firstToken),
-      !BasicFormat().requiresNewline(between: previousToken, and: firstToken)
+    if node.shouldBeInsertedBeforePreviousTokenTrivia,
+      let previousToken = node.previousToken(viewMode: .fixedUp)
     {
       // If the previous token and this node don't need to be separated, remove
       // the separation.

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -445,6 +445,8 @@ extension ParseDiagnosticsGenerator {
       position = overridePosition
     } else if node.shouldBeInsertedAfterNextTokenTrivia, let nextToken = node.nextToken(viewMode: .sourceAccurate) {
       position = nextToken.positionAfterSkippingLeadingTrivia
+    } else if node.shouldBeInsertedBeforePreviousTokenTrivia, let previousToken = node.previousToken(viewMode: .sourceAccurate) {
+      position = previousToken.endPositionBeforeTrailingTrivia
     } else {
       position = node.endPosition
     }

--- a/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftBasicFormat
 @_spi(Diagnostics) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
 
@@ -128,6 +129,22 @@ extension SyntaxProtocol {
     if !self.raw.kind.isMissing,
       let memberDeclItem = self.ancestorOrSelf(mapping: { $0.as(MemberBlockItemSyntax.self) }),
       memberDeclItem.firstToken(viewMode: .all) == self.firstToken(viewMode: .all)
+    {
+      return true
+    } else {
+      return false
+    }
+  }
+
+  /// Returns `true` if the previous token and this node don't need to be separated,
+  /// when it is switched from being missing to present.
+  var shouldBeInsertedBeforePreviousTokenTrivia: Bool {
+    if let previousToken = self.previousToken(viewMode: .fixedUp),
+      previousToken.isPresent,
+      let firstToken = self.firstToken(viewMode: .all),
+      previousToken.trailingTrivia.allSatisfy({ $0.isWhitespace }),
+      !BasicFormat().requiresWhitespace(between: previousToken, and: firstToken),
+      !BasicFormat().requiresNewline(between: previousToken, and: firstToken)
     {
       return true
     } else {

--- a/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
+++ b/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
@@ -128,11 +128,26 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
 
     let expectedOutput = """
       \u{001B}[0;36m1 │\u{001B}[0;0m for \u{001B}[4;39m(i\u{001B}[0;0m \u{001B}[4;39m= 🐮; i != 👩‍👩‍👦‍👦; i += 1)\u{001B}[0;0m { }
-        \u{001B}[0;36m│\u{001B}[0;0m │      ╰─ \u{001B}[1;31merror: \u{001B}[1;39mexpected ')' to end tuple pattern\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m │     ╰─ \u{001B}[1;31merror: \u{001B}[1;39mexpected ')' to end tuple pattern\u{001B}[0;0m
         \u{001B}[0;36m│\u{001B}[0;0m ╰─ \u{001B}[1;31merror: \u{001B}[1;39mC-style for statement has been removed in Swift 3\u{001B}[0;0m
 
       """
 
     assertStringsEqualWithDiff(annotate(source: source, colorize: true), expectedOutput)
+  }
+
+  func testRighParenLocation() {
+    let source = """
+      let _ : Float  -> Int
+      """
+
+    let expectedOutput = """
+      1 │ let _ : Float  -> Int
+        │         │    ╰─ error: expected ')' in function type
+        │         ╰─ error: expected '(' to start function type
+
+      """
+
+    assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
   }
 }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -850,7 +850,7 @@ final class DeclarationTests: ParserTestCase {
 
   func testMissingColonInFunctionSignature() {
     assertParse(
-      "func test(first second 1️⃣Int)",
+      "func test(first second1️⃣ Int)",
       diagnostics: [
         DiagnosticSpec(message: "expected ':' in parameter", fixIts: ["insert ':'"])
       ],
@@ -887,7 +887,7 @@ final class DeclarationTests: ParserTestCase {
 
   func testMissingOpeningParenInFunctionSignature() {
     assertParse(
-      "func test 1️⃣first second: Int)",
+      "func test1️⃣ first second: Int)",
       diagnostics: [
         DiagnosticSpec(message: "expected '(' to start parameter clause", fixIts: ["insert '('"])
       ],
@@ -1368,7 +1368,7 @@ final class DeclarationTests: ParserTestCase {
 
   func testDontRecoverFromDeclKeyword() {
     assertParse(
-      "func fooℹ️(first second 1️⃣third 2️⃣struct3️⃣: Int4️⃣) {}",
+      "func fooℹ️(first second1️⃣ third2️⃣ struct3️⃣: Int4️⃣) {}",
       substructure: FunctionParameterSyntax(
         firstName: .identifier("first"),
         secondName: .identifier("second"),
@@ -1426,7 +1426,7 @@ final class DeclarationTests: ParserTestCase {
 
   func testDontRecoverFromUnbalancedParens() {
     assertParse(
-      "func foo(first second 1️⃣[third 2️⃣fourth: Int) {}",
+      "func foo(first second1️⃣ 2️⃣[third3️⃣ 4️⃣fourth: Int) {}",
       substructure: FunctionParameterSyntax(
         firstName: .identifier("first"),
         secondName: .identifier("second"),
@@ -1444,13 +1444,13 @@ final class DeclarationTests: ParserTestCase {
           fixIts: ["insert ':'"]
         ),
         DiagnosticSpec(
-          locationMarker: "2️⃣",
+          locationMarker: "3️⃣",
           message: "expected ']' to end array type",
-          notes: [NoteSpec(locationMarker: "1️⃣", message: "to match this opening '['")],
+          notes: [NoteSpec(locationMarker: "2️⃣", message: "to match this opening '['")],
           fixIts: ["insert ']'"]
         ),
         DiagnosticSpec(
-          locationMarker: "2️⃣",
+          locationMarker: "4️⃣",
           message: "unexpected code 'fourth: Int' in parameter clause"
         ),
       ],
@@ -1463,7 +1463,7 @@ final class DeclarationTests: ParserTestCase {
   func testDontRecoverIfNewlineIsBeforeColon() {
     assertParse(
       """
-      func fooℹ️(first second 1️⃣third2️⃣
+      func fooℹ️(first second1️⃣ third2️⃣
       3️⃣: Int) {}
       """,
       substructure: FunctionParameterSyntax(
@@ -2273,7 +2273,7 @@ final class DeclarationTests: ParserTestCase {
 
     assertParse(
       """
-      macro m1 1️⃣= A
+      macro m11️⃣ = A
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected parameter clause in function signature", fixIts: ["insert parameter clause"])
@@ -2462,7 +2462,7 @@ final class DeclarationTests: ParserTestCase {
 
   func testMisplaceSpecifierInTupleTypeBody() {
     assertParse(
-      "func test(a: (1️⃣borrowing F 2️⃣o))",
+      "func test(a: (1️⃣borrowing F2️⃣ o))",
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'borrowing' in tuple type"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ',' in tuple type", fixIts: ["insert ','"]),
@@ -2628,7 +2628,7 @@ final class DeclarationTests: ParserTestCase {
 
     assertParse(
       """
-      typealias T = 1️⃣~Int 2️⃣-> Bool
+      typealias T = 1️⃣~Int2️⃣ -> Bool
       """,
       diagnostics: [
         DiagnosticSpec(

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2717,7 +2717,7 @@ final class StatementExpressionTests: ParserTestCase {
   func testClosureWithMissingParentheses() {
     assertParse(
       """
-      _ = { 1️⃣a: Int, b: Int 2️⃣in
+      _ = { 1️⃣a: Int, b: Int2️⃣ in
       }
       """,
       diagnostics: [
@@ -2742,7 +2742,7 @@ final class StatementExpressionTests: ParserTestCase {
   func testClosureWithReturnArrowAndMissingParentheses() {
     assertParse(
       """
-      _ = { 1️⃣a: Int, b: 2️⃣Int 3️⃣-> Int 4️⃣in
+      _ = { 1️⃣a: Int, b: 2️⃣Int3️⃣ -> Int4️⃣ in
       }
       """,
       diagnostics: [
@@ -2834,12 +2834,12 @@ final class StatementExpressionTests: ParserTestCase {
       fixedSource: "[() async throws (MyError) -> Void]()"
     )
     assertParse(
-      "[() 1️⃣try(MyError) async -> Void]()",
+      "[()1️⃣ try(MyError) async -> Void]()",
       diagnostics: [DiagnosticSpec(message: "expected ',' in array element", fixIts: ["insert ','"])],
       fixedSource: "[(), try(MyError) async -> Void]()"
     )
     assertParse(
-      "[() 1️⃣try async(MyError) -> Void]()",
+      "[()1️⃣ try async(MyError) -> Void]()",
       diagnostics: [DiagnosticSpec(message: "expected ',' in array element", fixIts: ["insert ','"])],
       fixedSource: "[(), try async(MyError) -> Void]()"
     )
@@ -2859,7 +2859,7 @@ final class StatementExpressionTests: ParserTestCase {
       fixedSource: "[() async throws (MyError) -> Void]()"
     )
     assertParse(
-      "[() 1️⃣try(MyError) 2️⃣await 3️⃣-> Void]()",
+      "[()1️⃣ try(MyError)2️⃣ await 3️⃣-> Void]()",
       diagnostics: [
         DiagnosticSpec(
           locationMarker: "1️⃣",
@@ -2880,22 +2880,22 @@ final class StatementExpressionTests: ParserTestCase {
       fixedSource: "[(), try(MyError), await <#expression#> -> Void]()"
     )
     assertParse(
-      "[() 1️⃣try await(MyError) -> Void]()",
+      "[()1️⃣ try await(MyError) -> Void]()",
       diagnostics: [DiagnosticSpec(message: "expected ',' in array element", fixIts: ["insert ','"])],
       fixedSource: "[(), try await(MyError) -> Void]()"
     )
     assertParse(
-      "[() 1️⃣async(MyError) -> Void]()",
+      "[()1️⃣ async(MyError) -> Void]()",
       diagnostics: [DiagnosticSpec(message: "expected ',' in array element", fixIts: ["insert ','"])],
       fixedSource: "[(), async(MyError) -> Void]()"
     )
     assertParse(
-      "[() 1️⃣await(MyError) -> Void]()",
+      "[()1️⃣ await(MyError) -> Void]()",
       diagnostics: [DiagnosticSpec(message: "expected ',' in array element", fixIts: ["insert ','"])],
       fixedSource: "[(), await(MyError) -> Void]()"
     )
     assertParse(
-      "[() 1️⃣try(MyError) -> Void]()",
+      "[()1️⃣ try(MyError) -> Void]()",
       diagnostics: [DiagnosticSpec(message: "expected ',' in array element", fixIts: ["insert ','"])],
       fixedSource: "[(), try(MyError) -> Void]()"
     )
@@ -2914,7 +2914,7 @@ final class StatementExpressionTests: ParserTestCase {
     assertParse("[() ()]")
 
     assertParse(
-      "[1 1️⃣2]",
+      "[11️⃣ 2]",
       diagnostics: [
         DiagnosticSpec(
           message: "expected ',' in array element",
@@ -2925,7 +2925,7 @@ final class StatementExpressionTests: ParserTestCase {
     )
 
     assertParse(
-      #"["hello" 1️⃣"world"]"#,
+      #"["hello"1️⃣ "world"]"#,
       diagnostics: [
         DiagnosticSpec(
           message: "expected ',' in array element",
@@ -2938,7 +2938,7 @@ final class StatementExpressionTests: ParserTestCase {
 
   func testDictionaryExprWithNoCommas() {
     assertParse(
-      "[1: () 1️⃣2: ()]",
+      "[1: ()1️⃣ 2: ()]",
       diagnostics: [
         DiagnosticSpec(
           message: "expected ',' in dictionary element",
@@ -2949,7 +2949,7 @@ final class StatementExpressionTests: ParserTestCase {
     )
 
     assertParse(
-      #"["foo": 1 1️⃣"bar": 2]"#,
+      #"["foo": 11️⃣ "bar": 2]"#,
       diagnostics: [
         DiagnosticSpec(
           message: "expected ',' in dictionary element",
@@ -2960,7 +2960,7 @@ final class StatementExpressionTests: ParserTestCase {
     )
 
     assertParse(
-      #"[1: "hello" 1️⃣2: "world"]"#,
+      #"[1: "hello"1️⃣ 2: "world"]"#,
       diagnostics: [
         DiagnosticSpec(
           message: "expected ',' in dictionary element",

--- a/Tests/SwiftParserTest/RegexLiteralTests.swift
+++ b/Tests/SwiftParserTest/RegexLiteralTests.swift
@@ -776,7 +776,7 @@ final class RegexLiteralTests: ParserTestCase {
     // FIXME: The diagnostic should be one character back
     assertParse(
       #"""
-      \ 1️⃣/^ x/
+      \1️⃣ /^ x/
       """#,
       diagnostics: [
         DiagnosticSpec(message: "expected root in key path", fixIts: ["insert root"])

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -18,7 +18,7 @@ final class TypeTests: ParserTestCase {
   func testMissingColonInType() {
     assertParse(
       """
-      var foo 1️⃣Bar = 1
+      var foo1️⃣ Bar = 1
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ':' in type annotation", fixIts: ["insert ':'"])

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -55,7 +55,7 @@ final class VariadicGenericsTests: ParserTestCase {
   func testInvalidPackElement() {
     assertParse(
       """
-      func invalid<each T>() -> (each any 1️⃣T) {}
+      func invalid<each T>() -> (each any1️⃣ T) {}
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ',' in tuple type", fixIts: ["insert ','"])
@@ -564,7 +564,7 @@ final class TypeParameterPackTests: ParserTestCase {
 
     assertParse(
       """
-      var foo: (bar: Int 1️⃣bar2: Int)
+      var foo: (bar: Int1️⃣ bar2: Int)
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ',' in tuple type", fixIts: ["insert ','"])
@@ -576,7 +576,7 @@ final class TypeParameterPackTests: ParserTestCase {
 
     assertParse(
       """
-      var foo: (bar: Int 1️⃣Int)
+      var foo: (bar: Int1️⃣ Int)
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ',' in tuple type", fixIts: ["insert ','"])
@@ -588,7 +588,7 @@ final class TypeParameterPackTests: ParserTestCase {
 
     assertParse(
       """
-      var foo: (a 1️⃣Int)
+      var foo: (a1️⃣ Int)
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ':' in tuple type", fixIts: ["insert ':'"])
@@ -600,7 +600,7 @@ final class TypeParameterPackTests: ParserTestCase {
 
     assertParse(
       """
-      var foo: (A 1️⃣Int)
+      var foo: (A1️⃣ Int)
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ',' in tuple type", fixIts: ["insert ','"])
@@ -612,7 +612,7 @@ final class TypeParameterPackTests: ParserTestCase {
 
     assertParse(
       """
-      var foo: (_ 1️⃣a 2️⃣Int)
+      var foo: (_1️⃣ a2️⃣ Int)
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in tuple type", fixIts: ["insert ':'"]),
@@ -625,7 +625,7 @@ final class TypeParameterPackTests: ParserTestCase {
 
     assertParse(
       """
-      var foo: (Array<Foo> 1️⃣Array<Bar>)
+      var foo: (Array<Foo>1️⃣ Array<Bar>)
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ',' in tuple type", fixIts: ["insert ','"])
@@ -637,7 +637,7 @@ final class TypeParameterPackTests: ParserTestCase {
 
     assertParse(
       """
-      var foo: (a 1️⃣Array<Bar>)
+      var foo: (a1️⃣ Array<Bar>)
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ':' in tuple type", fixIts: ["insert ':'"])
@@ -649,7 +649,7 @@ final class TypeParameterPackTests: ParserTestCase {
 
     assertParse(
       """
-      var foo: (Array<Foo> 1️⃣a)
+      var foo: (Array<Foo>1️⃣ a)
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ',' in tuple type", fixIts: ["insert ','"])

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -135,7 +135,7 @@ final class AvailabilityQueryTests: ParserTestCase {
   func testAvailabilityQuery8() {
     assertParse(
       """
-      if #available( 1️⃣{
+      if #available(1️⃣ {
       }
       """,
       diagnostics: [
@@ -167,7 +167,7 @@ final class AvailabilityQueryTests: ParserTestCase {
   func testAvailabilityQuery10() {
     assertParse(
       """
-      if #availableℹ️(OSX 1️⃣{
+      if #availableℹ️(OSX1️⃣ {
       }
       """,
       diagnostics: [
@@ -198,7 +198,7 @@ final class AvailabilityQueryTests: ParserTestCase {
   func testAvailabilityQuery12() {
     assertParse(
       """
-      if #availableℹ️(OSX 10.51 1️⃣{
+      if #availableℹ️(OSX 10.511️⃣ {
       }
       """,
       diagnostics: [
@@ -327,7 +327,7 @@ final class AvailabilityQueryTests: ParserTestCase {
   func testAvailabilityQuery25() {
     assertParse(
       """
-      if #availableℹ️(* 1️⃣{
+      if #availableℹ️(*1️⃣ {
       }
       """,
       diagnostics: [
@@ -399,7 +399,7 @@ final class AvailabilityQueryTests: ParserTestCase {
   func testAvailabilityQuery29() {
     assertParse(
       """
-      if #availableℹ️(OSX 10.51, iOS 1️⃣{
+      if #availableℹ️(OSX 10.51, iOS1️⃣ {
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -112,7 +112,7 @@ final class AvailabilityQueryUnavailabilityTests: ParserTestCase {
   func testAvailabilityQueryUnavailability4() {
     assertParse(
       """
-      if #unavailable 1️⃣{
+      if #unavailable1️⃣ {
       }
       """,
       diagnostics: [
@@ -131,7 +131,7 @@ final class AvailabilityQueryUnavailabilityTests: ParserTestCase {
   func testAvailabilityQueryUnavailability5() {
     assertParse(
       """
-      if #unavailable( 1️⃣{
+      if #unavailable(1️⃣ {
       }
       """,
       diagnostics: [
@@ -166,7 +166,7 @@ final class AvailabilityQueryUnavailabilityTests: ParserTestCase {
   func testAvailabilityQueryUnavailability7() {
     assertParse(
       """
-      if #unavailableℹ️(OSX 1️⃣{
+      if #unavailableℹ️(OSX1️⃣ {
       }
       """,
       diagnostics: [
@@ -197,7 +197,7 @@ final class AvailabilityQueryUnavailabilityTests: ParserTestCase {
   func testAvailabilityQueryUnavailability9() {
     assertParse(
       """
-      if #unavailableℹ️(OSX 10.51 1️⃣{
+      if #unavailableℹ️(OSX 10.511️⃣ {
       }
       """,
       diagnostics: [
@@ -322,7 +322,7 @@ final class AvailabilityQueryUnavailabilityTests: ParserTestCase {
   func testAvailabilityQueryUnavailability20() {
     assertParse(
       """
-      if #unavailableℹ️(OSX 10 1️⃣{
+      if #unavailableℹ️(OSX 101️⃣ {
       }
       """,
       diagnostics: [
@@ -397,7 +397,7 @@ final class AvailabilityQueryUnavailabilityTests: ParserTestCase {
   func testAvailabilityQueryUnavailability24() {
     assertParse(
       """
-      if #unavailableℹ️(OSX 10.51, iOS 1️⃣{
+      if #unavailableℹ️(OSX 10.51, iOS1️⃣ {
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/DiagnoseDynamicReplacementTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseDynamicReplacementTests.swift
@@ -72,7 +72,7 @@ final class DiagnoseDynamicReplacementTests: ParserTestCase {
   func testDiagnoseDynamicReplacement4() {
     assertParse(
       """
-      @_dynamicReplacementℹ️(for: dynamically_replaceable() 1️⃣
+      @_dynamicReplacementℹ️(for: dynamically_replaceable()1️⃣ 
       func test_dynamic_replacement_for3() {
       }
       """,

--- a/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
+++ b/Tests/SwiftParserTest/translated/ForwardSlashRegexTests.swift
@@ -849,7 +849,7 @@ final class ForwardSlashRegexTests: ParserTestCase {
   func testForwardSlashRegex82() {
     assertParse(
       """
-      _ = 0 . 1️⃣/ 1 / 2
+      _ = 0 .1️⃣ / 1 / 2
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected name in member access", fixIts: ["insert name"])

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -20,7 +20,7 @@ final class InitDeinitTests: ParserTestCase {
     assertParse(
       """
       struct FooStructConstructorA {
-        init 1️⃣
+        init1️⃣ 
       }
       """,
       diagnostics: [
@@ -48,7 +48,7 @@ final class InitDeinitTests: ParserTestCase {
     assertParse(
       """
       struct FooStructConstructorC {
-        init 1️⃣{}
+        init1️⃣ {}
       }
       """,
       diagnostics: [
@@ -66,7 +66,7 @@ final class InitDeinitTests: ParserTestCase {
     assertParse(
       """
       struct FooStructConstructorC {
-        init<T> 1️⃣{}
+        init<T>1️⃣ {}
       }
       """,
       diagnostics: [
@@ -84,7 +84,7 @@ final class InitDeinitTests: ParserTestCase {
     assertParse(
       """
       struct FooStructConstructorC {
-        init? 1️⃣{ self.init() }
+        init?1️⃣ { self.init() }
       }
       """,
       diagnostics: [
@@ -234,7 +234,7 @@ final class InitDeinitTests: ParserTestCase {
   func testInitDeinit11() {
     assertParse(
       """
-      init 1️⃣{}
+      init1️⃣ {}
       init()
       init() {}
       """,

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -114,7 +114,7 @@ final class InvalidTests: ParserTestCase {
     assertParse(
       """
       func test3() {
-        undeclared_func( 1️⃣
+        undeclared_func(1️⃣ 
       }
       """,
       diagnostics: [
@@ -274,7 +274,7 @@ final class InvalidTests: ParserTestCase {
     // rdar://problem/18507467
     assertParse(
       """
-      func dℹ️(_ b: 1️⃣String 2️⃣-> 3️⃣<T>() -> T4️⃣) {}
+      func dℹ️(_ b: 1️⃣String2️⃣ -> 3️⃣<T>() -> T4️⃣) {}
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' to start function type", fixIts: ["insert '('"]),
@@ -317,7 +317,7 @@ final class InvalidTests: ParserTestCase {
       do {
         class Starfish {}
         struct Salmon {}
-        func f(s 1️⃣Starfish,
+        func f(s1️⃣ Starfish,
                   _ ss: Salmon) -> [Int] {}
         func g() { f(Starfish(), Salmon()) }
       }
@@ -589,7 +589,7 @@ final class InvalidTests: ParserTestCase {
     assertParse(
       """
       func were1️⃣
-      wolf2️⃣() 3️⃣{}
+      wolf2️⃣()3️⃣ {}
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' to start parameter clause", fixIts: ["insert '('"]),

--- a/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
@@ -404,7 +404,7 @@ final class OperatorDeclTests: ParserTestCase {
     assertParse(
       """
       precedencegroup A {
-        associativity 1️⃣right
+        associativity1️⃣ right
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/PoundAssertTests.swift
+++ b/Tests/SwiftParserTest/translated/PoundAssertTests.swift
@@ -82,7 +82,7 @@ final class PoundAssertTests: ParserTestCase {
     assertParse(
       """
       func unbalanced1() {
-        #assertℹ️(true 1️⃣
+        #assertℹ️(true1️⃣ 
       }
       """,
       diagnostics: [
@@ -106,7 +106,7 @@ final class PoundAssertTests: ParserTestCase {
     assertParse(
       #"""
       func unbalanced2() {
-        #assertℹ️(true, "hello world" 1️⃣
+        #assertℹ️(true, "hello world"1️⃣ 
       }
       """#,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -60,7 +60,7 @@ final class RecoveryTests: ParserTestCase {
     assertParse(
       """
       func useContainer() -> () {
-        var a : Containerℹ️<not 1️⃣2️⃣a type [skip 3️⃣this greater: >] >4️⃣, b : Int
+        var a : Containerℹ️<not1️⃣ 2️⃣a type [skip 3️⃣this greater: >] >4️⃣, b : Int
         b = 5 // no-warning
         a.exists()
       }
@@ -1103,7 +1103,7 @@ final class RecoveryTests: ParserTestCase {
       struct SS 1️⃣SS : Multi {
         private var a 2️⃣b : Int = ""
         func f() {
-          var c 3️⃣d = 5
+          var c3️⃣ d = 5
           let _ = 0
         }
       }
@@ -1140,7 +1140,7 @@ final class RecoveryTests: ParserTestCase {
   func testRecovery64a() {
     assertParse(
       """
-      let (efg 1️⃣hij, foobar) = (5, 6)
+      let (efg1️⃣ hij, foobar) = (5, 6)
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ',' in tuple pattern", fixIts: ["insert ','"])
@@ -1154,7 +1154,7 @@ final class RecoveryTests: ParserTestCase {
   func testRecovery64b() {
     assertParse(
       """
-      let (efg 1️⃣Hij, foobar) = (5, 6)
+      let (efg1️⃣ Hij, foobar) = (5, 6)
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected ':' in tuple pattern", fixIts: ["insert ':'"])
@@ -1283,7 +1283,7 @@ final class RecoveryTests: ParserTestCase {
     assertParse(
       """
       struct ErrorTypeInVarDecl5 {
-        var v1 : Intℹ️<Int 1️⃣
+        var v1 : Intℹ️<Int1️⃣ 
         var v2 : Int
       }
       """,
@@ -1308,7 +1308,7 @@ final class RecoveryTests: ParserTestCase {
       """
       struct ErrorTypeInVarDecl6 {
         var v1 : Intℹ️<Int,
-                     Int 1️⃣
+                     Int1️⃣ 
         var v2 : Int
       }
       """,
@@ -1560,7 +1560,7 @@ final class RecoveryTests: ParserTestCase {
     // Note: Don't move braces to a different line here.
     assertParse(
       """
-      struct ErrorGenericParameterList5ℹ️<T 1️⃣
+      struct ErrorGenericParameterList5ℹ️<T1️⃣ 
       {
       }
       """,
@@ -1763,7 +1763,7 @@ final class RecoveryTests: ParserTestCase {
       struct ErrorInFunctionSignatureResultArrayType1 1️⃣{
         func foo() -> Int2️⃣[ {
           return [0]
-        }  3️⃣
+        }3️⃣  
         func bar() -> Int4️⃣] {
           return [0]
         }
@@ -1810,7 +1810,7 @@ final class RecoveryTests: ParserTestCase {
     assertParse(
       """
       struct ErrorInFunctionSignatureResultArrayType2 1️⃣{
-        func foo() -> Int2️⃣[0 3️⃣{
+        func foo() -> Int2️⃣[03️⃣ {
           return [0]
         }4️⃣
       5️⃣}
@@ -2476,7 +2476,7 @@ final class RecoveryTests: ParserTestCase {
     // rdar://19605567
     assertParse(
       """
-      func F() { init1️⃣<2️⃣( 3️⃣} 4️⃣)}
+      func F() { init1️⃣<2️⃣(3️⃣ } 4️⃣)}
       struct InitializerWithName {
         init 5️⃣x() {}
       }
@@ -2572,7 +2572,7 @@ final class RecoveryTests: ParserTestCase {
   func testRecovery148() {
     assertParse(
       """
-      init 1️⃣c d: Int 2️⃣{}
+      init1️⃣ c d: Int2️⃣ {}
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' to start parameter clause", fixIts: ["insert '('"]),
@@ -3196,7 +3196,7 @@ final class RecoveryTests: ParserTestCase {
   func testRecovery183() {
     // Can be parsed and produces no diagnostics.
     assertParse(
-      "func f< 1️⃣>() {}",
+      "func f<1️⃣ >() {}",
       diagnostics: [
         DiagnosticSpec(
           message: "expected generic parameter in generic parameter clause",

--- a/Tests/SwiftParserTest/translated/SubscriptingTests.swift
+++ b/Tests/SwiftParserTest/translated/SubscriptingTests.swift
@@ -186,9 +186,9 @@ final class SubscriptingTests: ParserTestCase {
     assertParse(
       """
       struct A0 {
-        subscript 1️⃣
+        subscript1️⃣ 
           i : 2️⃣Int3️⃣
-           -> Int 4️⃣{
+           -> Int4️⃣ 5️⃣{
           get {
             return stored
           }
@@ -203,7 +203,7 @@ final class SubscriptingTests: ParserTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '(' to start function type", fixIts: ["insert '('"]),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' in function type", fixIts: ["insert ')'"]),
         DiagnosticSpec(locationMarker: "4️⃣", message: "expected ')' to end parameter clause", fixIts: ["insert ')'"]),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected '->' and return type in subscript", fixIts: ["insert '->' and return type"]),
+        DiagnosticSpec(locationMarker: "5️⃣", message: "expected '->' and return type in subscript", fixIts: ["insert '->' and return type"]),
       ],
       fixedSource: """
         struct A0 {
@@ -227,7 +227,7 @@ final class SubscriptingTests: ParserTestCase {
       """
       // Parsing errors
       struct A0 {
-        subscript 1️⃣-> Int {
+        subscript1️⃣ -> Int {
           return 1
         }
       }
@@ -519,7 +519,7 @@ final class SubscriptingTests: ParserTestCase {
     assertParse(
       """
       struct A11 {
-        subscript 1️⃣x y : 2️⃣Int 3️⃣-> Int 4️⃣{
+        subscript1️⃣ x y : 2️⃣Int3️⃣ -> Int4️⃣ 5️⃣{
           return 0
         }
       }
@@ -529,7 +529,7 @@ final class SubscriptingTests: ParserTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '(' to start function type", fixIts: ["insert '('"]),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' in function type", fixIts: ["insert ')'"]),
         DiagnosticSpec(locationMarker: "4️⃣", message: "expected ')' to end parameter clause", fixIts: ["insert ')'"]),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected '->' and return type in subscript", fixIts: ["insert '->' and return type"]),
+        DiagnosticSpec(locationMarker: "5️⃣", message: "expected '->' and return type in subscript", fixIts: ["insert '->' and return type"]),
       ],
       fixedSource: """
         struct A11 {

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -118,7 +118,7 @@ final class SwitchTests: ParserTestCase {
       """
       func parseError5(x: Int) {
         switch x {
-        case let z 1️⃣
+        case let z1️⃣ 
         }
       }
       """,
@@ -140,7 +140,7 @@ final class SwitchTests: ParserTestCase {
       """
       func parseError6(x: Int) {
         switch x {
-        default 1️⃣
+        default1️⃣ 
         }
       }
       """,
@@ -1254,7 +1254,7 @@ final class SwitchTests: ParserTestCase {
         switch x {
         case 1:
           return
-        @unknown default 1️⃣
+        @unknown default1️⃣ 
         }
       }
       """,
@@ -1305,7 +1305,7 @@ final class SwitchTests: ParserTestCase {
       func testIncompleteArrayLiteral() {
         switch x {
         case 1:
-          _ = ℹ️[1 1️⃣
+          _ = ℹ️[11️⃣ 
         @unknown default:
           ()
         }

--- a/Tests/SwiftParserTest/translated/TypeExprTests.swift
+++ b/Tests/SwiftParserTest/translated/TypeExprTests.swift
@@ -699,7 +699,7 @@ final class TypeExprTests: ParserTestCase {
   func testTypeExpr28() {
     assertParse(
       """
-      func takesVoid(f: 1️⃣Void 2️⃣-> ()) {}
+      func takesVoid(f: 1️⃣Void2️⃣ -> ()) {}
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' to start function type", fixIts: ["insert '('"]),
@@ -734,6 +734,21 @@ final class TypeExprTests: ParserTestCase {
         _ = Swift.Int
       }
       """
+    )
+  }
+
+  func testTypeExpr31() {
+    assertParse(
+      """
+      let _: 1️⃣Float2️⃣       -> Int
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' to start function type", fixIts: ["insert '('"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in function type", fixIts: ["insert ')'"]),
+      ],
+      fixedSource: """
+        let _: (Float) -> Int
+        """
     )
   }
 


### PR DESCRIPTION
Resolves #2431 

---

#### Changes Summary:

##### 1. Added `shouldBeInsertedBeforePreviousTokenTrivia`
Extracted this from existing code from `DiagnosticExtensions.swift`
Inserted this just after existing property `shouldBeInsertedAfterNextTokenTrivia`
This extraction is needed as we want to reuse this while deciding correct insertion location of fix-it

##### 2. Correct insertion location for fix-it in `MissingNodesError.swift`
This should correct `)`, `:`, `,` syntax positions which should be inserted before previous token trivia. i.e. should not have whitespace before them. (check unit tests corrections for examples) 

##### 3. Correction of Unit Tests
Corrected the existing unit tests where `missing ')' token` error was expected.
Notice that we only change location markers and not other things in the unit tests.
None of the `fixedSource` in the examples in unit tests are changed

##### 4. Added couple of Unit Tests 
- ParserDiagnosticsFormatterIntegrationTests.swift->`testRighParenLocation()`
- TypeExprTests.swift->`testTypeExpr31()`
