### PR TITLE
Remove a few lingering grammar doc comments

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1407,8 +1407,6 @@ extension Parser {
   ) -> RawAccessorDeclSyntax {
     // 'set' and 'willSet' can have an optional name.  This isn't valid in a
     // protocol, but we parse and then reject it for better QoI.
-    //
-    //     set-name    ::= '(' identifier ')'
     let parameters: RawAccessorParametersSyntax?
     if [AccessorDeclSyntax.AccessorSpecifierOptions.set, .willSet, .didSet, .`init`].contains(introducer.kind), let lparen = self.consume(if: .leftParen) {
       let (unexpectedBeforeName, name) = self.expectIdentifier()

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -1226,16 +1226,6 @@ extension Lexer.Cursor {
 // MARK: - Literals
 
 extension Lexer.Cursor {
-  /// lexNumber:
-  ///   integer_literal  ::= [0-9][0-9_]*
-  ///   integer_literal  ::= 0x[0-9a-fA-F][0-9a-fA-F_]*
-  ///   integer_literal  ::= 0o[0-7][0-7_]*
-  ///   integer_literal  ::= 0b[01][01_]*
-  ///   floating_literal ::= [0-9][0-9]_*\.[0-9][0-9_]*
-  ///   floating_literal ::= [0-9][0-9]*\.[0-9][0-9_]*[eE][+-]?[0-9][0-9_]*
-  ///   floating_literal ::= [0-9][0-9_]*[eE][+-]?[0-9][0-9_]*
-  ///   floating_literal ::= 0x[0-9A-Fa-f][0-9A-Fa-f_]*
-  ///                          (\.[0-9A-Fa-f][0-9A-Fa-f_]*)?[pP][+-]?[0-9][0-9_]*
   mutating func lexNumber() -> Lexer.Result {
     precondition(self.peek().map(Unicode.Scalar.init)?.isDigit == true, "Unexpected start")
 

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -235,7 +235,6 @@ extension Parser {
       break
     }
 
-    // matching-pattern ::= expr
     // Fall back to expression parsing for ambiguous forms. Name lookup will
     // disambiguate.
     let patternSyntax = self.parseSequenceExpression(flavor: .stmtCondition, pattern: context)
@@ -271,12 +270,6 @@ extension Parser.Lookahead {
     }
   }
 
-  ///   pattern ::= identifier
-  ///   pattern ::= '_'
-  ///   pattern ::= pattern-tuple
-  ///   pattern ::= 'var' pattern
-  ///   pattern ::= 'let' pattern
-  ///   pattern ::= 'inout' pattern
   mutating func canParsePattern() -> Bool {
     enum PurePatternStartTokens: TokenSpecSet {
       case identifier


### PR DESCRIPTION
A few cases that were missed by https://github.com/apple/swift-syntax/pull/2179.

rdar://113301253