### PR TITLE
include freestanding macros in lexical context

### DIFF
--- a/Sources/SwiftSyntaxMacros/Syntax+LexicalContext.swift
+++ b/Sources/SwiftSyntaxMacros/Syntax+LexicalContext.swift
@@ -57,6 +57,11 @@ extension SyntaxProtocol {
       patternBinding.initializer = nil
       return Syntax(patternBinding)
 
+    // Freestanding macros are fine as-is because if any arguments change
+    // the whole macro would have to be re-evaluated.
+    case let freestandingMacro as FreestandingMacroExpansionSyntax:
+      return Syntax(freestandingMacro.detached) as Syntax
+
     default:
       return nil
     }


### PR DESCRIPTION
This makes it possible for a macro to know if it appears within an argument to a freestanding macro.

[Updated: now includes the full freestanding macro syntax in the lexical context. However, this required a new way of unit testing, because the previous approach, which emitted all the decls from the lexical context as the expansion of a freestanding macro `#allLexicalContexts`, produced a cycle when one of the decls in the lexical context itself contained the macro `#allLexicalContexts`.]

rdar://122330706