### PR TITLE
[6.0] Fix renaming enum case parameters with unnamed associated arguments

### DIFF
--- a/Sources/SwiftIDEUtils/DeclNameLocation.swift
+++ b/Sources/SwiftIDEUtils/DeclNameLocation.swift
@@ -102,6 +102,12 @@ public struct DeclNameLocation: Equatable {
     /// The parameter of a function declaration, like `func foo(a b: Int)`
     case parameters([Argument])
 
+    /// An enum case declaration like `case myCase(label: String)`.
+    ///
+    /// For enum case parameters the argument label is removed when set to empty instead of being changed to eg.
+    /// `myCase(_ label: String)`
+    case enumCaseParameters([Argument])
+
     /// Same as `param` but the parameters can't be collapsed if they are the same. This is the case for subscript
     /// declarations.
     ///
@@ -123,6 +129,8 @@ public struct DeclNameLocation: Equatable {
         )
       case .parameters(let parameters):
         return .parameters(parameters.map { $0.advanced(by: utf8Offset) })
+      case .enumCaseParameters(let parameters):
+        return .enumCaseParameters(parameters.map { $0.advanced(by: utf8Offset) })
       case .noncollapsibleParameters(let parameters):
         return .noncollapsibleParameters(parameters.map { $0.advanced(by: utf8Offset) })
       case .selector(let arguments):

--- a/Sources/SwiftIDEUtils/NameMatcher.swift
+++ b/Sources/SwiftIDEUtils/NameMatcher.swift
@@ -298,7 +298,7 @@ public class NameMatcher: SyntaxAnyVisitor {
           return .unlabeled(argument: Syntax(argument.secondName) ?? Syntax(argument.colon) ?? Syntax(argument.type))
         }
       }
-      addResolvedLocIfRequested(baseName: node.name, argumentLabels: .parameters(argumentLabels))
+      addResolvedLocIfRequested(baseName: node.name, argumentLabels: .enumCaseParameters(argumentLabels))
     }
     return .visitChildren
   }

--- a/Tests/SwiftIDEUtilsTest/NameMatcherTests.swift
+++ b/Tests/SwiftIDEUtilsTest/NameMatcherTests.swift
@@ -51,6 +51,7 @@ private func assertNameMatcherResult(
     case .noArguments: argumentLabels = []
     case .call(let labels, _): argumentLabels = labels
     case .parameters(let labels): argumentLabels = labels
+    case .enumCaseParameters(let labels): argumentLabels = labels
     case .noncollapsibleParameters(let labels): argumentLabels = labels
     case .selector(let labels): argumentLabels = labels
     }
@@ -75,6 +76,7 @@ private struct DeclNameLocationSpec {
     case noArguments
     case call
     case parameters
+    case enumCaseParameters
     case noncollapsibleParameters
     case selector
 
@@ -83,6 +85,7 @@ private struct DeclNameLocationSpec {
       case .noArguments: self = .noArguments
       case .call: self = .call
       case .parameters: self = .parameters
+      case .enumCaseParameters: self = .enumCaseParameters
       case .noncollapsibleParameters: self = .noncollapsibleParameters
       case .selector: self = .selector
       }
@@ -323,6 +326,58 @@ class NameMatcherTests: XCTestCase {
       "1️⃣fn(x:)(1)",
       expected: [
         DeclNameLocationSpec(baseName: "fn", argumentLabels: ["x"], type: .selector)
+      ]
+    )
+  }
+
+  func testEnumCaseParameterWithLabels() {
+    assertNameMatcherResult(
+      """
+      enum MyEnum {
+        case 1️⃣myCase(label: String)
+      }
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "myCase", argumentLabels: ["label"], type: .enumCaseParameters)
+      ]
+    )
+  }
+
+  func testEnumCaseParameterWithoutLabels() {
+    assertNameMatcherResult(
+      """
+      enum MyEnum {
+        case 1️⃣myCase(String)
+      }
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "myCase", argumentLabels: [""], type: .enumCaseParameters)
+      ]
+    )
+  }
+
+  func testEnumCaseParameterWithoutAssociatedValues() {
+    assertNameMatcherResult(
+      """
+      enum MyEnum {
+        case 1️⃣myCase
+      }
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "myCase", argumentLabels: [], type: .noArguments)
+      ]
+    )
+  }
+
+  func testEnumCaseParameterWithoutWildcardAsExternalLabel() {
+    assertNameMatcherResult(
+      """
+      enum MyEnum {
+        case 1️⃣myCase(_ label: String)
+      }
+      """,
+      expected: [
+        DeclNameLocationSpec(baseName: "myCase", argumentLabels: ["_ label"], type: .enumCaseParameters)
       ]
     )
   }


### PR DESCRIPTION
- **Explanation**: We treated enum case parameters the same way as function parameters and weren’t considering that they can be unlabeled. That caused us to insert eg. `_ ` in front of the case’s type, producing `case myCase(_ String)`, which is invalid. Report `enumCaseParameters` as a special parameter kind so that sourcekitd can work with it.
- **Scope**: Rename in SourceKit
- **Risk**: Low, only affects rename of enum cases
- **Testing**: Added test cases
- **Issue**: rdar://127646036 / https://github.com/apple/sourcekit-lsp/issues/1228
- **Reviewer**:  @hamishknight on https://github.com/apple/swift-syntax/pull/2678