### PR TITLE
Make `DiagnosticDecorator` semi-public

### DIFF
--- a/Sources/SwiftDiagnostics/DiagnosticDecorators/ANSIDiagnosticDecorator.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticDecorators/ANSIDiagnosticDecorator.swift
@@ -12,7 +12,7 @@
 
 extension DiagnosticDecorator where Self == ANSIDiagnosticDecorator {
   /// - SeeAlso: ``ANSIDiagnosticDecorator``
-  static var ANSI: Self {
+  public static var ANSI: Self {
     Self()
   }
 }
@@ -21,9 +21,9 @@ extension DiagnosticDecorator where Self == ANSIDiagnosticDecorator {
 /// buffer outlines, and code highlights—by applying severity-based prefixes and ANSI color codes.
 ///
 /// This decorator uses ANSI codes—control characters specialized for text formatting in terminals—to provide visual cues.
-@_spi(Testing) public struct ANSIDiagnosticDecorator: DiagnosticDecorator {
+public struct ANSIDiagnosticDecorator: DiagnosticDecorator {
 
-  @_spi(Testing) public init() {}
+  public init() {}
 
   /// Decorates a diagnostic message by appending a severity-based prefix and applying ANSI color codes.
   ///
@@ -46,7 +46,7 @@ extension DiagnosticDecorator where Self == ANSIDiagnosticDecorator {
   /// ```bash
   /// printf "\e[1;31merror: \e[1;39mFile not found\e[0;0m\n"
   /// ```
-  @_spi(Testing) public func decorateMessage(
+  public func decorateMessage(
     _ message: String,
     basedOnSeverity severity: DiagnosticSeverity
   ) -> String {
@@ -85,7 +85,7 @@ extension DiagnosticDecorator where Self == ANSIDiagnosticDecorator {
   /// - Parameter bufferOutline: The string representation of the source code buffer outline.
   ///
   /// - Returns: A string featuring ANSI cyan color codes applied to the source code buffer outline.
-  @_spi(Testing) public func decorateBufferOutline(_ bufferOutline: String) -> String {
+  public func decorateBufferOutline(_ bufferOutline: String) -> String {
     colorizeIfNotEmpty(bufferOutline, usingAnnotation: .bufferOutline)
   }
 
@@ -109,7 +109,7 @@ extension DiagnosticDecorator where Self == ANSIDiagnosticDecorator {
   /// ```bash
   /// printf "\e[4;39mlet x = 10\e[0;0m\n"
   /// ```
-  @_spi(Testing) public func decorateHighlight(_ highlight: String) -> (
+  public func _decorateHighlight(_ highlight: String) -> (
     highlightedSourceCode: String, additionalHighlightedLine: String?
   ) {
     (

--- a/Sources/SwiftDiagnostics/DiagnosticDecorators/BasicDiagnosticDecorator.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticDecorators/BasicDiagnosticDecorator.swift
@@ -12,7 +12,7 @@
 
 extension DiagnosticDecorator where Self == BasicDiagnosticDecorator {
   /// - Seealso: ``BasicDiagnosticDecorator``
-  static var basic: Self {
+  public static var basic: Self {
     Self()
   }
 }
@@ -21,9 +21,9 @@ extension DiagnosticDecorator where Self == BasicDiagnosticDecorator {
 /// buffer outlines, and code highlights—by appending severity-based prefixes.
 ///
 /// Unlike `ANSIDiagnosticDecorator`, this decorator does not use ANSI color codes and solely relies on textual cues.
-@_spi(Testing) public struct BasicDiagnosticDecorator: DiagnosticDecorator {
+public struct BasicDiagnosticDecorator: DiagnosticDecorator {
 
-  @_spi(Testing) public init() {}
+  public init() {}
 
   /// Decorates a diagnostic message by appending a severity-based prefix.
   ///
@@ -32,7 +32,7 @@ extension DiagnosticDecorator where Self == BasicDiagnosticDecorator {
   ///   - severity: The severity level associated with the diagnostic message.
   ///
   /// - Returns: A string that combines the severity-specific prefix and the original diagnostic message.
-  @_spi(Testing) public func decorateMessage(
+  public func decorateMessage(
     _ message: String,
     basedOnSeverity severity: DiagnosticSeverity
   ) -> String {
@@ -57,7 +57,7 @@ extension DiagnosticDecorator where Self == BasicDiagnosticDecorator {
   /// - Parameter bufferOutline: The string representation of the source code buffer outline.
   ///
   /// - Returns: The original source code buffer outline.
-  @_spi(Testing) public func decorateBufferOutline(_ bufferOutline: String) -> String {
+  public func decorateBufferOutline(_ bufferOutline: String) -> String {
     return bufferOutline
   }
 
@@ -68,7 +68,7 @@ extension DiagnosticDecorator where Self == BasicDiagnosticDecorator {
   /// - Returns: A tuple containing:
   ///   - `highlightedSourceCode`: The original text segment.
   ///   - `additionalHighlightedLine`: Always nil.
-  @_spi(Testing) public func decorateHighlight(_ highlight: String) -> (
+  public func _decorateHighlight(_ highlight: String) -> (
     highlightedSourceCode: String, additionalHighlightedLine: String?
   ) {
     return (highlightedSourceCode: highlight, additionalHighlightedLine: nil)

--- a/Sources/SwiftDiagnostics/DiagnosticDecorators/DiagnosticDecorator.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticDecorators/DiagnosticDecorator.swift
@@ -28,7 +28,7 @@
 /// The protocol is designed to be easily customizable. Developers can create their own entities that conform
 /// to `DiagnosticDecorator` to implement custom decorating logic. This allows for different visual representations,
 /// such as using ANSI colors, underscores, emoji-based or other markers, for diagnostics in source code.
-protocol DiagnosticDecorator {
+public protocol DiagnosticDecorator {
   /// Decorates a diagnostic message based on its severity level.
   ///
   /// Implementations are expected to prepend a severity-specific prefix (e.g., "error: ", "warning: ") to the diagnostic message.
@@ -59,7 +59,12 @@ protocol DiagnosticDecorator {
   /// - Note: The method returns a tuple to offer more flexibility in decorating highlights.
   ///         This allows for a variety of techniques to be used, such as ANSI codes for color
   ///         and additional lines for contextual emphasis, which will be combined during the rendering process.
-  func decorateHighlight(_ highlight: String) -> (highlightedSourceCode: String, additionalHighlightedLine: String?)
+  ///
+  /// - Warning: This method is currently experimental and subject to change. It is marked with an underscore `_`
+  ///            to indicate that it is not yet considered stable API. The interface, behavior, and existence
+  ///            of this method may change in future releases without warning as we refine its implementation.
+  ///            Please use with caution and avoid relying heavily on it in production code.
+  func _decorateHighlight(_ highlight: String) -> (highlightedSourceCode: String, additionalHighlightedLine: String?)
 }
 
 extension DiagnosticDecorator {
@@ -70,5 +75,9 @@ extension DiagnosticDecorator {
   /// - Returns: A decorated version of the diagnostic message, determined by its severity level.
   func decorateDiagnosticMessage(_ diagnosticMessage: DiagnosticMessage) -> String {
     decorateMessage(diagnosticMessage.message, basedOnSeverity: diagnosticMessage.severity)
+  }
+
+  func _decorateHighlight(_ highlight: String) -> (highlightedSourceCode: String, additionalHighlightedLine: String?) {
+    return (highlightedSourceCode: highlight, additionalHighlightedLine: nil)
   }
 }

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -194,7 +194,7 @@ public struct DiagnosticsFormatter {
 
       // Highlighted source text
       let highlightString = String(sourceString[highlightRange])
-      resultSourceString += diagnosticDecorator.decorateHighlight(highlightString).highlightedSourceCode
+      resultSourceString += diagnosticDecorator._decorateHighlight(highlightString).highlightedSourceCode
 
       sourceIndex = highlightRange.upperBound
     }

--- a/Tests/SwiftDiagnosticsTest/DiagnosticDecorators/ANSIDiagnosticDecoratorTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticDecorators/ANSIDiagnosticDecoratorTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Testing) import SwiftDiagnostics
+import SwiftDiagnostics
 import XCTest
 import _SwiftSyntaxTestSupport
 
@@ -64,14 +64,14 @@ final class ANSIDiagnosticDecoratorTests: XCTestCase {
   func testDecorateHighlight() {
     let highlightedText = "let x = 10"
 
-    let decoratedHighlight = decorator.decorateHighlight(highlightedText)
+    let decoratedHighlight = decorator._decorateHighlight(highlightedText)
 
     assertStringsEqualWithDiff(decoratedHighlight.highlightedSourceCode, "\u{1B}[4;39mlet x = 10\u{1B}[0;0m")
     XCTAssertNil(decoratedHighlight.additionalHighlightedLine)
   }
 
   func testDecorateHighlightWithEmptyString() {
-    let decoratedHighlight = decorator.decorateHighlight("")
+    let decoratedHighlight = decorator._decorateHighlight("")
 
     assertStringsEqualWithDiff(decoratedHighlight.highlightedSourceCode, "")
     XCTAssertNil(decoratedHighlight.additionalHighlightedLine)

--- a/Tests/SwiftDiagnosticsTest/DiagnosticDecorators/BasicDiagnosticDecoratorTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticDecorators/BasicDiagnosticDecoratorTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Testing) import SwiftDiagnostics
+import SwiftDiagnostics
 import XCTest
 import _SwiftSyntaxTestSupport
 
@@ -51,7 +51,7 @@ final class BasicDiagnosticDecoratorTests: XCTestCase {
   func testDecorateHighlight() {
     let highlightedText = "let x = 10"
 
-    let decoratedHighlight = decorator.decorateHighlight(highlightedText)
+    let decoratedHighlight = decorator._decorateHighlight(highlightedText)
 
     assertStringsEqualWithDiff(decoratedHighlight.highlightedSourceCode, highlightedText)
     XCTAssertNil(decoratedHighlight.additionalHighlightedLine)


### PR DESCRIPTION
The refactored implementation of `DiagnosticFormatter`, as seen in [this pull request](https://github.com/apple/swift-syntax/pull/2214), is now closely integrated with `DiagnosticDecorator`. In order to expose the new initializers and methods of `DiagnosticFormatter` as public, it's necessary to also make `DiagnosticDecorator` public.

Given that `decorateHighlight` is still experimental, I've renamed it to start with an underscore (`_`) and added a warning to it's documentation to emphasize that this API is not yet intended for production use.
