### PR TITLE
[6.2] Avoid eating `"""` as closing `"` delimiter

### DIFF
--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -1882,6 +1882,62 @@ final class ExpressionTests: ParserTestCase {
     )
   }
 
+  func testInvalidMultiLineClosingDelimiter() {
+    assertParse(
+      #"""
+      "a"1️⃣""2️⃣ a3️⃣ a4️⃣ℹ️"""5️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(
+          locationMarker: "1️⃣",
+          message: "consecutive statements on a line must be separated by newline or ';'",
+          fixIts: [
+            "insert newline", "insert ';'",
+          ]
+        ),
+        DiagnosticSpec(
+          locationMarker: "2️⃣",
+          message: "consecutive statements on a line must be separated by newline or ';'",
+          fixIts: [
+            "insert newline", "insert ';'",
+          ]
+        ),
+        DiagnosticSpec(
+          locationMarker: "3️⃣",
+          message: "consecutive statements on a line must be separated by newline or ';'",
+          fixIts: [
+            "insert newline", "insert ';'",
+          ]
+        ),
+        DiagnosticSpec(
+          locationMarker: "4️⃣",
+          message: "consecutive statements on a line must be separated by newline or ';'",
+          fixIts: [
+            "insert newline", "insert ';'",
+          ]
+        ),
+        DiagnosticSpec(
+          locationMarker: "5️⃣",
+          message: #"expected '"""' to end string literal"#,
+          notes: [
+            NoteSpec(message: #"to match this opening '"""'"#)
+          ],
+          fixIts: [
+            #"insert '"""'"#
+          ]
+        ),
+      ],
+      fixedSource: #"""
+        "a"
+        ""
+        a
+        a
+        """
+        """
+        """#
+    )
+  }
+
   func testEmptyLineInMultilineStringLiteral() {
     assertParse(
       #"""


### PR DESCRIPTION
*6.2 cherry-pick of #3116*

- Explanation: Fixes a crash that could occur when a single-line string literal is terminated with `"""`
- Scope: Affects invalid string literals
- Issue: rdar://154172057, #3113
- Risk: Low, only affects invalid syntax
- Testing: Added tests to test suite
- Reviewer: Rintaro Ishizaki