### PR TITLE
[5.10] Change `load` to `loadUnaligned`

### DIFF
--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -210,7 +210,7 @@ internal struct PluginHostConnection: MessageConnection {
 
     // Decode the count.
     let count = header.withUnsafeBytes {
-      UInt64(littleEndian: $0.load(as: UInt64.self))
+      UInt64(littleEndian: $0.loadUnaligned(as: UInt64.self))
     }
     guard count >= 2 else {
       throw PluginMessageError.invalidPayloadSize


### PR DESCRIPTION
* **Explanation**: Same fix as https://github.com/apple/swift-package-manager/pull/6929 since the code in swift-syntax is based on what is in SwiftPM. We cherry-picked this from main to `package-release/509` but forgot to cherry-pick it to `release/5.10`
* **Scope**: This causes macro plugin crashes on Linux
* **Risk**: Low, we have had this change in the 509 release of swift-syntax and on `main`, just not on `release/5.10`
* **Testing**: We verified that this change fixed the issue in the 509 release and on `main`, it’s just missing on `release/5.10`
* **Issue**: n/a
* **Reviewer**:  @bnbarham and @rintaro on https://github.com/apple/swift-syntax/pull/2312