### PR TITLE
Make `SyntaxIndexInTree` public and serializable into a `UInt64`

### DIFF
--- a/Release Notes/600.md
+++ b/Release Notes/600.md
@@ -75,6 +75,22 @@
   - Description: With the change to parse `#if canImport(MyModule, _version: 1.2.3)` as a function call instead of a dedicated syntax node, `1.2.3` natively gets parsed as a member access `3` to the `1.2` float literal. This property allows the reinterpretation of such an expression as a version tuple.
   - Pull request: https://github.com/apple/swift-syntax/pull/2025
 
+- `SyntaxProtocol.node(at:)` 
+  - Description: Given a `SyntaxIdentifier`, returns the `Syntax` node with that identifier
+  - Pull request: https://github.com/apple/swift-syntax/pull/2594
+
+- `SyntaxIdentifier.IndexInTree`
+  - Description: Uniquely identifies a syntax node within a tree. This is similar to ``SyntaxIdentifier`` but does not store the root ID of the tree. It can thus be transferred across trees that are structurally equivalent, for example two copies of the same tree that live in different processes. The only public functions on this type are `toOpaque` and `init(fromOpaque:)`, which allow serialization of the `IndexInTree`.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2594
+  
+- `SyntaxIdentifier` conformance to `Comparable`:
+  - Description: A `SyntaxIdentifier` compares less than another `SyntaxIdentifier` if the node at that identifier occurs first during a depth-first traversal of the tree.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2594
+
+- `SyntaxIdentifier.indexInTree` and `SyntaxIdentifier.fromIndexInTree` 
+  - Description: `SyntaxIdentifier.indexInTree` allows the retrieval of a `SyntaxIdentifier` that identifies the syntax node independent of the syntax tree. `SyntaxIdentifier.fromIndexInTree` allows the creation for a `SyntaxIdentifier` from a tree-agnostic `SyntaxIdentifier.IndexInTree` and the tree's root node.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2594
+
 ## API Behavior Changes
 
 ## Deprecations

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -13,11 +13,11 @@
 #if swift(>=6)
 public import SwiftDiagnostics
 @_spi(Diagnostics) import SwiftParser
-@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) public import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) public import SwiftSyntax
 #else
 import SwiftDiagnostics
 @_spi(Diagnostics) import SwiftParser
-@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 #endif
 
 fileprivate func getTokens(between first: TokenSyntax, and second: TokenSyntax) -> [TokenSyntax] {
@@ -119,7 +119,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
         return false
       } else {
         // If multiple tokens are missing at the same location, emit diagnostics about nodes that occur earlier in the tree first.
-        return $0.node.id.indexInTree < $1.node.id.indexInTree
+        return $0.node.id < $1.node.id
       }
     }
     return diagProducer.diagnostics

--- a/Sources/SwiftSyntax/CommonAncestor.swift
+++ b/Sources/SwiftSyntax/CommonAncestor.swift
@@ -18,11 +18,11 @@ public func findCommonAncestorOrSelf(_ lhs: Syntax, _ rhs: Syntax) -> Syntax? {
     if lhs == rhs {
       return lhs
     }
-    if let lhsIndex = lhs?.indexInParent.data?.indexInTree, let rhsIndex = rhs?.indexInParent.data?.indexInTree {
-      if lhsIndex < rhsIndex {
-        rhs = rhs?.parent
+    if let lhsUnwrapped = lhs, let rhsUnwrapped = rhs {
+      if lhsUnwrapped.id < rhsUnwrapped.id {
+        rhs = rhsUnwrapped.parent
       } else {
-        lhs = lhs?.parent
+        lhs = lhsUnwrapped.parent
       }
     }
   }

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -22,8 +22,8 @@ struct SyntaxChildrenIndexData: Hashable, Comparable, Sendable {
   /// See `AbsoluteSyntaxPosition.indexInParent`
   let indexInParent: UInt32
   /// Unique value for a node within its own tree.
-  /// See `SyntaxIdentifier.indexIntree`
-  let indexInTree: SyntaxIndexInTree
+  /// See ``SyntaxIdentifier/indexInTree``
+  let indexInTree: SyntaxIdentifier.SyntaxIndexInTree
 
   static func < (
     lhs: SyntaxChildrenIndexData,
@@ -35,7 +35,7 @@ struct SyntaxChildrenIndexData: Hashable, Comparable, Sendable {
   fileprivate init(
     offset: UInt32,
     indexInParent: UInt32,
-    indexInTree: SyntaxIndexInTree
+    indexInTree: SyntaxIdentifier.SyntaxIndexInTree
   ) {
     self.offset = offset
     self.indexInParent = indexInParent
@@ -72,7 +72,7 @@ public struct SyntaxChildrenIndex: Hashable, Comparable, ExpressibleByNilLiteral
   fileprivate init(
     offset: UInt32,
     indexInParent: UInt32,
-    indexInTree: SyntaxIndexInTree
+    indexInTree: SyntaxIdentifier.SyntaxIndexInTree
   ) {
     self.data = SyntaxChildrenIndexData(
       offset: offset,
@@ -222,7 +222,7 @@ struct RawSyntaxChildren: BidirectionalCollection, Sendable {
       let offset = startIndex.offset + UInt32(parent.totalLength.utf8Length)
       let indexInParent = startIndex.indexInParent + UInt32(parentLayoutView.children.count)
       let indexInTree = startIndex.indexInTree.indexInTree + UInt32(parent.totalNodes) - 1
-      let syntaxIndexInTree = SyntaxIndexInTree(indexInTree: indexInTree)
+      let syntaxIndexInTree = SyntaxIdentifier.SyntaxIndexInTree(indexInTree: indexInTree)
       let materialized = SyntaxChildrenIndex(
         offset: offset,
         indexInParent: indexInParent,

--- a/Sources/SwiftSyntax/SyntaxProtocol.swift
+++ b/Sources/SwiftSyntax/SyntaxProtocol.swift
@@ -352,6 +352,28 @@ public extension SyntaxProtocol {
 
     fatalError("Children of syntax node do not cover all positions in it")
   }
+
+  /// If the node with the given `syntaxIdentifier` is a (recursive) child of this node, return the node with that
+  /// identifier.
+  ///
+  /// If the identifier references a node from a different tree (ie. one that has a different root ID in the
+  /// ``SyntaxIdentifier``) or if no node with the given identifier is a child of this syntax node, returns `nil`.
+  func node(at syntaxIdentifier: SyntaxIdentifier) -> Syntax? {
+    guard self.id <= syntaxIdentifier && syntaxIdentifier < self.id.advancedBySibling(self.raw) else {
+      // The syntax identifier is not part of this tree.
+      return nil
+    }
+    if self.id == syntaxIdentifier {
+      return Syntax(self)
+    }
+    for child in children(viewMode: .all) {
+      if let node = child.node(at: syntaxIdentifier) {
+        return node
+      }
+    }
+
+    preconditionFailure("syntaxIdentifier is covered by this node but not any of its children?")
+  }
 }
 
 // MARK: Recursive flags


### PR DESCRIPTION
If you have two copies of the same syntax tree within two processes, this allows us to communicate the identifier of a node in one process the the equivalent node in the other process.

rdar://126221355