### PR TITLE
Change release notes and version indicator module from 511 to 600

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -120,7 +120,7 @@ let package = Package(
 
     .target(
       name: "SwiftSyntax",
-      dependencies: ["_AtomicBool", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax511"],
+      dependencies: ["_AtomicBool", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600"],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
     ),
@@ -144,7 +144,7 @@ let package = Package(
     ),
 
     .target(
-      name: "SwiftSyntax511",
+      name: "SwiftSyntax600",
       dependencies: []
     ),
 

--- a/Release Notes/600.md
+++ b/Release Notes/600.md
@@ -1,4 +1,4 @@
-# Swift Syntax 511 Release Notes
+# Swift Syntax 600 Release Notes
 
 ## New APIs
 - FixIt now has a new computed propery named edits

--- a/Sources/SwiftSyntax600/Empty.swift
+++ b/Sources/SwiftSyntax600/Empty.swift
@@ -1,3 +1,3 @@
-// The SwiftSyntax511 module is intentionally empty.
+// The SwiftSyntax600 module is intentionally empty.
 // It serves as an indicator which version of swift-syntax a package is building against.
 // See the 'Macro Versioning.md' document for more details.


### PR DESCRIPTION
The next Swift version is called Swift 6.0. We should adjust swift-syntax to call the next version 600 instead of 511.