### PR TITLE
Don't use an instance property before it's defined

### DIFF
--- a/Sources/SwiftSyntax/TokenDiagnostic.swift
+++ b/Sources/SwiftSyntax/TokenDiagnostic.swift
@@ -129,8 +129,8 @@ public struct TokenDiagnostic: Hashable, Sendable {
   /// expect to hit this case most of the time.
   public init(_ kind: Kind, byteOffset: Int) {
     precondition(byteOffset >= 0)
-    // `type(of: self.byteOffset).max` gets optimized to a constant
-    if byteOffset > type(of: self.byteOffset).max {
+    // `UInt16.max` gets optimized to a constant
+    if byteOffset > UInt16.max {
       self.kind = .tokenDiagnosticOffsetOverflow
       self.byteOffset = 0
     } else {


### PR DESCRIPTION
We're using an instance property before it's been given a value, which wasn't being diagnosed by the compiler.