### PR TITLE
Fix up a mismatch between effect specifier lookahead and parsing

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -2428,10 +2428,15 @@ extension Parser.Lookahead {
   // Consume 'async', 'throws', and 'rethrows', but in any order.
   mutating func consumeEffectsSpecifiers() {
     var loopProgress = LoopProgressCondition()
-    while let (_, handle) = self.at(anyIn: EffectSpecifier.self),
+    while let (spec, handle) = self.at(anyIn: EffectSpecifier.self),
       self.hasProgressed(&loopProgress)
     {
       self.eat(handle)
+
+      if spec.isThrowsSpecifier, self.consume(if: .leftParen) != nil {
+        _ = self.canParseSimpleOrCompositionType()
+        self.consume(if: .rightParen)
+      }
     }
   }
 

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2973,10 +2973,29 @@ final class StatementExpressionTests: ParserTestCase {
       "[() throws(MyError) -> Void]()"
     )
     assertParse(
+      "[() throws(any Error) -> Void]()"
+    )
+    assertParse(
       "X<() throws(MyError) -> Int>()"
     )
     assertParse(
       "X<() async throws(MyError) -> Int>()"
+    )
+  }
+
+  func testTypedThrowsClosureParam() {
+    assertParse(
+      """
+      try foo { (a, b) throws(S) in 1 }
+      """
+    )
+  }
+
+  func testTypedThrowsShorthandClosureParams() {
+    assertParse(
+      """
+      try foo { a, b throws(S) in 1 }
+      """
     )
   }
 


### PR DESCRIPTION
Lookahead was not consuming typed throw's error argument during lookahead for closures. `atFunctionTypeArrow` did mostly handle it, but only consumed a single token and thus wouldn't match `throws(any Error)`. Handle this in `consumeEffectsSpecifiers` and then use this for both.

Fixes #2648.
Resolves rdar://127750606.