### PR TITLE
Work around a diagnostic using `CommandLine.arguments` on older toolchains.

### DIFF
--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -92,7 +92,12 @@ extension CompilerPlugin {
       }
     }
 
-    let pluginPath = CommandLine.arguments.first ?? "<unknown>"
+    let pluginPath: String
+    if CommandLine.argc > 0, let cPluginPath = CommandLine.unsafeArgv[0] {
+      pluginPath = String(cString: cPluginPath)
+    } else {
+      pluginPath = "<unknown>"
+    }
     throw CompilerPluginError(
       message:
         "macro implementation type '\(moduleName).\(typeName)' could not be found in executable plugin '\(pluginPath)'"


### PR DESCRIPTION
…hains. (#2622)

`CommandLine.arguments` is declared read/write in older toolchains and this causes an error diagnostic when it's used in Swift 6 mode. This PR uses `CommandLine.argc` and `CommandLine.unsafeArgv` directly instead so the diagnostic does not occur.

Cherry-picked from `main` (#2622, 6c459f2728572a64c4b29ce3140daa90c3c6e7d1) because certain combinations of toolchains and swift-syntax versions are now incompatible. Until that issue is resolved and those toolchains have aged out, the workaround is needed, but we can presumably revert it in a few weeks if it's bothersome.

**Explanation:** Certain combinations of toolchains and swift-syntax versions are now incompatible. A build error occurs when using swift-syntax-600 with those toolchains.
**Scope:** Implementation only.
**Issue:** #2622
**Original PR:** #2622
**Risk:** No obvious risk. The implementation of `CommandLine.arguments` is equivalent to the code added in this PR.
**Testing:** Tested at desk with the change locally and pulling from the main branch after it was merged there. The diagnostic is gone.
**Reviewer:** @bnbarham @ahoppen