### PR TITLE
[6.0] Remove flag to disable Swift 6 mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -295,12 +295,7 @@ let package = Package(
       exclude: ["Inputs"]
     ),
   ],
-  // Disable Swift 6 mode when the `SWIFTSYNTAX_DISABLE_SWIFT_6_MODE` environment variable is set. This works around the following
-  // issue: The self-hosted SwiftPM job has Xcode 15.3 (Swift 5.10) installed and builds a Swift 6 SwiftPM from source.
-  // It then tries to build itself as a fat binary using the just-built Swift 6 SwiftPM, which uses xcbuild from Xcode
-  // as the build system. But the xcbuild in the installed Xcode is too old and doesn't know about Swift 6 mode, so it
-  // fails with: SWIFT_VERSION '6' is unsupported, supported versions are: 4.0, 4.2, 5.0 (rdar://126952308)
-  swiftLanguageVersions: hasEnvironmentVariable("SWIFTSYNTAX_DISABLE_SWIFT_6_MODE") ? [.v5] : [.v5, .version("6")]
+  swiftLanguageVersions: [.v5, .version("6")]
 )
 
 // This is a fake target that depends on all targets in the package.


### PR DESCRIPTION
* **Explanation**: Remove code that forced swift-syntax to be built in Swift 5 mode because the underlying issue was fixed by https://github.com/apple/swift-package-manager/pull/7504
* **Scope**: None, SwiftPM was the only client to set the environment variable and it has removed the setting in https://github.com/apple/swift-package-manager/pull/7558
* **Risk**: Low, if there are any issues, they will be caught at build time
* **Testing**: n/a
* **Issue**: n/a
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-syntax/pull/2650