### PR TITLE
Don’t add a space between `private` and `(`

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -322,6 +322,7 @@ open class BasicFormat: SyntaxRewriter {
       (.keyword(.Any), .period),  // Any.Type
       (.keyword(.`init`), .leftAngle),  // init<T>()
       (.keyword(.`init`), .leftParen),  // init()
+      (.keyword(.private), .leftParen),  // private(set)
       (.keyword(.self), .period),  // self.someProperty
       (.keyword(.self), .leftParen),  // self()
       (.keyword(.self), .leftSquare),  // self[]

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -645,4 +645,12 @@ final class BasicFormatTest: XCTestCase {
       """
     assertFormatted(source: source, expected: source)
   }
+
+  func testPrivateSetVar() {
+    let source = """
+      private(set) var x = 1
+      """
+
+    assertFormatted(source: source, expected: source)
+  }
 }


### PR DESCRIPTION
rdar://124569733