### PR TITLE
Heap allocate our atomics

### DIFF
--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -82,3 +82,6 @@ add_swift_syntax_library(SwiftSyntax
   generated/syntaxNodes/SyntaxNodesQRS.swift
   generated/syntaxNodes/SyntaxNodesTUVWXYZ.swift
 )
+
+target_link_swift_syntax_libraries(SwiftSyntax PRIVATE
+  _SwiftSyntaxCShims)

--- a/Sources/_SwiftSyntaxCShims/include/AtomicBool.h
+++ b/Sources/_SwiftSyntaxCShims/include/AtomicBool.h
@@ -14,26 +14,28 @@
 #define SWIFTSYNTAX_ATOMICBOOL_H
 
 #include <stdbool.h>
+#include <stdlib.h>
 
 typedef struct {
   _Atomic(bool) value;
 } AtomicBool;
 
-__attribute__((swift_name("AtomicBool.init(initialValue:)")))
-static inline AtomicBool atomic_bool_create(bool initialValue) {
-  AtomicBool atomic;
-  atomic.value = initialValue;
+static inline AtomicBool *_Nonnull swiftsyntax_atomic_bool_create(bool initialValue) {
+  AtomicBool *atomic = malloc(sizeof(AtomicBool));
+  atomic->value = initialValue;
   return atomic;
 }
 
-__attribute__((swift_name("getter:AtomicBool.value(self:)")))
-static inline bool atomic_bool_get(AtomicBool *atomic) {
+static inline bool swiftsyntax_atomic_bool_get(AtomicBool *_Nonnull atomic) {
   return atomic->value;
 }
 
-__attribute__((swift_name("setter:AtomicBool.value(self:_:)")))
-static inline void atomic_bool_set(AtomicBool *atomic, bool newValue) {
+static inline void swiftsyntax_atomic_bool_set(AtomicBool *_Nonnull atomic, bool newValue) {
   atomic->value = newValue;
+}
+
+static inline void swiftsyntax_atomic_bool_destroy(AtomicBool *_Nonnull atomic) {
+  free(atomic);
 }
 
 #endif // SWIFTSYNTAX_ATOMICBOOL_H


### PR DESCRIPTION
We used C atomics but these were allocated as Swift variables. Even thought they were atomic, concurrent accesses to them could violate Swift’s exclusivity laws, raising thread sanitizer errors.

Allocate the C atomic using malloc to fix this problem.

rdar://129170128