### PR TITLE
[6.0] Add option to install targets even when not top level

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -130,7 +130,7 @@ function(add_swift_syntax_library name)
     endif()
   endif()
 
-  if(PROJECT_IS_TOP_LEVEL)
+  if(PROJECT_IS_TOP_LEVEL OR SWIFT_SYNTAX_INSTALL_TARGETS)
     # Install this target
     install(TARGETS ${name}
       EXPORT SwiftSyntaxTargets
@@ -148,4 +148,5 @@ function(add_swift_syntax_library name)
   else()
     set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
   endif()
+  add_library(SwiftSyntax::${name} ALIAS ${name})
 endfunction()

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(PROJECT_IS_TOP_LEVEL)
+if(PROJECT_IS_TOP_LEVEL OR SWIFT_SYNTAX_INSTALL_TARGETS)
   export(EXPORT SwiftSyntaxTargets
          FILE ${CMAKE_CURRENT_BINARY_DIR}/SwiftSyntaxConfig.cmake
          NAMESPACE SwiftSyntax::)


### PR DESCRIPTION
- **Explanation**: Also add namespaced targets for any exported target to facilitate find_package and FetchContent both using the same target names.
- **Scope**: CMake build
- **Risk**: Any issues will be caught at build-time
- **Testing**: n/a
- **Issue**: n/a
- **Reviewer**:   @bnbarham on https://github.com/apple/swift-syntax/pull/2628