### PR TITLE
Deprecate `ByteSourceRange` in favor of `Range<AbsolutePosition>`

### DIFF
--- a/Release Notes/600.md
+++ b/Release Notes/600.md
@@ -75,21 +75,25 @@
   - Description: With the change to parse `#if canImport(MyModule, _version: 1.2.3)` as a function call instead of a dedicated syntax node, `1.2.3` natively gets parsed as a member access `3` to the `1.2` float literal. This property allows the reinterpretation of such an expression as a version tuple.
   - Pull request: https://github.com/apple/swift-syntax/pull/2025
 
-- `SyntaxProtocol.node(at:)` 
+- `SyntaxProtocol.node(at:)`
   - Description: Given a `SyntaxIdentifier`, returns the `Syntax` node with that identifier
   - Pull request: https://github.com/apple/swift-syntax/pull/2594
 
 - `SyntaxIdentifier.IndexInTree`
   - Description: Uniquely identifies a syntax node within a tree. This is similar to ``SyntaxIdentifier`` but does not store the root ID of the tree. It can thus be transferred across trees that are structurally equivalent, for example two copies of the same tree that live in different processes. The only public functions on this type are `toOpaque` and `init(fromOpaque:)`, which allow serialization of the `IndexInTree`.
   - Pull request: https://github.com/apple/swift-syntax/pull/2594
-  
+
 - `SyntaxIdentifier` conformance to `Comparable`:
   - Description: A `SyntaxIdentifier` compares less than another `SyntaxIdentifier` if the node at that identifier occurs first during a depth-first traversal of the tree.
   - Pull request: https://github.com/apple/swift-syntax/pull/2594
 
-- `SyntaxIdentifier.indexInTree` and `SyntaxIdentifier.fromIndexInTree` 
+- `SyntaxIdentifier.indexInTree` and `SyntaxIdentifier.fromIndexInTree`
   - Description: `SyntaxIdentifier.indexInTree` allows the retrieval of a `SyntaxIdentifier` that identifies the syntax node independent of the syntax tree. `SyntaxIdentifier.fromIndexInTree` allows the creation for a `SyntaxIdentifier` from a tree-agnostic `SyntaxIdentifier.IndexInTree` and the tree's root node.
   - Pull request: https://github.com/apple/swift-syntax/pull/2594
+
+- `Range<AbsolutePosition>`
+  - Description: `Range<AbsolutePosition>` gained a few convenience functions inspired from `ByteSourceRange`: `init(position:length:)`,  `length`, `intersectsOrTouches`, `intersects`, `intersecting`
+  - Pull request: https://github.com/apple/swift-syntax/pull/2587
 
 ## API Behavior Changes
 
@@ -123,6 +127,18 @@
 - ` CanImportExprSyntax` and `CanImportVersionInfoSyntax`
   - Description: Instead of parsing `canImport` inside `#if` directives as a special expression node, parse it as a functionc call expression. This is in-line with how the `swift(>=6.0)` and `compiler(>=6.0)` directives are parsed.
   - Pull request: https://github.com/apple/swift-syntax/pull/2025
+
+- `SyntaxClassifiedRange.offset`, `length` and `endOffset`
+  - Description: Deprecated these properties in favor of `range`.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2587
+
+- `SyntaxProtocol.totalByteRange` and `trimmedByteRange`
+  - Description: Renamed to `range` and `trimmedRange`, both now returning a `Range<AbsolutePosition>`.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2587
+
+- `ByteSourceRange` deprecated in favor of `Range<AbsolutePosition>`
+  - Description:  `ByteSourceRange` is being dropped for `Range<AbsolutePosition>`, where the latter clearly signifies that it uses UTF-8 byte positions. `Range<AbsolutePosition>` has deprecated compatibility layers to make it API-compatible with `ByteSourceRange`
+  - Pull request: https://github.com/apple/swift-syntax/pull/2587
 
 ## API-Incompatible Changes
 
@@ -176,6 +192,21 @@
   - Description: This module is only intended to be used from some internal components. Any other modules should not use them directly.
   - Pull request: https://github.com/apple/swift-syntax/pull/2489
   - Migration steps: Stop using this module.
+
+- `ByteSourceRange.length` changed from `Int` to `SourceLength`
+  - Description: `ByteSourceRange` has been deprecated and declared as a typealias for `Range<AbsolutePosition>`. At the same time, `Range<AbsolutePosition>` gained `length: SourceLength` that provides type-system information about the kind of length (UTF-8 byte length).
+  - Pull request: https://github.com/apple/swift-syntax/pull/2587
+
+- `IncrementalEdit.replacementLength` changed from `Int` to `SourceLength`
+  - Description: The type of `IncrementalEdit.replacementLength` has been changed from `Int` to `SourceLength` which provides type-system information about the kind of length (UTF-8 byte length).
+  - Pull request: https://github.com/apple/swift-syntax/pull/2587
+
+## API-Behavior Changes
+
+- `SyntaxProtocol.classifications(in:)` and `SyntaxProtocol.classification(at:)` take positions relative to the root of the syntax tree instead of relative to the start of the node
+  - Description: With the deprecation of `ByteSourceRange` in favor of `Range<AbsolutePosition>`, the `AbsolutePosition`s passed as the range are measured from the start of the syntax tree instead of the start of the current node.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2587
+  - Migration steps: Pass absolute positions measured from the root of the syntax tree instead of positions relative to the current node.
 
 ## Template
 

--- a/Release Notes/600.md
+++ b/Release Notes/600.md
@@ -92,7 +92,7 @@
   - Pull request: https://github.com/apple/swift-syntax/pull/2594
 
 - `Range<AbsolutePosition>`
-  - Description: `Range<AbsolutePosition>` gained a few convenience functions inspired from `ByteSourceRange`: `init(position:length:)`,  `length`, `intersectsOrTouches`, `intersects`, `intersecting`
+  - Description: `Range<AbsolutePosition>` gained a few convenience functions inspired from `ByteSourceRange`: `init(position:length:)`,  `length`, `overlapsOrTouches`
   - Pull request: https://github.com/apple/swift-syntax/pull/2587
 
 ## API Behavior Changes

--- a/Sources/SwiftIDEUtils/Syntax+Classifications.swift
+++ b/Sources/SwiftIDEUtils/Syntax+Classifications.swift
@@ -25,12 +25,11 @@ public extension SyntaxProtocol {
   /// consecutive tokens would have the same classification then a single classified
   /// range is provided for all of them.
   var classifications: SyntaxClassifications {
-    let fullRange = ByteSourceRange(offset: 0, length: totalLength.utf8Length)
-    return SyntaxClassifications(_syntaxNode, in: fullRange)
+    return SyntaxClassifications(_syntaxNode, in: self.range)
   }
 
   /// Sequence of ``SyntaxClassifiedRange``s contained in this syntax node within
-  /// a relative range.
+  /// a source range.
   ///
   /// The provided classified ranges may extend beyond the provided `range`.
   /// Active classifications (non-`none`) will extend the range to include the
@@ -41,9 +40,9 @@ public extension SyntaxProtocol {
   /// intersect the provided `range`.
   ///
   /// - Parameters:
-  ///   - in: The relative byte range to pull ``SyntaxClassifiedRange``s from.
+  ///   - in: The range to pull ``SyntaxClassifiedRange``s from.
   /// - Returns: Sequence of ``SyntaxClassifiedRange``s.
-  func classifications(in range: ByteSourceRange) -> SyntaxClassifications {
+  func classifications(in range: Range<AbsolutePosition>) -> SyntaxClassifications {
     return SyntaxClassifications(_syntaxNode, in: range)
   }
 
@@ -52,19 +51,20 @@ public extension SyntaxProtocol {
   ///   - at: The relative to the node byte offset.
   /// - Returns: The ``SyntaxClassifiedRange`` for the offset or nil if the source text
   ///   at the given offset is unclassified.
+  @available(*, deprecated, message: "Use classification(at: AbsolutePosition) instead.")
   func classification(at offset: Int) -> SyntaxClassifiedRange? {
-    let classifications = SyntaxClassifications(_syntaxNode, in: ByteSourceRange(offset: offset, length: 1))
-    var iterator = classifications.makeIterator()
-    return iterator.next()
+    return classification(at: AbsolutePosition(utf8Offset: offset + self.position.utf8Offset))
   }
 
   /// The ``SyntaxClassifiedRange`` for an absolute position.
   /// - Parameters:
   ///   - at: The absolute position.
-  /// - Returns: The ``SyntaxClassifiedRange`` for the position or nil if the source text
+  /// - Returns: The ``SyntaxClassifiedRange`` for the position or `nil`` if the source text
   ///   at the given position is unclassified.
   func classification(at position: AbsolutePosition) -> SyntaxClassifiedRange? {
-    let relativeOffset = position.utf8Offset - self.position.utf8Offset
-    return self.classification(at: relativeOffset)
+    let range = Range(position: position, length: SourceLength(utf8Length: 1))
+    let classifications = SyntaxClassifications(_syntaxNode, in: range)
+    var iterator = classifications.makeIterator()
+    return iterator.next()
   }
 }

--- a/Sources/SwiftParser/IncrementalParseTransition.swift
+++ b/Sources/SwiftParser/IncrementalParseTransition.swift
@@ -23,7 +23,7 @@ extension Parser {
     }
 
     let currentOffset = self.lexemes.offsetToStart(self.currentToken)
-    if let node = parseLookup!.lookUp(currentOffset, kind: kind) {
+    if let node = parseLookup!.lookUp(AbsolutePosition(utf8Offset: currentOffset), kind: kind) {
       self.lexemes.advance(by: node.totalLength.utf8Length, currentToken: &self.currentToken)
       return node
     }
@@ -117,16 +117,15 @@ struct IncrementalParseLookup {
   /// has invalidated the previous ``Syntax`` node.
   ///
   /// - Parameters:
-  ///   - offset: The byte offset of the source string that is currently parsed.
+  ///   - position: The position in the source string that is currently parsed.
   ///   - kind: The `CSyntaxKind` that the parser expects at this position.
   /// - Returns: A ``Syntax`` node from the previous parse invocation,
   ///            representing the contents of this region, if it is still valid
   ///            to re-use. `nil` otherwise.
-  fileprivate mutating func lookUp(_ newOffset: Int, kind: SyntaxKind) -> Syntax? {
-    guard let prevOffset = translateToPreEditOffset(newOffset) else {
+  fileprivate mutating func lookUp(_ newPosition: AbsolutePosition, kind: SyntaxKind) -> Syntax? {
+    guard let prevPosition = translateToPreEditPosition(newPosition) else {
       return nil
     }
-    let prevPosition = AbsolutePosition(utf8Offset: prevOffset)
     let node = cursorLookup(prevPosition: prevPosition, kind: kind)
     if let node {
       reusedCallback?(node)
@@ -162,7 +161,7 @@ struct IncrementalParseLookup {
 
     // Fast path check: if parser is past all the edits then any matching node
     // can be re-used.
-    if !edits.edits.isEmpty && edits.edits.last!.range.endOffset < node.position.utf8Offset {
+    if !edits.edits.isEmpty && edits.edits.last!.range.upperBound < node.position {
       return true
     }
 
@@ -172,15 +171,12 @@ struct IncrementalParseLookup {
       return false
     }
 
-    let nodeAffectRange = ByteSourceRange(
-      offset: node.position.utf8Offset,
-      length: nodeAffectRangeLength
-    )
+    let nodeAffectRange = node.position..<node.position.advanced(by: nodeAffectRangeLength)
 
     for edit in edits.edits {
       // Check if this node or the trivia of the next node has been edited. If
       // it has, we cannot reuse it.
-      if edit.range.offset > nodeAffectRange.endOffset {
+      if edit.range.lowerBound > nodeAffectRange.upperBound {
         // Remaining edits don't affect the node. (Edits are sorted)
         break
       }
@@ -192,19 +188,19 @@ struct IncrementalParseLookup {
     return true
   }
 
-  fileprivate func translateToPreEditOffset(_ postEditOffset: Int) -> Int? {
+  fileprivate func translateToPreEditPosition(_ postEditOffset: AbsolutePosition) -> AbsolutePosition? {
     var offset = postEditOffset
     for edit in edits.edits {
-      if edit.range.offset > offset {
+      if edit.range.lowerBound > offset {
         // Remaining edits doesn't affect the position. (Edits are sorted)
         break
       }
-      if edit.range.offset + edit.replacementLength > offset {
+      if edit.range.lowerBound + edit.replacementLength > offset {
         // This is a position inserted by the edit, and thus doesn't exist in
         // the pre-edit version of the file.
         return nil
       }
-      offset = offset - edit.replacementLength + edit.range.length
+      offset = offset + edit.range.length - edit.replacementLength
     }
     return offset
   }
@@ -354,22 +350,30 @@ public struct ConcurrentEdits: Sendable {
       for (index, existingEdit) in concurrentEdits.enumerated() {
         if existingEdit.replacementRange.intersectsOrTouches(editToAdd.range) {
           let intersectionLength =
-            existingEdit.replacementRange.intersected(editToAdd.range).length
+            existingEdit.replacementRange.intersecting(editToAdd.range)?.length ?? SourceLength(utf8Length: 0)
           let replacement: [UInt8]
           replacement =
-            existingEdit.replacement.prefix(max(0, editToAdd.offset - existingEdit.replacementRange.offset))
+            existingEdit.replacement.prefix(
+              max(0, editToAdd.range.lowerBound.utf8Offset - existingEdit.replacementRange.lowerBound.utf8Offset)
+            )
             + editToAdd.replacement
-            + existingEdit.replacement.suffix(max(0, existingEdit.replacementRange.endOffset - editToAdd.endOffset))
+            + existingEdit.replacement.suffix(
+              max(0, existingEdit.replacementRange.upperBound.utf8Offset - editToAdd.range.upperBound.utf8Offset)
+            )
           editToAdd = IncrementalEdit(
-            offset: Swift.min(existingEdit.offset, editToAdd.offset),
-            length: existingEdit.length + editToAdd.length - intersectionLength,
+            range: Range(
+              position: Swift.min(existingEdit.range.lowerBound, editToAdd.range.lowerBound),
+              length: existingEdit.range.length + editToAdd.range.length - intersectionLength
+            ),
             replacement: replacement
           )
           editIndicesMergedWithNewEdit.append(index)
-        } else if existingEdit.offset < editToAdd.endOffset {
+        } else if existingEdit.range.lowerBound < editToAdd.range.upperBound {
           editToAdd = IncrementalEdit(
-            offset: editToAdd.offset - existingEdit.replacementLength + existingEdit.length,
-            length: editToAdd.length,
+            range: Range(
+              position: editToAdd.range.lowerBound + existingEdit.range.length - existingEdit.replacementLength,
+              length: editToAdd.range.length
+            ),
             replacement: editToAdd.replacement
           )
         }
@@ -380,7 +384,7 @@ public struct ConcurrentEdits: Sendable {
       }
       let insertPos =
         concurrentEdits.firstIndex(where: { edit in
-          editToAdd.endOffset <= edit.offset
+          editToAdd.range.upperBound <= edit.range.lowerBound
         }) ?? concurrentEdits.count
       concurrentEdits.insert(editToAdd, at: insertPos)
       precondition(ConcurrentEdits.isValidConcurrentEditArray(concurrentEdits))
@@ -397,7 +401,7 @@ public struct ConcurrentEdits: Sendable {
     for i in 1..<edits.count {
       let prevEdit = edits[i - 1]
       let curEdit = edits[i]
-      if curEdit.range.offset < prevEdit.range.endOffset {
+      if curEdit.range.lowerBound < prevEdit.range.upperBound {
         return false
       }
       if curEdit.intersectsRange(prevEdit.range) {

--- a/Sources/SwiftParser/IncrementalParseTransition.swift
+++ b/Sources/SwiftParser/IncrementalParseTransition.swift
@@ -348,9 +348,9 @@ public struct ConcurrentEdits: Sendable {
       var editToAdd = editToAdd
       var editIndicesMergedWithNewEdit: [Int] = []
       for (index, existingEdit) in concurrentEdits.enumerated() {
-        if existingEdit.replacementRange.intersectsOrTouches(editToAdd.range) {
+        if existingEdit.replacementRange.overlapsOrTouches(editToAdd.range) {
           let intersectionLength =
-            existingEdit.replacementRange.intersecting(editToAdd.range)?.length ?? SourceLength(utf8Length: 0)
+            existingEdit.replacementRange.clamped(to: editToAdd.range).length
           let replacement: [UInt8]
           replacement =
             existingEdit.replacement.prefix(

--- a/Sources/SwiftSyntax/SyntaxProtocol.swift
+++ b/Sources/SwiftSyntax/SyntaxProtocol.swift
@@ -444,19 +444,34 @@ public extension SyntaxProtocol {
   }
 
   /// The byte source range of this node including leading and trailing trivia.
+  @available(*, deprecated, renamed: "range")
   var totalByteRange: ByteSourceRange {
     return ByteSourceRange(offset: position.utf8Offset, length: totalLength.utf8Length)
+  }
+
+  /// The range of this node including leading and trailing trivia.
+  var range: Range<AbsolutePosition> {
+    return position..<endPosition
   }
 
   /// The byte source range of this node excluding leading and trailing trivia.
   ///
   /// - Note: If this node consists of multiple tokens, only the first token’s
   ///   leading and the last token’s trailing trivia will be trimmed.
+  @available(*, deprecated, renamed: "trimmedRange")
   var trimmedByteRange: ByteSourceRange {
     return ByteSourceRange(
       offset: positionAfterSkippingLeadingTrivia.utf8Offset,
       length: trimmedLength.utf8Length
     )
+  }
+
+  /// The range of this node excluding leading and trailing trivia.
+  ///
+  /// - Note: If this node consists of multiple tokens, only the first token’s
+  ///   leading and the last token’s trailing trivia will be trimmed.
+  var trimmedRange: Range<AbsolutePosition> {
+    return positionAfterSkippingLeadingTrivia..<endPositionBeforeTrailingTrivia
   }
 
   @available(*, deprecated, renamed: "trimmedLength")

--- a/Sources/SwiftSyntax/Utils.swift
+++ b/Sources/SwiftSyntax/Utils.swift
@@ -31,7 +31,7 @@ public extension Range<AbsolutePosition> {
   ///
   /// If the intersection is empty, this returns a range starting at offset 0 and having length 0.
   func intersected(_ other: Range<AbsolutePosition>) -> Range<AbsolutePosition> {
-    return self.intersecting(other) ?? AbsolutePosition(utf8Offset: 0)..<AbsolutePosition(utf8Offset: 0)
+    return self.clamped(to: other)
   }
 }
 
@@ -43,13 +43,21 @@ extension Range<AbsolutePosition> {
     self = position..<(position + length)
   }
 
+  // Returns `true` if the intersection between this range and `other` is non-empty or if the two ranges are directly
+  /// adjacent to each other.
+  public func overlapsOrTouches(_ other: Range<AbsolutePosition>) -> Bool {
+    return self.upperBound >= other.lowerBound && self.lowerBound <= other.upperBound
+  }
+
   /// Returns `true` if the intersection between this range and `other` is non-empty or if the two ranges are directly
   /// adjacent to each other.
+  @available(*, deprecated, renamed: "overlapsOrTouches(_:)")
   public func intersectsOrTouches(_ other: Range<AbsolutePosition>) -> Bool {
     return self.upperBound >= other.lowerBound && self.lowerBound <= other.upperBound
   }
 
   /// Returns `true` if the intersection between this range and `other` is non-empty.
+  @available(*, deprecated, renamed: "overlaps(_:)")
   public func intersects(_ other: Range<AbsolutePosition>) -> Bool {
     return self.upperBound > other.lowerBound && self.lowerBound < other.upperBound
   }
@@ -57,6 +65,7 @@ extension Range<AbsolutePosition> {
   /// Returns the range for the overlapping region between two ranges.
   ///
   /// If the intersection is empty, this returns `nil`.
+  @available(*, deprecated, message: "Use clamped(to:) instead")
   public func intersecting(_ other: Range<AbsolutePosition>) -> Range<AbsolutePosition>? {
     let lowerBound = Swift.max(self.lowerBound, other.lowerBound)
     let upperBound = Swift.min(self.upperBound, other.upperBound)
@@ -114,11 +123,11 @@ public struct IncrementalEdit: Equatable, Sendable {
   }
 
   public func intersectsOrTouchesRange(_ other: Range<AbsolutePosition>) -> Bool {
-    return self.range.intersectsOrTouches(other)
+    return self.range.overlapsOrTouches(other)
   }
 
   public func intersectsRange(_ other: Range<AbsolutePosition>) -> Bool {
-    return self.range.intersects(other)
+    return self.range.overlaps(other)
   }
 }
 

--- a/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
+++ b/Sources/_SwiftSyntaxTestSupport/IncrementalParseTestUtils.swift
@@ -99,17 +99,17 @@ public func assertIncrementalParse(
 
   var lastRangeUpperBound = originalString.startIndex
   for expectedReusedNode in expectedReusedNodes {
-    guard let range = byteSourceRange(for: expectedReusedNode.source, in: originalString, after: lastRangeUpperBound)
+    guard let range = positionRange(of: expectedReusedNode.source, in: originalString, after: lastRangeUpperBound)
     else {
       XCTFail("Fail to find string in original source,", file: expectedReusedNode.file, line: expectedReusedNode.line)
       continue
     }
 
-    guard let reusedNode = reusedNodes.first(where: { $0.trimmedByteRange == range }) else {
+    guard let reusedNode = reusedNodes.first(where: { $0.trimmedRange == range }) else {
       XCTFail(
         """
         Fail to match the range of \(expectedReusedNode.source) in:
-        \(reusedNodes.map({"\($0.trimmedByteRange): \($0.description)"}).joined(separator: "\n"))
+        \(reusedNodes.map({"\($0.trimmedRange): \($0.description)"}).joined(separator: "\n"))
         """,
         file: expectedReusedNode.file,
         line: expectedReusedNode.line
@@ -127,16 +127,19 @@ public func assertIncrementalParse(
       line: expectedReusedNode.line
     )
 
-    lastRangeUpperBound = originalString.index(originalString.startIndex, offsetBy: range.endOffset)
+    lastRangeUpperBound = originalString.utf8.index(originalString.startIndex, offsetBy: range.upperBound.utf8Offset)
   }
 }
 
-public func byteSourceRange(for substring: String, in sourceString: String, after: String.Index) -> ByteSourceRange? {
+public func positionRange(
+  of substring: String,
+  in sourceString: String,
+  after: String.Index
+) -> Range<AbsolutePosition>? {
   if let range = sourceString[after...].range(of: substring) {
-    return ByteSourceRange(
-      offset: sourceString.utf8.distance(from: sourceString.startIndex, to: range.lowerBound),
-      length: sourceString.utf8.distance(from: range.lowerBound, to: range.upperBound)
-    )
+    let lowerBound = sourceString.utf8.distance(from: sourceString.startIndex, to: range.lowerBound)
+    let upperBound = sourceString.utf8.distance(from: sourceString.startIndex, to: range.upperBound)
+    return AbsolutePosition(utf8Offset: lowerBound)..<AbsolutePosition(utf8Offset: upperBound)
   }
   return nil
 }
@@ -186,10 +189,9 @@ public func extractEditsAndSources(
 
     originalSource += source[lastStartIndex..<startIndex]
     let edit = IncrementalEdit(
-      offset: originalSource.utf8.count,
-      length: source.utf8.distance(
-        from: source.index(after: startIndex),
-        to: separateIndex
+      range: Range(
+        position: AbsolutePosition(utf8Offset: originalSource.utf8.count),
+        length: SourceLength(utf8Length: source.utf8.distance(from: source.index(after: startIndex), to: separateIndex))
       ),
       replacement: Array(source.utf8[source.index(after: separateIndex)..<endIndex])
     )
@@ -234,9 +236,9 @@ public func applyEdits(
   }
   var bytes = Array(testString.utf8)
   for edit in edits {
-    assert(edit.endOffset <= bytes.count)
-    bytes.removeSubrange(edit.offset..<edit.endOffset)
-    bytes.insert(contentsOf: edit.replacement, at: edit.offset)
+    assert(edit.range.upperBound.utf8Offset <= bytes.count)
+    bytes.removeSubrange(edit.range.lowerBound.utf8Offset..<edit.range.upperBound.utf8Offset)
+    bytes.insert(contentsOf: edit.replacement, at: edit.range.lowerBound.utf8Offset)
   }
   return String(bytes: bytes, encoding: .utf8)!
 }

--- a/Tests/SwiftIDEUtilsTest/Assertions.swift
+++ b/Tests/SwiftIDEUtilsTest/Assertions.swift
@@ -25,7 +25,7 @@ import _SwiftSyntaxTestSupport
 ///   - expected: The element order should respect to the order of  `ClassificationSpec.source` in `source`.
 func assertClassification(
   _ source: String,
-  in range: ByteSourceRange? = nil,
+  in range: Range<AbsolutePosition>? = nil,
   expected: [ClassificationSpec],
   file: StaticString = #filePath,
   line: UInt = #line
@@ -41,12 +41,16 @@ func assertClassification(
   classifications = classifications.filter { $0.kind != .none }
 
   if expected.count != classifications.count {
-    XCTFail("Expected \(expected.count) re-used nodes but received \(classifications.count)", file: file, line: line)
+    XCTFail(
+      "Expected \(expected.count) classifications \(classifications.count): \(classifications)",
+      file: file,
+      line: line
+    )
   }
 
   var lastRangeUpperBound = source.startIndex
   for (classification, spec) in zip(classifications, expected) {
-    guard let range = byteSourceRange(for: spec.source, in: source, after: lastRangeUpperBound) else {
+    guard let range = positionRange(of: spec.source, in: source, after: lastRangeUpperBound) else {
       XCTFail("Fail to find string in original source,", file: spec.file, line: spec.line)
       continue
     }
@@ -71,7 +75,7 @@ func assertClassification(
       line: spec.line
     )
 
-    lastRangeUpperBound = source.utf8.index(source.utf8.startIndex, offsetBy: range.endOffset)
+    lastRangeUpperBound = source.utf8.index(source.utf8.startIndex, offsetBy: range.upperBound.utf8Offset)
   }
 }
 

--- a/Tests/SwiftIDEUtilsTest/ClassificationTests.swift
+++ b/Tests/SwiftIDEUtilsTest/ClassificationTests.swift
@@ -35,7 +35,7 @@ class ClassificationTests: XCTestCase {
 
     assertClassification(
       "x/*yo*/ ",
-      in: ByteSourceRange(offset: 1, length: 6),
+      in: Range(position: AbsolutePosition(utf8Offset: 1), length: SourceLength(utf8Length: 6)),
       expected: [
         ClassificationSpec(source: "x", kind: .identifier),
         ClassificationSpec(source: "/*yo*/", kind: .blockComment),
@@ -49,7 +49,7 @@ class ClassificationTests: XCTestCase {
       // blah.
       let x/*yo*/ = 0
       """,
-      in: ByteSourceRange(offset: 7, length: 8),
+      in: Range(position: AbsolutePosition(utf8Offset: 7), length: SourceLength(utf8Length: 8)),
       expected: [
         ClassificationSpec(source: "// blah.", kind: .lineComment),
         ClassificationSpec(source: "let", kind: .keyword),
@@ -65,21 +65,24 @@ class ClassificationTests: XCTestCase {
       // blah.
       let x/*yo*/ = 0
       """,
-      in: ByteSourceRange(offset: 21, length: 2),
+      in: Range(position: AbsolutePosition(utf8Offset: 21), length: SourceLength(utf8Length: 2)),
       expected: []
     )
   }
 
   public func testClassificationAt() throws {
-    let tree = Parser.parse(source: "func foo() {}")
-    let keyword = try XCTUnwrap(tree.classification(at: 3))
-    let identifier = try XCTUnwrap(tree.classification(at: AbsolutePosition(utf8Offset: 6)))
+    let tree = Parser.parse(source: "func foo /* a */() {}")
 
+    let keyword = try XCTUnwrap(tree.classification(at: AbsolutePosition(utf8Offset: 3)))
     XCTAssertEqual(keyword.kind, .keyword)
-    XCTAssertEqual(keyword.range, ByteSourceRange(offset: 0, length: 4))
+    XCTAssertEqual(keyword.range, Range(position: AbsolutePosition(utf8Offset: 0), length: SourceLength(utf8Length: 4)))
 
+    let identifier = try XCTUnwrap(tree.classification(at: AbsolutePosition(utf8Offset: 6)))
     XCTAssertEqual(identifier.kind, .identifier)
-    XCTAssertEqual(identifier.range, ByteSourceRange(offset: 5, length: 3))
+    XCTAssertEqual(
+      identifier.range,
+      Range(position: AbsolutePosition(utf8Offset: 5), length: SourceLength(utf8Length: 3))
+    )
   }
 
   public func testTokenClassification() {

--- a/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
+++ b/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
@@ -52,7 +52,10 @@ func verifySequentialToConcurrentTranslation(
 
 fileprivate extension IncrementalEdit {
   init(offset: Int, length: Int, replacement: String) {
-    self.init(offset: offset, length: length, replacement: Array(replacement.utf8))
+    self.init(
+      range: Range(position: AbsolutePosition(utf8Offset: offset), length: SourceLength(utf8Length: length)),
+      replacement: Array(replacement.utf8)
+    )
   }
 }
 
@@ -344,7 +347,7 @@ final class TranslateSequentialToConcurrentEditsTests: ParserTestCase {
           IncrementalEdit(
             offset: Int.random(in: 0..<32),
             length: Int.random(in: 0..<32),
-            replacement: replacementBytes
+            replacement: String(data: Data(replacementBytes), encoding: .ascii)!
           )
         )
       }

--- a/Tests/SwiftSyntaxTestSupportTest/IncrementalParseTestUtilsTest.swift
+++ b/Tests/SwiftSyntaxTestSupportTest/IncrementalParseTestUtilsTest.swift
@@ -32,9 +32,18 @@ class IncrementalParseUtilTest: XCTestCase {
     XCTAssertEqual(
       concurrentEdits.edits,
       [
-        IncrementalEdit(offset: 0, length: 5, replacement: "struct"),
-        IncrementalEdit(offset: 27, length: 0, replacement: "let bar = 10"),
-        IncrementalEdit(offset: 35, length: 13, replacement: ""),
+        IncrementalEdit(
+          range: Range(position: AbsolutePosition(utf8Offset: 0), length: SourceLength(utf8Length: 5)),
+          replacement: "struct"
+        ),
+        IncrementalEdit(
+          range: Range(position: AbsolutePosition(utf8Offset: 27), length: SourceLength(utf8Length: 0)),
+          replacement: "let bar = 10"
+        ),
+        IncrementalEdit(
+          range: Range(position: AbsolutePosition(utf8Offset: 35), length: SourceLength(utf8Length: 13)),
+          replacement: ""
+        ),
       ]
     )
 
@@ -64,7 +73,10 @@ class IncrementalParseUtilTest: XCTestCase {
     XCTAssertEqual(
       concurrentEdits.edits,
       [
-        IncrementalEdit(offset: 0, length: 25, replacement: "🎉")
+        IncrementalEdit(
+          range: Range(position: AbsolutePosition(utf8Offset: 0), length: SourceLength(utf8Length: 25)),
+          replacement: "🎉"
+        )
       ]
     )
   }
@@ -79,7 +91,10 @@ class IncrementalParseUtilTest: XCTestCase {
     XCTAssertEqual(
       concurrentEdits.edits,
       [
-        IncrementalEdit(offset: 0, length: 1, replacement: "👨‍👩‍👧‍👦")
+        IncrementalEdit(
+          range: Range(position: AbsolutePosition(utf8Offset: 0), length: SourceLength(utf8Length: 1)),
+          replacement: "👨‍👩‍👧‍👦"
+        )
       ]
     )
   }


### PR DESCRIPTION
While being a little more verbose, this has a few advantages:
- We only have a single type to represent ranges in SwiftSyntax instead of `Range<AbsolutePosition>` and `ByteSourceRange`, both of which we needed to use in sourcekit-lsp
- Unifying the convenience functions on the two results in a single type that has all the convenience functions, instead of spreading them to two distinct sets
- The use of `AbsolutePosition` and `SourceLength` makes type-system guarantees that these are UTF-8 byte positions / length, making it harder to accidentally add eg. UTF-16 lengths with UTF-8 lengths.

rdar://125624626