### PR TITLE
[5.10] Fix warnings about retroactive conformances when building swift-syntax 510 with a Swift 6 compiler

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -68,7 +68,7 @@ extension BinaryOperatorExprSyntax {
 
 // MARK: - BooleanLiteralExpr
 
-extension BooleanLiteralExprSyntax: ExpressibleByBooleanLiteral {
+extension BooleanLiteralExprSyntax {
   public init(_ value: Bool) {
     self.init(literal: value ? .keyword(.true) : .keyword(.false))
   }
@@ -77,6 +77,11 @@ extension BooleanLiteralExprSyntax: ExpressibleByBooleanLiteral {
     self.init(value)
   }
 }
+#if compiler(>=6)
+extension BooleanLiteralExprSyntax: @retroactive ExpressibleByBooleanLiteral {}
+#else
+extension BooleanLiteralExprSyntax: ExpressibleByBooleanLiteral {}
+#endif
 
 // MARK: - CatchClause
 
@@ -153,7 +158,7 @@ extension ExprSyntax {
 
 // MARK: - FloatLiteralExprSyntax
 
-extension FloatLiteralExprSyntax: ExpressibleByFloatLiteral {
+extension FloatLiteralExprSyntax {
   public init(_ value: Float) {
     self.init(literal: .floatLiteral(String(value)))
   }
@@ -162,6 +167,12 @@ extension FloatLiteralExprSyntax: ExpressibleByFloatLiteral {
     self.init(value)
   }
 }
+
+#if compiler(>=6)
+extension FloatLiteralExprSyntax: @retroactive ExpressibleByFloatLiteral {}
+#else
+extension FloatLiteralExprSyntax: ExpressibleByFloatLiteral {}
+#endif
 
 // MARK: - FunctionCallExpr
 
@@ -190,7 +201,7 @@ extension FunctionCallExprSyntax {
 
 // MARK: - IntegerLiteralExpr
 
-extension IntegerLiteralExprSyntax: ExpressibleByIntegerLiteral {
+extension IntegerLiteralExprSyntax {
   public init(_ value: Int) {
     self.init(literal: .integerLiteral(String(value)))
   }
@@ -199,6 +210,12 @@ extension IntegerLiteralExprSyntax: ExpressibleByIntegerLiteral {
     self.init(value)
   }
 }
+
+#if compiler(>=6)
+extension IntegerLiteralExprSyntax: @retroactive ExpressibleByIntegerLiteral {}
+#else
+extension IntegerLiteralExprSyntax: ExpressibleByIntegerLiteral {}
+#endif
 
 // MARK: - StringLiteralExpr
 

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -444,6 +444,12 @@ extension TokenSyntax: SyntaxExpressibleByStringInterpolation {
   }
 }
 
+#if compiler(>=6)
+// Silence warning that TokenSyntax has a retroactive conformance to `ExpressibleByStringInterpolation` through
+// `SyntaxExpressibleByStringInterpolation`.
+extension TokenSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 // MARK: - Trivia expressible as string
 
 extension TriviaPiece {
@@ -466,7 +472,7 @@ struct UnexpectedTrivia: DiagnosticMessage {
 
 }
 
-extension Trivia: ExpressibleByStringInterpolation {
+extension Trivia {
   public init(stringInterpolation: String.StringInterpolation) {
     var text = String(stringInterpolation: stringInterpolation)
     let pieces = text.withUTF8 { (buf) -> [TriviaPiece] in
@@ -484,3 +490,9 @@ extension Trivia: ExpressibleByStringInterpolation {
     self.init(stringInterpolation: interpolation)
   }
 }
+
+#if compiler(>=6)
+extension Trivia: @retroactive ExpressibleByStringInterpolation {}
+#else
+extension Trivia: ExpressibleByStringInterpolation {}
+#endif

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -16,42 +16,127 @@ import SwiftSyntax
 
 extension AccessorBlockSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension AccessorBlockSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension AccessorDeclSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension AccessorDeclSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
 
 extension AttributeSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension AttributeSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension CatchClauseSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension CatchClauseSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
 
 extension ClosureParameterSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension ClosureParameterSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension CodeBlockItemSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension CodeBlockItemSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
 
 extension DeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension DeclSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension EnumCaseParameterSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension EnumCaseParameterSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
 
 extension ExprSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension ExprSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension FunctionParameterSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension FunctionParameterSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
 
 extension GenericParameterClauseSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension GenericParameterClauseSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension MemberBlockSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension MemberBlockSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
 
 extension PatternSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension PatternSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension SourceFileSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension SourceFileSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
 
 extension StmtSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension StmtSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension SwitchCaseSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension SwitchCaseSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
 
 extension TypeSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension TypeSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension AccessorDeclListSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension AccessorDeclListSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
 
 extension AttributeListSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension AttributeListSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension CodeBlockItemListSyntax: SyntaxExpressibleByStringInterpolation {}
 
+#if compiler(>=6)
+extension CodeBlockItemListSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+
 extension MemberBlockItemListSyntax: SyntaxExpressibleByStringInterpolation {}
+
+#if compiler(>=6)
+extension MemberBlockItemListSyntax: @retroactive ExpressibleByStringInterpolation {}
+#endif
+


### PR DESCRIPTION
- **Explanation**: When building swift-syntax using a Swift 6 compiler, it emits warnings about retractive conformances. Add conditional compilation conditions to add `@retroactive` where needed if compiling with a Swift 6 compiler to fix those warnings.
- **Scope**: No functionality change. Does not require a new toolchain, will just be a new swift-syntax tag
- **Risk**: Low, no functionality change.
- **Testing**: Verified that swift-syntax still builds using a Swift 5 and Swift 6 compiler
- **Issue**: rdar://127134889
- **Reviewer**:  @bnbarham