### PR TITLE
[6.0] Fix parsing issues related to suppressed conformances / noncopyable generics

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -523,7 +523,7 @@ extension Parser {
       )
 
     case (.any, _)?:
-      if !atContextualExpressionModifier() {
+      if !atContextualExpressionModifier() && !self.peek().isContextualPunctuator("~") {
         break EXPR_PREFIX
       }
 

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -374,6 +374,9 @@ extension TokenConsumer {
         return false
       }
 
+    case .prefixOperator where lexeme.isContextualPunctuator("~"):
+      return true
+
     default:
       return false
     }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -694,6 +694,9 @@ extension Parser.Lookahead {
     switch self.currentToken {
     case TokenSpec(.Any):
       self.consumeAnyToken()
+    case TokenSpec(.prefixOperator) where self.currentToken.tokenText == "~":
+      self.consumeAnyToken();
+      fallthrough
     case TokenSpec(.Self), TokenSpec(.identifier):
       guard self.canParseTypeIdentifier() else {
         return false

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -343,6 +343,75 @@ final class TypeTests: ParserTestCase {
     )
   }
 
+  func testInverseTypesAsExpr() {
+    assertParse(
+      "(~Copyable).self"
+    )
+
+    assertParse(
+      "~Copyable.self"
+    )
+
+    assertParse(
+      "(any ~Copyable).self"
+    )
+  }
+
+  func testInverseTypesInParameter() {
+    assertParse(
+      "func f(_: borrowing ~Copyable) {}"
+    )
+
+    assertParse(
+      "func f(_: consuming ~Copyable) {}"
+    )
+
+    assertParse(
+      "func f(_: borrowing any ~Copyable) {}"
+    )
+
+    assertParse(
+      "func f(_: consuming any ~Copyable) {}"
+    )
+
+    assertParse(
+      "func f(_: ~Copyable) {}"
+    )
+
+    assertParse(
+      "typealias T = (~Copyable) -> Void"
+    )
+
+    assertParse(
+      "typealias T = (_ x: ~Copyable) -> Void"
+    )
+
+    assertParse(
+      "typealias T = (borrowing ~Copyable) -> Void"
+    )
+
+    assertParse(
+      "typealias T = (_ x: borrowing ~Copyable) -> Void"
+    )
+
+    assertParse(
+      "typealias T = (borrowing any ~Copyable) -> Void"
+    )
+
+    assertParse(
+      "typealias T = (_ x: borrowing any ~Copyable) -> Void"
+    )
+
+    assertParse(
+      "func f(_: any borrowing 1️⃣~Copyable) {}",
+      diagnostics: [
+        DiagnosticSpec(
+          message: "unexpected code '~Copyable' in parameter clause"
+        )
+      ]
+    )
+  }
+
   func testTypedThrows() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -309,6 +309,40 @@ final class TypeTests: ParserTestCase {
     )
   }
 
+  func testInverseTypes() {
+    assertParse(
+      "[~Copyable]()"
+    )
+
+    assertParse(
+      "[any ~Copyable]()"
+    )
+
+    assertParse(
+      "[any P & ~Copyable]()"
+    )
+
+    assertParse(
+      "[P & ~Copyable]()"
+    )
+
+    assertParse(
+      "X<~Copyable>()"
+    )
+
+    assertParse(
+      "X<any ~Copyable>()"
+    )
+
+    assertParse(
+      "X<P & ~Copyable>()"
+    )
+
+    assertParse(
+      "X<any P & ~Copyable>()"
+    )
+  }
+
   func testTypedThrows() {
     assertParse(
       """


### PR DESCRIPTION
* **Explanation**: Fix a few parsing issues related to suppressed conformances (e.g., `~Copyable`), including missing parsing of ownership modifiers on parameters (`borrowing` and `consuming`) and failure to parse such types within expression context (e.g., `[~Copyable]()`).
* **Issue**: rdar://123728228, rdar://125201146
* **Original PR**: https://github.com/apple/swift-syntax/pull/2579, https://github.com/apple/swift-syntax/pull/2580
* **Risk**: Low. These are narrowly-scoped disambiguations for new parsing rules.
* **Testing**: New tests.
