### PR TITLE
Don’t pass `--enable-test-discovery` when building on non-Darwin

### DIFF
--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SwiftPMBuilder.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/SwiftPMBuilder.swift
@@ -93,10 +93,6 @@ struct SwiftPMBuilder {
       args += ["-Xswiftc", "-warnings-as-errors"]
     }
 
-    #if !canImport(Darwin)
-    args += ["--enable-test-discovery"]
-    #endif
-
     if release {
       args += ["--configuration", "release"]
     }


### PR DESCRIPTION
Test discovery is enabled by default since Swift 5.4 and the flag has recently been removed.