### PR TITLE
Exclude SwiftCompilerPlugin from `all` target

### DIFF
--- a/Sources/SwiftCompilerPlugin/CMakeLists.txt
+++ b/Sources/SwiftCompilerPlugin/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_syntax_library(SwiftCompilerPlugin
+  EXCLUDE_FROM_ALL
   CompilerPlugin.swift
 )
 


### PR DESCRIPTION
The SwiftCompilerPlugin library is only needed when writing Swift macros, but not by the rest of the Swift compiler. The Swift build-script only knows how to build the `all` target, resulting in this target also being built as part of the compiler when it should not be.

rdar://124395736