### PR TITLE
[6.0] Make swift-syntax build in Swift 6 language mode

### DIFF
--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/TokenSpecStaticMembersFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparser/TokenSpecStaticMembersFile.swift
@@ -16,7 +16,15 @@ import SyntaxSupport
 import Utils
 
 let tokenSpecStaticMembersFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
-  DeclSyntax("@_spi(RawSyntax) import SwiftSyntax")
+  DeclSyntax(
+    """
+    #if swift(>=6)
+    @_spi(RawSyntax) internal import SwiftSyntax
+    #else
+    @_spi(RawSyntax) import SwiftSyntax
+    #endif
+    """
+  )
 
   try! ExtensionDeclSyntax("extension TokenSpec") {
     for tokenSpec in Token.allCases.map(\.spec) where tokenSpec.kind != .keyword {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparserdiagnostics/ChildNameForDiagnosticsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparserdiagnostics/ChildNameForDiagnosticsFile.swift
@@ -16,7 +16,15 @@ import SyntaxSupport
 import Utils
 
 let childNameForDiagnosticFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
-  DeclSyntax("@_spi(ExperimentalLanguageFeatures) import SwiftSyntax")
+  DeclSyntax(
+    """
+    #if swift(>=6)
+    @_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+    #else
+    @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+    #endif
+    """
+  )
 
   try! FunctionDeclSyntax(
     "private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String?"

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparserdiagnostics/SyntaxKindNameForDiagnosticsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparserdiagnostics/SyntaxKindNameForDiagnosticsFile.swift
@@ -16,7 +16,15 @@ import SyntaxSupport
 import Utils
 
 let syntaxKindNameForDiagnosticFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
-  DeclSyntax("@_spi(ExperimentalLanguageFeatures) import SwiftSyntax")
+  DeclSyntax(
+    """
+    #if swift(>=6)
+    @_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+    #else
+    @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+    #endif
+    """
+  )
 
   try! ExtensionDeclSyntax("extension SyntaxKind") {
     try VariableDeclSyntax("var nameForDiagnostics: String?") {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftparserdiagnostics/TokenNameForDiagnosticsFile.swift
@@ -16,7 +16,15 @@ import SyntaxSupport
 import Utils
 
 let tokenNameForDiagnosticFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
-  DeclSyntax("@_spi(RawSyntax) import SwiftSyntax")
+  DeclSyntax(
+    """
+    #if swift(>=6)
+    @_spi(RawSyntax) internal import SwiftSyntax
+    #else
+    @_spi(RawSyntax) import SwiftSyntax
+    #endif
+    """
+  )
 
   try! ExtensionDeclSyntax("extension TokenKind") {
     try! VariableDeclSyntax("var nameForDiagnostics: String") {

--- a/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
+++ b/CodeGeneration/Sources/generate-swift-syntax/templates/swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
@@ -16,7 +16,15 @@ import SyntaxSupport
 import Utils
 
 let syntaxExpressibleByStringInterpolationConformancesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
-  DeclSyntax("import SwiftSyntax")
+  DeclSyntax(
+    """
+    #if swift(>=6)
+    internal import SwiftSyntax
+    #else
+    import SwiftSyntax
+    #endif
+    """
+  )
 
   let typesExpressibleByStringInterpolation =
     SYNTAX_NODES

--- a/Package.swift
+++ b/Package.swift
@@ -297,7 +297,8 @@ let package = Package(
       dependencies: ["_InstructionCounter", "_SwiftSyntaxTestSupport", "SwiftIDEUtils", "SwiftParser", "SwiftSyntax"],
       exclude: ["Inputs"]
     ),
-  ]
+  ],
+  swiftLanguageVersions: [.v5, .version("6")]
 )
 
 // This is a fake target that depends on all targets in the package.

--- a/Package.swift
+++ b/Package.swift
@@ -298,7 +298,12 @@ let package = Package(
       exclude: ["Inputs"]
     ),
   ],
-  swiftLanguageVersions: [.v5, .version("6")]
+  // Disable Swift 6 mode when the `SWIFTSYNTAX_DISABLE_SWIFT_6_MODE` environment variable is set. This works around the following
+  // issue: The self-hosted SwiftPM job has Xcode 15.3 (Swift 5.10) installed and builds a Swift 6 SwiftPM from source.
+  // It then tries to build itself as a fat binary using the just-built Swift 6 SwiftPM, which uses xcbuild from Xcode
+  // as the build system. But the xcbuild in the installed Xcode is too old and doesn't know about Swift 6 mode, so it
+  // fails with: SWIFT_VERSION '6' is unsupported, supported versions are: 4.0, 4.2, 5.0 (rdar://126952308)
+  swiftLanguageVersions: hasEnvironmentVariable("SWIFTSYNTAX_DISABLE_SWIFT_6_MODE") ? [.v5] : [.v5, .version("6")]
 )
 
 // This is a fake target that depends on all targets in the package.

--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftDiagnostics
+internal import SwiftSyntax
+#else
 import SwiftDiagnostics
 import SwiftSyntax
+#endif
 
 /// Errors in macro handing.
 enum MacroExpansionError {

--- a/Sources/SwiftCompilerPluginMessageHandling/JSON/JSONEncoding.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/JSON/JSONEncoding.swift
@@ -17,7 +17,7 @@ func encodeToJSON(value: some Encodable) throws -> [UInt8] {
 }
 
 /// Intermediate representation for serializing JSON structure.
-private class JSONReference {
+private final class JSONReference {
   enum Backing {
     case null
     case trueKeyword
@@ -60,9 +60,17 @@ private class JSONReference {
     backing = .array(arr)
   }
 
+  #if swift(>=6)
+  // nonisolated(unsafe) is fine for these properties because they represent primitives
+  // that are never modified.
+  nonisolated(unsafe) static let null: JSONReference = .init(backing: .null)
+  nonisolated(unsafe) static let trueKeyword: JSONReference = .init(backing: .trueKeyword)
+  nonisolated(unsafe) static let falseKeyword: JSONReference = .init(backing: .falseKeyword)
+  #else
   static let null: JSONReference = .init(backing: .null)
   static let trueKeyword: JSONReference = .init(backing: .trueKeyword)
   static let falseKeyword: JSONReference = .init(backing: .falseKeyword)
+  #endif
 
   @inline(__always)
   static func newArray() -> JSONReference {

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftBasicFormat
+internal import SwiftDiagnostics
+internal import SwiftOperators
+internal import SwiftSyntax
+@_spi(MacroExpansion) @_spi(ExperimentalLanguageFeature) internal import SwiftSyntaxMacroExpansion
+@_spi(ExperimentalLanguageFeature) internal import SwiftSyntaxMacros
+#else
 import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntax
 @_spi(MacroExpansion) @_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacroExpansion
 @_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
+#endif
 
 extension CompilerPluginMessageHandler {
   /// Get concrete macro type from a pair of module name and type name.

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftDiagnostics
+internal import SwiftOperators
+internal import SwiftParser
+internal import SwiftSyntax
+internal import SwiftSyntaxMacros
+#else
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxMacros
+#endif
 
 /// Manages known source code combined with their filename/fileID. This can be
 /// used to get line/column from a syntax node in the managed source code.

--- a/Sources/SwiftIDEUtils/SyntaxClassification.swift
+++ b/Sources/SwiftIDEUtils/SyntaxClassification.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 public enum SyntaxClassification: Sendable {
   /// An attribute starting with an `@`.

--- a/Sources/SwiftIDEUtils/Utils.swift
+++ b/Sources/SwiftIDEUtils/Utils.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 extension Range<AbsolutePosition> {
   /// Shift the range `utf8Offset` bytes to the right, ie. add `utf8Offset` to the upper and lower bound.

--- a/Sources/SwiftOperators/OperatorError+Diagnostics.swift
+++ b/Sources/SwiftOperators/OperatorError+Diagnostics.swift
@@ -12,8 +12,8 @@
 
 #if swift(>=6)
 public import SwiftDiagnostics
-import SwiftParser
-import SwiftSyntax
+internal import SwiftParser
+internal import SwiftSyntax
 #else
 import SwiftDiagnostics
 import SwiftParser

--- a/Sources/SwiftOperators/OperatorTable+Defaults.swift
+++ b/Sources/SwiftOperators/OperatorTable+Defaults.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 /// Prefabricated operator precedence graphs.
 extension OperatorTable {

--- a/Sources/SwiftOperators/OperatorTable.swift
+++ b/Sources/SwiftOperators/OperatorTable.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 /// Maintains and validates information about all operators in a Swift program.
 ///

--- a/Sources/SwiftOperators/PrecedenceGraph.swift
+++ b/Sources/SwiftOperators/PrecedenceGraph.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 /// Describes the relative precedence of two groups.
 enum Precedence: Sendable {

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension Parser {
   mutating func parseAttributeList() -> RawAttributeListSyntax {

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension Parser {
   /// Parse a list of availability arguments.

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension DeclarationModifier {
   var canHaveParenthesizedArgument: Bool {

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension Parser {
   private enum IfConfigContinuationClauseStartKeyword: TokenSpecSet {

--- a/Sources/SwiftParser/ExpressionInterpretedAsVersionTuple.swift
+++ b/Sources/SwiftParser/ExpressionInterpretedAsVersionTuple.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) public import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension ExprSyntax {
   /// Parse the source code of this node as a `VersionTupleSyntax`.

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension TokenConsumer {
   mutating func atStartOfExpression() -> Bool {

--- a/Sources/SwiftParser/IsValidIdentifier.swift
+++ b/Sources/SwiftParser/IsValidIdentifier.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 /// Context in which to check if a name can be used as an identifier.
 ///

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) @_spi(BumpPtrAllocator) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) @_spi(BumpPtrAllocator) import SwiftSyntax
+#endif
 
 extension SyntaxText {
   fileprivate func containsPlaceholderEnd() -> Bool {

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) @_spi(BumpPtrAllocator) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) @_spi(BumpPtrAllocator) import SwiftSyntax
+#endif
 
 extension Lexer {
   /// A sequence of ``Lexer/Lexeme`` tokens starting from a ``Lexer/Cursor``

--- a/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
+++ b/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) @_spi(BumpPtrAllocator) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) @_spi(BumpPtrAllocator) import SwiftSyntax
+#endif
 
 /// A separate lexer specifically for regex literals.
 fileprivate struct RegexLiteralLexer {

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension Parser {
   /// Token lookahead for the parser.

--- a/Sources/SwiftParser/LoopProgressCondition.swift
+++ b/Sources/SwiftParser/LoopProgressCondition.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 /// A type that can be used to make sure that a loop in the parser makes process.
 ///

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension Parser {
   mutating func parseDeclModifierList() -> RawDeclModifierListSyntax {

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension Parser {
   mutating func parseAnyIdentifier() -> RawTokenSyntax {

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 protocol NominalTypeDeclarationTrait {
   associatedtype PrimaryOrGenerics

--- a/Sources/SwiftParser/Parameters.swift
+++ b/Sources/SwiftParser/Parameters.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 // MARK: - Traits
 

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+#endif
 
 extension Parser {
   /// Parse a pattern.

--- a/Sources/SwiftParser/README.md
+++ b/Sources/SwiftParser/README.md
@@ -8,7 +8,11 @@ The easiest way to parse Swift source code is to call the `Parser.parse` method,
 
 ```swift
 import SwiftParser
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 let sourceText =
 """

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 // MARK: Lookahead
 

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+#endif
 
 extension TokenConsumer {
   /// Returns `true` if the current token represents the start of a statement

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 // MARK: - Check multiline string literal indentation
 

--- a/Sources/SwiftParser/SwiftParser.docc/SwiftParser.md
+++ b/Sources/SwiftParser/SwiftParser.docc/SwiftParser.md
@@ -12,7 +12,11 @@ The easiest way to parse Swift source code is to call the `Parser.parse` method,
 
 ```swift
 import SwiftParser
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 let sourceText =
 """

--- a/Sources/SwiftParser/SwiftParserCompatibility.swift
+++ b/Sources/SwiftParser/SwiftParserCompatibility.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 // This file provides compatibility aliases to keep dependents of SwiftSyntax building.
 // All users of the declarations in this file should transition away from them ASAP.

--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 // MARK: - Unexpected nodes
 

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 /// A type that consumes  instances of ``TokenSyntax``.
 protocol TokenConsumer {

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+#endif
 
 /// Describes how distinctive a token is for parser recovery.
 ///

--- a/Sources/SwiftParser/TokenSpec.swift
+++ b/Sources/SwiftParser/TokenSpec.swift
@@ -49,7 +49,7 @@ struct PrepareForKeywordMatch {
 /// matching against and is thus able to rule out one of the branches in
 /// `matches(rawTokenKind:text:)` based on the matched kind.
 @_spi(AlternateTokenIntrospection)
-public struct TokenSpec {
+public struct TokenSpec: Sendable {
   /// The kind we expect the token that we want to consume to have.
   /// This can be a keyword, in which case the ``TokenSpec`` will also match an
   /// identifier with the same text as the keyword and remap it to that keyword

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=6)
-@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) public import SwiftSyntax
-#else
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
-#endif
 
 /// A set of `TokenSpecs`. We expect to consume one of the sets specs in the
 /// parser.

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+#endif
 
 /// A set of `TokenSpecs`. We expect to consume one of the sets specs in the
 /// parser.

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension Parser {
   /// Consumes and returns all remaining tokens in the source file.

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+#endif
 
 extension Parser {
   /// Parse a type.

--- a/Sources/SwiftParser/generated/TokenSpecStaticMembers.swift
+++ b/Sources/SwiftParser/generated/TokenSpecStaticMembers.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension TokenSpec {
   static var arrow: TokenSpec {

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftBasicFormat
+internal import SwiftDiagnostics
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 import SwiftBasicFormat
 import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension FixIt {
   /// A more complex set of changes that affects multiple syntax nodes and thus

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -12,7 +12,7 @@
 
 #if swift(>=6)
 public import SwiftDiagnostics
-@_spi(Diagnostics) import SwiftParser
+@_spi(Diagnostics) internal import SwiftParser
 @_spi(RawSyntax) public import SwiftSyntax
 #else
 import SwiftDiagnostics

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6)
-import SwiftBasicFormat
-import SwiftDiagnostics
+internal import SwiftBasicFormat
+internal import SwiftDiagnostics
 @_spi(RawSyntax) public import SwiftSyntax
 #else
 import SwiftBasicFormat

--- a/Sources/SwiftParserDiagnostics/MissingTokenError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingTokenError.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftDiagnostics
+@_spi(Diagnostics) internal import SwiftParser
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 import SwiftDiagnostics
 @_spi(Diagnostics) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension ParseDiagnosticsGenerator {
   func handleMissingToken(_ missingToken: TokenSyntax) {

--- a/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftDiagnostics
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 /// A diagnostic that `MultiLineStringLiteralIndentationDiagnosticsGenerator` is building.
 /// As indentation errors are found on more lines, this diagnostic is modified

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -12,7 +12,7 @@
 
 #if swift(>=6)
 public import SwiftDiagnostics
-@_spi(Diagnostics) import SwiftParser
+@_spi(Diagnostics) internal import SwiftParser
 @_spi(ExperimentalLanguageFeatures) public import SwiftSyntax
 #else
 import SwiftDiagnostics

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -12,7 +12,7 @@
 
 #if swift(>=6)
 public import SwiftDiagnostics
-@_spi(Diagnostics) import SwiftParser
+@_spi(Diagnostics) internal import SwiftParser
 @_spi(RawSyntax) public import SwiftSyntax
 #else
 import SwiftDiagnostics

--- a/Sources/SwiftParserDiagnostics/PresenceUtils.swift
+++ b/Sources/SwiftParserDiagnostics/PresenceUtils.swift
@@ -10,9 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftBasicFormat
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 import SwiftBasicFormat
 @_spi(RawSyntax) import SwiftSyntax
-
+#endif
 /// Walks a tree and checks whether the tree contained any present tokens.
 class PresentNodeChecker: SyntaxAnyVisitor {
   var hasPresentToken: Bool = false

--- a/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftBasicFormat
+@_spi(Diagnostics) internal import SwiftParser
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+#else
 import SwiftBasicFormat
 @_spi(Diagnostics) import SwiftParser
 @_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+#endif
 
 extension UnexpectedNodesSyntax {
   func presentTokens(satisfying isIncluded: (TokenSyntax) -> Bool) -> [TokenSyntax] {

--- a/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+#else
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+#endif
 
 private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
   switch keyPath {

--- a/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(ExperimentalLanguageFeatures) internal import SwiftSyntax
+#else
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+#endif
 
 extension SyntaxKind {
   var nameForDiagnostics: String? {

--- a/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/TokenNameForDiagnostics.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+@_spi(RawSyntax) internal import SwiftSyntax
+#else
 @_spi(RawSyntax) import SwiftSyntax
+#endif
 
 extension TokenKind {
   var nameForDiagnostics: String {

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6)
-@_spi(RawSyntax) import SwiftParser
+@_spi(RawSyntax) internal import SwiftParser
 @_spi(RawSyntax) public import SwiftSyntax
 #else
 @_spi(RawSyntax) import SwiftParser

--- a/Sources/SwiftSyntaxBuilder/SwiftSyntaxBuilderCompatibility.swift
+++ b/Sources/SwiftSyntaxBuilder/SwiftSyntaxBuilderCompatibility.swift
@@ -13,7 +13,11 @@
 // This file provides compatibility aliases to keep dependents of SwiftSyntaxBuilder building.
 // All users of the declarations in this file should transition away from them ASAP.
 
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 @available(*, deprecated, renamed: "ImportPathComponentListBuilder")
 public typealias AccessPathBuilder = ImportPathComponentListBuilder

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -12,8 +12,8 @@
 
 #if swift(>=6)
 public import SwiftBasicFormat
-import SwiftDiagnostics
-@_spi(RawSyntax) @_spi(Testing) import SwiftParser
+internal import SwiftDiagnostics
+@_spi(RawSyntax) @_spi(Testing) internal import SwiftParser
 @_spi(RawSyntax) public import SwiftSyntax
 #else
 import SwiftBasicFormat

--- a/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxParsable+ExpressibleByStringInterpolation.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6)
-import SwiftDiagnostics
+internal import SwiftDiagnostics
 public import SwiftParser
-import SwiftParserDiagnostics
-import SwiftSyntax
+internal import SwiftParserDiagnostics
+internal import SwiftSyntax
 #else
 import SwiftDiagnostics
 import SwiftParser

--- a/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6)
-import SwiftDiagnostics
-import SwiftParserDiagnostics
+internal import SwiftDiagnostics
+internal import SwiftParserDiagnostics
 public import SwiftSyntax
 #else
 import SwiftDiagnostics

--- a/Sources/SwiftSyntaxBuilder/WithTrailingCommaSyntax+EnsuringTrailingComma.swift
+++ b/Sources/SwiftSyntaxBuilder/WithTrailingCommaSyntax+EnsuringTrailingComma.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 extension WithTrailingCommaSyntax {
   func ensuringTrailingComma() -> Self {

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 extension AccessorBlockSyntax: SyntaxExpressibleByStringInterpolation {}
 

--- a/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
@@ -12,7 +12,7 @@
 
 #if swift(>=6)
 public import SwiftDiagnostics
-import SwiftOperators
+internal import SwiftOperators
 public import SwiftSyntax
 public import SwiftSyntaxMacros
 #else

--- a/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6)
+internal import SwiftSyntax
+#else
 import SwiftSyntax
+#endif
 
 // MARK: SyntaxProtocol.indentationOfFirstLine
 

--- a/Sources/SwiftSyntaxMacroExpansion/MacroArgument.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroArgument.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6)
-import SwiftDiagnostics
+internal import SwiftDiagnostics
 public import SwiftSyntax
 #else
 import SwiftDiagnostics

--- a/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroReplacement.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6)
-import SwiftDiagnostics
+internal import SwiftDiagnostics
 public import SwiftSyntax
-import SwiftSyntaxBuilder
+internal import SwiftSyntaxBuilder
 #else
 import SwiftDiagnostics
 import SwiftSyntax

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -11,11 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6)
-import SwiftDiagnostics
-import SwiftOperators
-@_spi(MacroExpansion) import SwiftParser
+internal import SwiftDiagnostics
+internal import SwiftOperators
+@_spi(MacroExpansion) internal import SwiftParser
 public import SwiftSyntax
-import SwiftSyntaxBuilder
+internal import SwiftSyntaxBuilder
 @_spi(MacroExpansion) @_spi(ExperimentalLanguageFeature) public import SwiftSyntaxMacros
 #else
 import SwiftDiagnostics

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -63,7 +63,7 @@ public struct NoteSpec {
     message: String,
     line: Int,
     column: Int,
-    originatorFile: StaticString = #file,
+    originatorFile: StaticString = #filePath,
     originatorLine: UInt = #line
   ) {
     self.message = message

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6)
-import SwiftBasicFormat
-@_spi(Testing) import SwiftParser
+internal import SwiftBasicFormat
+@_spi(Testing) internal import SwiftParser
 @_spi(RawSyntax) public import SwiftSyntax
-import SwiftSyntaxBuilder
+internal import SwiftSyntaxBuilder
 #else
 import SwiftBasicFormat
 @_spi(Testing) import SwiftParser

--- a/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Paths.swift
+++ b/SwiftSyntaxDevUtils/Sources/swift-syntax-dev-utils/common/Paths.swift
@@ -14,7 +14,7 @@ import Foundation
 
 enum Paths {
   static var packageDir: URL {
-    URL(fileURLWithPath: #file)
+    URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .deletingLastPathComponent()

--- a/Tests/PerformanceTest/InstructionsCountAssertion.swift
+++ b/Tests/PerformanceTest/InstructionsCountAssertion.swift
@@ -17,7 +17,7 @@ fileprivate var baselineURL: URL {
   if let baselineFile = ProcessInfo.processInfo.environment["BASELINE_FILE"] {
     return URL(fileURLWithPath: baselineFile)
   } else {
-    return URL(fileURLWithPath: #file)
+    return URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .appendingPathComponent("baselines.json")
   }

--- a/Tests/PerformanceTest/ParsingPerformanceTests.swift
+++ b/Tests/PerformanceTest/ParsingPerformanceTests.swift
@@ -18,7 +18,7 @@ import _SwiftSyntaxTestSupport
 class ParsingPerformanceTests: XCTestCase {
 
   var inputFile: URL {
-    return URL(fileURLWithPath: #file)
+    return URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .appendingPathComponent("Inputs")
       .appendingPathComponent("MinimalCollections.swift.input")

--- a/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
+++ b/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
@@ -19,7 +19,7 @@ import _SwiftSyntaxTestSupport
 class SyntaxClassifierPerformanceTests: XCTestCase {
 
   var inputFile: URL {
-    return URL(fileURLWithPath: #file)
+    return URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .appendingPathComponent("Inputs")
       .appendingPathComponent("MinimalCollections.swift.input")

--- a/Tests/PerformanceTest/VisitorPerformanceTests.swift
+++ b/Tests/PerformanceTest/VisitorPerformanceTests.swift
@@ -18,7 +18,7 @@ import _SwiftSyntaxTestSupport
 class VisitorPerformanceTests: XCTestCase {
 
   var inputFile: URL {
-    return URL(fileURLWithPath: #file)
+    return URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .appendingPathComponent("Inputs")
       .appendingPathComponent("MinimalCollections.swift.input")

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -61,7 +61,8 @@ class ParserTests: ParserTestCase {
     checkDiagnostics: Bool,
     shouldExclude: @Sendable (URL) -> Bool = { _ in false }
   ) {
-    let fileURLs = FileManager.default
+    // nonisolated(unsafe) because [URL] is not marked Sendable on Linux.
+    let _fileURLs = FileManager.default
       .enumerator(at: path, includingPropertiesForKeys: nil)!
       .compactMap({ $0 as? URL })
       .filter {
@@ -69,6 +70,11 @@ class ParserTests: ParserTestCase {
           || $0.pathExtension == "sil"
           || $0.pathExtension == "swiftinterface"
       }
+    #if swift(>=6.0)
+    nonisolated(unsafe) let fileURLs = _fileURLs
+    #else
+    let fileURLs = _fileURLs
+    #endif
 
     print("\(name) - processing \(fileURLs.count) source files")
     DispatchQueue.concurrentPerform(iterations: fileURLs.count) { fileURLIndex in
@@ -85,7 +91,7 @@ class ParserTests: ParserTestCase {
     }
   }
 
-  let packageDir = URL(fileURLWithPath: #file)
+  let packageDir = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .deletingLastPathComponent()
     .deletingLastPathComponent()

--- a/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
+++ b/Tests/SwiftParserTest/SequentialToConcurrentEditTranslationTests.swift
@@ -37,7 +37,7 @@ func verifySequentialToConcurrentTranslation(
   _ sequential: [IncrementalEdit],
   _ expectedConcurrent: [IncrementalEdit],
   testString: String = longString,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) {
   let concurrent = ConcurrentEdits(fromSequential: sequential)

--- a/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/LexicalContextTests.swift
@@ -200,8 +200,8 @@ struct AllLexicalContextsMacro: DeclarationMacro {
   }
 }
 
-public struct LexicalContextDescriptionMacro: ExpressionMacro {
-  public static func expansion(
+struct LexicalContextDescriptionMacro: ExpressionMacro {
+  static func expansion(
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
   ) throws -> ExprSyntax {


### PR DESCRIPTION
- **Explanation**: This makes swift-syntax build in Swift 6 mode when using a Swift 6 compiler
- **Scope**: The Swift package build of swift-syntax. The CMake build is unaffected
- **Risk**: All possible issues caused by this will be found at build time
- **Testing**: Tested that swift-syntax builds without warnings with both a Swift 5 and Swift 6 compiler
- **Issue**: rdar://125579439
- **Reviewer**:  @bnbarham on #2568 and #2621