### PR TITLE
Use character columns instead of UTF-8 columns in the diagnostics printer

### DIFF
--- a/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
+++ b/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
@@ -150,4 +150,37 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
 
     assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
   }
+
+  func testDontCrashIfFullLineHighlightContainsEmoji() {
+    let source = """
+      func o() {
+      }👨‍👩‍👧‍👦}
+      }
+      """
+
+    let expectedOutput = """
+      1 │ func o() {
+      2 │ }👨‍👩‍👧‍👦}
+        │  │╰─ error: extraneous braces at top level
+        │  ╰─ error: consecutive statements on a line must be separated by newline or ';'
+      3 │ }
+
+      """
+
+    assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
+  }
+
+  func testEmojiInSourceCode() {
+    let source = """
+      let 👨‍👩‍👧‍👦 = ;
+      """
+
+    let expectedOutput = """
+      1 │ let 👨‍👩‍👧‍👦 = ;
+        │         ╰─ error: expected expression in variable
+
+      """
+
+    assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
+  }
 }


### PR DESCRIPTION
Fixes a crash and improves the printing of errors on lines that contain multi-byte UTF-8 characters.

Fixes #2507
rdar://123409748