### PR TITLE
Parse types with inverted constraints in expressions

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -523,7 +523,7 @@ extension Parser {
       )
 
     case (.any, _)?:
-      if !atContextualExpressionModifier() {
+      if !atContextualExpressionModifier() && !self.peek().isContextualPunctuator("~") {
         break EXPR_PREFIX
       }
 

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -694,6 +694,9 @@ extension Parser.Lookahead {
     switch self.currentToken {
     case TokenSpec(.Any):
       self.consumeAnyToken()
+    case TokenSpec(.prefixOperator) where self.currentToken.tokenText == "~":
+      self.consumeAnyToken();
+      fallthrough
     case TokenSpec(.Self), TokenSpec(.identifier):
       guard self.canParseTypeIdentifier() else {
         return false

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -309,6 +309,40 @@ final class TypeTests: ParserTestCase {
     )
   }
 
+  func testInverseTypes() {
+    assertParse(
+      "[~Copyable]()"
+    )
+
+    assertParse(
+      "[any ~Copyable]()"
+    )
+
+    assertParse(
+      "[any P & ~Copyable]()"
+    )
+
+    assertParse(
+      "[P & ~Copyable]()"
+    )
+
+    assertParse(
+      "X<~Copyable>()"
+    )
+
+    assertParse(
+      "X<any ~Copyable>()"
+    )
+
+    assertParse(
+      "X<P & ~Copyable>()"
+    )
+
+    assertParse(
+      "X<any P & ~Copyable>()"
+    )
+  }
+
   func testTypedThrows() {
     assertParse(
       """


### PR DESCRIPTION
Lookahead to determine when we are parsing a type within an expression context was failing to consider inverted constraints. Make sure we look past the `~` to an identifier.