### PR TITLE
[SwiftRefactor] PackageManifest: Add a public initializer to `FileSystem`

### DIFF
--- a/Sources/SwiftRefactor/PackageManifest/PackageDependency.swift
+++ b/Sources/SwiftRefactor/PackageManifest/PackageDependency.swift
@@ -24,6 +24,10 @@ public enum PackageDependency: Sendable {
 
   public struct FileSystem: Sendable {
     public let path: String
+
+    public init(path: String) {
+      self.path = path
+    }
   }
 
   public struct SourceControl: Sendable {
@@ -47,6 +51,11 @@ public enum PackageDependency: Sendable {
   public struct Registry: Sendable {
     public let identity: String
     public let requirement: Requirement
+
+    public init(identity: String, requirement: Requirement) {
+      self.identity = identity
+      self.requirement = requirement
+    }
 
     /// The dependency requirement.
     public enum Requirement: Sendable {


### PR DESCRIPTION
... and `Registry`

The initial PR that introduced these types missed that, which made it impossible to use `PackageDependency` and `AddDependency` refactoring externally.