### PR TITLE
[6.0] Mark all PluginMessageHandling symbols SPI

### DIFF
--- a/Release Notes/600.md
+++ b/Release Notes/600.md
@@ -172,6 +172,11 @@
   - Pull request: https://github.com/apple/swift-syntax/pull/2531
   - Migration steps: Use `if case .backslash = triviaPiece` instead
 
+- All symbols in `SwiftCompilerPluginMessageHandling` are now SPI
+  - Description: This module is only intended to be used from some internal components. Any other modules should not use them directly.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2489
+  - Migration steps: Stop using this module.
+
 ## Template
 
 - *Affected API or two word description*

--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -15,11 +15,11 @@
 #if swift(>=6.0)
 public import SwiftSyntaxMacros
 private import Foundation
-private import SwiftCompilerPluginMessageHandling
+@_spi(PluginMessage) private import SwiftCompilerPluginMessageHandling
 #else
 import SwiftSyntaxMacros
 import Foundation
-import SwiftCompilerPluginMessageHandling
+@_spi(PluginMessage) import SwiftCompilerPluginMessageHandling
 #endif
 
 #if os(Windows)

--- a/Sources/SwiftCompilerPluginMessageHandling/CompilerPluginMessageHandler.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/CompilerPluginMessageHandler.swift
@@ -17,11 +17,13 @@ import SwiftSyntaxMacros
 #endif
 
 /// Optional features.
+@_spi(PluginMessage)
 public enum PluginFeature: String {
   case loadPluginLibrary = "load-plugin-library"
 }
 
 /// A type that provides the actual plugin functions.
+@_spi(PluginMessage)
 public protocol PluginProvider {
   /// Resolve macro type by the module name and the type name.
   func resolveMacro(moduleName: String, typeName: String) throws -> Macro.Type
@@ -37,6 +39,7 @@ public protocol PluginProvider {
 
 /// Low level message connection to the plugin host.
 /// This encapsulates the connection and the message serialization.
+@_spi(PluginMessage)
 public protocol MessageConnection {
   /// Send a message to the peer.
   func sendMessage<TX: Encodable>(_ message: TX) throws
@@ -66,6 +69,7 @@ struct HostCapability {
 /// the response.
 ///
 /// The low level connection and the provider is injected by the client.
+@_spi(PluginMessage)
 public class CompilerPluginMessageHandler<Connection: MessageConnection, Provider: PluginProvider> {
   /// Message channel for bidirectional communication with the plugin host.
   let connection: Connection

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -14,7 +14,7 @@ import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntax
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacroExpansion
+@_spi(MacroExpansion) @_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacroExpansion
 @_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
 
 extension CompilerPluginMessageHandler {

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessageCompatibility.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessageCompatibility.swift
@@ -11,7 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 /// Old compiler might send '.declaration' as "freeStandingDeclaration".
-@_spi(PluginMessage) public extension PluginMessage.MacroRole {
+@_spi(PluginMessage)
+public extension PluginMessage.MacroRole {
   init(from decoder: Decoder) throws {
     let stringValue = try decoder.singleValueContainer().decode(String.self)
     if let role = Self(rawValue: stringValue) {

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
@@ -12,6 +12,7 @@
 
 // NOTE: Types in this file should be self-contained and should not depend on any non-stdlib types.
 
+@_spi(PluginMessage)
 public enum HostToPluginMessage: Codable {
   /// Send capability of the host, and get capability of the plugin.
   case getCapability(
@@ -49,6 +50,7 @@ public enum HostToPluginMessage: Codable {
   )
 }
 
+@_spi(PluginMessage)
 public enum PluginToHostMessage: Codable {
   case getCapabilityResult(
     capability: PluginMessage.PluginCapability
@@ -78,6 +80,7 @@ public enum PluginToHostMessage: Codable {
   )
 }
 
+@_spi(PluginMessage)
 public enum PluginMessage {
   public static var PROTOCOL_VERSION_NUMBER: Int { 7 }  // Pass extension protocol list
 


### PR DESCRIPTION
Cherry-pick #2489 into release/6.0

* **Explanation**:  `SwiftCompilerPluginMessageHandling` is only intended to be used from internal modules like `SwiftCompilerPlugin`, or `ASTGen` and `swift-plugin-server` in swift repository. Make all the public symbols SPI so other third party modules don't accidentally use it.
* **Scope**: Macro plugins
* **Risk**: Low, Nobody should depends on `SwiftCompilerPluginMessageHandling` APIs
* **Testing**: Passes current test suite
* **Issue**: N/A
* **Reviewer**: Alex Hoppen (@ahoppen)