### PR TITLE
Never bulid the `Examples` package with `-warnings-as-errors`

### DIFF
--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Build.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Build.swift
@@ -30,9 +30,9 @@ struct Build: ParsableCommand {
         release: arguments.release,
         enableRawSyntaxValidation: arguments.enableRawSyntaxValidation,
         enableTestFuzzing: arguments.enableTestFuzzing,
-        warningsAsErrors: arguments.warningsAsErrors,
         verbose: arguments.verbose
-      )
+      ),
+      warningsAsErrors: arguments.warningsAsErrors
     )
     try executor.run()
   }
@@ -40,15 +40,18 @@ struct Build: ParsableCommand {
 
 struct BuildExecutor {
   private let swiftPMBuilder: SwiftPMBuilder
+  private let warningsAsErrors: Bool
 
-  init(swiftPMBuilder: SwiftPMBuilder) {
+  init(swiftPMBuilder: SwiftPMBuilder, warningsAsErrors: Bool = false) {
     self.swiftPMBuilder = swiftPMBuilder
+    self.warningsAsErrors = warningsAsErrors
   }
 
   func run() throws {
-    try swiftPMBuilder.buildTarget(packageDir: Paths.packageDir, targetName: "SwiftSyntax-all")
-    try swiftPMBuilder.buildTarget(packageDir: Paths.examplesDir, targetName: "Examples-all")
-    try swiftPMBuilder.buildTarget(packageDir: Paths.swiftParserCliDir, targetName: "swift-parser-cli")
+    try swiftPMBuilder.buildTarget(packageDir: Paths.packageDir, targetName: "SwiftSyntax-all", warningsAsErrors: self.warningsAsErrors)
+    // Never build examples with `warningsAsErrors`. Some of the macro examples are expected to generate warnings.
+    try swiftPMBuilder.buildTarget(packageDir: Paths.examplesDir, targetName: "Examples-all", warningsAsErrors: false)
+    try swiftPMBuilder.buildTarget(packageDir: Paths.swiftParserCliDir, targetName: "swift-parser-cli", warningsAsErrors: self.warningsAsErrors)
     try buildEditorExtension()
   }
 

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Test.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/commands/Test.swift
@@ -30,9 +30,9 @@ struct Test: ParsableCommand {
         release: arguments.release,
         enableRawSyntaxValidation: arguments.enableRawSyntaxValidation,
         enableTestFuzzing: arguments.enableTestFuzzing,
-        warningsAsErrors: arguments.warningsAsErrors,
         verbose: arguments.verbose
-      )
+      ),
+      warningsAsErrors: arguments.warningsAsErrors
     )
     try executor.run()
   }
@@ -40,9 +40,11 @@ struct Test: ParsableCommand {
 
 struct TestExecutor {
   private let swiftPMBuilder: SwiftPMBuilder
+  private let warningsAsErrors: Bool
 
-  init(swiftPMBuilder: SwiftPMBuilder) {
+  init(swiftPMBuilder: SwiftPMBuilder, warningsAsErrors: Bool = false) {
     self.swiftPMBuilder = swiftPMBuilder
+    self.warningsAsErrors = warningsAsErrors
   }
 
   func run() throws {
@@ -59,6 +61,7 @@ struct TestExecutor {
     try swiftPMBuilder.invokeSwiftPM(
       action: "test",
       packageDir: Paths.packageDir,
+      warningsAsErrors: warningsAsErrors,
       additionalArguments: ["--test-product", "swift-syntaxPackageTests"],
       additionalEnvironment: swiftPMBuilder.swiftPMEnvironmentVariables,
       captureStdout: false,
@@ -71,6 +74,7 @@ struct TestExecutor {
     try swiftPMBuilder.invokeSwiftPM(
       action: "test",
       packageDir: Paths.codeGenerationDir,
+      warningsAsErrors: warningsAsErrors,
       additionalArguments: ["--test-product", "CodeGenerationPackageTests"],
       additionalEnvironment: swiftPMBuilder.swiftPMEnvironmentVariables,
       captureStdout: false,
@@ -83,6 +87,7 @@ struct TestExecutor {
     try swiftPMBuilder.invokeSwiftPM(
       action: "test",
       packageDir: Paths.examplesDir,
+      warningsAsErrors: warningsAsErrors,
       additionalArguments: ["--test-product", "ExamplesPackageTests"],
       additionalEnvironment: swiftPMBuilder.swiftPMEnvironmentVariables,
       captureStdout: false,
@@ -94,6 +99,7 @@ struct TestExecutor {
     return try swiftPMBuilder.invokeSwiftPM(
       action: "build",
       packageDir: packageDir,
+      warningsAsErrors: warningsAsErrors,
       additionalArguments: ["--show-bin-path"],
       additionalEnvironment: [:]
     ).stdout

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SwiftPMBuilder.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SwiftPMBuilder.swift
@@ -41,9 +41,6 @@ struct SwiftPMBuilder {
   /// A flag indicating whether to use local dependencies during the build process.
   let useLocalDeps: Bool
 
-  /// Treat all warnings as errors.
-  let warningsAsErrors: Bool
-
   /// Enable verbose logging.
   let verbose: Bool
 
@@ -55,7 +52,6 @@ struct SwiftPMBuilder {
     enableRawSyntaxValidation: Bool = false,
     enableTestFuzzing: Bool = false,
     useLocalDeps: Bool = true,
-    warningsAsErrors: Bool = false,
     verbose: Bool = false
   ) {
     self.toolchain = toolchain
@@ -65,11 +61,10 @@ struct SwiftPMBuilder {
     self.enableRawSyntaxValidation = enableRawSyntaxValidation
     self.enableTestFuzzing = enableTestFuzzing
     self.useLocalDeps = useLocalDeps
-    self.warningsAsErrors = warningsAsErrors
     self.verbose = verbose
   }
 
-  func buildTarget(packageDir: URL, targetName: String) throws {
+  func buildTarget(packageDir: URL, targetName: String, warningsAsErrors: Bool = false) throws {
     logSection("Building target " + targetName)
     try build(packageDir: packageDir, name: targetName, isProduct: false)
   }
@@ -78,6 +73,7 @@ struct SwiftPMBuilder {
   func invokeSwiftPM(
     action: String,
     packageDir: URL,
+    warningsAsErrors: Bool = false,
     additionalArguments: [String],
     additionalEnvironment: [String: String],
     captureStdout: Bool = true,
@@ -93,7 +89,7 @@ struct SwiftPMBuilder {
       args += ["--scratch-path", buildDir]
     }
 
-    if self.warningsAsErrors {
+    if warningsAsErrors {
       args += ["-Xswiftc", "-warnings-as-errors"]
     }
 
@@ -152,7 +148,7 @@ struct SwiftPMBuilder {
     return additionalEnvironment
   }
 
-  private func build(packageDir: URL, name: String, isProduct: Bool) throws {
+  private func build(packageDir: URL, name: String, isProduct: Bool, warningsAsErrors: Bool = false) throws {
     let args: [String]
 
     if isProduct {
@@ -164,6 +160,7 @@ struct SwiftPMBuilder {
     try invokeSwiftPM(
       action: "build",
       packageDir: packageDir,
+      warningsAsErrors: warningsAsErrors,
       additionalArguments: args,
       additionalEnvironment: swiftPMEnvironmentVariables,
       captureStdout: false,


### PR DESCRIPTION
Some macros in the Examples package are expected to produce errors, so we never want to build it with `-warnings-as-errors`