### PR TITLE
Add an umbrella header for _SwiftSyntaxCShims

### DIFF
--- a/Sources/_SwiftSyntaxCShims/include/SwiftSyntaxCShims.h
+++ b/Sources/_SwiftSyntaxCShims/include/SwiftSyntaxCShims.h
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "_includes.h"
+#include "AtomicBool.h"
+#include "swiftsyntax_errno.h"
+#include "swiftsyntax_stdio.h"


### PR DESCRIPTION
Having an umbrella header helps build swift-syntax in some build environments.