### PR TITLE
[CMake] Add cross-compilation flags for when built as part of the compiler

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -97,6 +97,16 @@ function(add_swift_syntax_library name)
     $<$<COMPILE_LANGUAGE:Swift>:-color-diagnostics>
   )
 
+  if(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
+    target_compile_options(${name} PRIVATE
+      $<$<COMPILE_LANGUAGE:Swift>:-sdk;${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH};>
+      $<$<COMPILE_LANGUAGE:Swift>:-resource-dir;${SWIFTLIB_DIR};>)
+    if(SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID" AND NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
+      swift_android_tools_path(${SWIFT_HOST_VARIANT_ARCH} tools_path)
+      target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-tools-directory;${tools_path};>)
+    endif()
+  endif()
+
   if(LLVM_USE_LINKER)
     target_link_options(${name} PRIVATE
       "-use-ld=${LLVM_USE_LINKER}"


### PR DESCRIPTION
The compiler build defines `BOOTSTRAPPING_MODE` and these other flags, so this will do nothing when they aren't set. Android requires using its patched clang for linking, so use that.

I made sure this won't break a standalone CMake build by running
```
cmake -GNinja . -DSWIFT_HOST_MODULE_TRIPLE=aarch64-unknown-linux-android
ninja
```
and everything built fine with this pull natively on Android too. This implements 2. of apple/swift#71507, and I just tested it by [cross-compiling a recent trunk compiler for Android](https://github.com/finagolfin/termux-packages/actions/runs/8007466151) and running the resulting Swift 5.11 toolchain on my Android phone.