### PR TITLE
[6.0] Don’t add a space between `private` and `(`

### DIFF
--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -322,6 +322,7 @@ open class BasicFormat: SyntaxRewriter {
       (.keyword(.Any), .period),  // Any.Type
       (.keyword(.`init`), .leftAngle),  // init<T>()
       (.keyword(.`init`), .leftParen),  // init()
+      (.keyword(.private), .leftParen),  // private(set)
       (.keyword(.self), .period),  // self.someProperty
       (.keyword(.self), .leftParen),  // self()
       (.keyword(.self), .leftSquare),  // self[]

--- a/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
+++ b/Tests/SwiftBasicFormatTest/BasicFormatTests.swift
@@ -645,4 +645,12 @@ final class BasicFormatTest: XCTestCase {
       """
     assertFormatted(source: source, expected: source)
   }
+
+  func testPrivateSetVar() {
+    let source = """
+      private(set) var x = 1
+      """
+
+    assertFormatted(source: source, expected: source)
+  }
 }


### PR DESCRIPTION
* **Explanation**: BasicFormat was adding a space between `private` and `(` in `private(set)`, which started raising a warning with recent compilers: Extraneous whitespace between attribute name and '('; this is an error in Swift 6
* **Scope**: Formatting of `private(set)`
* **Risk**: Very low, very targeted fix
* **Testing**: Added a test case 
* **Issue**: rdar://124569733
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/2590