### PR TITLE
[6.0][bazel] Improve bazel support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,4 +5,12 @@ common --lockfile_mode=off
 build --features=swift.use_explicit_swift_module_map
 build --host_features=swift.use_explicit_swift_module_map
 
+# Improved build performance
+build --host_swiftcopt=-whole-module-optimization
+build --swiftcopt=-whole-module-optimization
+
+# Keep in sync with Package.swift
+build --host_macos_minimum_os=10.15
+build --macos_minimum_os=10.15
+
 test --test_output=errors

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,34 +1,21 @@
-load("//utils/bazel:swift_syntax_library.bzl", "swift_syntax_library")
+load("@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl", "ios_xctestrun_runner")
+load("//utils/bazel:swift_syntax_library.bzl", "swift_syntax_library", "swift_syntax_test")
 
 package(default_visibility = ["//visibility:public"])
-
-cc_library(
-    name = "_AtomicBool",
-    srcs = glob(["Sources/_AtomicBool/src/*.c"]),
-    hdrs = glob(["Sources/_AtomicBool/include/*.h"]),
-    includes = ["Sources/_AtomicBool/include"],
-    tags = ["swift_module=_AtomicBool"],
-)
-
-swift_syntax_library(
-    name = "SwiftIDEUtils",
-    deps = [
-        ":SwiftParser",
-        ":SwiftSyntax",
-    ],
-)
-
-swift_syntax_library(
-    name = "SwiftSyntax",
-    deps = [
-        ":_AtomicBool",
-    ],
-)
 
 swift_syntax_library(
     name = "SwiftBasicFormat",
     deps = [
         ":SwiftSyntax",
+    ],
+)
+
+swift_syntax_test(
+    name = "SwiftBasicFormatTest",
+    deps = [
+        ":SwiftBasicFormat",
+        ":SwiftSyntaxBuilder",
+        ":_SwiftSyntaxTestSupport",
     ],
 )
 
@@ -46,17 +33,16 @@ swift_syntax_library(
         ":SwiftDiagnostics",
         ":SwiftOperators",
         ":SwiftParser",
+        ":SwiftSyntax",
         ":SwiftSyntaxMacroExpansion",
         ":SwiftSyntaxMacros",
     ],
 )
 
-swift_syntax_library(
-    name = "SwiftSyntaxMacroExpansion",
+swift_syntax_test(
+    name = "SwiftCompilerPluginTest",
     deps = [
-        ":SwiftOperators",
-        ":SwiftSyntax",
-        ":SwiftSyntaxMacros",
+        ":SwiftCompilerPlugin",
     ],
 )
 
@@ -67,21 +53,56 @@ swift_syntax_library(
     ],
 )
 
+swift_syntax_test(
+    name = "SwiftDiagnosticsTest",
+    deps = [
+        ":SwiftDiagnostics",
+        ":SwiftParser",
+        ":SwiftParserDiagnostics",
+        ":_SwiftSyntaxTestSupport",
+    ],
+)
+
 swift_syntax_library(
-    name = "SwiftSyntaxMacros",
+    name = "SwiftIDEUtils",
     deps = [
         ":SwiftDiagnostics",
         ":SwiftParser",
         ":SwiftSyntax",
-        ":SwiftSyntaxBuilder",
+    ],
+)
+
+swift_syntax_test(
+    name = "SwiftIDEUtilsTest",
+    deps = [
+        ":SwiftIDEUtils",
+        ":SwiftParser",
+        ":SwiftSyntax",
+        ":_SwiftSyntaxTestSupport",
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftOperators",
+    deps = [
+        ":SwiftDiagnostics",
+        ":SwiftParser",
+        ":SwiftSyntax",
+    ],
+)
+
+swift_syntax_test(
+    name = "SwiftOperatorsTest",
+    deps = [
+        ":SwiftOperators",
+        ":SwiftParser",
+        ":_SwiftSyntaxTestSupport",
     ],
 )
 
 swift_syntax_library(
     name = "SwiftParser",
     deps = [
-        ":SwiftBasicFormat",
-        ":SwiftDiagnostics",
         ":SwiftSyntax",
     ],
 )
@@ -96,28 +117,124 @@ swift_syntax_library(
     ],
 )
 
-swift_syntax_library(
-    name = "SwiftSyntaxBuilder",
+swift_syntax_test(
+    name = "SwiftParserDiagnosticsTest",
     deps = [
-        ":SwiftBasicFormat",
-        ":SwiftParser",
+        ":SwiftDiagnostics",
         ":SwiftParserDiagnostics",
-        ":SwiftSyntax",
     ],
 )
 
-swift_syntax_library(
-    name = "SwiftOperators",
+swift_syntax_test(
+    name = "SwiftParserTest",
     deps = [
         ":SwiftDiagnostics",
+        ":SwiftIDEUtils",
+        ":SwiftOperators",
         ":SwiftParser",
-        ":SwiftSyntax",
+        ":SwiftSyntaxBuilder",
+        ":_SwiftSyntaxTestSupport",
     ],
 )
 
 swift_syntax_library(
     name = "SwiftRefactor",
     deps = [
+        ":SwiftBasicFormat",
+        ":SwiftParser",
+        ":SwiftSyntax",
+        ":SwiftSyntaxBuilder",
+    ],
+)
+
+swift_syntax_test(
+    name = "SwiftRefactorTest",
+    deps = [
+        ":SwiftRefactor",
+        ":_SwiftSyntaxTestSupport",
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntax",
+    deps = [
+        ":SwiftSyntax509",
+        ":SwiftSyntax510",
+        ":SwiftSyntax600",
+        ":_AtomicBool",
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntax509",
+    srcs = glob(["Sources/VersionMarkerModules/SwiftSyntax509/**/*.swift"]),
+    deps = [
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntax510",
+    srcs = glob(["Sources/VersionMarkerModules/SwiftSyntax510/**/*.swift"]),
+    deps = [
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntax600",
+    srcs = glob(["Sources/VersionMarkerModules/SwiftSyntax600/**/*.swift"]),
+    deps = [
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntaxBuilder",
+    deps = [
+        ":SwiftBasicFormat",
+        ":SwiftDiagnostics",
+        ":SwiftParser",
+        ":SwiftParserDiagnostics",
+        ":SwiftSyntax",
+    ],
+)
+
+swift_syntax_test(
+    name = "SwiftSyntaxBuilderTest",
+    deps = [
+        ":SwiftSyntaxBuilder",
+        ":_SwiftSyntaxTestSupport",
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntaxMacroExpansion",
+    deps = [
+        ":SwiftDiagnostics",
+        ":SwiftOperators",
+        ":SwiftSyntax",
+        ":SwiftSyntaxBuilder",
+        ":SwiftSyntaxMacros",
+    ],
+)
+
+swift_syntax_test(
+    name = "SwiftSyntaxMacroExpansionTest",
+    deps = [
+        ":SwiftDiagnostics",
+        ":SwiftOperators",
+        ":SwiftParser",
+        ":SwiftSyntax",
+        ":SwiftSyntaxBuilder",
+        ":SwiftSyntaxMacroExpansion",
+        ":SwiftSyntaxMacros",
+        ":SwiftSyntaxMacrosTestSupport",
+        ":_SwiftSyntaxTestSupport",
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntaxMacros",
+    deps = [
+        ":SwiftDiagnostics",
         ":SwiftParser",
         ":SwiftSyntax",
         ":SwiftSyntaxBuilder",
@@ -129,11 +246,57 @@ swift_syntax_library(
     testonly = True,
     deps = [
         ":SwiftDiagnostics",
+        ":SwiftIDEUtils",
         ":SwiftParser",
         ":SwiftSyntaxMacroExpansion",
         ":SwiftSyntaxMacros",
         ":_SwiftSyntaxTestSupport",
     ],
+)
+
+swift_syntax_test(
+    name = "SwiftSyntaxMacrosTestSupportTests",
+    deps = [
+        ":SwiftDiagnostics",
+        ":SwiftSyntax",
+        ":SwiftSyntaxMacros",
+        ":SwiftSyntaxMacrosTestSupport",
+    ],
+)
+
+swift_syntax_test(
+    name = "SwiftSyntaxTest",
+    deps = [
+        ":SwiftSyntax",
+        ":SwiftSyntaxBuilder",
+        ":_SwiftSyntaxTestSupport",
+    ],
+)
+
+swift_syntax_test(
+    name = "SwiftSyntaxTestSupportTest",
+    deps = [
+        ":SwiftParser",
+        ":_SwiftSyntaxTestSupport",
+    ],
+)
+
+cc_library(
+    name = "_AtomicBool",
+    srcs = glob(["Sources/_AtomicBool/src/*.c"]),
+    hdrs = glob(["Sources/_AtomicBool/include/*.h"]),
+    includes = ["Sources/_AtomicBool/include"],
+    tags = ["swift_module=_AtomicBool"],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "_InstructionCounter",
+    srcs = glob(["Sources/_InstructionCounter/src/*.c"]),
+    hdrs = glob(["Sources/_InstructionCounter/include/*.h"]),
+    includes = ["Sources/_InstructionCounter/include"],
+    tags = ["swift_module=_InstructionCounter"],
+    visibility = ["//visibility:private"],
 )
 
 swift_syntax_library(
@@ -145,4 +308,11 @@ swift_syntax_library(
         ":SwiftSyntaxBuilder",
         ":SwiftSyntaxMacroExpansion",
     ],
+)
+
+ios_xctestrun_runner(
+    name = "ios_test_runner",
+    random = False,
+    reuse_simulator = True,
+    visibility = ["//visibility:private"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,5 +4,6 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "apple_support", version = "1.13.0", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "rules_apple", version = "3.3.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_swift", version = "1.16.0", repo_name = "build_bazel_rules_swift")
-bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")

--- a/utils/bazel/swift_syntax_library.bzl
+++ b/utils/bazel/swift_syntax_library.bzl
@@ -1,12 +1,13 @@
 """Convenience wrapper for swift_library targets using this repo's conventions"""
 
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test")
 load(":opt_wrapper.bzl", "opt_wrapper")
 
-def swift_syntax_library(name, deps, testonly = False):
+def swift_syntax_library(name, deps, srcs = None, testonly = False):
     swift_library(
         name = name,
-        srcs = native.glob(
+        srcs = srcs or native.glob(
             ["Sources/{}/**/*.swift".format(name)],
             exclude = ["**/*.docc/**"],
             allow_empty = False,
@@ -20,4 +21,39 @@ def swift_syntax_library(name, deps, testonly = False):
         name = name + "_opt",
         dep = name,
         testonly = testonly,
+    )
+
+def swift_syntax_test(name, deps):
+    srcs = native.glob(
+        ["Tests/{}/**/*.swift".format(name)],
+        allow_empty = False,
+    )
+
+    swift_test(
+        name = name,
+        srcs = srcs,
+        module_name = name,
+        deps = deps,
+        testonly = True,
+        data = srcs,
+    )
+
+    swift_library(
+        name = name + ".library",
+        srcs = srcs,
+        module_name = name,
+        tags = ["manual"],
+        deps = deps,
+        testonly = True,
+    )
+
+    ios_unit_test(
+        name = name + ".ios",
+        deps = [name + ".library"],
+        # Keep in sync with Package.swift
+        minimum_os_version = "13.0",
+        tags = ["exclusive"],
+        # These tests load source files they don't have access to in the iOS test bundle with bazel.
+        test_filter = "-SwiftParserTest.StringLiteralRepresentedLiteralValueTests",
+        runner = "//:ios_test_runner",
     )


### PR DESCRIPTION
- **Explanation**: This adds bazel targets for SwiftSyntax's test targets which makes us more confident in the integration. The new test targets support macOS and iOS.
- **Scope**: Bazel build files
- **Risk**: Only affects the bazel build
- **Testing**: I assume @keith tested it on https://github.com/apple/swift-syntax/pull/2523
- **Issue**: n/a
- **Reviewer**:  @keith