### PR TITLE
Check compiler version to determine if scoped imports are supported

### DIFF
--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -14,7 +14,7 @@
 
 import SwiftSyntaxMacros
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 private import Foundation
 private import SwiftCompilerPluginMessageHandling
 #else
@@ -23,7 +23,7 @@ import SwiftCompilerPluginMessageHandling
 #endif
 
 #if os(Windows)
-#if swift(>=5.11)
+#if compiler(>=5.11)
 private import ucrt
 #else
 import ucrt

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 #if canImport(Darwin)
 private import Darwin
 #elseif canImport(Glibc)

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -20,7 +20,7 @@ import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import _SwiftSyntaxTestSupport
 
-#if swift(>=5.11)
+#if compiler(>=5.11)
 private import XCTest
 #else
 import XCTest


### PR DESCRIPTION
We were checking for the language version, which is 5.10 for a Swift 6 compiler in Swift 5 mode (which is the default). But we don’t actually care about the selected language mode, but about the compiler’s version to check if scoped imports are supported.