### PR TITLE
[6.0] Fix up a mismatch between effect specifier lookahead and parsing

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -2418,10 +2418,15 @@ extension Parser.Lookahead {
   // Consume 'async', 'throws', and 'rethrows', but in any order.
   mutating func consumeEffectsSpecifiers() {
     var loopProgress = LoopProgressCondition()
-    while let (_, handle) = self.at(anyIn: EffectSpecifier.self),
+    while let (spec, handle) = self.at(anyIn: EffectSpecifier.self),
       self.hasProgressed(&loopProgress)
     {
       self.eat(handle)
+
+      if spec.isThrowsSpecifier, self.consume(if: .leftParen) != nil {
+        _ = self.canParseSimpleOrCompositionType()
+        self.consume(if: .rightParen)
+      }
     }
   }
 

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2973,10 +2973,29 @@ final class StatementExpressionTests: ParserTestCase {
       "[() throws(MyError) -> Void]()"
     )
     assertParse(
+      "[() throws(any Error) -> Void]()"
+    )
+    assertParse(
       "X<() throws(MyError) -> Int>()"
     )
     assertParse(
       "X<() async throws(MyError) -> Int>()"
+    )
+  }
+
+  func testTypedThrowsClosureParam() {
+    assertParse(
+      """
+      try foo { (a, b) throws(S) in 1 }
+      """
+    )
+  }
+
+  func testTypedThrowsShorthandClosureParams() {
+    assertParse(
+      """
+      try foo { a, b throws(S) in 1 }
+      """
     )
   }
 


### PR DESCRIPTION
- **Explanation**: Fixes a couple typed throws misparses where lookahead would fail to skip past typed throws.
- **Scope**: Parsing of types and closures
- **Risk**: Moderate - changes lookahead for effect specifiers
- **Testing**: New tests for the known typed throws misparses
- **Issue**: rdar://127750606
- **Reviewer**:   @DougGregor @ahoppen on https://github.com/apple/swift-syntax/pull/2660 