### PR TITLE
Detach node when accessing .trimmed

### DIFF
--- a/Release Notes/601.md
+++ b/Release Notes/601.md
@@ -9,6 +9,10 @@
 
 ## API Behavior Changes
 
+- `SyntaxProtocol.trimmed` detaches the node
+  - Description: Getting a trimmed version of a node detaches it from its parent. Having the trimmed node be attached to a parent was not intuitive because eg. printing the parent node would have the trimmed trivia missing, most likely forming invalid Swift code.
+  - Pull Request: https://github.com/apple/swift-syntax/pull/2689
+
 ## Deprecations
 
 - `IncrementalEdit` deprecated in favor of `SourceEdit`

--- a/Sources/SwiftSyntax/SyntaxProtocol.swift
+++ b/Sources/SwiftSyntax/SyntaxProtocol.swift
@@ -578,9 +578,11 @@ extension SyntaxProtocol {
 
   /// A copy of this node without the leading trivia of the first token in the
   /// node and the trailing trivia of the last token in the node.
+  ///
+  /// The trimmed node is detached from its parent.
   public var trimmed: Self {
     // TODO: Should only need one new node here
-    return self.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
+    return self.detached.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
   }
 
   /// A copy of this node with pieces that match `matching` trimmed from the


### PR DESCRIPTION
Having the trimmed node be attached to a parent was not intuitive because eg. printing the parent node would have the trimmed trivia missing, most likely forming invalid Swift code.

Motivated by https://github.com/apple/swift-syntax/issues/2687