### PR TITLE
Don’t add space after `nonisolated` in `nonisolated(unsafe)`

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -322,6 +322,7 @@ open class BasicFormat: SyntaxRewriter {
       (.keyword(.Any), .period),  // Any.Type
       (.keyword(.`init`), .leftAngle),  // init<T>()
       (.keyword(.`init`), .leftParen),  // init()
+      (.keyword(.nonisolated), .leftParen),  // nonisolated(unsafe)
       (.keyword(.private), .leftParen),  // private(set)
       (.keyword(.self), .period),  // self.someProperty
       (.keyword(.self), .leftParen),  // self()

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -650,7 +650,11 @@ final class BasicFormatTest: XCTestCase {
     let source = """
       private(set) var x = 1
       """
+    assertFormatted(source: source, expected: source)
+  }
 
+  func testNonisolatedUnsafeDoesNotAddSpace() throws {
+    let source = "nonisolated(unsafe) var foo = 0"
     assertFormatted(source: source, expected: source)
   }
 }


### PR DESCRIPTION
rdar://125801054