### PR TITLE
Bazel - Missing dependency for SwiftCompilerPlugin

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,7 @@ swift_syntax_library(
     deps = [
         ":SwiftCompilerPluginMessageHandling",
         ":SwiftSyntaxMacros",
+        ":SwiftOperators",
     ],
 )
 


### PR DESCRIPTION
Problem: When using `SwiftSyntax` in Bazel project with the following WORKSPACE config

```sh
http_archive(
    name = "SwiftSyntax",
    sha256 = "f361dc786c1b54a12e947cdf616031c3f366946deb4960f36bda396a6b012183",
    strip_prefix = "swift-syntax-509.1.1",
    url = "https://github.com/apple/swift-syntax/archive/refs/tags/509.1.1.tar.gz",
)
```
Building `SwiftCompilerPlugin` fails due to missing deps `SwiftOperators`

```sh
INFO: Invocation ID: 950fc6bc-5b88-4620-bf23-e6d264287fb9
INFO: Analyzed target @SwiftSyntax//:SwiftCompilerPlugin (0 packages loaded, 128 targets configured).
INFO: Found 1 target...
ERROR: /private/var/tmp/_bazel/c521a9a21d038f4621de7189edd70c86/external/SwiftSyntax/BUILD.bazel:43:21: Compiling Swift module @SwiftSyntax//:SwiftSyntaxMacroExpansion failed: (Exit 1): universal_worker failed: error executing command (from target @SwiftSyntax//:SwiftSyntaxMacroExpansion) bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/build_bazel_rules_swift/tools/worker/universal_worker swiftc ... (remaining 1 argument skipped)
error: emit-module command failed with exit code 1 (use -v to see invocation)
external/SwiftSyntax/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift:14:8: error: no such module 'SwiftOperators'
import SwiftOperators
       ^
external/SwiftSyntax/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift:14:8: error: no such module 'SwiftOperators'
import SwiftOperators
       ^
error: fatalError
Target @SwiftSyntax//:SwiftCompilerPlugin failed to build
Use --verbose_failures to see the command lines of failed build steps.
```

If we specify a BUILD file location in the `http_archive` and append `SwiftOperators` as a dependency in `SwiftCompilerPlugin`, we then see that it builds successfully. 

```sh
INFO: Analyzed target //:SwiftCompilerPlugin (0 packages loaded, 141 targets configured).
INFO: Found 1 target...
Target //:SwiftCompilerPlugin up-to-date:
  bazel-bin/SwiftCompilerPlugin.swiftdoc
  bazel-bin/SwiftCompilerPlugin.swiftmodule
  bazel-bin/SwiftCompilerPlugin.swiftsourceinfo
  bazel-bin/libSwiftCompilerPlugin.a
INFO: Elapsed time: 1.673s, Critical Path: 1.51s
INFO: 12 processes: 1 internal, 1 darwin-sandbox, 10 worker.
INFO: Build completed successfully, 12 total actions
```

This PR is to add the missing dependency so we can build SwiftCompilerPlugin directly from WORKSPACE with

```sh
bazel build @SwiftSyntax//:SwiftCompilerPlugin
```