### PR TITLE
[Macros] Add a default implementation of `MacroExpansionContext.lexicalContext`.

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
@@ -81,6 +81,12 @@ extension MacroExpansionContext {
   ) -> AbstractSourceLocation? {
     return location(of: node, at: .afterLeadingTrivia, filePathMode: .fileID)
   }
+
+  public var lexicalContext: [Syntax] {
+    fatalError(
+      "`MacroExpansionContext` conformance must implement `lexicalContext`"
+    )
+  }
 }
 
 /// Diagnostic message used for thrown errors.


### PR DESCRIPTION
Existing macro adopters have conformances to `MacroExpansionContext`, so add a default implementation of `lexicalContext` to preserve source compatibility. We can consider deprecating the default implementation to prompt conformances to implement the requirement.