### PR TITLE
[6.0] Remove `public` from the extension declaration and add it to each declaration in the extension

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/String+Extensions.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/String+Extensions.swift
@@ -10,20 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-public extension StringProtocol {
-  var withFirstCharacterLowercased: String {
+extension StringProtocol {
+  public var withFirstCharacterLowercased: String {
     guard first?.isLetter ?? false else {
       return String(first!) + dropFirst().withFirstCharacterLowercased
     }
     return prefix(1).lowercased() + dropFirst()
   }
-  var withFirstCharacterUppercased: String {
+  public var withFirstCharacterUppercased: String {
     guard first?.isLetter ?? false else {
       return String(first!) + dropFirst().withFirstCharacterUppercased
     }
     return prefix(1).uppercased() + dropFirst()
   }
-  var backtickedIfNeeded: String {
+  public var backtickedIfNeeded: String {
     if Keyword.allCases.map(\.spec).contains(where: {
       $0.name == self && ($0.isLexerClassified || $0.name == "Type" || $0.name == "Protocol")
     }) {

--- a/CodeGeneration/Sources/SyntaxSupport/Utils.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Utils.swift
@@ -58,9 +58,9 @@ extension SwiftSyntax.Trivia {
   }
 }
 
-public extension Collection {
+extension Collection {
   /// If the collection contains a single element, return it, otherwise `nil`.
-  var only: Element? {
+  public var only: Element? {
     if !isEmpty && index(after: startIndex) == endIndex {
       return self.first!
     } else {
@@ -69,8 +69,8 @@ public extension Collection {
   }
 }
 
-public extension TokenSyntax {
-  var backtickedIfNeeded: TokenSyntax {
+extension TokenSyntax {
+  public var backtickedIfNeeded: TokenSyntax {
     if Keyword.allCases.map(\.spec).contains(where: {
       $0.name == self.description && ($0.isLexerClassified || $0.name == "Type" || $0.name == "Protocol")
     }) {

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -23,10 +23,10 @@ public enum SyntaxOrTokenNodeKind: Hashable {
 
 /// Extension to the ``Child`` type to provide functionality specific to
 /// SwiftSyntaxBuilder.
-public extension Child {
+extension Child {
   /// The type of this child, represented by a ``SyntaxBuildableType``, which can
   /// be used to create the corresponding `Buildable` and `ExpressibleAs` types.
-  var buildableType: SyntaxBuildableType {
+  public var buildableType: SyntaxBuildableType {
     let buildableKind: SyntaxOrTokenNodeKind
     switch kind {
     case .node(kind: let kind):
@@ -44,7 +44,7 @@ public extension Child {
     )
   }
 
-  var parameterBaseType: TypeSyntax {
+  public var parameterBaseType: TypeSyntax {
     switch kind {
     case .nodeChoices:
       return self.syntaxChoicesType
@@ -53,11 +53,11 @@ public extension Child {
     }
   }
 
-  var parameterType: TypeSyntax {
+  public var parameterType: TypeSyntax {
     return self.buildableType.optionalWrapped(type: parameterBaseType)
   }
 
-  var defaultValue: ExprSyntax? {
+  public var defaultValue: ExprSyntax? {
     if isOptional || isUnexpectedNodes {
       if buildableType.isBaseType && kind.isNodeChoicesEmpty {
         return ExprSyntax("\(buildableType.buildable).none")
@@ -85,7 +85,7 @@ public extension Child {
   /// If the child node has a default value, return an expression of the form
   /// ` = default_value` that can be used as the default value to for a
   /// function parameter. Otherwise, return `nil`.
-  var defaultInitialization: InitializerClauseSyntax? {
+  public var defaultInitialization: InitializerClauseSyntax? {
     if let defaultValue {
       return InitializerClauseSyntax(
         equal: .equalToken(leadingTrivia: .space, trailingTrivia: .space),
@@ -99,7 +99,7 @@ public extension Child {
   /// If this node is a token that can't contain arbitrary text, generate a Swift
   /// `precondition` statement that verifies the variable with name var_name and of type
   /// ``TokenSyntax`` contains one of the supported text options. Otherwise return `nil`.
-  func generateAssertStmtTextChoices(varName: String) -> FunctionCallExprSyntax? {
+  public func generateAssertStmtTextChoices(varName: String) -> FunctionCallExprSyntax? {
     guard case .token(choices: let choices, requiresLeadingSpace: _, requiresTrailingSpace: _) = kind else {
       return nil
     }

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableNode.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableNode.swift
@@ -14,14 +14,14 @@ import SyntaxSupport
 
 /// Extension to the ``Node`` type to provide functionality specific to
 /// SwiftSyntaxBuilder.
-public extension Node {
+extension Node {
   /// The node's syntax kind as ``SyntaxBuildableType``.
-  var type: SyntaxBuildableType {
+  public var type: SyntaxBuildableType {
     SyntaxBuildableType(kind: .node(kind: kind))
   }
 
   /// The node's syntax kind as ``SyntaxBuildableType``.
-  var baseType: SyntaxBuildableType {
+  public var baseType: SyntaxBuildableType {
     if base == .syntaxCollection {
       return SyntaxBuildableType(kind: .node(kind: .syntax))
     } else {
@@ -29,7 +29,7 @@ public extension Node {
     }
   }
 
-  static func from(type: SyntaxBuildableType) -> Node {
+  public static func from(type: SyntaxBuildableType) -> Node {
     guard case .node(kind: let kind) = type.kind, let node = SYNTAX_NODE_MAP[kind] else {
       fatalError("Base name \(type) does not have a syntax node")
     }
@@ -37,18 +37,18 @@ public extension Node {
   }
 }
 
-public extension LayoutNode {
+extension LayoutNode {
   /// Assuming this node has a single child without a default value, that child.
-  var singleNonDefaultedChild: Child {
+  public var singleNonDefaultedChild: Child {
     let nonDefaultedParams = children.filter { $0.defaultInitialization == nil }
     precondition(nonDefaultedParams.count == 1)
     return nonDefaultedParams[0]
   }
 }
 
-public extension CollectionNode {
+extension CollectionNode {
   /// Assuming this node is a syntax collection, the type of its elements.
-  var collectionElementType: SyntaxBuildableType {
+  public var collectionElementType: SyntaxBuildableType {
     if elementChoices.count > 1 {
       return SyntaxBuildableType(kind: .node(kind: .syntax))
     } else {

--- a/Sources/SwiftBasicFormat/SyntaxProtocol+Formatted.swift
+++ b/Sources/SwiftBasicFormat/SyntaxProtocol+Formatted.swift
@@ -16,9 +16,9 @@ public import SwiftSyntax
 import SwiftSyntax
 #endif
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Build a syntax node from this `Buildable` and format it with the given format.
-  func formatted(using format: BasicFormat = BasicFormat()) -> Syntax {
+  public func formatted(using format: BasicFormat = BasicFormat()) -> Syntax {
     format.reset()
     return format.rewrite(self)
   }

--- a/Sources/SwiftCompilerPluginMessageHandling/CompilerPluginMessageHandler.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/CompilerPluginMessageHandler.swift
@@ -186,13 +186,13 @@ struct UnimplementedError: Error, CustomStringConvertible {
 }
 
 /// Default implementation of 'PluginProvider' requirements.
-public extension PluginProvider {
-  var features: [PluginFeature] {
+extension PluginProvider {
+  public var features: [PluginFeature] {
     // No optional features by default.
     return []
   }
 
-  func loadPluginLibrary(libraryPath: String, moduleName: String) throws {
+  public func loadPluginLibrary(libraryPath: String, moduleName: String) throws {
     // This should be unreachable. The host should not call 'loadPluginLibrary'
     // unless the feature is not declared.
     throw UnimplementedError()

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessageCompatibility.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessageCompatibility.swift
@@ -11,9 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 /// Old compiler might send '.declaration' as "freeStandingDeclaration".
-@_spi(PluginMessage)
-public extension PluginMessage.MacroRole {
-  init(from decoder: Decoder) throws {
+extension PluginMessage.MacroRole {
+  @_spi(PluginMessage) public init(from decoder: Decoder) throws {
     let stringValue = try decoder.singleValueContainer().decode(String.self)
     if let role = Self(rawValue: stringValue) {
       self = role

--- a/Sources/SwiftIDEUtils/SwiftIDEUtilsCompatibility.swift
+++ b/Sources/SwiftIDEUtils/SwiftIDEUtilsCompatibility.swift
@@ -13,35 +13,35 @@
 // This file provides compatiblity aliases to keep dependents of SwiftSyntax building.
 // All users of the declarations in this file should transition away from them ASAP.
 
-public extension SyntaxClassification {
+extension SyntaxClassification {
   /// A `#` keyword like `#warning`.
   @available(*, deprecated, renamed: "ifConfigDirective")
-  static var poundDirective: SyntaxClassification {
+  public static var poundDirective: SyntaxClassification {
     return .ifConfigDirective
   }
 
   @available(*, deprecated, renamed: "ifConfigDirective")
-  static var buildConfigId: SyntaxClassification {
+  public static var buildConfigId: SyntaxClassification {
     return .ifConfigDirective
   }
 
   @available(*, deprecated, message: "String interpolation anchors are now classified as .none")
-  static var stringInterpolationAnchor: SyntaxClassification {
+  public static var stringInterpolationAnchor: SyntaxClassification {
     return .none
   }
 
   @available(*, deprecated, renamed: "type")
-  static var typeIdentifier: SyntaxClassification {
+  public static var typeIdentifier: SyntaxClassification {
     return .type
   }
 
   @available(*, deprecated, renamed: "operator")
-  static var operatorIdentifier: SyntaxClassification {
+  public static var operatorIdentifier: SyntaxClassification {
     return .operator
   }
 
   @available(*, deprecated, renamed: "floatLiteral")
-  static var floatingLiteral: SyntaxClassification {
+  public static var floatingLiteral: SyntaxClassification {
     return .floatLiteral
   }
 }

--- a/Sources/SwiftIDEUtils/Syntax+Classifications.swift
+++ b/Sources/SwiftIDEUtils/Syntax+Classifications.swift
@@ -16,7 +16,7 @@ public import SwiftSyntax
 import SwiftSyntax
 #endif
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
 
   /// Sequence of ``SyntaxClassifiedRange``s for this syntax node.
   ///
@@ -24,7 +24,7 @@ public extension SyntaxProtocol {
   /// text of the node. The ranges may also span multiple tokens, if multiple
   /// consecutive tokens would have the same classification then a single classified
   /// range is provided for all of them.
-  var classifications: SyntaxClassifications {
+  public var classifications: SyntaxClassifications {
     let fullRange = ByteSourceRange(offset: 0, length: totalLength.utf8Length)
     return SyntaxClassifications(_syntaxNode, in: fullRange)
   }
@@ -43,7 +43,7 @@ public extension SyntaxProtocol {
   /// - Parameters:
   ///   - in: The relative byte range to pull ``SyntaxClassifiedRange``s from.
   /// - Returns: Sequence of ``SyntaxClassifiedRange``s.
-  func classifications(in range: ByteSourceRange) -> SyntaxClassifications {
+  public func classifications(in range: ByteSourceRange) -> SyntaxClassifications {
     return SyntaxClassifications(_syntaxNode, in: range)
   }
 
@@ -52,7 +52,7 @@ public extension SyntaxProtocol {
   ///   - at: The relative to the node byte offset.
   /// - Returns: The ``SyntaxClassifiedRange`` for the offset or nil if the source text
   ///   at the given offset is unclassified.
-  func classification(at offset: Int) -> SyntaxClassifiedRange? {
+  public func classification(at offset: Int) -> SyntaxClassifiedRange? {
     let classifications = SyntaxClassifications(_syntaxNode, in: ByteSourceRange(offset: offset, length: 1))
     var iterator = classifications.makeIterator()
     return iterator.next()
@@ -63,7 +63,7 @@ public extension SyntaxProtocol {
   ///   - at: The absolute position.
   /// - Returns: The ``SyntaxClassifiedRange`` for the position or nil if the source text
   ///   at the given position is unclassified.
-  func classification(at position: AbsolutePosition) -> SyntaxClassifiedRange? {
+  public func classification(at position: AbsolutePosition) -> SyntaxClassifiedRange? {
     let relativeOffset = position.utf8Offset - self.position.utf8Offset
     return self.classification(at: relativeOffset)
   }

--- a/Sources/SwiftParser/SwiftParserCompatibility.swift
+++ b/Sources/SwiftParser/SwiftParserCompatibility.swift
@@ -15,14 +15,14 @@ import SwiftSyntax
 // This file provides compatibility aliases to keep dependents of SwiftSyntax building.
 // All users of the declarations in this file should transition away from them ASAP.
 
-public extension TokenSpec {
+extension TokenSpec {
   @available(*, deprecated, renamed: "leftSquare")
-  static var leftSquareBracket: TokenSpec {
+  public static var leftSquareBracket: TokenSpec {
     return .leftSquare
   }
 
   @available(*, deprecated, renamed: "rightSquare")
-  static var rightSquareBracket: TokenSpec {
+  public static var rightSquareBracket: TokenSpec {
     return .rightSquare
   }
 }

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -27,16 +27,16 @@ public protocol TokenError: DiagnosticMessage {
   var diagnosticID: MessageID { get }
 }
 
-public extension TokenError {
-  static var diagnosticID: MessageID {
+extension TokenError {
+  public static var diagnosticID: MessageID {
     return MessageID(domain: diagnosticDomain, id: "\(self)")
   }
 
-  var diagnosticID: MessageID {
+  public var diagnosticID: MessageID {
     return Self.diagnosticID
   }
 
-  var severity: DiagnosticSeverity {
+  public var severity: DiagnosticSeverity {
     return .error
   }
 }
@@ -46,16 +46,16 @@ public protocol TokenWarning: DiagnosticMessage {
   var diagnosticID: MessageID { get }
 }
 
-public extension TokenWarning {
-  static var diagnosticID: MessageID {
+extension TokenWarning {
+  public static var diagnosticID: MessageID {
     return MessageID(domain: diagnosticDomain, id: "\(self)")
   }
 
-  var diagnosticID: MessageID {
+  public var diagnosticID: MessageID {
     return Self.diagnosticID
   }
 
-  var severity: DiagnosticSeverity {
+  public var severity: DiagnosticSeverity {
     return .warning
   }
 }
@@ -180,11 +180,11 @@ public struct ErrorToWarningDowngrade: TokenWarning {
 
 // MARK: - Convert TokenDiagnostic from SwiftSyntax to error messages
 
-public extension SwiftSyntax.TokenDiagnostic {
+extension SwiftSyntax.TokenDiagnostic {
   /// `tokenText` is the entire text of the token in which the ``TokenDiagnostic``
   /// occurred, including trivia.
   @_spi(RawSyntax)
-  func diagnosticMessage(in token: TokenSyntax) -> DiagnosticMessage {
+  public func diagnosticMessage(in token: TokenSyntax) -> DiagnosticMessage {
     var scalarAtErrorOffset: UnicodeScalar {
       // Fall back to the Unicode replacement character U+FFFD in case we can't
       // lex the unicode character at `byteOffset`. It's the best we can do
@@ -241,7 +241,7 @@ public extension SwiftSyntax.TokenDiagnostic {
     }
   }
 
-  func position(in token: TokenSyntax) -> AbsolutePosition {
+  public func position(in token: TokenSyntax) -> AbsolutePosition {
     switch kind {
     case .extraneousLeadingWhitespaceError, .extraneousLeadingWhitespaceWarning:
       if let previousToken = token.previousToken(viewMode: .all) {
@@ -253,7 +253,7 @@ public extension SwiftSyntax.TokenDiagnostic {
     return token.position.advanced(by: Int(byteOffset))
   }
 
-  func fixIts(in token: TokenSyntax) -> [FixIt] {
+  public func fixIts(in token: TokenSyntax) -> [FixIt] {
     switch self.kind {
     case .nonBreakingSpace:
       let replaceNonBreakingSpace = { (piece: TriviaPiece) -> TriviaPiece in

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -27,16 +27,16 @@ public protocol ParserError: DiagnosticMessage {
   var diagnosticID: MessageID { get }
 }
 
-public extension ParserError {
-  static var diagnosticID: MessageID {
+extension ParserError {
+  public static var diagnosticID: MessageID {
     return MessageID(domain: diagnosticDomain, id: "\(self)")
   }
 
-  var diagnosticID: MessageID {
+  public var diagnosticID: MessageID {
     return Self.diagnosticID
   }
 
-  var severity: DiagnosticSeverity {
+  public var severity: DiagnosticSeverity {
     return .error
   }
 }
@@ -45,17 +45,17 @@ public protocol ParserNote: NoteMessage {
   var noteID: MessageID { get }
 }
 
-public extension ParserNote {
+extension ParserNote {
   @available(*, deprecated, message: "Use noteID instead.", renamed: "noteID")
-  static var fixItID: MessageID {
+  public static var fixItID: MessageID {
     return Self.noteID
   }
 
-  static var noteID: MessageID {
+  public static var noteID: MessageID {
     return MessageID(domain: diagnosticDomain, id: "\(self)")
   }
 
-  var noteID: MessageID {
+  public var noteID: MessageID {
     return Self.noteID
   }
 }
@@ -64,12 +64,12 @@ public protocol ParserFixIt: FixItMessage {
   var fixItID: MessageID { get }
 }
 
-public extension ParserFixIt {
-  static var fixItID: MessageID {
+extension ParserFixIt {
+  public static var fixItID: MessageID {
     return MessageID(domain: diagnosticDomain, id: "\(self)")
   }
 
-  var fixItID: MessageID {
+  public var fixItID: MessageID {
     return Self.fixItID
   }
 }

--- a/Sources/SwiftSyntax/MissingNodeInitializers.swift
+++ b/Sources/SwiftSyntax/MissingNodeInitializers.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-public extension MissingDeclSyntax {
-  init(
+extension MissingDeclSyntax {
+  public init(
     attributes: AttributeListSyntax,
     modifiers: DeclModifierListSyntax,
     arena: __shared SyntaxArena
@@ -24,40 +24,40 @@ public extension MissingDeclSyntax {
   }
 }
 
-public extension MissingExprSyntax {
-  init() {
+extension MissingExprSyntax {
+  public init() {
     self.init(
       placeholder: TokenSyntax.identifier("<#expression#>")
     )
   }
 }
 
-public extension MissingPatternSyntax {
-  init() {
+extension MissingPatternSyntax {
+  public init() {
     self.init(
       placeholder: TokenSyntax.identifier("<#pattern#>")
     )
   }
 }
 
-public extension MissingStmtSyntax {
-  init() {
+extension MissingStmtSyntax {
+  public init() {
     self.init(
       placeholder: TokenSyntax.identifier("<#statement#>")
     )
   }
 }
 
-public extension MissingTypeSyntax {
-  init() {
+extension MissingTypeSyntax {
+  public init() {
     self.init(
       placeholder: TokenSyntax.identifier("<#type#>")
     )
   }
 }
 
-public extension MissingSyntax {
-  init() {
+extension MissingSyntax {
+  public init() {
     self.init(
       placeholder: TokenSyntax.identifier("<#syntax#>")
     )
@@ -66,8 +66,8 @@ public extension MissingSyntax {
 
 // MARK: - Raw
 
-public extension RawMissingDeclSyntax {
-  init(
+extension RawMissingDeclSyntax {
+  public init(
     attributes: RawAttributeListSyntax,
     modifiers: RawDeclModifierListSyntax,
     arena: __shared SyntaxArena
@@ -81,8 +81,8 @@ public extension RawMissingDeclSyntax {
   }
 }
 
-public extension RawMissingExprSyntax {
-  init(arena: __shared SyntaxArena) {
+extension RawMissingExprSyntax {
+  public init(arena: __shared SyntaxArena) {
     self.init(
       placeholder: RawTokenSyntax(missing: .identifier, text: "<#expression#>", arena: arena),
       arena: arena
@@ -90,8 +90,8 @@ public extension RawMissingExprSyntax {
   }
 }
 
-public extension RawMissingPatternSyntax {
-  init(arena: __shared SyntaxArena) {
+extension RawMissingPatternSyntax {
+  public init(arena: __shared SyntaxArena) {
     self.init(
       placeholder: RawTokenSyntax(missing: .identifier, text: "<#pattern#>", arena: arena),
       arena: arena
@@ -99,8 +99,8 @@ public extension RawMissingPatternSyntax {
   }
 }
 
-public extension RawMissingStmtSyntax {
-  init(arena: __shared SyntaxArena) {
+extension RawMissingStmtSyntax {
+  public init(arena: __shared SyntaxArena) {
     self.init(
       placeholder: RawTokenSyntax(missing: .identifier, text: "<#statement#>", arena: arena),
       arena: arena
@@ -108,8 +108,8 @@ public extension RawMissingStmtSyntax {
   }
 }
 
-public extension RawMissingTypeSyntax {
-  init(arena: __shared SyntaxArena) {
+extension RawMissingTypeSyntax {
+  public init(arena: __shared SyntaxArena) {
     self.init(
       placeholder: RawTokenSyntax(missing: .identifier, text: "<#type#>", arena: arena),
       arena: arena
@@ -117,8 +117,8 @@ public extension RawMissingTypeSyntax {
   }
 }
 
-public extension RawMissingSyntax {
-  init(arena: __shared SyntaxArena) {
+extension RawMissingSyntax {
+  public init(arena: __shared SyntaxArena) {
     self.init(
       placeholder: RawTokenSyntax(missing: .identifier, text: "<#syntax#>", arena: arena),
       arena: arena

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -24,30 +24,30 @@ public protocol RawSyntaxNodeProtocol: CustomStringConvertible, TextOutputStream
   init?(_ other: some RawSyntaxNodeProtocol)
 }
 
-public extension RawSyntaxNodeProtocol {
+extension RawSyntaxNodeProtocol {
   /// Cast to the specified raw syntax type if possible.
-  func `as`<Node: RawSyntaxNodeProtocol>(_: Node.Type) -> Node? {
+  public func `as`<Node: RawSyntaxNodeProtocol>(_: Node.Type) -> Node? {
     Node(self)
   }
 
   /// Check if this instance can be cast to the specified syntax type.
-  func `is`<Node: RawSyntaxNodeProtocol>(_: Node.Type) -> Bool {
+  public func `is`<Node: RawSyntaxNodeProtocol>(_: Node.Type) -> Bool {
     Node.isKindOf(self.raw)
   }
 
-  func cast<S: RawSyntaxNodeProtocol>(_ syntaxType: S.Type) -> S {
+  public func cast<S: RawSyntaxNodeProtocol>(_ syntaxType: S.Type) -> S {
     return self.as(S.self)!
   }
 
-  var description: String {
+  public var description: String {
     raw.description
   }
 
-  func write(to target: inout some TextOutputStream) {
+  public func write(to target: inout some TextOutputStream) {
     raw.write(to: &target)
   }
 
-  var isEmpty: Bool {
+  public var isEmpty: Bool {
     return raw.byteLength == 0
   }
 
@@ -55,7 +55,7 @@ public extension RawSyntaxNodeProtocol {
   ///  - missing nodes or
   ///  - unexpected nodes or
   ///  - tokens with a ``TokenDiagnostic`` of severity `error`
-  var hasError: Bool {
+  public var hasError: Bool {
     return raw.recursiveFlags.contains(.hasError)
   }
 }

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -394,14 +394,14 @@ public final class SourceLocationConverter {
   }
 }
 
-public extension Syntax {
+extension Syntax {
   /// The starting location, in the provided file, of this Syntax node.
   /// - Parameters:
   ///   - converter: The `SourceLocationConverter` that was previously
   ///     initialized using the root tree of this node.
   ///   - afterLeadingTrivia: Whether to skip leading trivia when getting
   ///                         the node's location. Defaults to `true`.
-  func startLocation(
+  public func startLocation(
     converter: SourceLocationConverter,
     afterLeadingTrivia: Bool = true
   ) -> SourceLocation {
@@ -415,7 +415,7 @@ public extension Syntax {
   ///     initialized using the root tree of this node.
   ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
   ///                          the node's location. Defaults to `false`.
-  func endLocation(
+  public func endLocation(
     converter: SourceLocationConverter,
     afterTrailingTrivia: Bool = false
   ) -> SourceLocation {
@@ -436,7 +436,7 @@ public extension Syntax {
   ///                          the node's start location. Defaults to `true`.
   ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
   ///                          the node's end location. Defaults to `false`.
-  func sourceRange(
+  public func sourceRange(
     converter: SourceLocationConverter,
     afterLeadingTrivia: Bool = true,
     afterTrailingTrivia: Bool = false
@@ -453,14 +453,14 @@ public extension Syntax {
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// The starting location, in the provided file, of this Syntax node.
   /// - Parameters:
   ///   - converter: The `SourceLocationConverter` that was previously
   ///     initialized using the root tree of this node.
   ///   - afterLeadingTrivia: Whether to skip leading trivia when getting
   ///                         the node's location. Defaults to `true`.
-  func startLocation(
+  public func startLocation(
     converter: SourceLocationConverter,
     afterLeadingTrivia: Bool = true
   ) -> SourceLocation {
@@ -476,7 +476,7 @@ public extension SyntaxProtocol {
   ///     initialized using the root tree of this node.
   ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
   ///                          the node's location. Defaults to `false`.
-  func endLocation(
+  public func endLocation(
     converter: SourceLocationConverter,
     afterTrailingTrivia: Bool = false
   ) -> SourceLocation {
@@ -494,7 +494,7 @@ public extension SyntaxProtocol {
   ///                          the node's start location. Defaults to `true`.
   ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
   ///                          the node's end location. Defaults to `false`.
-  func sourceRange(
+  public func sourceRange(
     converter: SourceLocationConverter,
     afterLeadingTrivia: Bool = true,
     afterTrailingTrivia: Bool = false

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -13,10 +13,10 @@
 // This file provides compatibility aliases to keep dependents of SwiftSyntax building.
 // All users of the declarations in this file should transition away from them ASAP.
 
-public extension AccessorEffectSpecifiersSyntax {
+extension AccessorEffectSpecifiersSyntax {
   @_disfavoredOverload
   @available(*, deprecated, message: "use throwsClause instead of throwsSpecifier")
-  init(
+  public init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAsyncSpecifier: UnexpectedNodesSyntax? = nil,
     asyncSpecifier: TokenSyntax? = nil,
@@ -132,9 +132,9 @@ extension ClosureSignatureSyntax.ParameterClause {
   }
 }
 
-public extension DeclGroupSyntax {
+extension DeclGroupSyntax {
   @available(*, deprecated, renamed: "memberBlock")
-  var members: MemberDeclBlockSyntax {
+  public var members: MemberDeclBlockSyntax {
     get {
       return memberBlock
     }
@@ -144,15 +144,15 @@ public extension DeclGroupSyntax {
   }
 }
 
-public extension EffectSpecifiersSyntax {
+extension EffectSpecifiersSyntax {
   @available(*, deprecated, renamed: "unexpectedBetweenAsyncSpecifierAndThrowsClause")
-  var unexpectedBetweenAsyncSpecifierAndThrowsSpecifier: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenAsyncSpecifierAndThrowsSpecifier: UnexpectedNodesSyntax? {
     get { unexpectedBetweenAsyncSpecifierAndThrowsClause }
     set { unexpectedBetweenAsyncSpecifierAndThrowsClause = newValue }
   }
 
   @available(*, deprecated, message: "use throwsClause.throwsSpecifier")
-  var throwsSpecifier: TokenSyntax? {
+  public var throwsSpecifier: TokenSyntax? {
     get { throwsClause?.throwsSpecifier }
 
     set {
@@ -170,16 +170,16 @@ public extension EffectSpecifiersSyntax {
   }
 
   @available(*, deprecated, renamed: "unexpectedAfterThrowsClause")
-  var unexpectedAfterThrowsSpecifier: UnexpectedNodesSyntax? {
+  public var unexpectedAfterThrowsSpecifier: UnexpectedNodesSyntax? {
     get { unexpectedAfterThrowsClause }
     set { unexpectedAfterThrowsClause = newValue }
   }
 }
 
-public extension FunctionEffectSpecifiersSyntax {
+extension FunctionEffectSpecifiersSyntax {
   @_disfavoredOverload
   @available(*, deprecated, message: "use throwsClause instead of throwsSpecifier")
-  init(
+  public init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAsyncSpecifier: UnexpectedNodesSyntax? = nil,
     asyncSpecifier: TokenSyntax? = nil,
@@ -200,9 +200,9 @@ public extension FunctionEffectSpecifiersSyntax {
   }
 }
 
-public extension FreestandingMacroExpansionSyntax {
+extension FreestandingMacroExpansionSyntax {
   @available(*, deprecated, renamed: "pound")
-  var poundToken: TokenSyntax {
+  public var poundToken: TokenSyntax {
     get {
       return pound
     }
@@ -212,7 +212,7 @@ public extension FreestandingMacroExpansionSyntax {
   }
 
   @available(*, deprecated, renamed: "macroName")
-  var macro: TokenSyntax {
+  public var macro: TokenSyntax {
     get {
       return macroName
     }
@@ -222,7 +222,7 @@ public extension FreestandingMacroExpansionSyntax {
   }
 
   @available(*, deprecated, renamed: "genericArgumentClause")
-  var genericArguments: GenericArgumentClauseSyntax? {
+  public var genericArguments: GenericArgumentClauseSyntax? {
     get {
       return genericArgumentClause
     }
@@ -232,7 +232,7 @@ public extension FreestandingMacroExpansionSyntax {
   }
 
   @available(*, deprecated, renamed: "arguments")
-  var argumentList: LabeledExprListSyntax {
+  public var argumentList: LabeledExprListSyntax {
     get {
       return arguments
     }
@@ -339,81 +339,81 @@ extension MemberAccessExprSyntax {
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   @available(*, deprecated, message: "Use detached computed property instead.")
-  func detach() -> Self {
+  public func detach() -> Self {
     return detached
   }
 }
 
-public extension TokenKind {
+extension TokenKind {
   @available(*, deprecated, renamed: "regexPoundDelimiter")
-  static func extendedRegexDelimiter(_ text: String) -> TokenKind {
+  public static func extendedRegexDelimiter(_ text: String) -> TokenKind {
     return .regexPoundDelimiter(text)
   }
 
   @available(*, deprecated, renamed: "floatLiteral")
-  static func floatingLiteral(_ text: String) -> TokenKind {
+  public static func floatingLiteral(_ text: String) -> TokenKind {
     return .floatLiteral(text)
   }
 
   @available(*, deprecated, renamed: "leftSquare")
-  static var leftSquareBracket: TokenKind {
+  public static var leftSquareBracket: TokenKind {
     return .leftSquare
   }
 
   @available(*, deprecated, renamed: "poundAvailable")
-  static var poundAvailableKeyword: TokenKind {
+  public static var poundAvailableKeyword: TokenKind {
     return .poundAvailable
   }
 
   @available(*, deprecated, renamed: "poundElse")
-  static var poundElseKeyword: TokenKind {
+  public static var poundElseKeyword: TokenKind {
     return .poundElse
   }
 
   @available(*, deprecated, renamed: "poundElseif")
-  static var poundElseifKeyword: TokenKind {
+  public static var poundElseifKeyword: TokenKind {
     return .poundElseif
   }
 
   @available(*, deprecated, renamed: "poundEndif")
-  static var poundEndifKeyword: TokenKind {
+  public static var poundEndifKeyword: TokenKind {
     return .poundEndif
   }
 
   @available(*, deprecated, renamed: "poundIf")
-  static var poundIfKeyword: TokenKind {
+  public static var poundIfKeyword: TokenKind {
     return .poundIf
   }
 
   @available(*, deprecated, renamed: "poundSourceLocation")
-  static var poundSourceLocationKeyword: TokenKind {
+  public static var poundSourceLocationKeyword: TokenKind {
     return .poundSourceLocation
   }
 
   @available(*, deprecated, renamed: "poundUnavailable")
-  static var poundUnavailableKeyword: TokenKind {
+  public static var poundUnavailableKeyword: TokenKind {
     return .poundUnavailable
   }
 
   @available(*, deprecated, renamed: "rawStringPoundDelimiter")
-  static func rawStringDelimiter(_ text: String) -> TokenKind {
+  public static func rawStringDelimiter(_ text: String) -> TokenKind {
     return .rawStringPoundDelimiter(text)
   }
 
   @available(*, deprecated, renamed: "rightSquare")
-  static var rightSquareBracket: TokenKind {
+  public static var rightSquareBracket: TokenKind {
     return .rightSquare
   }
 
   @available(*, deprecated, renamed: "endOfFile")
-  static var eof: TokenKind { .endOfFile }
+  public static var eof: TokenKind { .endOfFile }
 }
 
-public extension TokenSyntax {
+extension TokenSyntax {
   @available(*, deprecated, renamed: "regexPoundDelimiter")
-  static func extendedRegexDelimiter(
+  public static func extendedRegexDelimiter(
     _ text: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
@@ -428,7 +428,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "floatLiteral")
-  static func floatingLiteral(
+  public static func floatingLiteral(
     _ text: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
@@ -443,7 +443,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "leftSquareToken")
-  static func leftSquareBracketToken(
+  public static func leftSquareBracketToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -456,7 +456,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "poundAvailableToken")
-  static func poundAvailableKeyword(
+  public static func poundAvailableKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -469,7 +469,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "poundElseToken")
-  static func poundElseKeyword(
+  public static func poundElseKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -482,7 +482,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "poundElseifToken")
-  static func poundElseifKeyword(
+  public static func poundElseifKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -495,7 +495,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "poundEndifToken")
-  static func poundEndifKeyword(
+  public static func poundEndifKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -508,7 +508,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "poundIfToken")
-  static func poundIfKeyword(
+  public static func poundIfKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -521,7 +521,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "poundSourceLocationToken")
-  static func poundSourceLocationKeyword(
+  public static func poundSourceLocationKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -534,7 +534,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "poundUnavailableToken")
-  static func poundUnavailableKeyword(
+  public static func poundUnavailableKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -547,7 +547,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "rawStringPoundDelimiter")
-  static func rawStringDelimiter(
+  public static func rawStringDelimiter(
     _ text: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
@@ -562,7 +562,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "rightSquareToken")
-  static func rightSquareBracketToken(
+  public static func rightSquareBracketToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -575,7 +575,7 @@ public extension TokenSyntax {
   }
 
   @available(*, deprecated, renamed: "endOfFileToken")
-  static func eof(
+  public static func eof(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],
     presence: SourcePresence = .present
@@ -588,9 +588,9 @@ public extension TokenSyntax {
   }
 }
 
-public extension TypeEffectSpecifiersSyntax {
+extension TypeEffectSpecifiersSyntax {
   @available(*, deprecated, message: "use throwsClause instead of throwsSpecifier")
-  init(
+  public init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAsyncSpecifier: UnexpectedNodesSyntax? = nil,
     asyncSpecifier: TokenSyntax? = nil,
@@ -611,9 +611,9 @@ public extension TypeEffectSpecifiersSyntax {
   }
 }
 
-public extension WildcardPatternSyntax {
+extension WildcardPatternSyntax {
   @available(*, deprecated, message: "remove 'typeAnnotation'")
-  init(
+  public init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil,
     wildcard: TokenSyntax = .wildcardToken(),
@@ -632,19 +632,19 @@ public extension WildcardPatternSyntax {
   }
 
   @available(*, deprecated, message: "'unexpectedBetweenWildcardAndTypeAnnotation' was removed")
-  var unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? {
     get { nil }
     set {}
   }
 
   @available(*, deprecated, message: "'typeAnnotation' was removed")
-  var typeAnnotation: TypeAnnotationSyntax? {
+  public var typeAnnotation: TypeAnnotationSyntax? {
     get { nil }
     set {}
   }
 
   @available(*, deprecated, renamed: "unexpectedAfterWildcard")
-  var unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? {
+  public var unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? {
     get { unexpectedAfterWildcard }
     set { unexpectedAfterWildcard = newValue }
   }

--- a/Sources/SwiftSyntax/SyntaxHashable.swift
+++ b/Sources/SwiftSyntax/SyntaxHashable.swift
@@ -15,12 +15,12 @@ public protocol SyntaxHashable: Hashable {
   var _syntaxNode: Syntax { get }
 }
 
-public extension SyntaxHashable {
-  func hash(into hasher: inout Hasher) {
+extension SyntaxHashable {
+  public func hash(into hasher: inout Hasher) {
     return _syntaxNode.id.hash(into: &hasher)
   }
 
-  static func == (lhs: Self, rhs: Self) -> Bool {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
     return lhs._syntaxNode.id == rhs._syntaxNode.id
   }
 }

--- a/Sources/SwiftSyntax/SyntaxProtocol.swift
+++ b/Sources/SwiftSyntax/SyntaxProtocol.swift
@@ -42,11 +42,11 @@ extension SyntaxProtocol {
 // MARK: Casting
 
 // Casting functions to specialized syntax nodes.
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Initializes a new instance of the conforming type from a given specialized syntax node.
   ///
   /// Returns `nil` if the conversion isn't possible, or if the provided node is `nil`.
-  init?<S: SyntaxProtocol>(_ node: S?) {
+  public init?<S: SyntaxProtocol>(_ node: S?) {
     guard let node = node else {
       return nil
     }
@@ -56,7 +56,7 @@ public extension SyntaxProtocol {
   /// Checks if the current syntax node can be cast to a given specialized syntax type.
   ///
   /// - Returns: `true` if the node can be cast, `false` otherwise.
-  func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return self.as(syntaxType) != nil
   }
 
@@ -67,7 +67,7 @@ public extension SyntaxProtocol {
   /// - Note: This method overloads the general `is` method and is marked deprecated to produce a warning
   ///         informing the user that the upcast will always succeed.
   @available(*, deprecated, message: "This cast will always succeed")
-  func `is`(_ syntaxType: Syntax.Type) -> Bool {
+  public func `is`(_ syntaxType: Syntax.Type) -> Bool {
     return true
   }
 
@@ -78,14 +78,14 @@ public extension SyntaxProtocol {
   /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always succeed.
   @available(*, deprecated, message: "This cast will always succeed")
-  func `is`(_ syntaxType: Self.Type) -> Bool {
+  public func `is`(_ syntaxType: Self.Type) -> Bool {
     return true
   }
 
   /// Attempts to cast the current syntax node to a given specialized syntax type.
   ///
   /// - Returns: An instance of the specialized type, or `nil` if the cast fails.
-  func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(self)
   }
 
@@ -96,7 +96,7 @@ public extension SyntaxProtocol {
   /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
   ///         informing the user the upcast should be performed using the base node's initializer.
   @available(*, deprecated, message: "Use `Syntax.init` for upcasting.")
-  func `as`(_ syntaxType: Syntax.Type) -> Syntax? {
+  public func `as`(_ syntaxType: Syntax.Type) -> Syntax? {
     return Syntax(self)
   }
 
@@ -107,7 +107,7 @@ public extension SyntaxProtocol {
   /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always succeed.
   @available(*, deprecated, message: "This cast will always succeed")
-  func `as`(_ syntaxType: Self.Type) -> Self? {
+  public func `as`(_ syntaxType: Self.Type) -> Self? {
     return self
   }
 
@@ -115,7 +115,7 @@ public extension SyntaxProtocol {
   ///
   /// - Returns: An instance of the specialized type.
   /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
-  func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+  public func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
     return self.as(S.self)!
   }
 
@@ -126,7 +126,7 @@ public extension SyntaxProtocol {
   /// - Note: This method overloads the general `as` method and is marked deprecated to produce a warning
   ///         informing the user the upcast should be performed using the base node's initializer.
   @available(*, deprecated, message: "Use `Syntax.init` for upcasting.")
-  func cast(_ syntaxType: Syntax.Type) -> Syntax {
+  public func cast(_ syntaxType: Syntax.Type) -> Syntax {
     return Syntax(self)
   }
 
@@ -137,17 +137,17 @@ public extension SyntaxProtocol {
   /// - Note: This method overloads the general `cast` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always succeed.
   @available(*, deprecated, message: "This cast will always succeed")
-  func cast(_ syntaxType: Self.Type) -> Self {
+  public func cast(_ syntaxType: Self.Type) -> Self {
     return self
   }
 }
 
 // MARK: Modifying
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Returns a new syntax node that has the child at `keyPath` replaced by
   /// `value`.
-  func with<T>(_ keyPath: WritableKeyPath<Self, T>, _ value: T) -> Self {
+  public func with<T>(_ keyPath: WritableKeyPath<Self, T>, _ value: T) -> Self {
     var copy = self
     copy[keyPath: keyPath] = value
     return copy
@@ -155,7 +155,7 @@ public extension SyntaxProtocol {
 
   /// Return this subtree with this node as the root, ie. detach this node
   /// from its parent.
-  var detached: Self {
+  public var detached: Self {
     // Make sure `self` (and thus the arena of `self.raw`) can’t get deallocated
     // before the detached node can be created.
     return withExtendedLifetime(self) {
@@ -188,15 +188,15 @@ extension SyntaxProtocol {
 
 // MARK: Children / parent
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// A sequence over the children of this node.
-  func children(viewMode: SyntaxTreeViewMode) -> SyntaxChildren {
+  public func children(viewMode: SyntaxTreeViewMode) -> SyntaxChildren {
     return SyntaxChildren(_syntaxNode, viewMode: viewMode)
   }
 
   /// The index of this node in a ``SyntaxChildren`` collection.
   @available(*, deprecated, message: "Use index(of:) on the collection that contains this node")
-  var index: SyntaxChildrenIndex {
+  public var index: SyntaxChildrenIndex {
     return indexInParent
   }
 
@@ -206,12 +206,12 @@ public extension SyntaxProtocol {
   }
 
   /// The parent of this syntax node, or `nil` if this node is the root.
-  var parent: Syntax? {
+  public var parent: Syntax? {
     return Syntax(self).parent
   }
 
   /// The root of the tree in which this node resides.
-  var root: Syntax {
+  public var root: Syntax {
     var this = _syntaxNode
     while let parent = this.parent {
       this = parent
@@ -220,11 +220,11 @@ public extension SyntaxProtocol {
   }
 
   /// Whether or not this node has a parent.
-  var hasParent: Bool {
+  public var hasParent: Bool {
     return parent != nil
   }
 
-  var keyPathInParent: AnyKeyPath? {
+  public var keyPathInParent: AnyKeyPath? {
     guard let parent = self.parent else {
       return nil
     }
@@ -235,17 +235,17 @@ public extension SyntaxProtocol {
   }
 
   @available(*, deprecated, message: "Use previousToken(viewMode:) instead")
-  var previousToken: TokenSyntax? {
+  public var previousToken: TokenSyntax? {
     return self.previousToken(viewMode: .sourceAccurate)
   }
 }
 
 // MARK: Accessing tokens
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Recursively walks through the tree to find the token semantically before
   /// this node.
-  func previousToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
+  public func previousToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
     guard let parent = self.parent else {
       return nil
     }
@@ -264,13 +264,13 @@ public extension SyntaxProtocol {
   }
 
   @available(*, deprecated, message: "Use nextToken(viewMode:) instead")
-  var nextToken: TokenSyntax? {
+  public var nextToken: TokenSyntax? {
     return self.nextToken(viewMode: .sourceAccurate)
   }
 
   /// Recursively walks through the tree to find the next token semantically
   /// after this node.
-  func nextToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
+  public func nextToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
     guard let parent = self.parent else {
       return nil
     }
@@ -286,12 +286,12 @@ public extension SyntaxProtocol {
   }
 
   @available(*, deprecated, message: "Use firstToken(viewMode: .sourceAccurate) instead")
-  var firstToken: TokenSyntax? {
+  public var firstToken: TokenSyntax? {
     return self.firstToken(viewMode: .sourceAccurate)
   }
 
   /// Returns the first token node that is part of this syntax node.
-  func firstToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
+  public func firstToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
     guard viewMode.shouldTraverse(node: raw) else { return nil }
     if let token = _syntaxNode.as(TokenSyntax.self) {
       return token
@@ -306,12 +306,12 @@ public extension SyntaxProtocol {
   }
 
   @available(*, deprecated, message: "Use lastToken(viewMode: .sourceAccurate) instead")
-  var lastToken: TokenSyntax? {
+  public var lastToken: TokenSyntax? {
     return self.lastToken(viewMode: .sourceAccurate)
   }
 
   /// Returns the last token node that is part of this syntax node.
-  func lastToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
+  public func lastToken(viewMode: SyntaxTreeViewMode) -> TokenSyntax? {
     guard viewMode.shouldTraverse(node: raw) else { return nil }
     if let token = _syntaxNode.as(TokenSyntax.self) {
       return token
@@ -326,13 +326,13 @@ public extension SyntaxProtocol {
   }
 
   /// Sequence of tokens that are part of this Syntax node.
-  func tokens(viewMode: SyntaxTreeViewMode) -> TokenSequence {
+  public func tokens(viewMode: SyntaxTreeViewMode) -> TokenSequence {
     return TokenSequence(_syntaxNode, viewMode: viewMode)
   }
 
   /// Find the syntax token at the given absolute position within this
   /// syntax node or any of its children.
-  func token(at position: AbsolutePosition) -> TokenSyntax? {
+  public func token(at position: AbsolutePosition) -> TokenSyntax? {
     // If the position isn't within this node at all, return early.
     guard position >= self.position && position < self.endPosition else {
       return nil
@@ -358,7 +358,7 @@ public extension SyntaxProtocol {
   ///
   /// If the identifier references a node from a different tree (ie. one that has a different root ID in the
   /// ``SyntaxIdentifier``) or if no node with the given identifier is a child of this syntax node, returns `nil`.
-  func node(at syntaxIdentifier: SyntaxIdentifier) -> Syntax? {
+  public func node(at syntaxIdentifier: SyntaxIdentifier) -> Syntax? {
     guard self.id <= syntaxIdentifier && syntaxIdentifier < self.id.advancedBySibling(self.raw) else {
       // The syntax identifier is not part of this tree.
       return nil
@@ -378,59 +378,59 @@ public extension SyntaxProtocol {
 
 // MARK: Recursive flags
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Whether the tree contained by this layout has any
   ///  - missing nodes or
   ///  - unexpected nodes or
   ///  - tokens with a ``TokenDiagnostic`` of severity ``TokenDiagnostic/Severity-swift.enum/error``.
-  var hasError: Bool {
+  public var hasError: Bool {
     return raw.hasError
   }
 
   /// Whether the tree contained by this layout has any tokens with a
   /// ``TokenDiagnostic`` of severity `warning`.
-  var hasWarning: Bool {
+  public var hasWarning: Bool {
     return raw.recursiveFlags.contains(.hasWarning)
   }
 
   /// Whether this tree contains a missing token or unexpected node.
-  var hasSequenceExpr: Bool {
+  public var hasSequenceExpr: Bool {
     return raw.recursiveFlags.contains(.hasSequenceExpr)
   }
 
-  var hasMaximumNestingLevelOverflow: Bool {
+  public var hasMaximumNestingLevelOverflow: Bool {
     return raw.recursiveFlags.contains(.hasMaximumNestingLevelOverflow)
   }
 }
 
 // MARK: Position / length / range
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// The absolute position of the starting point of this node. If the first token
   /// is with leading trivia, the position points to the start of the leading
   /// trivia.
-  var position: AbsolutePosition {
+  public var position: AbsolutePosition {
     return Syntax(self).position
   }
 
   /// The absolute position of the starting point of this node, skipping any
   /// leading trivia attached to the first token syntax.
-  var positionAfterSkippingLeadingTrivia: AbsolutePosition {
+  public var positionAfterSkippingLeadingTrivia: AbsolutePosition {
     return Syntax(self).positionAfterSkippingLeadingTrivia
   }
 
   /// The end position of this node's content, before any trailing trivia.
-  var endPositionBeforeTrailingTrivia: AbsolutePosition {
+  public var endPositionBeforeTrailingTrivia: AbsolutePosition {
     return Syntax(self).endPositionBeforeTrailingTrivia
   }
 
   /// The end position of this node, including its trivia.
-  var endPosition: AbsolutePosition {
+  public var endPosition: AbsolutePosition {
     return Syntax(self).endPosition
   }
 
   /// The length of this node including all of its trivia.
-  var totalLength: SourceLength {
+  public var totalLength: SourceLength {
     return raw.totalLength
   }
 
@@ -439,12 +439,12 @@ public extension SyntaxProtocol {
   ///
   /// - Note: If this node consists of multiple tokens, only the first token’s
   ///   leading and the last token’s trailing trivia will be trimmed.
-  var trimmedLength: SourceLength {
+  public var trimmedLength: SourceLength {
     return raw.trimmedLength
   }
 
   /// The byte source range of this node including leading and trailing trivia.
-  var totalByteRange: ByteSourceRange {
+  public var totalByteRange: ByteSourceRange {
     return ByteSourceRange(offset: position.utf8Offset, length: totalLength.utf8Length)
   }
 
@@ -452,7 +452,7 @@ public extension SyntaxProtocol {
   ///
   /// - Note: If this node consists of multiple tokens, only the first token’s
   ///   leading and the last token’s trailing trivia will be trimmed.
-  var trimmedByteRange: ByteSourceRange {
+  public var trimmedByteRange: ByteSourceRange {
     return ByteSourceRange(
       offset: positionAfterSkippingLeadingTrivia.utf8Offset,
       length: trimmedLength.utf8Length
@@ -460,31 +460,31 @@ public extension SyntaxProtocol {
   }
 
   @available(*, deprecated, renamed: "trimmedLength")
-  var contentLength: SourceLength {
+  public var contentLength: SourceLength {
     return trimmedLength
   }
 
   @available(*, deprecated, renamed: "totalByteRange")
-  var byteRange: ByteSourceRange {
+  public var byteRange: ByteSourceRange {
     return ByteSourceRange(offset: position.utf8Offset, length: totalLength.utf8Length)
   }
 
   /// The textual byte length of this node including leading and trailing trivia.
   @available(*, deprecated, message: "Use totalLength.utf8Length")
-  var byteSize: Int {
+  public var byteSize: Int {
     return totalLength.utf8Length
   }
 
   /// The textual byte length of this node excluding leading and trailing trivia.
   @available(*, deprecated, message: "Use trimmedLength.utf8Length")
-  var byteSizeAfterTrimmingTrivia: Int {
+  public var byteSizeAfterTrimmingTrivia: Int {
     return trimmedLength.utf8Length
   }
 }
 
 // MARK: Trivia
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// The leading trivia of this syntax node.
   ///
   /// Trivia is always attached to tokens, not to layout nodes. This will return the leading trivia of the first token
@@ -495,7 +495,7 @@ public extension SyntaxProtocol {
   /// ```
   /// node.syntaxTextBytes.prefix(self.leadingTriviaLength.utf8Length)
   /// ```
-  var leadingTrivia: Trivia {
+  public var leadingTrivia: Trivia {
     get {
       return raw.formLeadingTrivia()
     }
@@ -514,7 +514,7 @@ public extension SyntaxProtocol {
   /// ```
   /// node.syntaxTextBytes[(node.byteSize - node.trailingTriviaLength.utf8Length)...]
   /// ```
-  var trailingTrivia: Trivia {
+  public var trailingTrivia: Trivia {
     get {
       return raw.formTrailingTrivia()
     }
@@ -524,12 +524,12 @@ public extension SyntaxProtocol {
   }
 
   /// The length this node's leading trivia takes up spelled out in source.
-  var leadingTriviaLength: SourceLength {
+  public var leadingTriviaLength: SourceLength {
     return raw.leadingTriviaLength
   }
 
   /// The length this node's trailing trivia takes up spelled out in source.
-  var trailingTriviaLength: SourceLength {
+  public var trailingTriviaLength: SourceLength {
     return raw.trailingTriviaLength
   }
 }
@@ -537,40 +537,40 @@ public extension SyntaxProtocol {
 // MARK: Content
 
 /// Provides the source-accurate text for a node
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// A source-accurate description of this node.
   ///
   /// Note that the resulting String cannot represent invalid UTF-8 that
   /// occurs within the syntax nodes. Use `syntaxTextBytes` for a
   /// byte-accurate representation of this node in the presence of
   /// invalid UTF-8.
-  var description: String {
+  public var description: String {
     return Syntax(self).raw.description
   }
 
   /// Retrieve the syntax text as an array of bytes that models the input
   /// source even in the presence of invalid UTF-8.
-  var syntaxTextBytes: [UInt8] {
+  public var syntaxTextBytes: [UInt8] {
     return Syntax(self).raw.syntaxTextBytes
   }
 
   /// Prints the raw value of this node to the provided stream.
   /// - Parameter stream: The stream to which to print the raw tree.
-  func write<Target>(to target: inout Target)
+  public func write<Target>(to target: inout Target)
   where Target: TextOutputStream {
     Syntax(self).raw.write(to: &target)
   }
 
   /// A copy of this node without the leading trivia of the first token in the
   /// node and the trailing trivia of the last token in the node.
-  var trimmed: Self {
+  public var trimmed: Self {
     // TODO: Should only need one new node here
     return self.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
   }
 
   /// A copy of this node with pieces that match `matching` trimmed from the
   /// leading trivia of the first token and trailing trivia of the last token.
-  func trimmed(matching filter: (TriviaPiece) -> Bool) -> Self {
+  public func trimmed(matching filter: (TriviaPiece) -> Bool) -> Self {
     // TODO: Should only need one new node here
     return self.with(
       \.leadingTrivia,
@@ -583,7 +583,7 @@ public extension SyntaxProtocol {
 
   /// The description of this node with leading whitespace of the first token
   /// and trailing whitespace of the last token removed.
-  var trimmedDescription: String {
+  public var trimmedDescription: String {
     // TODO: We shouldn't need to create to copies just to get the trimmed
     // description.
     return self.trimmed.description
@@ -592,7 +592,7 @@ public extension SyntaxProtocol {
   /// The description of this node with pieces that match `matching` removed
   /// from the leading trivia of the first token and trailing trivia of the
   /// last token.
-  func trimmedDescription(matching filter: (TriviaPiece) -> Bool) -> String {
+  public func trimmedDescription(matching filter: (TriviaPiece) -> Bool) -> String {
     // TODO: We shouldn't need to create to copies just to get the trimmed
     // description.
     return self.trimmed(matching: filter).description
@@ -601,16 +601,16 @@ public extension SyntaxProtocol {
 
 // MARK: Miscellaneous
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// When isImplicit is true, the syntax node doesn't include any
   /// underlying tokens, e.g. an empty CodeBlockItemList.
   @available(*, deprecated, message: "Check children(viewMode: .all).isEmpty instead")
-  var isImplicit: Bool {
+  public var isImplicit: Bool {
     return raw.isEmpty
   }
 
   /// Returns a value representing the unique identity of the node.
-  var id: SyntaxIdentifier {
+  public var id: SyntaxIdentifier {
     return Syntax(self).id
   }
 }
@@ -618,13 +618,13 @@ public extension SyntaxProtocol {
 // MARK: Debug description
 
 /// Provides debug descriptions for a node
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// A simple description of this node (ie. its type).
-  var debugDescription: String {
+  public var debugDescription: String {
     debugDescription()
   }
 
-  var customMirror: Mirror {
+  public var customMirror: Mirror {
     // Suppress printing of children when doing `po node` in the debugger.
     // `debugDescription` already prints them in a nicer way.
     return Mirror(self, children: [:])
@@ -640,7 +640,7 @@ public extension SyntaxProtocol {
   ///   the dump.
   ///   - indentLevel: The starting indent level, 0 by default. Each level is 2
   ///   spaces.
-  func debugDescription(
+  public func debugDescription(
     includeTrivia: Bool = false,
     converter: SourceLocationConverter? = nil,
     mark: SyntaxProtocol? = nil,
@@ -723,7 +723,7 @@ public extension SyntaxProtocol {
 /// possible types a child node might have.
 public protocol SyntaxChildChoices: SyntaxProtocol {}
 
-public extension SyntaxChildChoices {
+extension SyntaxChildChoices {
 
   /// Checks if the current ``SyntaxChildChoices`` instance can be cast to a given specialized syntax type.
   ///
@@ -731,7 +731,7 @@ public extension SyntaxChildChoices {
   ///
   /// - Note: This method is marked as deprecated because it is advised not to use it for unrelated casts.
   @available(*, deprecated, message: "This cast will always fail")
-  func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return self.as(syntaxType) != nil
   }
 
@@ -741,7 +741,7 @@ public extension SyntaxChildChoices {
   ///
   /// - Note: This method is marked as deprecated because it is advised not to use it for unrelated casts.
   @available(*, deprecated, message: "This cast will always fail")
-  func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(self)
   }
 
@@ -753,7 +753,7 @@ public extension SyntaxChildChoices {
   ///
   /// - Note: This method is marked as deprecated because it is advised not to use it for unrelated casts.
   @available(*, deprecated, message: "This cast will always fail")
-  func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+  public func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
     return self.as(S.self)!
   }
 }

--- a/Sources/SwiftSyntaxBuilder/DeclSyntaxParseable.swift
+++ b/Sources/SwiftSyntaxBuilder/DeclSyntaxParseable.swift
@@ -22,7 +22,7 @@ import SwiftSyntax
 /// - Warning: This protocol is considered an implementation detail. Do not rely
 ///   on it, only the initializer that it adds.
 public protocol DeclSyntaxParseable: DeclSyntaxProtocol {}
-public extension DeclSyntaxParseable {
+extension DeclSyntaxParseable {
   /// Create a syntax node from the given string interpolation.
   ///
   /// This initializer throws if the syntax node was not able to be parsed as
@@ -30,7 +30,7 @@ public extension DeclSyntaxParseable {
   ///
   /// If there are syntax errors in the string, the initializer will return a
   /// node that contains errors without throwing.
-  init(_ stringInterpolation: SyntaxNodeString) throws {
+  public init(_ stringInterpolation: SyntaxNodeString) throws {
     let node: DeclSyntax = "\(stringInterpolation)"
     if let castedDecl = node.as(Self.self) {
       self = castedDecl

--- a/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
@@ -69,8 +69,11 @@ public protocol HasTrailingCodeBlock: WithCodeBlockSyntax {
   init(_ header: SyntaxNodeString, @CodeBlockItemListBuilder bodyBuilder: () throws -> CodeBlockItemListSyntax) rethrows
 }
 
-public extension HasTrailingCodeBlock where Self: StmtSyntaxProtocol {
-  init(_ header: SyntaxNodeString, @CodeBlockItemListBuilder bodyBuilder: () throws -> CodeBlockItemListSyntax) throws {
+extension HasTrailingCodeBlock where Self: StmtSyntaxProtocol {
+  public init(
+    _ header: SyntaxNodeString,
+    @CodeBlockItemListBuilder bodyBuilder: () throws -> CodeBlockItemListSyntax
+  ) throws {
     let stmt = StmtSyntax("\(header) {}")
     guard let castedStmt = stmt.as(Self.self) else {
       throw SyntaxStringInterpolationInvalidNodeTypeError(expectedType: Self.self, actualNode: stmt)
@@ -97,7 +100,7 @@ extension WhileStmtSyntax: HasTrailingCodeBlock {}
 
 // MARK: - WithOptionalCodeBlockSyntax
 
-public extension WithOptionalCodeBlockSyntax where Self: DeclSyntaxProtocol {
+extension WithOptionalCodeBlockSyntax where Self: DeclSyntaxProtocol {
   /// Constructs a syntax node where `header` builds the text of the node before the body in braces and `bodyBuilder` is used to build the node’s body.
   ///
   /// For example, you can construct
@@ -117,7 +120,10 @@ public extension WithOptionalCodeBlockSyntax where Self: DeclSyntaxProtocol {
   /// ```
   ///
   /// Throws an error if `header` defines a different node type than the type the initializer is called on. E.g. if calling `try FunctionDeclSyntax("init") {}`
-  init(_ header: SyntaxNodeString, @CodeBlockItemListBuilder bodyBuilder: () throws -> CodeBlockItemListSyntax) throws {
+  public init(
+    _ header: SyntaxNodeString,
+    @CodeBlockItemListBuilder bodyBuilder: () throws -> CodeBlockItemListSyntax
+  ) throws {
     let decl = DeclSyntax("\(header) {}")
     guard let castedDecl = decl.as(Self.self) else {
       throw SyntaxStringInterpolationInvalidNodeTypeError(expectedType: Self.self, actualNode: decl)
@@ -159,8 +165,8 @@ public protocol HasTrailingMemberDeclBlock {
   ) throws
 }
 
-public extension HasTrailingMemberDeclBlock where Self: DeclSyntaxProtocol {
-  init(
+extension HasTrailingMemberDeclBlock where Self: DeclSyntaxProtocol {
+  public init(
     _ header: SyntaxNodeString,
     @MemberBlockItemListBuilder membersBuilder: () throws -> MemberBlockItemListSyntax
   ) throws {
@@ -184,7 +190,7 @@ extension StructDeclSyntax: HasTrailingMemberDeclBlock {}
 // IfExprSyntax is a special scenario as we also have the `else` body or an if-else
 // So we cannot conform to `HasTrailingCodeBlock`
 
-public extension IfExprSyntax {
+extension IfExprSyntax {
   /// Constructs an `if` expression with an optional `else` block.
   ///
   /// `header` specifies the part of the `if` expression before the body’s first brace.
@@ -202,7 +208,7 @@ public extension IfExprSyntax {
   /// This function takes care of inserting the braces as well.
   ///
   /// Throws an error if `header` does not start an `if` expression. E.g. if calling `try IfExprSyntax("while true") {}`
-  init(
+  public init(
     _ header: SyntaxNodeString,
     @CodeBlockItemListBuilder bodyBuilder: () throws -> CodeBlockItemListSyntax,
     @CodeBlockItemListBuilder `else` elseBuilder: () throws -> CodeBlockItemListSyntax? = { nil }
@@ -251,7 +257,7 @@ public extension IfExprSyntax {
   /// ```
   ///
   /// Throws an error if `header` does not start an `if` expression. E.g. if calling `try IfExprSyntax("while true", bodyBuilder: {}, elseIf: {})`
-  init(
+  public init(
     _ header: SyntaxNodeString,
     @CodeBlockItemListBuilder bodyBuilder: () throws -> CodeBlockItemListSyntax,
     elseIf: IfExprSyntax
@@ -301,7 +307,7 @@ extension SwitchCaseSyntax {
 // SwitchExprSyntax is a special scenario as it don't have body or members
 // So we cannot conform to `HasTrailingCodeBlock` or `HasTrailingMemberDeclBlock`
 
-public extension SwitchExprSyntax {
+extension SwitchExprSyntax {
   /// Constructs a `switch` expression where `header` builds the text before the opening `{` and `casesBuilder` can be used to build the case items.
   ///
   /// For example, to construct
@@ -325,7 +331,7 @@ public extension SwitchExprSyntax {
   /// ```
   ///
   /// Throws an error if `header` does not start a switch expression. E.g. if calling `try SwitchExprSyntax("if x < 42") {}`
-  init(
+  public init(
     _ header: SyntaxNodeString,
     @SwitchCaseListBuilder casesBuilder: () throws -> SwitchCaseListSyntax = { SwitchCaseListSyntax([]) }
   ) throws {
@@ -342,7 +348,7 @@ public extension SwitchExprSyntax {
 // VariableDeclSyntax is a special scenario as it don't have body or members
 // So we cannot conform to `HasTrailingCodeBlock` or `HasTrailingMemberDeclBlock`
 
-public extension VariableDeclSyntax {
+extension VariableDeclSyntax {
   /// Construct a variable with a single `get` accessor where `header` builds the text before the opening `{` and `accessor` builds the accessor body.
   ///
   /// For example, to construct
@@ -362,7 +368,10 @@ public extension VariableDeclSyntax {
   /// ```
   ///
   /// Throws an error if `header` does not start a variable declaration. E.g. if calling `try VariableDeclSyntax("func foo") {}`
-  init(_ header: SyntaxNodeString, @CodeBlockItemListBuilder accessor: () throws -> CodeBlockItemListSyntax) throws {
+  public init(
+    _ header: SyntaxNodeString,
+    @CodeBlockItemListBuilder accessor: () throws -> CodeBlockItemListSyntax
+  ) throws {
     let decl = DeclSyntax("\(header) {}")
     guard let castedDecl = decl.as(Self.self) else {
       throw SyntaxStringInterpolationInvalidNodeTypeError(expectedType: Self.self, actualNode: decl)

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/DeclarationMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/DeclarationMacro.swift
@@ -31,7 +31,7 @@ public protocol DeclarationMacro: FreestandingMacro {
   static var propagateFreestandingMacroModifiers: Bool { get }
 }
 
-public extension DeclarationMacro {
-  static var propagateFreestandingMacroAttributes: Bool { true }
-  static var propagateFreestandingMacroModifiers: Bool { true }
+extension DeclarationMacro {
+  public static var propagateFreestandingMacroAttributes: Bool { true }
+  public static var propagateFreestandingMacroModifiers: Bool { true }
 }

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/Macro+Format.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/Macro+Format.swift
@@ -22,8 +22,8 @@ public enum FormatMode {
   case disabled
 }
 
-public extension Macro {
-  static var formatMode: FormatMode {
+extension Macro {
+  public static var formatMode: FormatMode {
     return .auto
   }
 }

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/MemberMacro.swift
@@ -70,9 +70,9 @@ private struct UnimplementedExpansionMethodError: Error, CustomStringConvertible
   }
 }
 
-public extension MemberMacro {
+extension MemberMacro {
   /// Default implementation supplies no conformances.
-  static func expansion(
+  public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
@@ -81,7 +81,7 @@ public extension MemberMacro {
   }
 
   /// Default implementation that ignores the unhandled conformances.
-  static func expansion(
+  public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
     conformingTo protocols: [TypeSyntax],

--- a/Sources/_SwiftSyntaxTestSupport/String+TrimmingTrailingWhitespace.swift
+++ b/Sources/_SwiftSyntaxTestSupport/String+TrimmingTrailingWhitespace.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-public extension String {
+extension String {
   // This implementation is really slow; to use it outside a test it should be optimized.
-  func trimmingTrailingWhitespace() -> String {
+  public func trimmingTrailingWhitespace() -> String {
     return
       self
       .replacingOccurrences(of: "[ ]+\\n", with: "\n", options: .regularExpression)

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
@@ -90,10 +90,10 @@ extension TreeDifference: CustomDebugStringConvertible {
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Compares the current tree against a `baseline`, returning the first
   /// difference it finds.
-  func findFirstDifference(baseline: some SyntaxProtocol, includeTrivia: Bool = false) -> TreeDifference? {
+  public func findFirstDifference(baseline: some SyntaxProtocol, includeTrivia: Bool = false) -> TreeDifference? {
     if let reason = isDifferent(baseline: baseline, includeTrivia: includeTrivia) {
       return TreeDifference(node: self, baseline: baseline, reason: reason)
     }


### PR DESCRIPTION
Cherry-pick #2602 into release/6.0

* **Explanation**: In #2602, we refactored code by using the `swift-format` rule `NoAccessLevelOnExtensionDeclaration` and manually chose only changes with the `public` access level modifier. To reduce the risk of merge conflicts in cherry-picks into `release/6.0`, we are merging this refactored code into this branch as well.
* **Scope**: Entire codebase.
* **Risk**: Medium. During the cherry-pick, we encountered conflicts in the following files:
    * `Sources/SwiftIDEUtils/Syntax+Classifications.swift`
    * `Sources/SwiftSyntax/SyntaxProtocol.swift`
    * `Sources/SwiftSyntax/Utils.swift`

    The risk is that there are some extension members that don't have the `public` modifier transferred from their extension declaration.
* **Testing**: Passes current test suite.
* **Issue**: N/A
* **Reviewer**: Alex Hoppen (@ahoppen)