### PR TITLE
Handle macro expansion args in placeholder expansion

### DIFF
--- a/Release Notes/602.md
+++ b/Release Notes/602.md
@@ -54,7 +54,13 @@
   - Pull Request: https://github.com/swiftlang/swift-syntax/pull/3028
   - Migration steps: Use `AttributeSyntax.Arguments.argumentList(LabeledExprListSyntax)` instead.
   - Notes: Removed cases from `AttributeSyntax.Arguments`: `token(TokenSyntax)`, `string(StringLiteralExprSyntax)`, `conventionArguments(ConventionAttributeArgumentsSyntax)`, `conventionWitnessMethodArguments(ConventionWitnessMethodAttributeArgumentsSyntax)`, `opaqueReturnTypeOfAttributeArguments(OpaqueReturnTypeOfAttributeArgumentsSyntax)`, `exposeAttributeArguments(ExposeAttributeArgumentsSyntax)`, `underscorePrivateAttributeArguments(UnderscorePrivateAttributeArgumentsSyntax)`, and `unavailableFromAsyncArguments(UnavailableFromAsyncAttributeArgumentsSyntax)`. Removed Syntax kinds: `ConventionAttributeArgumentsSyntax`, `ConventionWitnessMethodAttributeArgumentsSyntax`, `OpaqueReturnTypeOfAttributeArgumentsSyntax`, `ExposeAttributeArgumentsSyntax`, `UnderscorePrivateAttributeArgumentsSyntax`, and `UnavailableFromAsyncAttributeArgumentsSyntax`.
-,
+
+- `ExpandEditorPlaceholdersToLiteralClosures` & `CallToTrailingClosures` now take a `Syntax` parameter
+  - Description: These refactorings now take an arbitrary `Syntax` and return a `Syntax?`. If a non-function-like syntax node is passed, `nil` is returned. The previous `FunctionCallExprSyntax` overloads are deprecated.
+  - Pull Request: https://github.com/swiftlang/swift-syntax/pull/3092
+  - Migration steps: Insert a `Syntax(...)` initializer call for the argument, and cast the result with `.as(...)` if necessary.
+  - Notes: This allows the refactorings to correctly handle macro expansion expressions and declarations.
+
 ## Template
 
 - *Affected API or two word description*

--- a/Sources/SwiftRefactor/CMakeLists.txt
+++ b/Sources/SwiftRefactor/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_swift_syntax_library(SwiftRefactor
   AddSeparatorsToIntegerLiteral.swift
+  CallLikeSyntax.swift
   CallToTrailingClosures.swift
   ConvertComputedPropertyToStored.swift
   ConvertComputedPropertyToZeroParameterFunction.swift

--- a/Sources/SwiftRefactor/CallLikeSyntax.swift
+++ b/Sources/SwiftRefactor/CallLikeSyntax.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6)
+public import SwiftSyntax
+#else
+import SwiftSyntax
+#endif
+
+// TODO: We ought to consider exposing this as a public syntax protocol.
+@_spi(Testing) public protocol CallLikeSyntax: SyntaxProtocol {
+  var arguments: LabeledExprListSyntax { get set }
+  var leftParen: TokenSyntax? { get set }
+  var rightParen: TokenSyntax? { get set }
+  var trailingClosure: ClosureExprSyntax? { get set }
+  var additionalTrailingClosures: MultipleTrailingClosureElementListSyntax { get set }
+}
+@_spi(Testing) extension FunctionCallExprSyntax: CallLikeSyntax {}
+@_spi(Testing) extension MacroExpansionExprSyntax: CallLikeSyntax {}
+@_spi(Testing) extension MacroExpansionDeclSyntax: CallLikeSyntax {}
+
+extension SyntaxProtocol {
+  @_spi(Testing) public func asProtocol(_: CallLikeSyntax.Protocol) -> (any CallLikeSyntax)? {
+    Syntax(self).asProtocol(SyntaxProtocol.self) as? CallLikeSyntax
+  }
+}


### PR DESCRIPTION
Update `ExpandEditorPlaceholdersToLiteralClosures` and `CallToTrailingClosures` such that they can handle macro expansion exprs and decls. This unfortunately requires changing them such that they take a `Syntax` input and output to satisfy the conformance to `SyntaxRefactoringProvider`, but that seems preferable to making the refactoring types themselves generic.

If in the future we decide to expose `CallLikeSyntax` as a public protocol, we could decide to expose additional generic `refactor` overloads here. However it's not clear there's enough clients of these APIs to motivate doing that in this PR.