### PR TITLE
Remove Swift 6 mode from package manifest declaration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -298,7 +298,7 @@ let package = Package(
       exclude: ["Inputs"]
     ),
   ],
-  swiftLanguageVersions: [.v5, .version("6")]
+  swiftLanguageVersions: [.v5]
 )
 
 // This is a fake target that depends on all targets in the package.


### PR DESCRIPTION
Declaring Swift 6 conformance in swift-syntax breaks the SwiftPM CI job (rdar://126952308).