### PR TITLE
[CompilerPlugin] Sink error exit logic to "message listener"

### DIFF
--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -112,12 +112,6 @@ extension CompilerPlugin {
     let connection = try StandardIOMessageConnection()
     let provider = MacroProviderAdapter(plugin: Self())
     let impl = CompilerPluginMessageListener(connection: connection, provider: provider)
-    do {
-      try impl.main()
-    } catch {
-      // Emit a diagnostic and indicate failure to the plugin host,
-      // and exit with an error code.
-      fatalError("Internal Error: \(error)")
-    }
+    impl.main()
   }
 }


### PR DESCRIPTION
And print the error to `stderr` manually, instead of `fatalError()`. We don't want to print the file name / line number for this.