### PR TITLE
Specify attributes inside `#if` before any unconditional attributes

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
@@ -33,8 +33,8 @@ let resultBuildersFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       // MARK: - \(type.resultBuilderType)
 
-      @resultBuilder
       \(node.node.apiAttributes())\
+      @resultBuilder
       public struct \(type.resultBuilderType): ListBuilder
       """
     ) {

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -431,10 +431,10 @@ public extension LabeledExprListSyntax {
 
 // MARK: - LifetimeSpecifierArgumentListBuilder
 
-@resultBuilder
 #if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
 #endif
+@resultBuilder
 public struct LifetimeSpecifierArgumentListBuilder: ListBuilder {
   public typealias FinalResult = LifetimeSpecifierArgumentListSyntax
 }


### PR DESCRIPTION
Looks like the Swift 5.7 compiler errors if unconditional attributes are before attributes inside `#if`.

Fixes #2546
rdar://124979624