### PR TITLE
Move the `TokenSyntax.identifier` release notes to 600.md

### DIFF
--- a/Release Notes/600.md
+++ b/Release Notes/600.md
@@ -99,6 +99,10 @@
   - Description: A version of the `SwiftSyntaxMacrosTestSupport` module that doesn't depend on `Foundation` or `XCTest` and can thus be used to write macro tests using `swift-testing`. Since swift-syntax can't depend on swift-testing (which would incur a circular dependency since swift-testing depends on swift-syntax), users need to manually specify a failure handler like the following, that fails the swift-testing test: `Issue.record("\($0.message)", fileID: $0.location.fileID, filePath: $0.location.filePath, line: $0.location.line, column: $0.location.column)`
   - Pull request: https://github.com/apple/swift-syntax/pull/2647
 
+- `TokenSyntax.identifier`
+  - Description: Adds an `identifier` property to `TokenSyntax` which returns a canonicalized representation of an identifier that strips away backticks.
+  - Pull request: https://github.com/apple/swift-syntax/pull/2576
+
 ## API Behavior Changes
 
 ## Deprecations

--- a/Release Notes/601.md
+++ b/Release Notes/601.md
@@ -7,10 +7,6 @@
   - Issue: https://github.com/apple/swift-syntax/issues/405
   - Pull Request: https://github.com/apple/swift-syntax/pull/2605
 
-- `TokenSyntax.identifier`
-  - Description: Adds an `identifier` property to `TokenSyntax` which returns a canonicalized representation of an identifier that strips away backticks.
-  - Pull request: https://github.com/apple/swift-syntax/pull/2576
-
 ## API Behavior Changes
 
 ## Deprecations


### PR DESCRIPTION
We are cherry-picking this change to `release/6.0` in https://github.com/apple/swift-syntax/pull/2666.