### PR TITLE
[6.0] Enable `borrowingSwitch` syntax.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -19,7 +19,6 @@ public struct KeywordSpec {
   /// The experimental feature the keyword is part of, or `nil` if this isn't
   /// for an experimental feature.
   public let experimentalFeature: ExperimentalFeature?
-  public let experimentalFeature2: ExperimentalFeature?
 
   /// Indicates if the token kind is switched from being an identifier to a keyword in the lexer.
   public let isLexerClassified: Bool
@@ -69,26 +68,6 @@ public struct KeywordSpec {
   ) {
     self.name = name
     self.experimentalFeature = experimentalFeature
-    self.experimentalFeature2 = nil
-    self.isLexerClassified = isLexerClassified
-  }
-
-  /// Initializes a new `KeywordSpec` instance.
-  ///
-  /// - Parameters:
-  ///   - name: A name of the keyword.
-  ///   - experimentalFeature: The experimental feature the keyword is part of, or `nil` if this isn't for an experimental feature.
-  ///   - or: A second experimental feature the keyword is also part of, or `nil` if this isn't for an experimental feature.
-  ///   - isLexerClassified: Indicates if the token kind is switched from being an identifier to a keyword in the lexer.
-  init(
-    _ name: String,
-    experimentalFeature: ExperimentalFeature,
-    or experimentalFeature2: ExperimentalFeature,
-    isLexerClassified: Bool = false
-  ) {
-    self.name = name
-    self.experimentalFeature = experimentalFeature
-    self.experimentalFeature2 = experimentalFeature2
     self.isLexerClassified = isLexerClassified
   }
 }
@@ -340,7 +319,7 @@ public enum Keyword: CaseIterable {
     case ._borrow:
       return KeywordSpec("_borrow")
     case ._borrowing:
-      return KeywordSpec("_borrowing", experimentalFeature: .referenceBindings, or: .borrowingSwitch)
+      return KeywordSpec("_borrowing")
     case ._BridgeObject:
       return KeywordSpec("_BridgeObject")
     case ._cdecl:

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ParserTokenSpecSetFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/ParserTokenSpecSetFile.swift
@@ -17,15 +17,11 @@ import Utils
 
 func tokenCaseMatch(
   _ caseName: TokenSyntax,
-  experimentalFeature: ExperimentalFeature?,
-  experimentalFeature2: ExperimentalFeature?
+  experimentalFeature: ExperimentalFeature?
 ) -> SwitchCaseSyntax {
   var whereClause = ""
   if let feature = experimentalFeature {
     whereClause += "where experimentalFeatures.contains(.\(feature.token))"
-    if let feature2 = experimentalFeature2 {
-      whereClause += " || experimentalFeatures.contains(.\(feature2.token))"
-    }
   }
   return "case TokenSpec(.\(caseName))\(raw: whereClause): self = .\(caseName)"
 }
@@ -74,14 +70,12 @@ let parserTokenSpecSetFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                   case .keyword(let keyword):
                     tokenCaseMatch(
                       keyword.spec.varOrCaseName,
-                      experimentalFeature: keyword.spec.experimentalFeature,
-                      experimentalFeature2: keyword.spec.experimentalFeature2
+                      experimentalFeature: keyword.spec.experimentalFeature
                     )
                   case .token(let token):
                     tokenCaseMatch(
                       token.spec.varOrCaseName,
-                      experimentalFeature: token.spec.experimentalFeature,
-                      experimentalFeature2: nil
+                      experimentalFeature: token.spec.experimentalFeature
                     )
                   }
                 }

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -272,8 +272,7 @@ extension Parser.Lookahead {
     // TODO: the other ownership modifiers (borrowing/consuming/mutating) more
     // than likely need to be made contextual as well before finalizing their
     // grammar.
-    case ._borrowing where experimentalFeatures.contains(.borrowingSwitch),
-      .borrowing where experimentalFeatures.contains(.borrowingSwitch):
+    case ._borrowing, .borrowing:
       return peek(isAt: TokenSpec(.identifier, allowAtStartOfLine: false))
     default:
       // Other keywords can be parsed unconditionally.

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -2915,9 +2915,6 @@ extension OptionalBindingConditionSyntax {
     @_spi(ExperimentalLanguageFeatures)
     #endif
     case _mutating
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _borrowing
     #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
@@ -2934,7 +2931,7 @@ extension OptionalBindingConditionSyntax {
         self = .inout
       case TokenSpec(._mutating) where experimentalFeatures.contains(.referenceBindings):
         self = ._mutating
-      case TokenSpec(._borrowing) where experimentalFeatures.contains(.referenceBindings) || experimentalFeatures.contains(.borrowingSwitch):
+      case TokenSpec(._borrowing):
         self = ._borrowing
       case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
         self = ._consuming
@@ -3897,9 +3894,6 @@ extension ValueBindingPatternSyntax {
     @_spi(ExperimentalLanguageFeatures)
     #endif
     case _mutating
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _borrowing
     #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
@@ -3917,7 +3911,7 @@ extension ValueBindingPatternSyntax {
         self = .inout
       case TokenSpec(._mutating) where experimentalFeatures.contains(.referenceBindings):
         self = ._mutating
-      case TokenSpec(._borrowing) where experimentalFeatures.contains(.referenceBindings) || experimentalFeatures.contains(.borrowingSwitch):
+      case TokenSpec(._borrowing):
         self = ._borrowing
       case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
         self = ._consuming
@@ -4003,9 +3997,6 @@ extension VariableDeclSyntax {
     @_spi(ExperimentalLanguageFeatures)
     #endif
     case _mutating
-    #if compiler(>=5.8)
-    @_spi(ExperimentalLanguageFeatures)
-    #endif
     case _borrowing
     #if compiler(>=5.8)
     @_spi(ExperimentalLanguageFeatures)
@@ -4022,7 +4013,7 @@ extension VariableDeclSyntax {
         self = .inout
       case TokenSpec(._mutating) where experimentalFeatures.contains(.referenceBindings):
         self = ._mutating
-      case TokenSpec(._borrowing) where experimentalFeatures.contains(.referenceBindings) || experimentalFeatures.contains(.borrowingSwitch):
+      case TokenSpec(._borrowing):
         self = ._borrowing
       case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
         self = ._consuming

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -20,9 +20,6 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case _alignment
   case _backDeploy
   case _borrow
-  #if compiler(>=5.8)
-  @_spi(ExperimentalLanguageFeatures)
-  #endif
   case _borrowing
   case _BridgeObject
   case _cdecl

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -616,8 +616,7 @@ final class MatchingPatternsTests: ParserTestCase {
         break
       }
       """,
-      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing"))),
-      experimentalFeatures: .borrowingSwitch
+      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing")))
     )
 
     assertParse(
@@ -627,8 +626,7 @@ final class MatchingPatternsTests: ParserTestCase {
         break
       }
       """,
-      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing"))),
-      experimentalFeatures: .borrowingSwitch
+      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing")))
     )
 
     assertParse(
@@ -692,8 +690,7 @@ final class MatchingPatternsTests: ParserTestCase {
           bindingSpecifier: .keyword(.let),
           pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("borrowing")))
         )
-      ),
-      experimentalFeatures: .borrowingSwitch
+      )
     )
     assertParse(
       """
@@ -702,8 +699,7 @@ final class MatchingPatternsTests: ParserTestCase {
         break
       }
       """,
-      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing"))),
-      experimentalFeatures: .borrowingSwitch
+      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing")))
     )
     assertParse(
       """
@@ -717,8 +713,7 @@ final class MatchingPatternsTests: ParserTestCase {
           bindingSpecifier: .keyword(.let),
           pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("borrowing")))
         )
-      ),
-      experimentalFeatures: .borrowingSwitch
+      )
     )
     assertParse(
       """
@@ -727,8 +722,7 @@ final class MatchingPatternsTests: ParserTestCase {
         break
       }
       """,
-      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing"))),
-      experimentalFeatures: .borrowingSwitch
+      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing")))
     )
   }
 }


### PR DESCRIPTION
Explanation: Promotes noncopyable `switch` statements to an upcoming feature, and removes the remaining conditional logic guarding the new functionality.
Scope: New feature enablement.
Issue: rdar://128145071
Original PR: https://github.com/apple/swift-syntax/pull/2596
Risk: Low. We have a number of adopters who have been using the compiler with this feature enabled already with no problems; this change only removes the conditional enablement logic.
Testing: Swift CI, compatibility suite
Reviewer: @ahoppen 