### PR TITLE
[SwiftParser] Handle extraneous case keyword after comma in switch case.

### DIFF
--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -1351,4 +1351,17 @@ final class SwitchTests: ParserTestCase {
         """
     )
   }
+
+  func testSwitch84() {
+    assertParse(
+      """
+      switch x {
+      case 1, 1️⃣case 2, 3:
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "unexpected 'case' keyword in switch case")
+      ]
+    )
+  }
 }


### PR DESCRIPTION
For errors of the form `case .a, case .b:` instead of the expected `case .a, .b:`, produce just a single initial unexpected token in the second `SwitchCaseItemSyntax` instead of a bad pattern and then a second separate full case.

See <https://github.com/apple/swift/pull/74071>, which is essentially the same change made to the old parser.