### PR TITLE
Add test cases for transferring type specifiers

### DIFF
--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3293,4 +3293,19 @@ final class DeclarationTests: ParserTestCase {
     // Not actually valid, needs to be diagnosed during type checking
     assertParse("public init() -> Int")
   }
+
+  func testTransferringTypeSpecifier() {
+    assertParse(
+      "func testVarDeclTupleElt() -> (transferring String, String) {}",
+      experimentalFeatures: .transferringArgsAndResults
+    )
+    assertParse(
+      "func testVarDeclTuple2(_ x: (transferring String)) {}",
+      experimentalFeatures: .transferringArgsAndResults
+    )
+    assertParse(
+      "func testVarDeclTuple2(_ x: (transferring String, String)) {}",
+      experimentalFeatures: .transferringArgsAndResults
+    )
+  }
 }


### PR DESCRIPTION
Turns out we do support `transferring` already.

rdar://123876615