### PR TITLE
[6.0] Wrap `<SyntaxNode>.parse` calls in a closure inside tests

### DIFF
--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -361,7 +361,7 @@ final class AttributeTests: ParserTestCase {
 
       assertParse(
         "@_implements(1️⃣\(baseType), f())",
-        AttributeSyntax.parse,
+        { AttributeSyntax.parse(from: &$0) },
         substructure: TypeSyntax.parse(from: &parser),
         substructureAfterMarker: "1️⃣",
         line: line

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -271,7 +271,7 @@ final class ExpressionTests: ParserTestCase {
 
       assertParse(
         "\\\(rootType).y",
-        ExprSyntax.parse,
+        { ExprSyntax.parse(from: &$0) },
         substructure: KeyPathExprSyntax(
           root: TypeSyntax.parse(from: &parser),
           components: KeyPathComponentListSyntax([

--- a/Tests/SwiftParserTest/ExpressionTypeTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTypeTests.swift
@@ -74,7 +74,7 @@ final class ExpressionTypeTests: ParserTestCase {
     for (line, type) in cases {
       assertParse(
         "G<\(type)>.self",
-        ExprSyntax.parse,
+        { ExprSyntax.parse(from: &$0) },
         substructure: IdentifierTypeSyntax(name: .identifier("X")),
         substructureAfterMarker: "1️⃣",
         line: line
@@ -84,7 +84,7 @@ final class ExpressionTypeTests: ParserTestCase {
     // Void
     assertParse(
       "G<1️⃣()>.self",
-      ExprSyntax.parse,
+      { ExprSyntax.parse(from: &$0) },
       substructure: TupleTypeSyntax(elements: .init([])),
       substructureAfterMarker: "1️⃣"
     )
@@ -92,7 +92,7 @@ final class ExpressionTypeTests: ParserTestCase {
     // Any
     assertParse(
       "G<1️⃣Any>.self",
-      ExprSyntax.parse,
+      { ExprSyntax.parse(from: &$0) },
       substructure: IdentifierTypeSyntax(name: .keyword(.Any)),
       substructureAfterMarker: "1️⃣"
     )
@@ -100,7 +100,7 @@ final class ExpressionTypeTests: ParserTestCase {
     // Self
     assertParse(
       "G<1️⃣Self>.self",
-      ExprSyntax.parse,
+      { ExprSyntax.parse(from: &$0) },
       substructure: IdentifierTypeSyntax(name: .keyword(.Self)),
       substructureAfterMarker: "1️⃣"
     )

--- a/Tests/SwiftParserTest/TypeCompositionTests.swift
+++ b/Tests/SwiftParserTest/TypeCompositionTests.swift
@@ -51,7 +51,7 @@ final class TypeCompositionTests: ParserTestCase {
 
       assertParse(
         "\(component) & \(component) & \(component)",
-        TypeSyntax.parse,
+        { TypeSyntax.parse(from: &$0) },
         substructure: CompositionTypeSyntax(
           elements: .init([
             CompositionTypeElementSyntax(type: componentSyntax, ampersand: .binaryOperator("&")),

--- a/Tests/SwiftParserTest/TypeMemberTests.swift
+++ b/Tests/SwiftParserTest/TypeMemberTests.swift
@@ -18,7 +18,7 @@ final class TypeMemberTests: ParserTestCase {
   func testKeyword() {
     assertParse(
       "MyType.class",
-      TypeSyntax.parse,
+      { TypeSyntax.parse(from: &$0) },
       substructure: MemberTypeSyntax(
         baseType: IdentifierTypeSyntax(
           name: .identifier("MyType")
@@ -31,7 +31,7 @@ final class TypeMemberTests: ParserTestCase {
   func testMissing() {
     assertParse(
       "MyType.1️⃣",
-      TypeSyntax.parse,
+      { TypeSyntax.parse(from: &$0) },
       substructure: MemberTypeSyntax(
         baseType: IdentifierTypeSyntax(
           name: .identifier("MyType")
@@ -69,7 +69,7 @@ final class TypeMemberTests: ParserTestCase {
     for (line, source) in cases {
       assertParse(
         source,
-        TypeSyntax.parse,
+        { TypeSyntax.parse(from: &$0) },
         substructure: expected,
         line: line
       )
@@ -86,7 +86,7 @@ final class TypeMemberTests: ParserTestCase {
     for (line, source) in cases {
       assertParse(
         source,
-        TypeSyntax.parse,
+        { TypeSyntax.parse(from: &$0) },
         diagnostics: [DiagnosticSpec(message: "extraneous whitespace after '.' is not permitted", fixIts: ["remove whitespace"])],
         fixedSource: expected,
         line: line
@@ -136,14 +136,14 @@ final class TypeMemberTests: ParserTestCase {
 
       assertParse(
         "\(baseType).Z",
-        TypeSyntax.parse,
+        { TypeSyntax.parse(from: &$0) },
         substructure: expectedSyntax,
         line: line
       )
 
       assertParse(
         "\(baseType).Z<W>",
-        TypeSyntax.parse,
+        { TypeSyntax.parse(from: &$0) },
         substructure: expectedSyntax.with(
           \.genericArgumentClause,
           GenericArgumentClauseSyntax(

--- a/Tests/SwiftParserTest/TypeMetatypeTests.swift
+++ b/Tests/SwiftParserTest/TypeMetatypeTests.swift
@@ -55,7 +55,7 @@ final class TypeMetatypeTests: ParserTestCase {
       for metaKind in [.`Type`, .`Protocol`] as [Keyword] {
         assertParse(
           "\(baseType).\(metaKind)",
-          TypeSyntax.parse,
+          { TypeSyntax.parse(from: &$0) },
           substructure: MetatypeTypeSyntax(
             baseType: baseTypeSyntax,
             metatypeSpecifier: .keyword(metaKind)

--- a/Tests/SwiftParserTest/translated/TypeExprTests.swift
+++ b/Tests/SwiftParserTest/translated/TypeExprTests.swift
@@ -116,9 +116,9 @@ final class TypeExprTests: ParserTestCase {
       """
     )
 
-    assertParse("(X).Y.self", ExprSyntax.parse)
-    assertParse("(X.Y).Z.self", ExprSyntax.parse)
-    assertParse("((X).Y).Z.self", ExprSyntax.parse)
+    assertParse("(X).Y.self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X.Y).Z.self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((X).Y).Z.self", { ExprSyntax.parse(from: &$0) })
   }
 
   func testTypeExpr9() {
@@ -154,9 +154,9 @@ final class TypeExprTests: ParserTestCase {
       """
     )
 
-    assertParse("X?.self", ExprSyntax.parse)
-    assertParse("[X].self", ExprSyntax.parse)
-    assertParse("[X : Y].self", ExprSyntax.parse)
+    assertParse("X?.self", { ExprSyntax.parse(from: &$0) })
+    assertParse("[X].self", { ExprSyntax.parse(from: &$0) })
+    assertParse("[X : Y].self", { ExprSyntax.parse(from: &$0) })
   }
 
   func testTypeExpr11() {
@@ -182,12 +182,12 @@ final class TypeExprTests: ParserTestCase {
       """
     )
 
-    assertParse("(G<X>).Y.self", ExprSyntax.parse)
-    assertParse("X?.Y.self", ExprSyntax.parse)
-    assertParse("(X)?.Y.self", ExprSyntax.parse)
-    assertParse("(X?).Y.self", ExprSyntax.parse)
-    assertParse("[X].Y.self", ExprSyntax.parse)
-    assertParse("[X : Y].Z.self", ExprSyntax.parse)
+    assertParse("(G<X>).Y.self", { ExprSyntax.parse(from: &$0) })
+    assertParse("X?.Y.self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X)?.Y.self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X?).Y.self", { ExprSyntax.parse(from: &$0) })
+    assertParse("[X].Y.self", { ExprSyntax.parse(from: &$0) })
+    assertParse("[X : Y].Z.self", { ExprSyntax.parse(from: &$0) })
   }
 
   func testTypeExpr12() {
@@ -578,57 +578,57 @@ final class TypeExprTests: ParserTestCase {
   }
 
   func testCompositionTypeExpr() {
-    assertParse("P & Q", ExprSyntax.parse)
-    assertParse("P & Q.self", ExprSyntax.parse)
-    assertParse("any P & Q", ExprSyntax.parse)
+    assertParse("P & Q", { ExprSyntax.parse(from: &$0) })
+    assertParse("P & Q.self", { ExprSyntax.parse(from: &$0) })
+    assertParse("any P & Q", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(P & Q).self", ExprSyntax.parse)
-    assertParse("((P) & (Q)).self", ExprSyntax.parse)
+    assertParse("(P & Q).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((P) & (Q)).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(A.B & C.D).self", ExprSyntax.parse)
-    assertParse("((A).B & (C).D).self", ExprSyntax.parse)
+    assertParse("(A.B & C.D).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((A).B & (C).D).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(G<X> & G<Y>).self", ExprSyntax.parse)
-    assertParse("(X? & Y?).self", ExprSyntax.parse)
-    assertParse("([X] & [Y]).self", ExprSyntax.parse)
-    assertParse("([A : B] & [C : D]).self", ExprSyntax.parse)
+    assertParse("(G<X> & G<Y>).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X? & Y?).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("([X] & [Y]).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("([A : B] & [C : D]).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(G<A>.B & G<C>.D).self", ExprSyntax.parse)
-    assertParse("(A?.B & C?.D).self", ExprSyntax.parse)
-    assertParse("([A].B & [A].B).self", ExprSyntax.parse)
-    assertParse("([A : B].C & [D : E].F).self", ExprSyntax.parse)
+    assertParse("(G<A>.B & G<C>.D).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(A?.B & C?.D).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("([A].B & [A].B).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("([A : B].C & [D : E].F).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(X.Type & Y.Type).self", ExprSyntax.parse)
-    assertParse("(X.Protocol & Y.Protocol).self", ExprSyntax.parse)
+    assertParse("(X.Type & Y.Type).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X.Protocol & Y.Protocol).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("((A, B) & (C, D)).self", ExprSyntax.parse)
+    assertParse("((A, B) & (C, D)).self", { ExprSyntax.parse(from: &$0) })
   }
 
   func testTupleTypeExpr() {
-    assertParse("(X).self", ExprSyntax.parse)
+    assertParse("(X).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(X, Y)", ExprSyntax.parse)
+    assertParse("(X, Y)", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(X, Y).self", ExprSyntax.parse)
-    assertParse("((X), (Y)).self", ExprSyntax.parse)
+    assertParse("(X, Y).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((X), (Y)).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(A.B, C.D).self", ExprSyntax.parse)
-    assertParse("((A).B, (C).D).self", ExprSyntax.parse)
+    assertParse("(A.B, C.D).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((A).B, (C).D).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(G<X>, G<Y>).self", ExprSyntax.parse)
-    assertParse("(X?, Y?).self", ExprSyntax.parse)
-    assertParse("([X], [Y]).self", ExprSyntax.parse)
-    assertParse("([A : B], [C : D]).self", ExprSyntax.parse)
+    assertParse("(G<X>, G<Y>).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X?, Y?).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("([X], [Y]).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("([A : B], [C : D]).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(G<A>.B, G<C>.D).self", ExprSyntax.parse)
-    assertParse("(A?.B, C?.D).self", ExprSyntax.parse)
-    assertParse("([A].B, [C].D).self", ExprSyntax.parse)
-    assertParse("([A : B].C, [D : E].F).self", ExprSyntax.parse)
+    assertParse("(G<A>.B, G<C>.D).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(A?.B, C?.D).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("([A].B, [C].D).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("([A : B].C, [D : E].F).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(X.Type, Y.Type).self", ExprSyntax.parse)
-    assertParse("(X.Protocol, Y.Protocol).self", ExprSyntax.parse)
+    assertParse("(X.Type, Y.Type).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X.Protocol, Y.Protocol).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(P & Q, P & Q).self", ExprSyntax.parse)
+    assertParse("(P & Q, P & Q).self", { ExprSyntax.parse(from: &$0) })
 
     assertParse(
       """
@@ -636,41 +636,41 @@ final class TypeExprTests: ParserTestCase {
         (G<X>.Y) -> (P) & X?.Y, (X.Y, [X : Y?].Type), [(G<X>).Y], [A.B.C].D
       ).self
       """,
-      ExprSyntax.parse
+      { ExprSyntax.parse(from: &$0) }
     )
   }
 
   func testFunctionTypeExpr() {
-    assertParse("X -> Y", ExprSyntax.parse)
-    assertParse("(X) -> Y", ExprSyntax.parse)
-    assertParse("(X) -> Y -> Z", ExprSyntax.parse)
-    assertParse("P & Q -> X", ExprSyntax.parse)
-    assertParse("A & B -> C & D -> X", ExprSyntax.parse)
-    assertParse("(X -> Y).self", ExprSyntax.parse)
-    assertParse("(A & B -> C & D).self", ExprSyntax.parse)
+    assertParse("X -> Y", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X) -> Y", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X) -> Y -> Z", { ExprSyntax.parse(from: &$0) })
+    assertParse("P & Q -> X", { ExprSyntax.parse(from: &$0) })
+    assertParse("A & B -> C & D -> X", { ExprSyntax.parse(from: &$0) })
+    assertParse("(X -> Y).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(A & B -> C & D).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("((X) -> Y).self", ExprSyntax.parse)
-    assertParse("(((X)) -> (Y)).self", ExprSyntax.parse)
+    assertParse("((X) -> Y).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(((X)) -> (Y)).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("((A.B) -> C.D).self", ExprSyntax.parse)
-    assertParse("(((A).B) -> (C).D).self", ExprSyntax.parse)
+    assertParse("((A.B) -> C.D).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(((A).B) -> (C).D).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("((G<X>) -> G<Y>).self", ExprSyntax.parse)
-    assertParse("((X?) -> Y?).self", ExprSyntax.parse)
-    assertParse("(([X]) -> [Y]).self", ExprSyntax.parse)
-    assertParse("(([A : B]) -> [C : D]).self", ExprSyntax.parse)
+    assertParse("((G<X>) -> G<Y>).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((X?) -> Y?).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(([X]) -> [Y]).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(([A : B]) -> [C : D]).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("((Gen<Foo>.Bar) -> Gen<Foo>.Bar).self", ExprSyntax.parse)
-    assertParse("((Foo?.Bar) -> Foo?.Bar).self", ExprSyntax.parse)
-    assertParse("(([Foo].Element) -> [Foo].Element).self", ExprSyntax.parse)
-    assertParse("(([Int : Foo].Element) -> [Int : Foo].Element).self", ExprSyntax.parse)
+    assertParse("((Gen<Foo>.Bar) -> Gen<Foo>.Bar).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((Foo?.Bar) -> Foo?.Bar).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(([Foo].Element) -> [Foo].Element).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("(([Int : Foo].Element) -> [Int : Foo].Element).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("((X.Type) -> Y.Type).self", ExprSyntax.parse)
-    assertParse("((X.Protocol) -> Y.Protocol).self", ExprSyntax.parse)
+    assertParse("((X.Type) -> Y.Type).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((X.Protocol) -> Y.Protocol).self", { ExprSyntax.parse(from: &$0) })
 
-    assertParse("(() -> X & Y).self", ExprSyntax.parse)
-    assertParse("((A & B) -> C & D).self", ExprSyntax.parse)
-    assertParse("((A & B) -> (C & D) -> E & Any).self", ExprSyntax.parse)
+    assertParse("(() -> X & Y).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((A & B) -> C & D).self", { ExprSyntax.parse(from: &$0) })
+    assertParse("((A & B) -> (C & D) -> E & Any).self", { ExprSyntax.parse(from: &$0) })
 
     assertParse(
       """
@@ -678,7 +678,7 @@ final class TypeExprTests: ParserTestCase {
         ((P) & X?.Y, G<X>.Y, (X, [A : B?].Type)) -> ([(X).Y]) -> [X].Y
       ).self
       """,
-      ExprSyntax.parse
+      { ExprSyntax.parse(from: &$0) }
     )
   }
 


### PR DESCRIPTION
* **Explanation**: Because SE-0418 has not been implemented in Swift 5.10, we get a warning “Converting non-sendable function value to 'https://github.com/sendable (inout Parser) -> TypeSyntax' may introduce data races” when building SwiftSyntax tests using Swift 5.10. Wrapping the calls to parse in closures allows the type system to infer the actor isolation for the closure, fixing the warning.
* **Scope**: Tests only 
* **Risk**: Low, only changes tests
* **Testing**: Verified that the warning no longer appears with the fix applied
* **Issue**: rdar://124993444
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/2547