### PR TITLE
Work around a diagnostic using `CommandLine.arguments` on older toolchains

### DIFF
--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -92,7 +92,12 @@ extension CompilerPlugin {
       }
     }
 
-    let pluginPath = CommandLine.arguments.first ?? "<unknown>"
+    let pluginPath: String
+    if CommandLine.argc > 0, let cPluginPath = CommandLine.unsafeArgv[0] {
+      pluginPath = String(cString: cPluginPath)
+    } else {
+      pluginPath = "<unknown>"
+    }
     throw CompilerPluginError(
       message:
         "macro implementation type '\(moduleName).\(typeName)' could not be found in executable plugin '\(pluginPath)'"


### PR DESCRIPTION
`CommandLine.arguments` is declared read/write in older toolchains and this causes an error diagnostic when it's used in Swift 6 mode. This PR uses `CommandLine.argc` and `CommandLine.unsafeArgv` directly instead so the diagnostic does not occur.