### PR TITLE
Allow return types on initializers

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -968,7 +968,7 @@ extension Parser {
     }
 
     // Parse the signature.
-    let signature = self.parseFunctionSignature(allowOutput: false)
+    let signature = self.parseFunctionSignature()
 
     let whereClause: RawGenericWhereClauseSyntax?
     if self.at(.keyword(.where)) {
@@ -1131,7 +1131,7 @@ extension Parser {
     )
   }
 
-  mutating func parseFunctionSignature(allowOutput: Bool = true) -> RawFunctionSignatureSyntax {
+  mutating func parseFunctionSignature() -> RawFunctionSignatureSyntax {
     let parameterClause = self.parseParameterClause(RawFunctionParameterClauseSyntax.self) { parser in
       parser.parseFunctionParameter()
     }
@@ -1148,19 +1148,10 @@ extension Parser {
       returnClause = nil
     }
 
-    var unexpectedAfterReturnClause: RawUnexpectedNodesSyntax?
-    if !allowOutput,
-      let unexpectedOutput = returnClause
-    {
-      returnClause = nil
-      unexpectedAfterReturnClause = RawUnexpectedNodesSyntax([unexpectedOutput], arena: self.arena)
-    }
-
     return RawFunctionSignatureSyntax(
       parameterClause: parameterClause,
       effectSpecifiers: effectSpecifiers,
       returnClause: returnClause,
-      unexpectedAfterReturnClause,
       arena: self.arena
     )
   }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -1212,14 +1212,6 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       )
     }
 
-    if let unexpectedOutput = node.signature.unexpectedAfterReturnClause {
-      addDiagnostic(
-        unexpectedOutput,
-        .initializerCannotHaveResultType,
-        handledNodes: [unexpectedOutput.id]
-      )
-    }
-
     return .visitChildren
   }
 

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -182,9 +182,6 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var initializerCannotHaveName: Self {
     .init("initializers cannot have a name")
   }
-  public static var initializerCannotHaveResultType: Self {
-    .init("initializers cannot have a result type")
-  }
   public static var invalidFlagAfterPrecedenceGroupAssignment: Self {
     .init("expected 'true' or 'false' after 'assignment'")
   }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3156,4 +3156,14 @@ final class DeclarationTests: ParserTestCase {
       XCTAssertEqual(decl.description, input, line: line)
     }
   }
+
+  func testInitializerWithReturnType() {
+    assertParse(
+      "init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) -> _borrow(a) Self",
+      experimentalFeatures: .nonescapableTypes
+    )
+
+    // Not actually valid, needs to be diagnosed during type checking
+    assertParse("public init() -> Int")
+  }
 }

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -104,10 +104,7 @@ final class InitDeinitTests: ParserTestCase {
       struct FooStructConstructorD {
         init() 1️⃣-> FooStructConstructorD { }
       }
-      """,
-      diagnostics: [
-        DiagnosticSpec(message: "initializers cannot have a result type")
-      ]
+      """
     )
   }
 
@@ -425,10 +422,7 @@ final class InitDeinitTests: ParserTestCase {
     assertParse(
       """
       init(_ foo: T) 1️⃣-> Int where T: Comparable {}
-      """,
-      diagnostics: [
-        DiagnosticSpec(message: "initializers cannot have a result type")
-      ]
+      """
     )
   }
 


### PR DESCRIPTION
SE-2305 allows returning `Self` and `Self?` from initializers so that the return type can be annotated with `_borrow(a)` etc.

So we need to allow return clauses on initializers.

rdar://123905900