### PR TITLE
Mark `IntegerLiteralExprSyntax.Radix` as `Sendable`

### DIFF
--- a/Sources/SwiftSyntax/Convenience.swift
+++ b/Sources/SwiftSyntax/Convenience.swift
@@ -84,7 +84,7 @@ extension FloatLiteralExprSyntax {
 }
 
 extension IntegerLiteralExprSyntax {
-  public enum Radix {
+  public enum Radix: Sendable {
     case binary
     case octal
     case decimal


### PR DESCRIPTION
Found this while making the `SourceKitLSP` module build in Swift 6 mode.