### PR TITLE
Use presumed file/line number when printing grouped diagnostics

### DIFF
--- a/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
+++ b/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
@@ -207,7 +207,7 @@ extension GroupedDiagnostics {
 
         // Display file/line/column and diagnostic text for the primary diagnostic.
         prefixString =
-          "\(location.file):\(location.line):\(location.column): \(diagnosticDecorator.decorateDiagnosticMessage(primaryDiag.diagMessage))\n"
+          "\(location.presumedFile):\(location.presumedLine):\(location.column): \(diagnosticDecorator.decorateDiagnosticMessage(primaryDiag.diagMessage))\n"
 
         // If the primary diagnostic source file is not the same as the root source file, we're pointing into a generated buffer.
         // Provide a link back to the original source file where this generated buffer occurred, so it's easy to find if

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -60,6 +60,31 @@ extension GroupedDiagnostics {
 }
 
 final class GroupedDiagnosticsFormatterTests: XCTestCase {
+  func testSourceLocations() {
+    var group = GroupedDiagnostics()
+
+    // Main source file.
+    _ = group.addTestFile(
+      """
+      #sourceLocation(file: "other.swift", line: 123)
+      let pi = 3.14159 x
+      """,
+      displayName: "main.swift",
+      diagnosticDescriptors: []
+    )
+    let annotated = DiagnosticsFormatter.annotateSources(in: group)
+    assertStringsEqualWithDiff(
+      annotated,
+      """
+      other.swift:123:17: error: consecutive statements on a line must be separated by newline or ';'
+      1 │ #sourceLocation(file: "other.swift", line: 123)
+      2 │ let pi = 3.14159 x
+        │                 ╰─ error: consecutive statements on a line must be separated by newline or ';'
+
+      """
+    )
+  }
+
   func testGroupingForMacroExpansion() {
     var group = GroupedDiagnostics()
 


### PR DESCRIPTION
For the primary diagnostic, print the presumed file/line number in the same manner as the Swift compiler does. In the actual code listing, keep the line numbers and code from the actual source file that was parsed, because there's no sensible way to map the source from the `#sourceLocation`-named file (which might not exist).