### PR TITLE
[6.0] Allow `borrowing` without underscore in pattern matches.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/PatternNodes.swift
@@ -201,6 +201,7 @@ public let PATTERN_NODES: [Node] = [
         kind: .token(choices: [
           .keyword(.let), .keyword(.var), .keyword(.inout),
           .keyword(._mutating), .keyword(._borrowing), .keyword(._consuming),
+          .keyword(.borrowing),
         ])
       ),
       Child(

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -268,7 +268,8 @@ extension Parser.Lookahead {
     // TODO: the other ownership modifiers (borrowing/consuming/mutating) more
     // than likely need to be made contextual as well before finalizing their
     // grammar.
-    case ._borrowing where experimentalFeatures.contains(.borrowingSwitch):
+    case ._borrowing where experimentalFeatures.contains(.borrowingSwitch),
+      .borrowing where experimentalFeatures.contains(.borrowingSwitch):
       return peek(isAt: TokenSpec(.identifier, allowAtStartOfLine: false))
     default:
       // Other keywords can be parsed unconditionally.

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -3905,6 +3905,7 @@ extension ValueBindingPatternSyntax {
     @_spi(ExperimentalLanguageFeatures)
     #endif
     case _consuming
+    case borrowing
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
@@ -3920,6 +3921,8 @@ extension ValueBindingPatternSyntax {
         self = ._borrowing
       case TokenSpec(._consuming) where experimentalFeatures.contains(.referenceBindings):
         self = ._consuming
+      case TokenSpec(.borrowing):
+        self = .borrowing
       default:
         return nil
       }
@@ -3939,6 +3942,8 @@ extension ValueBindingPatternSyntax {
         self = ._borrowing
       case TokenSpec(._consuming):
         self = ._consuming
+      case TokenSpec(.borrowing):
+        self = .borrowing
       default:
         return nil
       }
@@ -3958,6 +3963,8 @@ extension ValueBindingPatternSyntax {
         return .keyword(._borrowing)
       case ._consuming:
         return .keyword(._consuming)
+      case .borrowing:
+        return .keyword(.borrowing)
       }
     }
     
@@ -3979,6 +3986,8 @@ extension ValueBindingPatternSyntax {
         return .keyword(._borrowing)
       case ._consuming:
         return .keyword(._consuming)
+      case .borrowing:
+        return .keyword(.borrowing)
       }
     }
   }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2706,7 +2706,8 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("inout"), 
             .keyword("_mutating"), 
             .keyword("_borrowing"), 
-            .keyword("_consuming")
+            .keyword("_consuming"), 
+            .keyword("borrowing")
           ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawPatternSyntax.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
@@ -3256,7 +3256,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable, _
 
 /// ### Children
 /// 
-///  - `bindingSpecifier`: (`let` | `var` | `inout` | `_mutating` | `_borrowing` | `_consuming`)
+///  - `bindingSpecifier`: (`let` | `var` | `inout` | `_mutating` | `_borrowing` | `_consuming` | `borrowing`)
 ///  - `pattern`: ``PatternSyntax``
 public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, _LeafPatternSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
@@ -3327,6 +3327,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable, 
   ///  - `_mutating`
   ///  - `_borrowing`
   ///  - `_consuming`
+  ///  - `borrowing`
   public var bindingSpecifier: TokenSyntax {
     get {
       return Syntax(self).child(at: 1)!.cast(TokenSyntax.self)

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -612,67 +612,65 @@ final class MatchingPatternsTests: ParserTestCase {
     assertParse(
       """
       switch 42 {
-      case _borrowing .foo(): // parses as `_borrowing.foo()` as before
+      case borrowing .foo(): // parses as `borrowing.foo()` as before
         break
       }
       """,
-      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("_borrowing"))),
+      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing"))),
       experimentalFeatures: .borrowingSwitch
     )
 
     assertParse(
       """
       switch 42 {
-      case _borrowing (): // parses as `_borrowing()` as before
+      case borrowing (): // parses as `borrowing()` as before
         break
       }
       """,
-      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("_borrowing"))),
+      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing"))),
       experimentalFeatures: .borrowingSwitch
     )
 
     assertParse(
       """
       switch 42 {
-      case _borrowing x: // parses as binding
+      case borrowing x: // parses as binding
         break
       }
       """,
       substructure: PatternSyntax(
         ValueBindingPatternSyntax(
-          bindingSpecifier: .keyword(._borrowing),
+          bindingSpecifier: .keyword(.borrowing),
           pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("x")))
         )
-      ),
-      experimentalFeatures: .borrowingSwitch
+      )
     )
 
     assertParse(
       """
       switch bar {
-      case .payload(_borrowing x): // parses as binding
+      case .payload(borrowing x): // parses as binding
         break
       }
       """,
       substructure: PatternSyntax(
         ValueBindingPatternSyntax(
-          bindingSpecifier: .keyword(._borrowing),
+          bindingSpecifier: .keyword(.borrowing),
           pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("x")))
         )
-      ),
-      experimentalFeatures: .borrowingSwitch
+      )
     )
 
     assertParse(
       """
       switch bar {
-      case _borrowing x.member: // parses as var introducer surrounding postfix expression (which never is valid)
+      case borrowing x.member: // parses as var introducer surrounding postfix expression (which never is valid)
         break
       }
       """,
       substructure: PatternSyntax(
         ValueBindingPatternSyntax(
-          bindingSpecifier: .keyword(._borrowing),
+          bindingSpecifier: .keyword(.borrowing),
           pattern: ExpressionPatternSyntax(
             expression: MemberAccessExprSyntax(
               base: DeclReferenceExprSyntax(baseName: .identifier("x")),
@@ -680,20 +678,19 @@ final class MatchingPatternsTests: ParserTestCase {
             )
           )
         )
-      ),
-      experimentalFeatures: .borrowingSwitch
+      )
     )
     assertParse(
       """
       switch 42 {
-      case let _borrowing: // parses as let binding named '_borrowing'
+      case let borrowing: // parses as let binding named 'borrowing'
         break
       }
       """,
       substructure: PatternSyntax(
         ValueBindingPatternSyntax(
           bindingSpecifier: .keyword(.let),
-          pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("_borrowing")))
+          pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("borrowing")))
         )
       ),
       experimentalFeatures: .borrowingSwitch
@@ -701,24 +698,24 @@ final class MatchingPatternsTests: ParserTestCase {
     assertParse(
       """
       switch 42 {
-      case _borrowing + _borrowing: // parses as expr pattern
+      case borrowing + borrowing: // parses as expr pattern
         break
       }
       """,
-      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("_borrowing"))),
+      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing"))),
       experimentalFeatures: .borrowingSwitch
     )
     assertParse(
       """
       switch 42 {
-      case _borrowing(let _borrowing): // parses as let binding named '_borrowing' inside a case pattern named 'borrowing'
+      case borrowing(let borrowing): // parses as let binding named 'borrowing' inside a case pattern named 'borrowing'
         break
       }
       """,
       substructure: PatternSyntax(
         ValueBindingPatternSyntax(
           bindingSpecifier: .keyword(.let),
-          pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("_borrowing")))
+          pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("borrowing")))
         )
       ),
       experimentalFeatures: .borrowingSwitch
@@ -726,11 +723,11 @@ final class MatchingPatternsTests: ParserTestCase {
     assertParse(
       """
       switch 42 {
-      case {}(_borrowing + _borrowing): // parses as expr pattern
+      case {}(borrowing + borrowing): // parses as expr pattern
         break
       }
       """,
-      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("_borrowing"))),
+      substructure: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("borrowing"))),
       experimentalFeatures: .borrowingSwitch
     )
   }


### PR DESCRIPTION
Explanation: Allows `borrowing x` in addition to `_borrowing x` in pattern matches when the `BorrowingSwitch` experimental feature flag is enabled.
Scope: New feature enablement
Issue: rdar://126305009
Original PR: https://github.com/apple/swift-syntax/pull/2599
Risk: Low. The new syntax is enabled in a way that should keep the keyword usage contextual so that existing code does not break.
Testing: Swift CI, compatibility test suite
Reviewer: @ahoppen 

