### PR TITLE
Add an accessor macro example

### DIFF
--- a/Examples/Sources/MacroExamples/Implementation/Accessor/EnvironmentValueMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Accessor/EnvironmentValueMacro.swift
@@ -26,10 +26,10 @@ public struct EnvironmentValueMacro: AccessorMacro {
 
     return [
       """
-      get { self[\(raw: argument.expression)] }
+      get { self[\(argument.expression)] }
       """,
       """
-      set { self[\(raw: argument.expression)] = newValue }
+      set { self[\(argument.expression)] = newValue }
       """,
     ]
   }

--- a/Examples/Sources/MacroExamples/Implementation/Accessor/EnvironmentValueMacro.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Accessor/EnvironmentValueMacro.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct EnvironmentValueMacro: AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    guard
+      case let .argumentList(arguments) = node.arguments,
+      let argument = arguments.first
+    else { return [] }
+
+    return [
+      """
+      get { self[\(raw: argument.expression)] }
+      """,
+      """
+      set { self[\(raw: argument.expression)] = newValue }
+      """,
+    ]
+  }
+}

--- a/Examples/Sources/MacroExamples/Implementation/Plugin.swift
+++ b/Examples/Sources/MacroExamples/Implementation/Plugin.swift
@@ -26,6 +26,7 @@ struct MyPlugin: CompilerPlugin {
     DefaultFatalErrorImplementationMacro.self,
     DictionaryStorageMacro.self,
     DictionaryStoragePropertyMacro.self,
+    EnvironmentValueMacro.self,
     EquatableExtensionMacro.self,
     FontLiteralMacro.self,
     FuncUniqueMacro.self,

--- a/Examples/Sources/MacroExamples/Interface/AccessorMacros.swift
+++ b/Examples/Sources/MacroExamples/Interface/AccessorMacros.swift
@@ -14,6 +14,7 @@ import SwiftUI
 
 // MARK: - EnvironmentValue Accessor
 
+/// Adds getter / setter to an attached environment value with specified EnvironmentKey
 @attached(accessor)
 public macro EnvironmentValue(for key: any EnvironmentKey.Type) =
   #externalMacro(module: "MacroExamplesImplementation", type: "EnvironmentValueMacro")

--- a/Examples/Sources/MacroExamples/Interface/AccessorMacros.swift
+++ b/Examples/Sources/MacroExamples/Interface/AccessorMacros.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftUI
+
+// MARK: - EnvironmentValue Accessor
+
+@attached(accessor)
+public macro EnvironmentValue(for key: any EnvironmentKey.Type) =
+  #externalMacro(module: "MacroExamplesImplementation", type: "EnvironmentValueMacro")

--- a/Examples/Sources/MacroExamples/Interface/AccessorMacros.swift
+++ b/Examples/Sources/MacroExamples/Interface/AccessorMacros.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(SwiftUI)
+
 import SwiftUI
 
 // MARK: - EnvironmentValue Accessor
@@ -18,3 +20,5 @@ import SwiftUI
 @attached(accessor)
 public macro EnvironmentValue(for key: any EnvironmentKey.Type) =
   #externalMacro(module: "MacroExamplesImplementation", type: "EnvironmentValueMacro")
+
+#endif

--- a/Examples/Sources/MacroExamples/Playground/AccessorMacrosPlayground.swift
+++ b/Examples/Sources/MacroExamples/Playground/AccessorMacrosPlayground.swift
@@ -13,6 +13,9 @@
 // MARK: - EnvironmentValue Accessor
 
 import MacroExamplesInterface
+
+#if canImport(SwiftUI)
+
 import SwiftUI
 
 private struct MyEnvironmentKey: EnvironmentKey {
@@ -30,3 +33,5 @@ func runEnvironmentValueAccessorMacroPlayground() {
   environmentValues.myCustomValue = "New value"
   print("New myCustomValue: \(environmentValues.myCustomValue)")
 }
+
+#endif

--- a/Examples/Sources/MacroExamples/Playground/AccessorMacrosPlayground.swift
+++ b/Examples/Sources/MacroExamples/Playground/AccessorMacrosPlayground.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: - EnvironmentValue Accessor
+
+import MacroExamplesInterface
+import SwiftUI
+
+private struct MyEnvironmentKey: EnvironmentKey {
+  static let defaultValue: String = "Default value"
+}
+
+extension EnvironmentValues {
+  @EnvironmentValue(for: MyEnvironmentKey.self)
+  var myCustomValue: String
+}
+
+func runEnvironmentValueAccessorMacroPlayground() {
+  var environmentValues = EnvironmentValues()
+  print("Default myCustomValue: \(environmentValues.myCustomValue)")
+  environmentValues.myCustomValue = "New value"
+  print("New myCustomValue: \(environmentValues.myCustomValue)")
+}

--- a/Examples/Sources/MacroExamples/Playground/main.swift
+++ b/Examples/Sources/MacroExamples/Playground/main.swift
@@ -50,4 +50,8 @@ runPeerMacrosPlayground()
 
 // MARK: - Accessor Macros
 
+#if canImport(SwiftUI)
+
 runEnvironmentValueAccessorMacroPlayground()
+
+#endif

--- a/Examples/Sources/MacroExamples/Playground/main.swift
+++ b/Examples/Sources/MacroExamples/Playground/main.swift
@@ -48,6 +48,6 @@ runMemberMacrosPlayground()
 
 runPeerMacrosPlayground()
 
-// MARKL - Accessor Macros
+// MARK: - Accessor Macros
 
 runEnvironmentValueAccessorMacroPlayground()

--- a/Examples/Sources/MacroExamples/Playground/main.swift
+++ b/Examples/Sources/MacroExamples/Playground/main.swift
@@ -47,3 +47,7 @@ runMemberMacrosPlayground()
 // MARK: - Peer Macros
 
 runPeerMacrosPlayground()
+
+// MARKL - Accessor Macros
+
+runEnvironmentValueAccessorMacroPlayground()

--- a/Examples/Tests/MacroExamples/Implementation/Accessor/EnvironmentValueMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/Accessor/EnvironmentValueMacroTests.swift
@@ -21,20 +21,12 @@ final class EnvironmentValueMacroMacroTests: XCTestCase {
   func testEnvironmentValue() {
     assertMacroExpansion(
       """
-      private struct MyEnvironmentKey: EnvironmentKey {
-          static let defaultValue: String = "Default value"
-      }
-
       extension EnvironmentValues {
           @EnvironmentValue(for: MyEnvironmentKey.self)
           var myCustomValue: String
       }
       """,
       expandedSource: """
-        private struct MyEnvironmentKey: EnvironmentKey {
-            static let defaultValue: String = "Default value"
-        }
-
         extension EnvironmentValues {
             var myCustomValue: String {
                 get {

--- a/Examples/Tests/MacroExamples/Implementation/Accessor/EnvironmentValueMacroTests.swift
+++ b/Examples/Tests/MacroExamples/Implementation/Accessor/EnvironmentValueMacroTests.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import MacroExamplesImplementation
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+final class EnvironmentValueMacroMacroTests: XCTestCase {
+  private let macros = ["EnvironmentValue": EnvironmentValueMacro.self]
+
+  func testEnvironmentValue() {
+    assertMacroExpansion(
+      """
+      private struct MyEnvironmentKey: EnvironmentKey {
+          static let defaultValue: String = "Default value"
+      }
+
+      extension EnvironmentValues {
+          @EnvironmentValue(for: MyEnvironmentKey.self)
+          var myCustomValue: String
+      }
+      """,
+      expandedSource: """
+        private struct MyEnvironmentKey: EnvironmentKey {
+            static let defaultValue: String = "Default value"
+        }
+
+        extension EnvironmentValues {
+            var myCustomValue: String {
+                get {
+                    self[MyEnvironmentKey.self]
+                }
+                set {
+                    self[MyEnvironmentKey.self] = newValue
+                }
+            }
+        }
+        """,
+      macros: macros
+    )
+  }
+}


### PR DESCRIPTION
Issue: https://github.com/apple/swift-syntax/issues/2169

This PR introduces a new accessor macro example called `EnvironmentValueMacro` that automates the generation of getter / setter implementations for EnvironmentValues.

```diff
 private struct MyEnvironmentKey: EnvironmentKey {
     static let defaultValue: String = "Default value"
 }

 extension EnvironmentValues {
+    @EnvironmentValue(for: MyEnvironmentKey.self)
+    var myCustomValue: String
-    var myCustomValue: String {
-        get { self[MyEnvironmentKey.self] }
-        set { self[MyEnvironmentKey.self] = newValue }
-    }
 }
```