### PR TITLE
[6.2][SwiftParser] Handle nested '#if' in attribute list correctly

### DIFF
--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -254,7 +254,9 @@ extension Parser.Lookahead {
           didSeeAnyAttributes = true
           _ = self.consumeAttributeList()
         case .poundIf:
-          _ = self.consumeIfConfigOfAttributes()
+          if self.consumeIfConfigOfAttributes() {
+            didSeeAnyAttributes = true
+          }
         default:
           break ATTRIBUTE_LOOP
         }

--- a/Tests/SwiftParserTest/DirectiveTests.swift
+++ b/Tests/SwiftParserTest/DirectiveTests.swift
@@ -157,6 +157,42 @@ final class DirectiveTests: ParserTestCase {
     )
   }
 
+  func testPoundIfNestedStructure() {
+    assertParse(
+      """
+      #if true
+      #if true
+      @frozen
+      #endif
+      #endif
+      public struct S {}
+      """,
+      substructure: AttributeListSyntax([
+        .ifConfigDecl(
+          IfConfigDeclSyntax(clauses: [
+            IfConfigClauseSyntax(
+              poundKeyword: .poundIfToken(),
+              condition: ExprSyntax("true"),
+              elements: .attributes([
+                .ifConfigDecl(
+                  IfConfigDeclSyntax(clauses: [
+                    IfConfigClauseSyntax(
+                      poundKeyword: .poundIfToken(),
+                      condition: ExprSyntax("true"),
+                      elements: .attributes([
+                        .attribute("@frozen")
+                      ])
+                    )
+                  ])
+                )
+              ])
+            )
+          ])
+        )
+      ])
+    )
+  }
+
   func testHasAttribute() {
     assertParse(
       """


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift-syntax/pull/3133 into `release/6.2`

* **Explanation**: Nested `#if` in attribute position were not parsed correctly unless the outer `#if` contained any attribute. Fix it by correctly propagating "did see attributes" flag from the inner `#if` parsing
* **Scope**: SwiftParser
* **Risk**: Low, the change is simple and clear
* **Testing**: Added regression test case
* **Issues**: rdar://157211447
* **Reviewer**: Alex Hoppen