### PR TITLE
[6.0] Add test cases for transferring type specifiers 

### DIFF
--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3293,4 +3293,19 @@ final class DeclarationTests: ParserTestCase {
     // Not actually valid, needs to be diagnosed during type checking
     assertParse("public init() -> Int")
   }
+
+  func testTransferringTypeSpecifier() {
+    assertParse(
+      "func testVarDeclTupleElt() -> (transferring String, String) {}",
+      experimentalFeatures: .transferringArgsAndResults
+    )
+    assertParse(
+      "func testVarDeclTuple2(_ x: (transferring String)) {}",
+      experimentalFeatures: .transferringArgsAndResults
+    )
+    assertParse(
+      "func testVarDeclTuple2(_ x: (transferring String, String)) {}",
+      experimentalFeatures: .transferringArgsAndResults
+    )
+  }
 }


### PR DESCRIPTION
* **Explanation**: Turns out we do support `transferring` as a type specifier already. Add a test case for it.
* **Scope**: Test-only change
* **Risk**: Low, test-only change
* **Testing**: Added test case
* **Issue**: rdar://123876615
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/2542