### PR TITLE
Enable Swift 6 mode unless we are in a self-hosted Swift CI job

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -298,7 +298,12 @@ let package = Package(
       exclude: ["Inputs"]
     ),
   ],
-  swiftLanguageVersions: [.v5]
+  // Disable Swift 6 mode when the `SWIFTSYNTAX_DISABLE_SWIFT_6_MODE` environment variable is set. This works around the following
+  // issue: The self-hosted SwiftPM job has Xcode 15.3 (Swift 5.10) installed and builds a Swift 6 SwiftPM from source.
+  // It then tries to build itself as a fat binary using the just-built Swift 6 SwiftPM, which uses xcbuild from Xcode
+  // as the build system. But the xcbuild in the installed Xcode is too old and doesn't know about Swift 6 mode, so it
+  // fails with: SWIFT_VERSION '6' is unsupported, supported versions are: 4.0, 4.2, 5.0 (rdar://126952308)
+  swiftLanguageVersions: hasEnvironmentVariable("SWIFTSYNTAX_DISABLE_SWIFT_6_MODE") ? [.v5] : [.v5, .version("6")]
 )
 
 // This is a fake target that depends on all targets in the package.


### PR DESCRIPTION
We disable Swift 6 mode when the `SWIFTCI_IS_SELF_HOSTED` environment variable is set to work around the following issue: The self-hosted SwiftPM job has Xcode 15.3 (Swift 5.10) installed and builds a Swift 6 SwiftPM from source. It then tries to build itself as a fat binary using the just-built Swift 6 SwiftPM, which uses xcbuild from Xcode as the build system. But the xcbuild in the installed Xcode is too old and doesn't know about Swift 6 mode, so it fails with: SWIFT_VERSION '6' is unsupported, supported versions are: 4.0, 4.2, 5.0 (rdar://126952308)