### PR TITLE
Add dependsOn(immortal)

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -201,6 +201,7 @@ public enum Keyword: CaseIterable {
   case higherThan
   case `if`
   case `import`
+  case immortal
   case `in`
   case indirect
   case infix
@@ -537,6 +538,8 @@ public enum Keyword: CaseIterable {
       return KeywordSpec("higherThan")
     case .if:
       return KeywordSpec("if", isLexerClassified: true)
+    case .immortal:
+      return KeywordSpec("immortal", experimentalFeature: .nonescapableTypes)
     case .import:
       return KeywordSpec("import", isLexerClassified: true)
     case .in:

--- a/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TypeNodes.swift
@@ -517,13 +517,14 @@ public let TYPE_NODES: [Node] = [
     children: [
       Child(
         name: "parameter",
-        kind: .token(choices: [.token(.identifier), .keyword(.self), .token(.integerLiteral)]),
+        kind: .token(choices: [.token(.identifier), .keyword(.self), .token(.integerLiteral), .keyword(.immortal)]),
         nameForDiagnostics: "parameter reference",
         documentation: """
           The parameter on which the lifetime of this type depends. 
 
           This can be an identifier referring to an external parameter name, an integer literal to refer to an unnamed
-          parameter or `self` if the type's lifetime depends on the object the method is called on.
+          parameter, `self` if the type's lifetime depends on the object the method is called on or `immortal` when there
+          is no source of lifetime dependence. 
           """
       ),
       Child(

--- a/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
+++ b/Sources/SwiftParser/generated/Parser+TokenSpecSet.swift
@@ -2572,6 +2572,10 @@ extension LifetimeSpecifierArgumentSyntax {
     case identifier
     case `self`
     case integerLiteral
+    #if compiler(>=5.8)
+    @_spi(ExperimentalLanguageFeatures)
+    #endif
+    case immortal
     
     init?(lexeme: Lexer.Lexeme, experimentalFeatures: Parser.ExperimentalFeatures) {
       switch PrepareForKeywordMatch(lexeme) {
@@ -2581,6 +2585,8 @@ extension LifetimeSpecifierArgumentSyntax {
         self = .self
       case TokenSpec(.integerLiteral):
         self = .integerLiteral
+      case TokenSpec(.immortal) where experimentalFeatures.contains(.nonescapableTypes):
+        self = .immortal
       default:
         return nil
       }
@@ -2594,6 +2600,8 @@ extension LifetimeSpecifierArgumentSyntax {
         self = .self
       case TokenSpec(.integerLiteral):
         self = .integerLiteral
+      case TokenSpec(.immortal):
+        self = .immortal
       default:
         return nil
       }
@@ -2607,6 +2615,8 @@ extension LifetimeSpecifierArgumentSyntax {
         return .keyword(.self)
       case .integerLiteral:
         return .integerLiteral
+      case .immortal:
+        return .keyword(.immortal)
       }
     }
     
@@ -2622,6 +2632,8 @@ extension LifetimeSpecifierArgumentSyntax {
         return .keyword(.self)
       case .integerLiteral:
         return .integerLiteral("")
+      case .immortal:
+        return .keyword(.immortal)
       }
     }
   }

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -140,6 +140,10 @@ public enum Keyword: UInt8, Hashable, Sendable {
   case higherThan
   case `if`
   case `import`
+  #if compiler(>=5.8)
+  @_spi(ExperimentalLanguageFeatures)
+  #endif
+  case immortal
   case `in`
   case indirect
   case infix
@@ -523,6 +527,8 @@ public enum Keyword: UInt8, Hashable, Sendable {
         self = .escaping
       case "exported":
         self = .exported
+      case "immortal":
+        self = .immortal
       case "indirect":
         self = .indirect
       case "internal":
@@ -934,6 +940,7 @@ public enum Keyword: UInt8, Hashable, Sendable {
       "higherThan", 
       "if", 
       "import", 
+      "immortal", 
       "in", 
       "indirect", 
       "infix", 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1721,7 +1721,12 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .lifetimeSpecifierArgument:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier), .keyword("self"), .tokenKind(.integerLiteral)]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
+            .tokenKind(.identifier), 
+            .keyword("self"), 
+            .tokenKind(.integerLiteral), 
+            .keyword("immortal")
+          ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -1663,7 +1663,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable, _LeafSynt
 ///
 /// ### Children
 /// 
-///  - `parameter`: (`<identifier>` | `self` | `<integerLiteral>`)
+///  - `parameter`: (`<identifier>` | `self` | `<integerLiteral>` | `immortal`)
 ///  - `trailingComma`: `,`?
 #if compiler(>=5.8)
 @_spi(ExperimentalLanguageFeatures)
@@ -1732,7 +1732,8 @@ public struct LifetimeSpecifierArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
   /// The parameter on which the lifetime of this type depends. 
   /// 
   /// This can be an identifier referring to an external parameter name, an integer literal to refer to an unnamed
-  /// parameter or `self` if the type's lifetime depends on the object the method is called on.
+  /// parameter, `self` if the type's lifetime depends on the object the method is called on or `immortal` when there
+  /// is no source of lifetime dependence. 
   ///
   /// ### Tokens
   /// 
@@ -1740,6 +1741,7 @@ public struct LifetimeSpecifierArgumentSyntax: SyntaxProtocol, SyntaxHashable, _
   ///  - `<identifier>`
   ///  - `self`
   ///  - `<integerLiteral>`
+  ///  - `immortal`
   public var parameter: TokenSyntax {
     get {
       return Syntax(self).child(at: 1)!.cast(TokenSyntax.self)

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -532,5 +532,7 @@ final class TypeTests: ParserTestCase {
       fixedSource: "func foo() -> dependsOn(<#identifier#>-1) X",
       experimentalFeatures: [.nonescapableTypes]
     )
+
+    assertParse("func foo() -> dependsOn(immortal) X", experimentalFeatures: [.nonescapableTypes])
   }
 }


### PR DESCRIPTION
Used in cases where a nonescapable value must be constructed without any owner that can stand in as the source of a dependence. See https://gist.github.com/atrick/9ed708431e9a18059c22d37d18759c6d for details

Fixes rdar://129183196