### PR TITLE
Resolve `switch covers known cases, but 'Enum' may have additional unknown values` warnings

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
@@ -29,6 +29,21 @@ let tokenNameForDiagnosticFile = SourceFileSyntax(leadingTrivia: copyrightHeader
         SwitchCaseSyntax("case .keyword(let keyword):") {
           StmtSyntax("return String(syntaxText: keyword.defaultText)")
         }
+        IfConfigDeclSyntax(
+          clauses: IfConfigClauseListSyntax {
+            IfConfigClauseSyntax(
+              poundKeyword: .poundIfToken(),
+              condition: ExprSyntax("RESILIENT_LIBRARIES"),
+              elements: .switchCases(
+                SwitchCaseListSyntax {
+                  SwitchCaseSyntax("@unknown default:") {
+                    StmtSyntax("fatalError()")
+                  }
+                }
+              )
+            )
+          }
+        )
       }
     }
   }

--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -54,6 +54,9 @@ extension PluginMessage.Diagnostic.Severity {
     case .warning: self = .warning
     case .note: self = .note
     case .remark: self = .remark
+    #if RESILIENT_LIBRARIES
+    @unknown default: fatalError()
+    #endif
     }
   }
 }
@@ -122,6 +125,10 @@ extension PluginMessage.Diagnostic {
               to: .afterTrailingTrivia
             )
             text = newTrivia.description
+          #if RESILIENT_LIBRARIES
+          @unknown default:
+            fatalError()
+          #endif
           }
           guard let range = range else {
             return nil

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -153,6 +153,9 @@ class SourceManager {
     switch filePathMode {
     case .fileID: file = base.location.fileID
     case .filePath: file = base.location.fileName
+    #if RESILIENT_LIBRARIES
+    @unknown default: fatalError()
+    #endif
     }
 
     let localPosition = node.position(at: kind)
@@ -185,6 +188,10 @@ fileprivate extension Syntax {
       return self.endPositionBeforeTrailingTrivia
     case .afterTrailingTrivia:
       return self.endPosition
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 }

--- a/Sources/SwiftOperators/OperatorTable+Semantics.swift
+++ b/Sources/SwiftOperators/OperatorTable+Semantics.swift
@@ -62,6 +62,10 @@ extension PrecedenceGroup {
         default:
           break
         }
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     }
   }

--- a/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
+++ b/Sources/SwiftParser/StringLiteralRepresentedLiteralValue.swift
@@ -43,6 +43,10 @@ extension StringLiteralExprSyntax {
       case .expressionSegment:
         // Bail out if there are any interpolation segments.
         return nil
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     }
 

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -167,7 +167,10 @@ extension Parser {
     openQuoteHasTrailingNewline: Bool,
     middleSegments: inout [RawStringLiteralSegmentListSyntax.Element]
   ) -> Bool {
-    switch middleSegments.last {
+    guard let segment = middleSegments.last else {
+      return openQuoteHasTrailingNewline
+    }
+    switch segment {
     case .stringSegment(let lastMiddleSegment):
       if !lastMiddleSegment.content.trailingTriviaPieces.isEmpty {
         precondition(
@@ -218,8 +221,10 @@ extension Parser {
       }
     case .expressionSegment:
       return false
-    case nil:
-      return openQuoteHasTrailingNewline
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 
@@ -282,6 +287,10 @@ extension Parser {
         if let rewrittenSegment = expressionIndentationChecker.checkIndentation(of: segment) {
           middleSegments[index] = .expressionSegment(rewrittenSegment)
         }
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     }
   }

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -358,6 +358,10 @@ enum TokenPrecedence: Comparable {
       .wrt,
       .unsafe:
       self = .exprKeyword
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 }

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -230,6 +230,10 @@ public extension SwiftSyntax.TokenDiagnostic {
     case .unicodeCurlyQuote: return StaticTokenError.unicodeCurlyQuote
     case .unprintableAsciiCharacter: return StaticTokenError.unprintableAsciiCharacter
     case .unterminatedBlockComment: return StaticTokenError.unterminatedBlockComment
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 

--- a/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
@@ -216,6 +216,10 @@ extension TypeSpecifierListSyntax {
       switch specifier {
       case .simpleTypeSpecifier(let specifier): return specifier.specifier
       case .lifetimeTypeSpecifier: return nil
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     }
   }

--- a/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
@@ -117,6 +117,9 @@ extension TokenKind {
       return "wildcard"
     case .keyword(let keyword):
       return String(syntaxText: keyword.defaultText)
+    #if RESILIENT_LIBRARIES
+    @unknown default:fatalError()
+    #endif
     }
   }
 }

--- a/Sources/SwiftRefactor/FormatRawStringLiteral.swift
+++ b/Sources/SwiftRefactor/FormatRawStringLiteral.swift
@@ -47,6 +47,10 @@ public struct FormatRawStringLiteral: SyntaxRefactoringProvider {
       case .stringSegment(let string):
         // Find the longest run of # characters in the content of the literal.
         maximumHashes = max(maximumHashes, string.content.text.longestRun(of: "#"))
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     }
 

--- a/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
@@ -230,6 +230,11 @@ extension BasicMacroExpansionContext: MacroExpansionContext {
 
     case .filePath:
       fileName = knownRoot.fullFilePath
+
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
 
     // Find the node's offset relative to its root.
@@ -246,6 +251,11 @@ extension BasicMacroExpansionContext: MacroExpansionContext {
 
     case .afterTrailingTrivia:
       rawPosition = node.endPosition
+
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
 
     // Do the location lookup.

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -402,6 +402,10 @@ fileprivate extension SyntaxProtocol {
       formatted = self.formatted(using: BasicFormat(indentationWidth: indentationWidth))
     case .disabled:
       formatted = Syntax(self)
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
     return formatted.trimmedDescription(matching: { $0.isWhitespace })
   }

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -1296,6 +1296,10 @@ private extension AccessorBlockSyntax {
         )
       )
       result.accessors = .accessors(AccessorDeclListSyntax([getterAsAccessor] + Array(newAccessors)))
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
     return result
   }

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -73,6 +73,7 @@ function(add_swift_syntax_library name)
   # Configure the emission of the Swift module files.
   target_compile_options("${name}" PRIVATE
     $<$<COMPILE_LANGUAGE:Swift>:
+      -DRESILIENT_LIBRARIES;
       -module-name;${name};
       -enable-library-evolution;
       -emit-module-path;${module_file};


### PR DESCRIPTION
When building with CMake during the Swift compiler build, the libraries in this package are built with library evolution enabled. That causes the compiler to emit diagnostics that encourage use of `@unknown default` to handle unknown cases that might be added in the future. Silence these warnings by adding `@unknown default` cases where they are missing. Guard these with the `RESILIENT_LIBRARIES` compilation condition to avoid triggering a `Default will never be executed` diagnostic during the package build.