### PR TITLE
Mark MacroSpec as Sendable

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSpec.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSpec.swift
@@ -21,7 +21,7 @@ import SwiftSyntaxMacros
 /// The information of a macro declaration, to be used with `assertMacroExpansion`.
 ///
 /// In addition to specifying the macro’s type, this allows the specification of conformances that will be passed to the macro’s `expansion` function.
-public struct MacroSpec {
+public struct MacroSpec: Sendable {
   /// The type of macro.
   let type: Macro.Type
   /// The list of types for which the macro needs to add conformances.


### PR DESCRIPTION
Without making this change, compiling the default `XCTestCase` created for a macro project under Swift 6 will produce the error “Let `testMacros` is not concurrency-safe because non-`Sendable` type `[String : MacroSpec]` may have shared mutable state.” Fortunately there is no shared mutable state here — syntax nodes are already `Sendable`, and metatypes [are also `Sendable`](https://github.com/apple/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md#metatype-conformance-to-sendable).