### PR TITLE
[Diagnostics] Stop using unicode line characters

### DIFF
--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -268,13 +268,13 @@ public struct DiagnosticsFormatter {
       // line numbers should be right aligned
       let lineNumberString = String(lineNumber)
       let leadingSpaces = String(repeating: " ", count: maxNumberOfDigits - lineNumberString.count)
-      let linePrefix = "\(leadingSpaces)\(diagnosticDecorator.decorateBufferOutline("\(lineNumberString) │")) "
+      let linePrefix = "\(leadingSpaces)\(diagnosticDecorator.decorateBufferOutline("\(lineNumberString) |")) "
 
       // If necessary, print a line that indicates that there was lines skipped in the source code
       if hasLineBeenSkipped && !annotatedSource.isEmpty {
         let lineMissingInfoLine =
           indentString + String(repeating: " ", count: maxNumberOfDigits)
-          + " \(diagnosticDecorator.decorateBufferOutline("┆"))"
+          + " \(diagnosticDecorator.decorateBufferOutline(":"))"
         annotatedSource.append("\(lineMissingInfoLine)\n")
       }
       hasLineBeenSkipped = false
@@ -313,20 +313,20 @@ public struct DiagnosticsFormatter {
         // compute the string that is shown before each message
         var preMessage =
           indentString + String(repeating: " ", count: maxNumberOfDigits) + " "
-          + diagnosticDecorator.decorateBufferOutline("│")
+          + diagnosticDecorator.decorateBufferOutline("|")
         for c in 0..<column {
           if columnsWithDiagnostics.contains(c) {
-            preMessage.append("│")
+            preMessage.append("|")
           } else {
             preMessage.append(" ")
           }
         }
 
         for diag in diags.dropLast(1) {
-          annotatedSource.append("\(preMessage)├─ \(diagnosticDecorator.decorateDiagnosticMessage(diag.diagMessage))\n")
+          annotatedSource.append("\(preMessage)|- \(diagnosticDecorator.decorateDiagnosticMessage(diag.diagMessage))\n")
         }
         annotatedSource.append(
-          "\(preMessage)╰─ \(diagnosticDecorator.decorateDiagnosticMessage(diags.last!.diagMessage))\n"
+          "\(preMessage)`- \(diagnosticDecorator.decorateDiagnosticMessage(diags.last!.diagMessage))\n"
         )
       }
 

--- a/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
+++ b/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
@@ -193,7 +193,7 @@ extension GroupedDiagnostics {
       let childSource = annotateSource(
         childBufferID,
         formatter: formatter,
-        indentString: indentString + String(repeating: " ", count: childPadding) + "│"
+        indentString: indentString + String(repeating: " ", count: childPadding) + "|"
       )
 
       childSources[sourceFiles[childBufferID.id].parent!.1, default: ""].append(childSource)
@@ -232,7 +232,7 @@ extension GroupedDiagnostics {
               "expanded code originates here",
               basedOnSeverity: .note
             )
-            prefixString += "╰─ \(bufferLoc.file):\(bufferLoc.line):\(bufferLoc.column): \(decoratedMessage)\n"
+            prefixString += "`- \(bufferLoc.file):\(bufferLoc.line):\(bufferLoc.column): \(decoratedMessage)\n"
           }
         }
       } else {
@@ -249,16 +249,16 @@ extension GroupedDiagnostics {
       let extraLengthNeeded = targetLineLength - padding.count - sourceFile.displayName.count - 6
       let boxSuffix: String
       if extraLengthNeeded > 0 {
-        boxSuffix = diagnosticDecorator.decorateBufferOutline(String(repeating: "─", count: extraLengthNeeded))
+        boxSuffix = diagnosticDecorator.decorateBufferOutline(String(repeating: "-", count: extraLengthNeeded))
       } else {
         boxSuffix = ""
       }
 
       prefixString =
-        diagnosticDecorator.decorateBufferOutline(padding + "╭─── ") + sourceFile.displayName + " " + boxSuffix + "\n"
+        diagnosticDecorator.decorateBufferOutline(padding + "+--- ") + sourceFile.displayName + " " + boxSuffix + "\n"
       suffixString =
         diagnosticDecorator.decorateBufferOutline(
-          padding + "╰───" + String(repeating: "─", count: sourceFile.displayName.count + 2)
+          padding + "+---" + String(repeating: "-", count: sourceFile.displayName.count + 2)
         ) + boxSuffix + "\n"
     }
 

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -77,9 +77,9 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       annotated,
       """
       other.swift:123:17: error: consecutive statements on a line must be separated by newline or ';'
-      1 │ #sourceLocation(file: "other.swift", line: 123)
-      2 │ let pi = 3.14159 x
-        │                 ╰─ error: consecutive statements on a line must be separated by newline or ';'
+      1 | #sourceLocation(file: "other.swift", line: 123)
+      2 | let pi = 3.14159 x
+        |                 `- error: consecutive statements on a line must be separated by newline or ';'
 
       """
     )
@@ -134,20 +134,20 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       annotated,
       """
       main.swift:6:14: error: expected ')' to end function call
-      3 │ // test
-      4 │ let pi = 3.14159
-      5 │ #myAssert(pi == 3)
-        │ ╰─ note: in expansion of macro 'myAssert' here
-        ╭─── #myAssert ───────────────────────────────────────────────────────
-        │1 │ let __a = pi
-        │2 │ let __b = 3
-        │3 │ if !(__a == __b) {
-        │  │          ╰─ error: no matching operator '==' for types 'Double' and 'Int'
-        │4 │   fatalError("assertion failed: pi != 3")
-        │5 │ }
-        ╰─────────────────────────────────────────────────────────────────────
-      6 │ print("hello"
-        │              ╰─ error: expected ')' to end function call
+      3 | // test
+      4 | let pi = 3.14159
+      5 | #myAssert(pi == 3)
+        | `- note: in expansion of macro 'myAssert' here
+        +--- #myAssert -------------------------------------------------------
+        |1 | let __a = pi
+        |2 | let __b = 3
+        |3 | if !(__a == __b) {
+        |  |          `- error: no matching operator '==' for types 'Double' and 'Int'
+        |4 |   fatalError("assertion failed: pi != 3")
+        |5 | }
+        +---------------------------------------------------------------------
+      6 | print("hello"
+        |              `- error: expected ')' to end function call
 
       """
     )
@@ -212,23 +212,23 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       annotated,
       """
       #invertedEqualityCheck:1:7: error: no matching operator '==' for types 'Double' and 'Int'
-      ╰─ main.swift:2:1: note: expanded code originates here
-      1 │ let pi = 3.14159
-      2 │ #myAssert(pi == 3)
-        │ ╰─ note: in expansion of macro 'myAssert' here
-        ╭─── #myAssert ───────────────────────────────────────────────────────
-        │1 │ let __a = pi
-        │2 │ let __b = 3
-        │3 │ if #invertedEqualityCheck(__a, __b) {
-        │  │    ╰─ note: in expansion of macro 'invertedEqualityCheck' here
-        │  ╭─── #invertedEqualityCheck ───────────────────────────────────────
-        │  │1 │ !(__a == __b)
-        │  │  │       ╰─ error: no matching operator '==' for types 'Double' and 'Int'
-        │  ╰──────────────────────────────────────────────────────────────────
-        │4 │   fatalError("assertion failed: pi != 3")
-        │5 │ }
-        ╰─────────────────────────────────────────────────────────────────────
-      3 │ print("hello")
+      `- main.swift:2:1: note: expanded code originates here
+      1 | let pi = 3.14159
+      2 | #myAssert(pi == 3)
+        | `- note: in expansion of macro 'myAssert' here
+        +--- #myAssert -------------------------------------------------------
+        |1 | let __a = pi
+        |2 | let __b = 3
+        |3 | if #invertedEqualityCheck(__a, __b) {
+        |  |    `- note: in expansion of macro 'invertedEqualityCheck' here
+        |  +--- #invertedEqualityCheck ---------------------------------------
+        |  |1 | !(__a == __b)
+        |  |  |       `- error: no matching operator '==' for types 'Double' and 'Int'
+        |  +------------------------------------------------------------------
+        |4 |   fatalError("assertion failed: pi != 3")
+        |5 | }
+        +---------------------------------------------------------------------
+      3 | print("hello")
 
       """
     )

--- a/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
+++ b/Tests/SwiftDiagnosticsTest/ParserDiagnosticsFormatterIntegrationTests.swift
@@ -29,8 +29,8 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
       var foo = bar +
       """
     let expectedOutput = """
-      1 │ var foo = bar +
-        │                ╰─ error: expected expression after operator
+      1 | var foo = bar +
+        |                `- error: expected expression after operator
 
       """
     assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
@@ -41,10 +41,10 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
       foo.[].[].[]
       """
     let expectedOutput = """
-      1 │ foo.[].[].[]
-        │     │  │  ╰─ error: expected name in member access
-        │     │  ╰─ error: expected name in member access
-        │     ╰─ error: expected name in member access
+      1 | foo.[].[].[]
+        |     |  |  `- error: expected name in member access
+        |     |  `- error: expected name in member access
+        |     `- error: expected name in member access
 
       """
     assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
@@ -65,17 +65,17 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
       i = bar(
       """
     let expectedOutput = """
-       2 │ i = 2
-       3 │ i = foo(
-       4 │ i = 4
-         │      ╰─ error: expected ')' to end function call
-       5 │ i = 5
-       6 │ i = 6
-         ┆
-       9 │ i = 9
-      10 │ i = 10
-      11 │ i = bar(
-         │         ╰─ error: expected value and ')' to end function call
+       2 | i = 2
+       3 | i = foo(
+       4 | i = 4
+         |      `- error: expected ')' to end function call
+       5 | i = 5
+       6 | i = 6
+         :
+       9 | i = 9
+      10 | i = 10
+      11 | i = bar(
+         |         `- error: expected value and ')' to end function call
 
       """
     assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
@@ -85,9 +85,9 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
     let source = "t as (..)"
 
     let expectedOutput = """
-      1 │ t as (..)
-        │       ├─ error: expected type in tuple type
-        │       ╰─ error: unexpected code '..' in tuple type
+      1 | t as (..)
+        |       |- error: expected type in tuple type
+        |       `- error: unexpected code '..' in tuple type
 
       """
 
@@ -100,8 +100,8 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
       """
 
     let expectedOutput = """
-      \u{001B}[0;36m1 │\u{001B}[0;0m var foo = bar +
-        \u{001B}[0;36m│\u{001B}[0;0m                ╰─ \u{001B}[1;31merror: \u{001B}[1;39mexpected expression after operator\u{001B}[0;0m
+      \u{001B}[0;36m1 |\u{001B}[0;0m var foo = bar +
+        \u{001B}[0;36m|\u{001B}[0;0m                `- \u{001B}[1;31merror: \u{001B}[1;39mexpected expression after operator\u{001B}[0;0m
 
       """
     assertStringsEqualWithDiff(annotate(source: source, colorize: true), expectedOutput)
@@ -112,10 +112,10 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
       foo.[].[].[]
       """
     let expectedOutput = """
-      \u{001B}[0;36m1 │\u{001B}[0;0m foo.[].[].[]
-        \u{001B}[0;36m│\u{001B}[0;0m     │  │  ╰─ \u{001B}[1;31merror: \u{001B}[1;39mexpected name in member access\u{001B}[0;0m
-        \u{001B}[0;36m│\u{001B}[0;0m     │  ╰─ \u{001B}[1;31merror: \u{001B}[1;39mexpected name in member access\u{001B}[0;0m
-        \u{001B}[0;36m│\u{001B}[0;0m     ╰─ \u{001B}[1;31merror: \u{001B}[1;39mexpected name in member access\u{001B}[0;0m
+      \u{001B}[0;36m1 |\u{001B}[0;0m foo.[].[].[]
+        \u{001B}[0;36m|\u{001B}[0;0m     |  |  `- \u{001B}[1;31merror: \u{001B}[1;39mexpected name in member access\u{001B}[0;0m
+        \u{001B}[0;36m|\u{001B}[0;0m     |  `- \u{001B}[1;31merror: \u{001B}[1;39mexpected name in member access\u{001B}[0;0m
+        \u{001B}[0;36m|\u{001B}[0;0m     `- \u{001B}[1;31merror: \u{001B}[1;39mexpected name in member access\u{001B}[0;0m
 
       """
     assertStringsEqualWithDiff(annotate(source: source, colorize: true), expectedOutput)
@@ -127,9 +127,9 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
       """
 
     let expectedOutput = """
-      \u{001B}[0;36m1 │\u{001B}[0;0m for \u{001B}[4;39m(i\u{001B}[0;0m \u{001B}[4;39m= 🐮; i != 👩‍👩‍👦‍👦; i += 1)\u{001B}[0;0m { }
-        \u{001B}[0;36m│\u{001B}[0;0m │     ╰─ \u{001B}[1;31merror: \u{001B}[1;39mexpected ')' to end tuple pattern\u{001B}[0;0m
-        \u{001B}[0;36m│\u{001B}[0;0m ╰─ \u{001B}[1;31merror: \u{001B}[1;39mC-style for statement has been removed in Swift 3\u{001B}[0;0m
+      \u{001B}[0;36m1 |\u{001B}[0;0m for \u{001B}[4;39m(i\u{001B}[0;0m \u{001B}[4;39m= 🐮; i != 👩‍👩‍👦‍👦; i += 1)\u{001B}[0;0m { }
+        \u{001B}[0;36m|\u{001B}[0;0m |     `- \u{001B}[1;31merror: \u{001B}[1;39mexpected ')' to end tuple pattern\u{001B}[0;0m
+        \u{001B}[0;36m|\u{001B}[0;0m `- \u{001B}[1;31merror: \u{001B}[1;39mC-style for statement has been removed in Swift 3\u{001B}[0;0m
 
       """
 
@@ -142,9 +142,9 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
       """
 
     let expectedOutput = """
-      1 │ let _ : Float  -> Int
-        │         │    ╰─ error: expected ')' in function type
-        │         ╰─ error: expected '(' to start function type
+      1 | let _ : Float  -> Int
+        |         |    `- error: expected ')' in function type
+        |         `- error: expected '(' to start function type
 
       """
 
@@ -159,11 +159,11 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
       """
 
     let expectedOutput = """
-      1 │ func o() {
-      2 │ }👨‍👩‍👧‍👦}
-        │  │╰─ error: extraneous braces at top level
-        │  ╰─ error: consecutive statements on a line must be separated by newline or ';'
-      3 │ }
+      1 | func o() {
+      2 | }👨‍👩‍👧‍👦}
+        |  |`- error: extraneous braces at top level
+        |  `- error: consecutive statements on a line must be separated by newline or ';'
+      3 | }
 
       """
 
@@ -176,8 +176,8 @@ final class ParserDiagnosticsFormatterIntegrationTests: XCTestCase {
       """
 
     let expectedOutput = """
-      1 │ let 👨‍👩‍👧‍👦 = ;
-        │         ╰─ error: expected expression in variable
+      1 | let 👨‍👩‍👧‍👦 = ;
+        |         `- error: expected expression in variable
 
       """
 

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -452,8 +452,8 @@ final class StringInterpolationTests: XCTestCase {
         String(describing: error),
         """
 
-        1 │ /*comment*/ invalid /*comm*/
-          │             ╰─ error: unexpected trivia 'invalid'
+        1 | /*comment*/ invalid /*comm*/
+          |             `- error: unexpected trivia 'invalid'
 
         """
       )
@@ -470,9 +470,9 @@ final class StringInterpolationTests: XCTestCase {
         String(describing: error),
         """
 
-        1 │ return 1
-          │ │       ╰─ error: expected declaration
-          │ ╰─ error: unexpected code 'return 1' before declaration
+        1 | return 1
+          | |       `- error: expected declaration
+          | `- error: unexpected code 'return 1' before declaration
 
         """
       )
@@ -489,9 +489,9 @@ final class StringInterpolationTests: XCTestCase {
         String(describing: error),
         """
 
-        1 │ struct Foo {}
-          │ │            ╰─ error: expected statement
-          │ ╰─ error: unexpected code 'struct Foo {}' before statement
+        1 | struct Foo {}
+          | |            `- error: expected statement
+          | `- error: unexpected code 'struct Foo {}' before statement
 
         """
       )
@@ -508,8 +508,8 @@ final class StringInterpolationTests: XCTestCase {
         String(describing: error),
         """
 
-        1 │ 
-          │ ╰─ error: expected declaration
+        1 | 
+          | `- error: expected declaration
 
         """
       )


### PR DESCRIPTION
ASCII characters are more reliable.

```
┆    → :
│    → |
├─   → |-
╰─   → `-
╭───   +---
│    → |
╰───   +---
```
