### PR TITLE
[Parser] Cleanup UnicodeScalar handling

### DIFF
--- a/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
+++ b/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
@@ -71,8 +71,9 @@ extension StringSegmentSyntax {
   ) {
     precondition(!hasError, "appendUnescapedLiteralValue relies on properly parsed literals")
 
-    var text = content.text
-    text.withUTF8 { buffer in
+    let rawText = content.rawText
+
+    rawText.withBuffer { buffer in
       var cursor = Lexer.Cursor(input: buffer, previous: 0)
 
       // Put the cursor in the string literal lexing state. This is just
@@ -88,10 +89,9 @@ extension StringSegmentSyntax {
         )
 
         switch lex {
-        case .success(let scalar):
+        case .success(let scalar),
+          .validatedEscapeSequence(let scalar):
           output.append(Character(scalar))
-        case .validatedEscapeSequence(let character):
-          output.append(character)
         case .endOfString, .error:
           // We get an error at the end of the string because
           // `lexCharacterInStringLiteral` expects the closing quote.

--- a/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
+++ b/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
@@ -72,6 +72,11 @@ extension StringSegmentSyntax {
     precondition(!hasError, "appendUnescapedLiteralValue relies on properly parsed literals")
 
     let rawText = content.rawText
+    if !rawText.contains("\\") {
+      // Fast path. No escape sequence.
+      output.append(String(syntaxText: rawText))
+      return
+    }
 
     rawText.withBuffer { buffer in
       var cursor = Lexer.Cursor(input: buffer, previous: 0)


### PR DESCRIPTION
Mostly just removing  redundant `UnicodeScalar()` callings.

Change associated type of `EscapedCharacterLex.success(UInt32)` and `CharacterLex.validatedEscapeSequence(Character)` to both `Unicode.Scalar` because there's no reason not to use it, and to avoid unnecessary conversions.