### PR TITLE
[6.0] Mark `IntegerLiteralExprSyntax.Radix` as `Sendable`

### DIFF
--- a/Sources/SwiftRefactor/IntegerLiteralUtilities.swift
+++ b/Sources/SwiftRefactor/IntegerLiteralUtilities.swift
@@ -17,7 +17,7 @@ import SwiftSyntax
 #endif
 
 extension IntegerLiteralExprSyntax {
-  public enum Radix {
+  public enum Radix: Sendable {
     case binary
     case octal
     case decimal


### PR DESCRIPTION
- **Explanation**: Mark `IntegerLiteralExprSyntax.Radix` as `Sendable`. This helps us build SourceKit-LSP in Swift 6 mode
- **Scope**: Adding `Sendable` conformance to `IntegerLiteralExprSyntax.Radix`
- **Risk**: Very low, just adds a `Sendable` conformance to `IntegerLiteralExprSyntax.Radix`
- **Testing**: Checked that allows us to build SourceKit-LSP in Swift 6 mode
- **Issue**: n/a
- **Reviewer**:   @bnbarham on https://github.com/apple/swift-syntax/pull/2651