### PR TITLE
[6.0] Specify attributes inside `#if` before any unconditional attributes

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
@@ -33,8 +33,8 @@ let resultBuildersFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       // MARK: - \(type.resultBuilderType)
 
-      @resultBuilder
       \(node.node.apiAttributes())\
+      @resultBuilder
       public struct \(type.resultBuilderType): ListBuilder
       """
     ) {

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -431,10 +431,10 @@ public extension LabeledExprListSyntax {
 
 // MARK: - LifetimeSpecifierArgumentListBuilder
 
-@resultBuilder
 #if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
 #endif
+@resultBuilder
 public struct LifetimeSpecifierArgumentListBuilder: ListBuilder {
   public typealias FinalResult = LifetimeSpecifierArgumentListSyntax
 }


### PR DESCRIPTION
* **Explanation**: Specifying the `#if` conditionalized attribute after an unconditional attribute results in a compilation error when using a Swift 5.7 compiler. Reversing the order makes swift-syntax build with a Swift 5.7 compiler.
* **Scope**: Fixes a compilation error when building swift-syntax with a 5.7 compiler
* **Risk**: Very low, just flips two declaration attributes
* **Testing**: Tested that that the package builds with 5.7 with this change
* **Issue**: rdar://124979624, #2546 
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/2548