### PR TITLE
[6.0] Move `public` from extension decl to each decl in the extension in generated files

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RenamedSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/RenamedSyntaxNodesFile.swift
@@ -34,14 +34,14 @@ let renamedSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     }
   }
 
-  try! ExtensionDeclSyntax("public extension SyntaxKind") {
+  try! ExtensionDeclSyntax("extension SyntaxKind") {
     let syntaxKinds = SyntaxNodeKind.allCases.sorted(by: { $0.deprecatedRawValue ?? "" < $1.deprecatedRawValue ?? "" })
     for syntaxKind in syntaxKinds {
       if let deprecatedName = syntaxKind.deprecatedRawValue {
         DeclSyntax(
           """
           \(deprecationAttribute(for: syntaxKind))
-          static var \(raw: deprecatedName): Self {
+          public static var \(raw: deprecatedName): Self {
             return .\(syntaxKind.varOrCaseName)
           }
           """

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -145,14 +145,14 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """#
     )
 
-    try! ExtensionDeclSyntax("public extension Syntax") {
+    try! ExtensionDeclSyntax("extension Syntax") {
       DeclSyntax(
         """
         /// Check whether the non-type erased version of this syntax node conforms to
         /// \(node.kind.protocolType).
         ///
         ///  - Note:  This will incur an existential conversion.
-        func isProtocol(_: \(node.kind.protocolType).Protocol) -> Bool {
+        public func isProtocol(_: \(node.kind.protocolType).Protocol) -> Bool {
           return self.asProtocol(\(node.kind.protocolType).self) != nil
         }
         """
@@ -164,7 +164,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         /// \(node.kind.protocolType). Otherwise return nil.
         ///
         ///  - Note:  This will incur an existential conversion.
-        func asProtocol(_: \(node.kind.protocolType).Protocol) -> \(node.kind.protocolType)? {
+        public func asProtocol(_: \(node.kind.protocolType).Protocol) -> \(node.kind.protocolType)? {
           return self.asProtocol(SyntaxProtocol.self) as? \(node.kind.protocolType)
         }
         """
@@ -337,7 +337,7 @@ private func leafProtocolDecl(type: TypeSyntax, inheritedType: TypeSyntax) -> De
 private func leafProtocolExtension(type: TypeSyntax, inheritedType: TypeSyntax) -> DeclSyntax {
   DeclSyntax(
     #"""
-    public extension \#(type) {
+    extension \#(type) {
       /// Checks if the current leaf syntax node can be cast to a different specified type.
       ///
       /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
@@ -345,7 +345,7 @@ private func leafProtocolExtension(type: TypeSyntax, inheritedType: TypeSyntax) 
       /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
       ///         informing the user that the cast will always fail.
       @available(*, deprecated, message: "This cast will always fail")
-      func `is`<S: \#(inheritedType)>(_ syntaxType: S.Type) -> Bool {
+      public func `is`<S: \#(inheritedType)>(_ syntaxType: S.Type) -> Bool {
         return false
       }
 
@@ -356,7 +356,7 @@ private func leafProtocolExtension(type: TypeSyntax, inheritedType: TypeSyntax) 
       /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
       ///         informing the user that the cast will always fail.
       @available(*, deprecated, message: "This cast will always fail")
-      func `as`<S: \#(inheritedType)>(_ syntaxType: S.Type) -> S? {
+      public func `as`<S: \#(inheritedType)>(_ syntaxType: S.Type) -> S? {
         return nil
       }
 
@@ -368,7 +368,7 @@ private func leafProtocolExtension(type: TypeSyntax, inheritedType: TypeSyntax) 
       ///         informing the user that the cast will always fail.
       /// - Warning: Invoking this method will lead to a fatal error.
       @available(*, deprecated, message: "This cast will always fail")
-      func cast<S: \#(inheritedType)>(_ syntaxType: S.Type) -> S {
+      public func cast<S: \#(inheritedType)>(_ syntaxType: S.Type) -> S {
         fatalError("\(Self.self) cannot be cast to \(S.self)")
       }
     }

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxEnumFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxEnumFile.swift
@@ -35,13 +35,13 @@ let syntaxEnumFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
   try! ExtensionDeclSyntax(
     """
-    public extension Syntax
+    extension Syntax
     """
   ) {
     try FunctionDeclSyntax(
       """
       /// Get an enum that can be used to exhaustively switch over all syntax nodes.
-      func `as`(_: SyntaxEnum.Type) -> SyntaxEnum
+      public func `as`(_: SyntaxEnum.Type) -> SyntaxEnum
       """
     ) {
       try SwitchExprSyntax("switch raw.kind") {
@@ -81,13 +81,13 @@ let syntaxEnumFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     try! ExtensionDeclSyntax(
       """
-      public extension \(baseKind.syntaxType)
+      extension \(baseKind.syntaxType)
       """
     ) {
       try FunctionDeclSyntax(
         """
         /// Get an enum that can be used to exhaustively switch over all \(raw: baseName) syntax nodes.
-        func `as`(_: \(enumType).Type) -> \(enumType)
+        public func `as`(_: \(enumType).Type) -> \(enumType)
         """
       ) {
         try SwitchExprSyntax("switch raw.kind") {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -39,13 +39,13 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       }
     }
 
-    try! ExtensionDeclSyntax("public extension \(trait.protocolName)") {
+    try! ExtensionDeclSyntax("extension \(trait.protocolName)") {
       DeclSyntax(
         """
         /// Without this function, the `with` function defined on `SyntaxProtocol`
         /// does not work on existentials of this protocol type.
         @_disfavoredOverload
-        func with<T>(_ keyPath: WritableKeyPath<\(trait.protocolName), T>, _ newChild: T) -> \(trait.protocolName) {
+        public func with<T>(_ keyPath: WritableKeyPath<\(trait.protocolName), T>, _ newChild: T) -> \(trait.protocolName) {
           var copy: \(trait.protocolName) = self
           copy[keyPath: keyPath] = newChild
           return copy
@@ -54,13 +54,13 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       )
     }
 
-    try! ExtensionDeclSyntax("public extension SyntaxProtocol") {
+    try! ExtensionDeclSyntax("extension SyntaxProtocol") {
       DeclSyntax(
         """
         /// Check whether the non-type erased version of this syntax node conforms to
         /// `\(trait.protocolName)`.
         /// Note that this will incur an existential conversion.
-        func isProtocol(_: \(trait.protocolName).Protocol) -> Bool {
+        public func isProtocol(_: \(trait.protocolName).Protocol) -> Bool {
           return self.asProtocol(\(trait.protocolName).self) != nil
         }
         """
@@ -71,7 +71,7 @@ let syntaxTraitsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         /// Return the non-type erased version of this syntax node if it conforms to
         /// `\(trait.protocolName)`. Otherwise return `nil`.
         /// Note that this will incur an existential conversion.
-        func asProtocol(_: \(trait.protocolName).Protocol) -> \(trait.protocolName)? {
+        public func asProtocol(_: \(trait.protocolName).Protocol) -> \(trait.protocolName)? {
           return Syntax(self).asProtocol(SyntaxProtocol.self) as? \(trait.protocolName)
         }
         """

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/ResultBuildersFile.swift
@@ -60,8 +60,8 @@ let resultBuildersFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      public extension \(type.syntaxBaseName) {
-        init(@\(type.resultBuilderType) itemsBuilder: () throws -> \(type.syntaxBaseName)) rethrows {
+      extension \(type.syntaxBaseName) {
+        public init(@\(type.resultBuilderType) itemsBuilder: () throws -> \(type.syntaxBaseName)) rethrows {
           self = try itemsBuilder()
         }
       }

--- a/Sources/SwiftSyntax/generated/RenamedNodesCompatibility.swift
+++ b/Sources/SwiftSyntax/generated/RenamedNodesCompatibility.swift
@@ -219,349 +219,349 @@ public typealias YieldExprListElementSyntax = YieldedExpressionSyntax
 @available(*, deprecated, renamed: "YieldedExpressionsClauseSyntax")
 public typealias YieldListSyntax = YieldedExpressionsClauseSyntax
 
-public extension SyntaxKind {
+extension SyntaxKind {
   @available(*, deprecated, renamed: "ImportPathComponentListSyntax")
-  static var accessPath: Self {
+  public static var accessPath: Self {
     return .importPathComponentList
   }
   
   @available(*, deprecated, renamed: "ImportPathComponentSyntax")
-  static var accessPathComponent: Self {
+  public static var accessPathComponent: Self {
     return .importPathComponent
   }
   
   @available(*, deprecated, renamed: "AccessorDeclListSyntax")
-  static var accessorList: Self {
+  public static var accessorList: Self {
     return .accessorDeclList
   }
   
   @available(*, deprecated, renamed: "AccessorParametersSyntax")
-  static var accessorParameter: Self {
+  public static var accessorParameter: Self {
     return .accessorParameters
   }
   
   @available(*, deprecated, renamed: "AssociatedTypeDeclSyntax")
-  static var associatedtypeDecl: Self {
+  public static var associatedtypeDecl: Self {
     return .associatedTypeDecl
   }
   
   @available(*, deprecated, renamed: "SpecializeAvailabilityArgumentSyntax")
-  static var availabilityEntry: Self {
+  public static var availabilityEntry: Self {
     return .specializeAvailabilityArgument
   }
   
   @available(*, deprecated, renamed: "AvailabilityArgumentListSyntax")
-  static var availabilitySpecList: Self {
+  public static var availabilitySpecList: Self {
     return .availabilityArgumentList
   }
   
   @available(*, deprecated, renamed: "PlatformVersionSyntax")
-  static var availabilityVersionRestriction: Self {
+  public static var availabilityVersionRestriction: Self {
     return .platformVersion
   }
   
   @available(*, deprecated, renamed: "PlatformVersionItemListSyntax")
-  static var availabilityVersionRestrictionList: Self {
+  public static var availabilityVersionRestrictionList: Self {
     return .platformVersionItemList
   }
   
   @available(*, deprecated, renamed: "PlatformVersionItemSyntax")
-  static var availabilityVersionRestrictionListEntry: Self {
+  public static var availabilityVersionRestrictionListEntry: Self {
     return .platformVersionItem
   }
   
   @available(*, deprecated, renamed: "BackDeployedAttributeArgumentsSyntax")
-  static var backDeployedAttributeSpecList: Self {
+  public static var backDeployedAttributeSpecList: Self {
     return .backDeployedAttributeArguments
   }
   
   @available(*, deprecated, message: "'canImport' directives are now represented as a `FunctionCallExpr`")
-  static var canImportExpr: Self {
+  public static var canImportExpr: Self {
     return ._canImportExpr
   }
   
   @available(*, deprecated, message: "'canImport' directives are now represented as a `FunctionCallExpr`")
-  static var canImportVersionInfo: Self {
+  public static var canImportVersionInfo: Self {
     return ._canImportVersionInfo
   }
   
   @available(*, deprecated, renamed: "SwitchCaseItemSyntax")
-  static var caseItem: Self {
+  public static var caseItem: Self {
     return .switchCaseItem
   }
   
   @available(*, deprecated, renamed: "SwitchCaseItemListSyntax")
-  static var caseItemList: Self {
+  public static var caseItemList: Self {
     return .switchCaseItemList
   }
   
   @available(*, deprecated, renamed: "ClosureCaptureSyntax")
-  static var closureCaptureItem: Self {
+  public static var closureCaptureItem: Self {
     return .closureCapture
   }
   
   @available(*, deprecated, renamed: "ClosureCaptureListSyntax")
-  static var closureCaptureItemList: Self {
+  public static var closureCaptureItemList: Self {
     return .closureCaptureList
   }
   
   @available(*, deprecated, renamed: "ClosureCaptureSpecifierSyntax")
-  static var closureCaptureItemSpecifier: Self {
+  public static var closureCaptureItemSpecifier: Self {
     return .closureCaptureSpecifier
   }
   
   @available(*, deprecated, renamed: "ClosureCaptureClauseSyntax")
-  static var closureCaptureSignature: Self {
+  public static var closureCaptureSignature: Self {
     return .closureCaptureClause
   }
   
   @available(*, deprecated, renamed: "ClosureShorthandParameterSyntax")
-  static var closureParam: Self {
+  public static var closureParam: Self {
     return .closureShorthandParameter
   }
   
   @available(*, deprecated, renamed: "ClosureShorthandParameterListSyntax")
-  static var closureParamList: Self {
+  public static var closureParamList: Self {
     return .closureShorthandParameterList
   }
   
   @available(*, deprecated, renamed: "SomeOrAnyTypeSyntax")
-  static var constrainedSugarType: Self {
+  public static var constrainedSugarType: Self {
     return .someOrAnyType
   }
   
   @available(*, deprecated, renamed: "DeinitializerEffectSpecifiersSyntax")
-  static var deinitEffectSpecifiers: Self {
+  public static var deinitEffectSpecifiers: Self {
     return .deinitializerEffectSpecifiers
   }
   
   @available(*, deprecated, renamed: "DerivativeAttributeArgumentsSyntax")
-  static var derivativeRegistrationAttributeArguments: Self {
+  public static var derivativeRegistrationAttributeArguments: Self {
     return .derivativeAttributeArguments
   }
   
   @available(*, deprecated, renamed: "DesignatedTypeSyntax")
-  static var designatedTypeElement: Self {
+  public static var designatedTypeElement: Self {
     return .designatedType
   }
   
   @available(*, deprecated, renamed: "DifferentiabilityArgumentSyntax")
-  static var differentiabilityParam: Self {
+  public static var differentiabilityParam: Self {
     return .differentiabilityArgument
   }
   
   @available(*, deprecated, renamed: "DifferentiabilityArgumentListSyntax")
-  static var differentiabilityParamList: Self {
+  public static var differentiabilityParamList: Self {
     return .differentiabilityArgumentList
   }
   
   @available(*, deprecated, renamed: "DifferentiabilityArgumentsSyntax")
-  static var differentiabilityParams: Self {
+  public static var differentiabilityParams: Self {
     return .differentiabilityArguments
   }
   
   @available(*, deprecated, renamed: "DifferentiabilityWithRespectToArgumentSyntax")
-  static var differentiabilityParamsClause: Self {
+  public static var differentiabilityParamsClause: Self {
     return .differentiabilityWithRespectToArgument
   }
   
   @available(*, deprecated, renamed: "DocumentationAttributeArgumentListSyntax")
-  static var documentationAttributeArguments: Self {
+  public static var documentationAttributeArguments: Self {
     return .documentationAttributeArgumentList
   }
   
   @available(*, deprecated, renamed: "DynamicReplacementAttributeArgumentsSyntax")
-  static var dynamicReplacementArguments: Self {
+  public static var dynamicReplacementArguments: Self {
     return .dynamicReplacementAttributeArguments
   }
   
   @available(*, deprecated, renamed: "EffectsAttributeArgumentListSyntax")
-  static var effectsArguments: Self {
+  public static var effectsArguments: Self {
     return .effectsAttributeArgumentList
   }
   
   @available(*, deprecated, renamed: "EnumCaseParameterClauseSyntax")
-  static var enumCaseAssociatedValue: Self {
+  public static var enumCaseAssociatedValue: Self {
     return .enumCaseParameterClause
   }
   
   @available(*, deprecated, renamed: "FallThroughStmtSyntax")
-  static var fallthroughStmt: Self {
+  public static var fallthroughStmt: Self {
     return .fallThroughStmt
   }
   
   @available(*, deprecated, renamed: "ForStmtSyntax")
-  static var forInStmt: Self {
+  public static var forInStmt: Self {
     return .forStmt
   }
   
   @available(*, deprecated, renamed: "ForceUnwrapExprSyntax")
-  static var forcedValueExpr: Self {
+  public static var forcedValueExpr: Self {
     return .forceUnwrapExpr
   }
   
   @available(*, deprecated, renamed: "DeclReferenceExprSyntax")
-  static var identifierExpr: Self {
+  public static var identifierExpr: Self {
     return .declReferenceExpr
   }
   
   @available(*, deprecated, renamed: "LabeledSpecializeArgumentSyntax")
-  static var labeledSpecializeEntry: Self {
+  public static var labeledSpecializeEntry: Self {
     return .labeledSpecializeArgument
   }
   
   @available(*, deprecated, renamed: "MemberBlockSyntax")
-  static var memberDeclBlock: Self {
+  public static var memberDeclBlock: Self {
     return .memberBlock
   }
   
   @available(*, deprecated, renamed: "MemberBlockItemListSyntax")
-  static var memberDeclList: Self {
+  public static var memberDeclList: Self {
     return .memberBlockItemList
   }
   
   @available(*, deprecated, renamed: "MemberBlockItemSyntax")
-  static var memberDeclListItem: Self {
+  public static var memberDeclListItem: Self {
     return .memberBlockItem
   }
   
   @available(*, deprecated, renamed: "MemberTypeSyntax")
-  static var memberTypeIdentifier: Self {
+  public static var memberTypeIdentifier: Self {
     return .memberType
   }
   
   @available(*, deprecated, renamed: "DeclModifierListSyntax")
-  static var modifierList: Self {
+  public static var modifierList: Self {
     return .declModifierList
   }
   
   @available(*, deprecated, renamed: "ConsumeExprSyntax")
-  static var moveExpr: Self {
+  public static var moveExpr: Self {
     return .consumeExpr
   }
   
   @available(*, deprecated, renamed: "ObjCSelectorPieceListSyntax")
-  static var objCSelector: Self {
+  public static var objCSelector: Self {
     return .objCSelectorPieceList
   }
   
   @available(*, deprecated, renamed: "OriginallyDefinedInAttributeArgumentsSyntax")
-  static var originallyDefinedInArguments: Self {
+  public static var originallyDefinedInArguments: Self {
     return .originallyDefinedInAttributeArguments
   }
   
   @available(*, deprecated, renamed: "PackElementTypeSyntax")
-  static var packReferenceType: Self {
+  public static var packReferenceType: Self {
     return .packElementType
   }
   
   @available(*, deprecated, renamed: "FunctionParameterClauseSyntax")
-  static var parameterClause: Self {
+  public static var parameterClause: Self {
     return .functionParameterClause
   }
   
   @available(*, deprecated, renamed: "PostfixOperatorExprSyntax")
-  static var postfixUnaryExpr: Self {
+  public static var postfixUnaryExpr: Self {
     return .postfixOperatorExpr
   }
   
   @available(*, deprecated, renamed: "PoundSourceLocationArgumentsSyntax")
-  static var poundSourceLocationArgs: Self {
+  public static var poundSourceLocationArgs: Self {
     return .poundSourceLocationArguments
   }
   
   @available(*, deprecated, renamed: "PrecedenceGroupNameSyntax")
-  static var precedenceGroupNameElement: Self {
+  public static var precedenceGroupNameElement: Self {
     return .precedenceGroupName
   }
   
   @available(*, deprecated, renamed: "RepeatStmtSyntax")
-  static var repeatWhileStmt: Self {
+  public static var repeatWhileStmt: Self {
     return .repeatStmt
   }
   
   @available(*, deprecated, renamed: "IdentifierTypeSyntax")
-  static var simpleTypeIdentifier: Self {
+  public static var simpleTypeIdentifier: Self {
     return .identifierType
   }
   
   @available(*, deprecated, renamed: "SpecializeAttributeArgumentListSyntax")
-  static var specializeAttributeSpecList: Self {
+  public static var specializeAttributeSpecList: Self {
     return .specializeAttributeArgumentList
   }
   
   @available(*, deprecated, renamed: "GenericSpecializationExprSyntax")
-  static var specializeExpr: Self {
+  public static var specializeExpr: Self {
     return .genericSpecializationExpr
   }
   
   @available(*, deprecated, renamed: "StringLiteralSegmentListSyntax")
-  static var stringLiteralSegments: Self {
+  public static var stringLiteralSegments: Self {
     return .stringLiteralSegmentList
   }
   
   @available(*, deprecated, renamed: "SubscriptCallExprSyntax")
-  static var subscriptExpr: Self {
+  public static var subscriptExpr: Self {
     return .subscriptCallExpr
   }
   
   @available(*, deprecated, renamed: "SuperExprSyntax")
-  static var superRefExpr: Self {
+  public static var superRefExpr: Self {
     return .superExpr
   }
   
   @available(*, deprecated, renamed: "SpecializeTargetFunctionArgumentSyntax")
-  static var targetFunctionEntry: Self {
+  public static var targetFunctionEntry: Self {
     return .specializeTargetFunctionArgument
   }
   
   @available(*, deprecated, renamed: "LabeledExprSyntax")
-  static var tupleExprElement: Self {
+  public static var tupleExprElement: Self {
     return .labeledExpr
   }
   
   @available(*, deprecated, renamed: "LabeledExprListSyntax")
-  static var tupleExprElementList: Self {
+  public static var tupleExprElementList: Self {
     return .labeledExprList
   }
   
   @available(*, deprecated, renamed: "InheritanceClauseSyntax")
-  static var typeInheritanceClause: Self {
+  public static var typeInheritanceClause: Self {
     return .inheritanceClause
   }
   
   @available(*, deprecated, renamed: "SimpleTypeSpecifierSyntax")
-  static var typeSpecifier: Self {
+  public static var typeSpecifier: Self {
     return .simpleTypeSpecifier
   }
   
   @available(*, deprecated, renamed: "TypeAliasDeclSyntax")
-  static var typealiasDecl: Self {
+  public static var typealiasDecl: Self {
     return .typeAliasDecl
   }
   
   @available(*, deprecated, renamed: "UnavailableFromAsyncAttributeArgumentsSyntax")
-  static var unavailableFromAsyncArguments: Self {
+  public static var unavailableFromAsyncArguments: Self {
     return .unavailableFromAsyncAttributeArguments
   }
   
   @available(*, deprecated, renamed: "PatternExprSyntax")
-  static var unresolvedPatternExpr: Self {
+  public static var unresolvedPatternExpr: Self {
     return .patternExpr
   }
   
   @available(*, deprecated, renamed: "YieldedExpressionListSyntax")
-  static var yieldExprList: Self {
+  public static var yieldExprList: Self {
     return .yieldedExpressionList
   }
   
   @available(*, deprecated, renamed: "YieldedExpressionSyntax")
-  static var yieldExprListElement: Self {
+  public static var yieldExprListElement: Self {
     return .yieldedExpression
   }
   
   @available(*, deprecated, renamed: "YieldedExpressionsClauseSyntax")
-  static var yieldList: Self {
+  public static var yieldList: Self {
     return .yieldedExpressionsClause
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -135,12 +135,12 @@ extension DeclSyntaxProtocol {
   }
 }
 
-public extension Syntax {
+extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// DeclSyntaxProtocol.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func isProtocol(_: DeclSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: DeclSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(DeclSyntaxProtocol.self) != nil
   }
   
@@ -148,7 +148,7 @@ public extension Syntax {
   /// DeclSyntaxProtocol. Otherwise return nil.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func asProtocol(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol? {
+  public func asProtocol(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? DeclSyntaxProtocol
   }
 }
@@ -275,7 +275,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 /// deprecated to prevent incorrect casting.
 public protocol _LeafDeclSyntaxNodeProtocol: DeclSyntaxProtocol {}
 
-public extension _LeafDeclSyntaxNodeProtocol {
+extension _LeafDeclSyntaxNodeProtocol {
   /// Checks if the current leaf syntax node can be cast to a different specified type.
   ///
   /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
@@ -283,7 +283,7 @@ public extension _LeafDeclSyntaxNodeProtocol {
   /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `is`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+  public func `is`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
   
@@ -295,7 +295,7 @@ public extension _LeafDeclSyntaxNodeProtocol {
   /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `as`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+  public func `as`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
   
@@ -308,7 +308,7 @@ public extension _LeafDeclSyntaxNodeProtocol {
   ///         informing the user that the cast will always fail.
   /// - Warning: Invoking this method will lead to a fatal error.
   @available(*, deprecated, message: "This cast will always fail")
-  func cast<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+  public func cast<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S {
     fatalError("\(Self.self) cannot be cast to \(S.self)")
   }
 }
@@ -436,12 +436,12 @@ extension ExprSyntaxProtocol {
   }
 }
 
-public extension Syntax {
+extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// ExprSyntaxProtocol.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func isProtocol(_: ExprSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: ExprSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(ExprSyntaxProtocol.self) != nil
   }
   
@@ -449,7 +449,7 @@ public extension Syntax {
   /// ExprSyntaxProtocol. Otherwise return nil.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func asProtocol(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol? {
+  public func asProtocol(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? ExprSyntaxProtocol
   }
 }
@@ -631,7 +631,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 /// deprecated to prevent incorrect casting.
 public protocol _LeafExprSyntaxNodeProtocol: ExprSyntaxProtocol {}
 
-public extension _LeafExprSyntaxNodeProtocol {
+extension _LeafExprSyntaxNodeProtocol {
   /// Checks if the current leaf syntax node can be cast to a different specified type.
   ///
   /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
@@ -639,7 +639,7 @@ public extension _LeafExprSyntaxNodeProtocol {
   /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `is`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+  public func `is`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
   
@@ -651,7 +651,7 @@ public extension _LeafExprSyntaxNodeProtocol {
   /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+  public func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
   
@@ -664,7 +664,7 @@ public extension _LeafExprSyntaxNodeProtocol {
   ///         informing the user that the cast will always fail.
   /// - Warning: Invoking this method will lead to a fatal error.
   @available(*, deprecated, message: "This cast will always fail")
-  func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+  public func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
     fatalError("\(Self.self) cannot be cast to \(S.self)")
   }
 }
@@ -792,12 +792,12 @@ extension PatternSyntaxProtocol {
   }
 }
 
-public extension Syntax {
+extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// PatternSyntaxProtocol.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func isProtocol(_: PatternSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: PatternSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(PatternSyntaxProtocol.self) != nil
   }
   
@@ -805,7 +805,7 @@ public extension Syntax {
   /// PatternSyntaxProtocol. Otherwise return nil.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func asProtocol(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol? {
+  public func asProtocol(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? PatternSyntaxProtocol
   }
 }
@@ -898,7 +898,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 /// deprecated to prevent incorrect casting.
 public protocol _LeafPatternSyntaxNodeProtocol: PatternSyntaxProtocol {}
 
-public extension _LeafPatternSyntaxNodeProtocol {
+extension _LeafPatternSyntaxNodeProtocol {
   /// Checks if the current leaf syntax node can be cast to a different specified type.
   ///
   /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
@@ -906,7 +906,7 @@ public extension _LeafPatternSyntaxNodeProtocol {
   /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `is`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+  public func `is`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
   
@@ -918,7 +918,7 @@ public extension _LeafPatternSyntaxNodeProtocol {
   /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `as`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+  public func `as`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
   
@@ -931,7 +931,7 @@ public extension _LeafPatternSyntaxNodeProtocol {
   ///         informing the user that the cast will always fail.
   /// - Warning: Invoking this method will lead to a fatal error.
   @available(*, deprecated, message: "This cast will always fail")
-  func cast<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+  public func cast<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S {
     fatalError("\(Self.self) cannot be cast to \(S.self)")
   }
 }
@@ -1059,12 +1059,12 @@ extension StmtSyntaxProtocol {
   }
 }
 
-public extension Syntax {
+extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// StmtSyntaxProtocol.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func isProtocol(_: StmtSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: StmtSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(StmtSyntaxProtocol.self) != nil
   }
   
@@ -1072,7 +1072,7 @@ public extension Syntax {
   /// StmtSyntaxProtocol. Otherwise return nil.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func asProtocol(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol? {
+  public func asProtocol(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? StmtSyntaxProtocol
   }
 }
@@ -1184,7 +1184,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 /// deprecated to prevent incorrect casting.
 public protocol _LeafStmtSyntaxNodeProtocol: StmtSyntaxProtocol {}
 
-public extension _LeafStmtSyntaxNodeProtocol {
+extension _LeafStmtSyntaxNodeProtocol {
   /// Checks if the current leaf syntax node can be cast to a different specified type.
   ///
   /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
@@ -1192,7 +1192,7 @@ public extension _LeafStmtSyntaxNodeProtocol {
   /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `is`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+  public func `is`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
   
@@ -1204,7 +1204,7 @@ public extension _LeafStmtSyntaxNodeProtocol {
   /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `as`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+  public func `as`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
   
@@ -1217,7 +1217,7 @@ public extension _LeafStmtSyntaxNodeProtocol {
   ///         informing the user that the cast will always fail.
   /// - Warning: Invoking this method will lead to a fatal error.
   @available(*, deprecated, message: "This cast will always fail")
-  func cast<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+  public func cast<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S {
     fatalError("\(Self.self) cannot be cast to \(S.self)")
   }
 }
@@ -1345,12 +1345,12 @@ extension TypeSyntaxProtocol {
   }
 }
 
-public extension Syntax {
+extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// TypeSyntaxProtocol.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func isProtocol(_: TypeSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: TypeSyntaxProtocol.Protocol) -> Bool {
     return self.asProtocol(TypeSyntaxProtocol.self) != nil
   }
   
@@ -1358,7 +1358,7 @@ public extension Syntax {
   /// TypeSyntaxProtocol. Otherwise return nil.
   ///
   ///  - Note:  This will incur an existential conversion.
-  func asProtocol(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol? {
+  public func asProtocol(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol? {
     return self.asProtocol(SyntaxProtocol.self) as? TypeSyntaxProtocol
   }
 }
@@ -1473,7 +1473,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 /// deprecated to prevent incorrect casting.
 public protocol _LeafTypeSyntaxNodeProtocol: TypeSyntaxProtocol {}
 
-public extension _LeafTypeSyntaxNodeProtocol {
+extension _LeafTypeSyntaxNodeProtocol {
   /// Checks if the current leaf syntax node can be cast to a different specified type.
   ///
   /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
@@ -1481,7 +1481,7 @@ public extension _LeafTypeSyntaxNodeProtocol {
   /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `is`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+  public func `is`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
   
@@ -1493,7 +1493,7 @@ public extension _LeafTypeSyntaxNodeProtocol {
   /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `as`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+  public func `as`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
   
@@ -1506,7 +1506,7 @@ public extension _LeafTypeSyntaxNodeProtocol {
   ///         informing the user that the cast will always fail.
   /// - Warning: Invoking this method will lead to a fatal error.
   @available(*, deprecated, message: "This cast will always fail")
-  func cast<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S {
+  public func cast<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S {
     fatalError("\(Self.self) cannot be cast to \(S.self)")
   }
 }
@@ -1811,7 +1811,7 @@ extension Syntax {
 /// deprecated to prevent incorrect casting.
 public protocol _LeafSyntaxNodeProtocol: SyntaxProtocol {}
 
-public extension _LeafSyntaxNodeProtocol {
+extension _LeafSyntaxNodeProtocol {
   /// Checks if the current leaf syntax node can be cast to a different specified type.
   ///
   /// - Returns: `false` since the leaf node cannot be cast to a different specified type.
@@ -1819,7 +1819,7 @@ public extension _LeafSyntaxNodeProtocol {
   /// - Note: This method overloads the general `is` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return false
   }
   
@@ -1831,7 +1831,7 @@ public extension _LeafSyntaxNodeProtocol {
   /// - Note: This method overloads the general `as` method and is marked as deprecated to produce a warning,
   ///         informing the user that the cast will always fail.
   @available(*, deprecated, message: "This cast will always fail")
-  func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return nil
   }
   
@@ -1844,7 +1844,7 @@ public extension _LeafSyntaxNodeProtocol {
   ///         informing the user that the cast will always fail.
   /// - Warning: Invoking this method will lead to a fatal error.
   @available(*, deprecated, message: "This cast will always fail")
-  func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+  public func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
     fatalError("\(Self.self) cannot be cast to \(S.self)")
   }
 }

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -315,9 +315,9 @@ public enum SyntaxEnum: Sendable {
   case yieldedExpressionsClause(YieldedExpressionsClauseSyntax)
 }
 
-public extension Syntax {
+extension Syntax {
   /// Get an enum that can be used to exhaustively switch over all syntax nodes.
-  func `as`(_: SyntaxEnum.Type) -> SyntaxEnum {
+  public func `as`(_: SyntaxEnum.Type) -> SyntaxEnum {
     switch raw.kind {
     case .token:
       return .token(TokenSyntax(self)!)
@@ -919,9 +919,9 @@ public enum DeclSyntaxEnum {
   case variableDecl(VariableDeclSyntax)
 }
 
-public extension DeclSyntax {
+extension DeclSyntax {
   /// Get an enum that can be used to exhaustively switch over all Decl syntax nodes.
-  func `as`(_: DeclSyntaxEnum.Type) -> DeclSyntaxEnum {
+  public func `as`(_: DeclSyntaxEnum.Type) -> DeclSyntaxEnum {
     switch raw.kind {
     case .accessorDecl:
       return .accessorDecl(AccessorDeclSyntax(self)!)
@@ -1037,9 +1037,9 @@ public enum ExprSyntaxEnum {
   case unresolvedTernaryExpr(UnresolvedTernaryExprSyntax)
 }
 
-public extension ExprSyntax {
+extension ExprSyntax {
   /// Get an enum that can be used to exhaustively switch over all Expr syntax nodes.
-  func `as`(_: ExprSyntaxEnum.Type) -> ExprSyntaxEnum {
+  public func `as`(_: ExprSyntaxEnum.Type) -> ExprSyntaxEnum {
     switch raw.kind {
     case .arrayExpr:
       return .arrayExpr(ArrayExprSyntax(self)!)
@@ -1164,9 +1164,9 @@ public enum PatternSyntaxEnum {
   case wildcardPattern(WildcardPatternSyntax)
 }
 
-public extension PatternSyntax {
+extension PatternSyntax {
   /// Get an enum that can be used to exhaustively switch over all Pattern syntax nodes.
-  func `as`(_: PatternSyntaxEnum.Type) -> PatternSyntaxEnum {
+  public func `as`(_: PatternSyntaxEnum.Type) -> PatternSyntaxEnum {
     switch raw.kind {
     case .expressionPattern:
       return .expressionPattern(ExpressionPatternSyntax(self)!)
@@ -1212,9 +1212,9 @@ public enum StmtSyntaxEnum {
   case yieldStmt(YieldStmtSyntax)
 }
 
-public extension StmtSyntax {
+extension StmtSyntax {
   /// Get an enum that can be used to exhaustively switch over all Stmt syntax nodes.
-  func `as`(_: StmtSyntaxEnum.Type) -> StmtSyntaxEnum {
+  public func `as`(_: StmtSyntaxEnum.Type) -> StmtSyntaxEnum {
     switch raw.kind {
     case .breakStmt:
       return .breakStmt(BreakStmtSyntax(self)!)
@@ -1278,9 +1278,9 @@ public enum TypeSyntaxEnum {
   case tupleType(TupleTypeSyntax)
 }
 
-public extension TypeSyntax {
+extension TypeSyntax {
   /// Get an enum that can be used to exhaustively switch over all Type syntax nodes.
-  func `as`(_: TypeSyntaxEnum.Type) -> TypeSyntaxEnum {
+  public func `as`(_: TypeSyntaxEnum.Type) -> TypeSyntaxEnum {
     switch raw.kind {
     case .arrayType:
       return .arrayType(ArrayTypeSyntax(self)!)

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -32,29 +32,29 @@ public protocol BracedSyntax: SyntaxProtocol {
   }
 }
 
-public extension BracedSyntax {
+extension BracedSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<BracedSyntax, T>, _ newChild: T) -> BracedSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<BracedSyntax, T>, _ newChild: T) -> BracedSyntax {
     var copy: BracedSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `BracedSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: BracedSyntax.Protocol) -> Bool {
+  public func isProtocol(_: BracedSyntax.Protocol) -> Bool {
     return self.asProtocol(BracedSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `BracedSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: BracedSyntax.Protocol) -> BracedSyntax? {
+  public func asProtocol(_: BracedSyntax.Protocol) -> BracedSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? BracedSyntax
   }
 }
@@ -105,29 +105,29 @@ public protocol DeclGroupSyntax: SyntaxProtocol, DeclSyntaxProtocol {
   }
 }
 
-public extension DeclGroupSyntax {
+extension DeclGroupSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<DeclGroupSyntax, T>, _ newChild: T) -> DeclGroupSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<DeclGroupSyntax, T>, _ newChild: T) -> DeclGroupSyntax {
     var copy: DeclGroupSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `DeclGroupSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: DeclGroupSyntax.Protocol) -> Bool {
+  public func isProtocol(_: DeclGroupSyntax.Protocol) -> Bool {
     return self.asProtocol(DeclGroupSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `DeclGroupSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: DeclGroupSyntax.Protocol) -> DeclGroupSyntax? {
+  public func asProtocol(_: DeclGroupSyntax.Protocol) -> DeclGroupSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? DeclGroupSyntax
   }
 }
@@ -166,29 +166,29 @@ public protocol EffectSpecifiersSyntax: SyntaxProtocol {
   }
 }
 
-public extension EffectSpecifiersSyntax {
+extension EffectSpecifiersSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<EffectSpecifiersSyntax, T>, _ newChild: T) -> EffectSpecifiersSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<EffectSpecifiersSyntax, T>, _ newChild: T) -> EffectSpecifiersSyntax {
     var copy: EffectSpecifiersSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `EffectSpecifiersSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: EffectSpecifiersSyntax.Protocol) -> Bool {
+  public func isProtocol(_: EffectSpecifiersSyntax.Protocol) -> Bool {
     return self.asProtocol(EffectSpecifiersSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `EffectSpecifiersSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: EffectSpecifiersSyntax.Protocol) -> EffectSpecifiersSyntax? {
+  public func asProtocol(_: EffectSpecifiersSyntax.Protocol) -> EffectSpecifiersSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? EffectSpecifiersSyntax
   }
 }
@@ -249,29 +249,29 @@ public protocol FreestandingMacroExpansionSyntax: SyntaxProtocol {
   }
 }
 
-public extension FreestandingMacroExpansionSyntax {
+extension FreestandingMacroExpansionSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<FreestandingMacroExpansionSyntax, T>, _ newChild: T) -> FreestandingMacroExpansionSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<FreestandingMacroExpansionSyntax, T>, _ newChild: T) -> FreestandingMacroExpansionSyntax {
     var copy: FreestandingMacroExpansionSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `FreestandingMacroExpansionSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: FreestandingMacroExpansionSyntax.Protocol) -> Bool {
+  public func isProtocol(_: FreestandingMacroExpansionSyntax.Protocol) -> Bool {
     return self.asProtocol(FreestandingMacroExpansionSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `FreestandingMacroExpansionSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: FreestandingMacroExpansionSyntax.Protocol) -> FreestandingMacroExpansionSyntax? {
+  public func asProtocol(_: FreestandingMacroExpansionSyntax.Protocol) -> FreestandingMacroExpansionSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? FreestandingMacroExpansionSyntax
   }
 }
@@ -288,29 +288,29 @@ public protocol NamedDeclSyntax: SyntaxProtocol {
   }
 }
 
-public extension NamedDeclSyntax {
+extension NamedDeclSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<NamedDeclSyntax, T>, _ newChild: T) -> NamedDeclSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<NamedDeclSyntax, T>, _ newChild: T) -> NamedDeclSyntax {
     var copy: NamedDeclSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `NamedDeclSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: NamedDeclSyntax.Protocol) -> Bool {
+  public func isProtocol(_: NamedDeclSyntax.Protocol) -> Bool {
     return self.asProtocol(NamedDeclSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `NamedDeclSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: NamedDeclSyntax.Protocol) -> NamedDeclSyntax? {
+  public func asProtocol(_: NamedDeclSyntax.Protocol) -> NamedDeclSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? NamedDeclSyntax
   }
 }
@@ -332,29 +332,29 @@ public protocol MissingNodeSyntax: SyntaxProtocol {
   }
 }
 
-public extension MissingNodeSyntax {
+extension MissingNodeSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<MissingNodeSyntax, T>, _ newChild: T) -> MissingNodeSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<MissingNodeSyntax, T>, _ newChild: T) -> MissingNodeSyntax {
     var copy: MissingNodeSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `MissingNodeSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: MissingNodeSyntax.Protocol) -> Bool {
+  public func isProtocol(_: MissingNodeSyntax.Protocol) -> Bool {
     return self.asProtocol(MissingNodeSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `MissingNodeSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: MissingNodeSyntax.Protocol) -> MissingNodeSyntax? {
+  public func asProtocol(_: MissingNodeSyntax.Protocol) -> MissingNodeSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? MissingNodeSyntax
   }
 }
@@ -379,29 +379,29 @@ public protocol ParenthesizedSyntax: SyntaxProtocol {
   }
 }
 
-public extension ParenthesizedSyntax {
+extension ParenthesizedSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<ParenthesizedSyntax, T>, _ newChild: T) -> ParenthesizedSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<ParenthesizedSyntax, T>, _ newChild: T) -> ParenthesizedSyntax {
     var copy: ParenthesizedSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `ParenthesizedSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: ParenthesizedSyntax.Protocol) -> Bool {
+  public func isProtocol(_: ParenthesizedSyntax.Protocol) -> Bool {
     return self.asProtocol(ParenthesizedSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `ParenthesizedSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: ParenthesizedSyntax.Protocol) -> ParenthesizedSyntax? {
+  public func asProtocol(_: ParenthesizedSyntax.Protocol) -> ParenthesizedSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? ParenthesizedSyntax
   }
 }
@@ -415,29 +415,29 @@ public protocol WithAttributesSyntax: SyntaxProtocol {
   }
 }
 
-public extension WithAttributesSyntax {
+extension WithAttributesSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<WithAttributesSyntax, T>, _ newChild: T) -> WithAttributesSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<WithAttributesSyntax, T>, _ newChild: T) -> WithAttributesSyntax {
     var copy: WithAttributesSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `WithAttributesSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: WithAttributesSyntax.Protocol) -> Bool {
+  public func isProtocol(_: WithAttributesSyntax.Protocol) -> Bool {
     return self.asProtocol(WithAttributesSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `WithAttributesSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: WithAttributesSyntax.Protocol) -> WithAttributesSyntax? {
+  public func asProtocol(_: WithAttributesSyntax.Protocol) -> WithAttributesSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithAttributesSyntax
   }
 }
@@ -451,29 +451,29 @@ public protocol WithCodeBlockSyntax: SyntaxProtocol {
   }
 }
 
-public extension WithCodeBlockSyntax {
+extension WithCodeBlockSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<WithCodeBlockSyntax, T>, _ newChild: T) -> WithCodeBlockSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<WithCodeBlockSyntax, T>, _ newChild: T) -> WithCodeBlockSyntax {
     var copy: WithCodeBlockSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `WithCodeBlockSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: WithCodeBlockSyntax.Protocol) -> Bool {
+  public func isProtocol(_: WithCodeBlockSyntax.Protocol) -> Bool {
     return self.asProtocol(WithCodeBlockSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `WithCodeBlockSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: WithCodeBlockSyntax.Protocol) -> WithCodeBlockSyntax? {
+  public func asProtocol(_: WithCodeBlockSyntax.Protocol) -> WithCodeBlockSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithCodeBlockSyntax
   }
 }
@@ -497,29 +497,29 @@ public protocol WithGenericParametersSyntax: SyntaxProtocol {
   }
 }
 
-public extension WithGenericParametersSyntax {
+extension WithGenericParametersSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<WithGenericParametersSyntax, T>, _ newChild: T) -> WithGenericParametersSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<WithGenericParametersSyntax, T>, _ newChild: T) -> WithGenericParametersSyntax {
     var copy: WithGenericParametersSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `WithGenericParametersSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: WithGenericParametersSyntax.Protocol) -> Bool {
+  public func isProtocol(_: WithGenericParametersSyntax.Protocol) -> Bool {
     return self.asProtocol(WithGenericParametersSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `WithGenericParametersSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: WithGenericParametersSyntax.Protocol) -> WithGenericParametersSyntax? {
+  public func asProtocol(_: WithGenericParametersSyntax.Protocol) -> WithGenericParametersSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithGenericParametersSyntax
   }
 }
@@ -533,29 +533,29 @@ public protocol WithModifiersSyntax: SyntaxProtocol {
   }
 }
 
-public extension WithModifiersSyntax {
+extension WithModifiersSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<WithModifiersSyntax, T>, _ newChild: T) -> WithModifiersSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<WithModifiersSyntax, T>, _ newChild: T) -> WithModifiersSyntax {
     var copy: WithModifiersSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `WithModifiersSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: WithModifiersSyntax.Protocol) -> Bool {
+  public func isProtocol(_: WithModifiersSyntax.Protocol) -> Bool {
     return self.asProtocol(WithModifiersSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `WithModifiersSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: WithModifiersSyntax.Protocol) -> WithModifiersSyntax? {
+  public func asProtocol(_: WithModifiersSyntax.Protocol) -> WithModifiersSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithModifiersSyntax
   }
 }
@@ -569,29 +569,29 @@ public protocol WithOptionalCodeBlockSyntax: SyntaxProtocol {
   }
 }
 
-public extension WithOptionalCodeBlockSyntax {
+extension WithOptionalCodeBlockSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<WithOptionalCodeBlockSyntax, T>, _ newChild: T) -> WithOptionalCodeBlockSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<WithOptionalCodeBlockSyntax, T>, _ newChild: T) -> WithOptionalCodeBlockSyntax {
     var copy: WithOptionalCodeBlockSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `WithOptionalCodeBlockSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: WithOptionalCodeBlockSyntax.Protocol) -> Bool {
+  public func isProtocol(_: WithOptionalCodeBlockSyntax.Protocol) -> Bool {
     return self.asProtocol(WithOptionalCodeBlockSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `WithOptionalCodeBlockSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: WithOptionalCodeBlockSyntax.Protocol) -> WithOptionalCodeBlockSyntax? {
+  public func asProtocol(_: WithOptionalCodeBlockSyntax.Protocol) -> WithOptionalCodeBlockSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithOptionalCodeBlockSyntax
   }
 }
@@ -605,29 +605,29 @@ public protocol WithStatementsSyntax: SyntaxProtocol {
   }
 }
 
-public extension WithStatementsSyntax {
+extension WithStatementsSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<WithStatementsSyntax, T>, _ newChild: T) -> WithStatementsSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<WithStatementsSyntax, T>, _ newChild: T) -> WithStatementsSyntax {
     var copy: WithStatementsSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `WithStatementsSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: WithStatementsSyntax.Protocol) -> Bool {
+  public func isProtocol(_: WithStatementsSyntax.Protocol) -> Bool {
     return self.asProtocol(WithStatementsSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `WithStatementsSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: WithStatementsSyntax.Protocol) -> WithStatementsSyntax? {
+  public func asProtocol(_: WithStatementsSyntax.Protocol) -> WithStatementsSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithStatementsSyntax
   }
 }
@@ -644,29 +644,29 @@ public protocol WithTrailingCommaSyntax: SyntaxProtocol {
   }
 }
 
-public extension WithTrailingCommaSyntax {
+extension WithTrailingCommaSyntax {
   /// Without this function, the `with` function defined on `SyntaxProtocol`
   /// does not work on existentials of this protocol type.
   @_disfavoredOverload
-  func with<T>(_ keyPath: WritableKeyPath<WithTrailingCommaSyntax, T>, _ newChild: T) -> WithTrailingCommaSyntax {
+  public func with<T>(_ keyPath: WritableKeyPath<WithTrailingCommaSyntax, T>, _ newChild: T) -> WithTrailingCommaSyntax {
     var copy: WithTrailingCommaSyntax = self
     copy[keyPath: keyPath] = newChild
     return copy
   }
 }
 
-public extension SyntaxProtocol {
+extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to
   /// `WithTrailingCommaSyntax`.
   /// Note that this will incur an existential conversion.
-  func isProtocol(_: WithTrailingCommaSyntax.Protocol) -> Bool {
+  public func isProtocol(_: WithTrailingCommaSyntax.Protocol) -> Bool {
     return self.asProtocol(WithTrailingCommaSyntax.self) != nil
   }
   
   /// Return the non-type erased version of this syntax node if it conforms to
   /// `WithTrailingCommaSyntax`. Otherwise return `nil`.
   /// Note that this will incur an existential conversion.
-  func asProtocol(_: WithTrailingCommaSyntax.Protocol) -> WithTrailingCommaSyntax? {
+  public func asProtocol(_: WithTrailingCommaSyntax.Protocol) -> WithTrailingCommaSyntax? {
     return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithTrailingCommaSyntax
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -25,8 +25,8 @@ public struct AccessorDeclListBuilder: ListBuilder {
   public typealias FinalResult = AccessorDeclListSyntax
 }
 
-public extension AccessorDeclListSyntax {
-  init(@AccessorDeclListBuilder itemsBuilder: () throws -> AccessorDeclListSyntax) rethrows {
+extension AccessorDeclListSyntax {
+  public init(@AccessorDeclListBuilder itemsBuilder: () throws -> AccessorDeclListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -38,8 +38,8 @@ public struct ArrayElementListBuilder: ListBuilder {
   public typealias FinalResult = ArrayElementListSyntax
 }
 
-public extension ArrayElementListSyntax {
-  init(@ArrayElementListBuilder itemsBuilder: () throws -> ArrayElementListSyntax) rethrows {
+extension ArrayElementListSyntax {
+  public init(@ArrayElementListBuilder itemsBuilder: () throws -> ArrayElementListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -59,8 +59,8 @@ public struct AttributeListBuilder: ListBuilder {
   }
 }
 
-public extension AttributeListSyntax {
-  init(@AttributeListBuilder itemsBuilder: () throws -> AttributeListSyntax) rethrows {
+extension AttributeListSyntax {
+  public init(@AttributeListBuilder itemsBuilder: () throws -> AttributeListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -72,8 +72,8 @@ public struct AvailabilityArgumentListBuilder: ListBuilder {
   public typealias FinalResult = AvailabilityArgumentListSyntax
 }
 
-public extension AvailabilityArgumentListSyntax {
-  init(@AvailabilityArgumentListBuilder itemsBuilder: () throws -> AvailabilityArgumentListSyntax) rethrows {
+extension AvailabilityArgumentListSyntax {
+  public init(@AvailabilityArgumentListBuilder itemsBuilder: () throws -> AvailabilityArgumentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -85,8 +85,8 @@ public struct CatchClauseListBuilder: ListBuilder {
   public typealias FinalResult = CatchClauseListSyntax
 }
 
-public extension CatchClauseListSyntax {
-  init(@CatchClauseListBuilder itemsBuilder: () throws -> CatchClauseListSyntax) rethrows {
+extension CatchClauseListSyntax {
+  public init(@CatchClauseListBuilder itemsBuilder: () throws -> CatchClauseListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -98,8 +98,8 @@ public struct CatchItemListBuilder: ListBuilder {
   public typealias FinalResult = CatchItemListSyntax
 }
 
-public extension CatchItemListSyntax {
-  init(@CatchItemListBuilder itemsBuilder: () throws -> CatchItemListSyntax) rethrows {
+extension CatchItemListSyntax {
+  public init(@CatchItemListBuilder itemsBuilder: () throws -> CatchItemListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -111,8 +111,8 @@ public struct ClosureCaptureListBuilder: ListBuilder {
   public typealias FinalResult = ClosureCaptureListSyntax
 }
 
-public extension ClosureCaptureListSyntax {
-  init(@ClosureCaptureListBuilder itemsBuilder: () throws -> ClosureCaptureListSyntax) rethrows {
+extension ClosureCaptureListSyntax {
+  public init(@ClosureCaptureListBuilder itemsBuilder: () throws -> ClosureCaptureListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -124,8 +124,8 @@ public struct ClosureParameterListBuilder: ListBuilder {
   public typealias FinalResult = ClosureParameterListSyntax
 }
 
-public extension ClosureParameterListSyntax {
-  init(@ClosureParameterListBuilder itemsBuilder: () throws -> ClosureParameterListSyntax) rethrows {
+extension ClosureParameterListSyntax {
+  public init(@ClosureParameterListBuilder itemsBuilder: () throws -> ClosureParameterListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -137,8 +137,8 @@ public struct ClosureShorthandParameterListBuilder: ListBuilder {
   public typealias FinalResult = ClosureShorthandParameterListSyntax
 }
 
-public extension ClosureShorthandParameterListSyntax {
-  init(@ClosureShorthandParameterListBuilder itemsBuilder: () throws -> ClosureShorthandParameterListSyntax) rethrows {
+extension ClosureShorthandParameterListSyntax {
+  public init(@ClosureShorthandParameterListBuilder itemsBuilder: () throws -> ClosureShorthandParameterListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -150,8 +150,8 @@ public struct CodeBlockItemListBuilder: ListBuilder {
   public typealias FinalResult = CodeBlockItemListSyntax
 }
 
-public extension CodeBlockItemListSyntax {
-  init(@CodeBlockItemListBuilder itemsBuilder: () throws -> CodeBlockItemListSyntax) rethrows {
+extension CodeBlockItemListSyntax {
+  public init(@CodeBlockItemListBuilder itemsBuilder: () throws -> CodeBlockItemListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -163,8 +163,8 @@ public struct CompositionTypeElementListBuilder: ListBuilder {
   public typealias FinalResult = CompositionTypeElementListSyntax
 }
 
-public extension CompositionTypeElementListSyntax {
-  init(@CompositionTypeElementListBuilder itemsBuilder: () throws -> CompositionTypeElementListSyntax) rethrows {
+extension CompositionTypeElementListSyntax {
+  public init(@CompositionTypeElementListBuilder itemsBuilder: () throws -> CompositionTypeElementListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -176,8 +176,8 @@ public struct ConditionElementListBuilder: ListBuilder {
   public typealias FinalResult = ConditionElementListSyntax
 }
 
-public extension ConditionElementListSyntax {
-  init(@ConditionElementListBuilder itemsBuilder: () throws -> ConditionElementListSyntax) rethrows {
+extension ConditionElementListSyntax {
+  public init(@ConditionElementListBuilder itemsBuilder: () throws -> ConditionElementListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -189,8 +189,8 @@ public struct DeclModifierListBuilder: ListBuilder {
   public typealias FinalResult = DeclModifierListSyntax
 }
 
-public extension DeclModifierListSyntax {
-  init(@DeclModifierListBuilder itemsBuilder: () throws -> DeclModifierListSyntax) rethrows {
+extension DeclModifierListSyntax {
+  public init(@DeclModifierListBuilder itemsBuilder: () throws -> DeclModifierListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -202,8 +202,8 @@ public struct DeclNameArgumentListBuilder: ListBuilder {
   public typealias FinalResult = DeclNameArgumentListSyntax
 }
 
-public extension DeclNameArgumentListSyntax {
-  init(@DeclNameArgumentListBuilder itemsBuilder: () throws -> DeclNameArgumentListSyntax) rethrows {
+extension DeclNameArgumentListSyntax {
+  public init(@DeclNameArgumentListBuilder itemsBuilder: () throws -> DeclNameArgumentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -215,8 +215,8 @@ public struct DesignatedTypeListBuilder: ListBuilder {
   public typealias FinalResult = DesignatedTypeListSyntax
 }
 
-public extension DesignatedTypeListSyntax {
-  init(@DesignatedTypeListBuilder itemsBuilder: () throws -> DesignatedTypeListSyntax) rethrows {
+extension DesignatedTypeListSyntax {
+  public init(@DesignatedTypeListBuilder itemsBuilder: () throws -> DesignatedTypeListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -228,8 +228,8 @@ public struct DictionaryElementListBuilder: ListBuilder {
   public typealias FinalResult = DictionaryElementListSyntax
 }
 
-public extension DictionaryElementListSyntax {
-  init(@DictionaryElementListBuilder itemsBuilder: () throws -> DictionaryElementListSyntax) rethrows {
+extension DictionaryElementListSyntax {
+  public init(@DictionaryElementListBuilder itemsBuilder: () throws -> DictionaryElementListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -241,8 +241,8 @@ public struct DifferentiabilityArgumentListBuilder: ListBuilder {
   public typealias FinalResult = DifferentiabilityArgumentListSyntax
 }
 
-public extension DifferentiabilityArgumentListSyntax {
-  init(@DifferentiabilityArgumentListBuilder itemsBuilder: () throws -> DifferentiabilityArgumentListSyntax) rethrows {
+extension DifferentiabilityArgumentListSyntax {
+  public init(@DifferentiabilityArgumentListBuilder itemsBuilder: () throws -> DifferentiabilityArgumentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -254,8 +254,8 @@ public struct DocumentationAttributeArgumentListBuilder: ListBuilder {
   public typealias FinalResult = DocumentationAttributeArgumentListSyntax
 }
 
-public extension DocumentationAttributeArgumentListSyntax {
-  init(@DocumentationAttributeArgumentListBuilder itemsBuilder: () throws -> DocumentationAttributeArgumentListSyntax) rethrows {
+extension DocumentationAttributeArgumentListSyntax {
+  public init(@DocumentationAttributeArgumentListBuilder itemsBuilder: () throws -> DocumentationAttributeArgumentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -267,8 +267,8 @@ public struct EffectsAttributeArgumentListBuilder: ListBuilder {
   public typealias FinalResult = EffectsAttributeArgumentListSyntax
 }
 
-public extension EffectsAttributeArgumentListSyntax {
-  init(@EffectsAttributeArgumentListBuilder itemsBuilder: () throws -> EffectsAttributeArgumentListSyntax) rethrows {
+extension EffectsAttributeArgumentListSyntax {
+  public init(@EffectsAttributeArgumentListBuilder itemsBuilder: () throws -> EffectsAttributeArgumentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -280,8 +280,8 @@ public struct EnumCaseElementListBuilder: ListBuilder {
   public typealias FinalResult = EnumCaseElementListSyntax
 }
 
-public extension EnumCaseElementListSyntax {
-  init(@EnumCaseElementListBuilder itemsBuilder: () throws -> EnumCaseElementListSyntax) rethrows {
+extension EnumCaseElementListSyntax {
+  public init(@EnumCaseElementListBuilder itemsBuilder: () throws -> EnumCaseElementListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -293,8 +293,8 @@ public struct EnumCaseParameterListBuilder: ListBuilder {
   public typealias FinalResult = EnumCaseParameterListSyntax
 }
 
-public extension EnumCaseParameterListSyntax {
-  init(@EnumCaseParameterListBuilder itemsBuilder: () throws -> EnumCaseParameterListSyntax) rethrows {
+extension EnumCaseParameterListSyntax {
+  public init(@EnumCaseParameterListBuilder itemsBuilder: () throws -> EnumCaseParameterListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -306,8 +306,8 @@ public struct ExprListBuilder: ListBuilder {
   public typealias FinalResult = ExprListSyntax
 }
 
-public extension ExprListSyntax {
-  init(@ExprListBuilder itemsBuilder: () throws -> ExprListSyntax) rethrows {
+extension ExprListSyntax {
+  public init(@ExprListBuilder itemsBuilder: () throws -> ExprListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -319,8 +319,8 @@ public struct FunctionParameterListBuilder: ListBuilder {
   public typealias FinalResult = FunctionParameterListSyntax
 }
 
-public extension FunctionParameterListSyntax {
-  init(@FunctionParameterListBuilder itemsBuilder: () throws -> FunctionParameterListSyntax) rethrows {
+extension FunctionParameterListSyntax {
+  public init(@FunctionParameterListBuilder itemsBuilder: () throws -> FunctionParameterListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -332,8 +332,8 @@ public struct GenericArgumentListBuilder: ListBuilder {
   public typealias FinalResult = GenericArgumentListSyntax
 }
 
-public extension GenericArgumentListSyntax {
-  init(@GenericArgumentListBuilder itemsBuilder: () throws -> GenericArgumentListSyntax) rethrows {
+extension GenericArgumentListSyntax {
+  public init(@GenericArgumentListBuilder itemsBuilder: () throws -> GenericArgumentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -345,8 +345,8 @@ public struct GenericParameterListBuilder: ListBuilder {
   public typealias FinalResult = GenericParameterListSyntax
 }
 
-public extension GenericParameterListSyntax {
-  init(@GenericParameterListBuilder itemsBuilder: () throws -> GenericParameterListSyntax) rethrows {
+extension GenericParameterListSyntax {
+  public init(@GenericParameterListBuilder itemsBuilder: () throws -> GenericParameterListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -358,8 +358,8 @@ public struct GenericRequirementListBuilder: ListBuilder {
   public typealias FinalResult = GenericRequirementListSyntax
 }
 
-public extension GenericRequirementListSyntax {
-  init(@GenericRequirementListBuilder itemsBuilder: () throws -> GenericRequirementListSyntax) rethrows {
+extension GenericRequirementListSyntax {
+  public init(@GenericRequirementListBuilder itemsBuilder: () throws -> GenericRequirementListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -371,8 +371,8 @@ public struct IfConfigClauseListBuilder: ListBuilder {
   public typealias FinalResult = IfConfigClauseListSyntax
 }
 
-public extension IfConfigClauseListSyntax {
-  init(@IfConfigClauseListBuilder itemsBuilder: () throws -> IfConfigClauseListSyntax) rethrows {
+extension IfConfigClauseListSyntax {
+  public init(@IfConfigClauseListBuilder itemsBuilder: () throws -> IfConfigClauseListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -384,8 +384,8 @@ public struct ImportPathComponentListBuilder: ListBuilder {
   public typealias FinalResult = ImportPathComponentListSyntax
 }
 
-public extension ImportPathComponentListSyntax {
-  init(@ImportPathComponentListBuilder itemsBuilder: () throws -> ImportPathComponentListSyntax) rethrows {
+extension ImportPathComponentListSyntax {
+  public init(@ImportPathComponentListBuilder itemsBuilder: () throws -> ImportPathComponentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -397,8 +397,8 @@ public struct InheritedTypeListBuilder: ListBuilder {
   public typealias FinalResult = InheritedTypeListSyntax
 }
 
-public extension InheritedTypeListSyntax {
-  init(@InheritedTypeListBuilder itemsBuilder: () throws -> InheritedTypeListSyntax) rethrows {
+extension InheritedTypeListSyntax {
+  public init(@InheritedTypeListBuilder itemsBuilder: () throws -> InheritedTypeListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -410,8 +410,8 @@ public struct KeyPathComponentListBuilder: ListBuilder {
   public typealias FinalResult = KeyPathComponentListSyntax
 }
 
-public extension KeyPathComponentListSyntax {
-  init(@KeyPathComponentListBuilder itemsBuilder: () throws -> KeyPathComponentListSyntax) rethrows {
+extension KeyPathComponentListSyntax {
+  public init(@KeyPathComponentListBuilder itemsBuilder: () throws -> KeyPathComponentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -423,8 +423,8 @@ public struct LabeledExprListBuilder: ListBuilder {
   public typealias FinalResult = LabeledExprListSyntax
 }
 
-public extension LabeledExprListSyntax {
-  init(@LabeledExprListBuilder itemsBuilder: () throws -> LabeledExprListSyntax) rethrows {
+extension LabeledExprListSyntax {
+  public init(@LabeledExprListBuilder itemsBuilder: () throws -> LabeledExprListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -439,8 +439,8 @@ public struct LifetimeSpecifierArgumentListBuilder: ListBuilder {
   public typealias FinalResult = LifetimeSpecifierArgumentListSyntax
 }
 
-public extension LifetimeSpecifierArgumentListSyntax {
-  init(@LifetimeSpecifierArgumentListBuilder itemsBuilder: () throws -> LifetimeSpecifierArgumentListSyntax) rethrows {
+extension LifetimeSpecifierArgumentListSyntax {
+  public init(@LifetimeSpecifierArgumentListBuilder itemsBuilder: () throws -> LifetimeSpecifierArgumentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -452,8 +452,8 @@ public struct MemberBlockItemListBuilder: ListBuilder {
   public typealias FinalResult = MemberBlockItemListSyntax
 }
 
-public extension MemberBlockItemListSyntax {
-  init(@MemberBlockItemListBuilder itemsBuilder: () throws -> MemberBlockItemListSyntax) rethrows {
+extension MemberBlockItemListSyntax {
+  public init(@MemberBlockItemListBuilder itemsBuilder: () throws -> MemberBlockItemListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -465,8 +465,8 @@ public struct MultipleTrailingClosureElementListBuilder: ListBuilder {
   public typealias FinalResult = MultipleTrailingClosureElementListSyntax
 }
 
-public extension MultipleTrailingClosureElementListSyntax {
-  init(@MultipleTrailingClosureElementListBuilder itemsBuilder: () throws -> MultipleTrailingClosureElementListSyntax) rethrows {
+extension MultipleTrailingClosureElementListSyntax {
+  public init(@MultipleTrailingClosureElementListBuilder itemsBuilder: () throws -> MultipleTrailingClosureElementListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -478,8 +478,8 @@ public struct ObjCSelectorPieceListBuilder: ListBuilder {
   public typealias FinalResult = ObjCSelectorPieceListSyntax
 }
 
-public extension ObjCSelectorPieceListSyntax {
-  init(@ObjCSelectorPieceListBuilder itemsBuilder: () throws -> ObjCSelectorPieceListSyntax) rethrows {
+extension ObjCSelectorPieceListSyntax {
+  public init(@ObjCSelectorPieceListBuilder itemsBuilder: () throws -> ObjCSelectorPieceListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -491,8 +491,8 @@ public struct PatternBindingListBuilder: ListBuilder {
   public typealias FinalResult = PatternBindingListSyntax
 }
 
-public extension PatternBindingListSyntax {
-  init(@PatternBindingListBuilder itemsBuilder: () throws -> PatternBindingListSyntax) rethrows {
+extension PatternBindingListSyntax {
+  public init(@PatternBindingListBuilder itemsBuilder: () throws -> PatternBindingListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -504,8 +504,8 @@ public struct PlatformVersionItemListBuilder: ListBuilder {
   public typealias FinalResult = PlatformVersionItemListSyntax
 }
 
-public extension PlatformVersionItemListSyntax {
-  init(@PlatformVersionItemListBuilder itemsBuilder: () throws -> PlatformVersionItemListSyntax) rethrows {
+extension PlatformVersionItemListSyntax {
+  public init(@PlatformVersionItemListBuilder itemsBuilder: () throws -> PlatformVersionItemListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -529,8 +529,8 @@ public struct PrecedenceGroupAttributeListBuilder: ListBuilder {
   }
 }
 
-public extension PrecedenceGroupAttributeListSyntax {
-  init(@PrecedenceGroupAttributeListBuilder itemsBuilder: () throws -> PrecedenceGroupAttributeListSyntax) rethrows {
+extension PrecedenceGroupAttributeListSyntax {
+  public init(@PrecedenceGroupAttributeListBuilder itemsBuilder: () throws -> PrecedenceGroupAttributeListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -542,8 +542,8 @@ public struct PrecedenceGroupNameListBuilder: ListBuilder {
   public typealias FinalResult = PrecedenceGroupNameListSyntax
 }
 
-public extension PrecedenceGroupNameListSyntax {
-  init(@PrecedenceGroupNameListBuilder itemsBuilder: () throws -> PrecedenceGroupNameListSyntax) rethrows {
+extension PrecedenceGroupNameListSyntax {
+  public init(@PrecedenceGroupNameListBuilder itemsBuilder: () throws -> PrecedenceGroupNameListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -555,8 +555,8 @@ public struct PrimaryAssociatedTypeListBuilder: ListBuilder {
   public typealias FinalResult = PrimaryAssociatedTypeListSyntax
 }
 
-public extension PrimaryAssociatedTypeListSyntax {
-  init(@PrimaryAssociatedTypeListBuilder itemsBuilder: () throws -> PrimaryAssociatedTypeListSyntax) rethrows {
+extension PrimaryAssociatedTypeListSyntax {
+  public init(@PrimaryAssociatedTypeListBuilder itemsBuilder: () throws -> PrimaryAssociatedTypeListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -568,8 +568,8 @@ public struct SimpleStringLiteralSegmentListBuilder: ListBuilder {
   public typealias FinalResult = SimpleStringLiteralSegmentListSyntax
 }
 
-public extension SimpleStringLiteralSegmentListSyntax {
-  init(@SimpleStringLiteralSegmentListBuilder itemsBuilder: () throws -> SimpleStringLiteralSegmentListSyntax) rethrows {
+extension SimpleStringLiteralSegmentListSyntax {
+  public init(@SimpleStringLiteralSegmentListBuilder itemsBuilder: () throws -> SimpleStringLiteralSegmentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -597,8 +597,8 @@ public struct SpecializeAttributeArgumentListBuilder: ListBuilder {
   }
 }
 
-public extension SpecializeAttributeArgumentListSyntax {
-  init(@SpecializeAttributeArgumentListBuilder itemsBuilder: () throws -> SpecializeAttributeArgumentListSyntax) rethrows {
+extension SpecializeAttributeArgumentListSyntax {
+  public init(@SpecializeAttributeArgumentListBuilder itemsBuilder: () throws -> SpecializeAttributeArgumentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -618,8 +618,8 @@ public struct StringLiteralSegmentListBuilder: ListBuilder {
   }
 }
 
-public extension StringLiteralSegmentListSyntax {
-  init(@StringLiteralSegmentListBuilder itemsBuilder: () throws -> StringLiteralSegmentListSyntax) rethrows {
+extension StringLiteralSegmentListSyntax {
+  public init(@StringLiteralSegmentListBuilder itemsBuilder: () throws -> StringLiteralSegmentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -631,8 +631,8 @@ public struct SwitchCaseItemListBuilder: ListBuilder {
   public typealias FinalResult = SwitchCaseItemListSyntax
 }
 
-public extension SwitchCaseItemListSyntax {
-  init(@SwitchCaseItemListBuilder itemsBuilder: () throws -> SwitchCaseItemListSyntax) rethrows {
+extension SwitchCaseItemListSyntax {
+  public init(@SwitchCaseItemListBuilder itemsBuilder: () throws -> SwitchCaseItemListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -652,8 +652,8 @@ public struct SwitchCaseListBuilder: ListBuilder {
   }
 }
 
-public extension SwitchCaseListSyntax {
-  init(@SwitchCaseListBuilder itemsBuilder: () throws -> SwitchCaseListSyntax) rethrows {
+extension SwitchCaseListSyntax {
+  public init(@SwitchCaseListBuilder itemsBuilder: () throws -> SwitchCaseListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -665,8 +665,8 @@ public struct TuplePatternElementListBuilder: ListBuilder {
   public typealias FinalResult = TuplePatternElementListSyntax
 }
 
-public extension TuplePatternElementListSyntax {
-  init(@TuplePatternElementListBuilder itemsBuilder: () throws -> TuplePatternElementListSyntax) rethrows {
+extension TuplePatternElementListSyntax {
+  public init(@TuplePatternElementListBuilder itemsBuilder: () throws -> TuplePatternElementListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -678,8 +678,8 @@ public struct TupleTypeElementListBuilder: ListBuilder {
   public typealias FinalResult = TupleTypeElementListSyntax
 }
 
-public extension TupleTypeElementListSyntax {
-  init(@TupleTypeElementListBuilder itemsBuilder: () throws -> TupleTypeElementListSyntax) rethrows {
+extension TupleTypeElementListSyntax {
+  public init(@TupleTypeElementListBuilder itemsBuilder: () throws -> TupleTypeElementListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -702,8 +702,8 @@ public struct TypeSpecifierListBuilder: ListBuilder {
   }
 }
 
-public extension TypeSpecifierListSyntax {
-  init(@TypeSpecifierListBuilder itemsBuilder: () throws -> TypeSpecifierListSyntax) rethrows {
+extension TypeSpecifierListSyntax {
+  public init(@TypeSpecifierListBuilder itemsBuilder: () throws -> TypeSpecifierListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -715,8 +715,8 @@ public struct UnexpectedNodesBuilder: ListBuilder {
   public typealias FinalResult = UnexpectedNodesSyntax
 }
 
-public extension UnexpectedNodesSyntax {
-  init(@UnexpectedNodesBuilder itemsBuilder: () throws -> UnexpectedNodesSyntax) rethrows {
+extension UnexpectedNodesSyntax {
+  public init(@UnexpectedNodesBuilder itemsBuilder: () throws -> UnexpectedNodesSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -728,8 +728,8 @@ public struct VersionComponentListBuilder: ListBuilder {
   public typealias FinalResult = VersionComponentListSyntax
 }
 
-public extension VersionComponentListSyntax {
-  init(@VersionComponentListBuilder itemsBuilder: () throws -> VersionComponentListSyntax) rethrows {
+extension VersionComponentListSyntax {
+  public init(@VersionComponentListBuilder itemsBuilder: () throws -> VersionComponentListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }
@@ -741,8 +741,8 @@ public struct YieldedExpressionListBuilder: ListBuilder {
   public typealias FinalResult = YieldedExpressionListSyntax
 }
 
-public extension YieldedExpressionListSyntax {
-  init(@YieldedExpressionListBuilder itemsBuilder: () throws -> YieldedExpressionListSyntax) rethrows {
+extension YieldedExpressionListSyntax {
+  public init(@YieldedExpressionListBuilder itemsBuilder: () throws -> YieldedExpressionListSyntax) rethrows {
     self = try itemsBuilder()
   }
 }


### PR DESCRIPTION
* **Explanation**: In the original PR, we refactored code in the `CodeGeneration` package to not contain `public` extensions. To reduce the risk of merging conflicts in cherry-picks into `release/6.0`, we are merging this refactored code into this branch as well.
* **Scope**: Generated code.
* **Issue**: N/A
* **Original PR**: #2609
* **Risk**: Low.
* **Testing**: Passes current test suite.
* **Reviewer**: Alex Hoppen (@ahoppen)