### PR TITLE
[6.2] Relax precondition in `postProcessMultilineStringLiteral`

### DIFF
--- a/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
@@ -243,4 +243,37 @@ final class StringLiteralEofTests: ParserTestCase {
         """##
     )
   }
+
+  func testSimpleMultilineStringLiteralWith() {
+    assertParse(
+      #"""
+      #sourceLocation1️⃣(file: 2️⃣"""3️⃣\(4️⃣"5️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "3️⃣", message: "argument cannot be an interpolated string literal"),
+        DiagnosticSpec(
+          locationMarker: "4️⃣",
+          message: #"expected '"""' to end simple string literal"#,
+          notes: [NoteSpec(locationMarker: "2️⃣", message: #"to match this opening '"""'"#)],
+          fixIts: [#"insert '"""'"#]
+        ),
+        DiagnosticSpec(
+          locationMarker: "4️⃣",
+          message: "expected ', line:' and line number in '#sourceLocation' arguments",
+          fixIts: ["insert ', line:' and line number"]
+        ),
+        DiagnosticSpec(
+          locationMarker: "4️⃣",
+          message: "expected ')' in '#sourceLocation' directive",
+          notes: [NoteSpec(locationMarker: "1️⃣", message: "to match this opening '('")],
+          fixIts: ["insert ')'"]
+        ),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "extra tokens following the #sourceLocation directive"),
+      ],
+      fixedSource: #"""
+        #sourceLocation(file: """\(
+        """, line: <#integer literal#>)"
+        """#
+    )
+  }
 }


### PR DESCRIPTION
*6.2 cherry-pick of #3098*

- Explanation: Fixes a crash that could occur when an invalid string literal is used with `#sourceLocation`
- Scope: Affects "simple" string literal parsing used for `#sourceLocation`/`@available`
- Issue: rdar://152839292, #3097
- Risk: Low, only affects invalid code, and only affects "simple" string literals
- Testing: Added tests to test suite
- Reviewer: Hamish Knight