### PR TITLE
Use an aspect hint instead of the `swift_module` tag

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -378,16 +378,16 @@ cc_library(
     name = "_InstructionCounter",
     srcs = glob(["Sources/_InstructionCounter/src/*.c"]),
     hdrs = glob(["Sources/_InstructionCounter/include/*.h"]),
+    aspect_hints = ["@build_bazel_rules_swift//swift:auto_module"],
     includes = ["Sources/_InstructionCounter/include"],
-    tags = ["swift_module=_InstructionCounter"],
     visibility = ["//visibility:private"],
 )
 
 cc_library(
     name = "_SwiftLibraryPluginProviderCShims",
     hdrs = glob(["Sources/_SwiftLibraryPluginProviderCShims/include/*.h"]),
+    aspect_hints = ["@build_bazel_rules_swift//swift:auto_module"],
     includes = ["Sources/_SwiftLibraryPluginProviderCShims/include"],
-    tags = ["swift_module=_SwiftLibraryPluginProviderCShims"],
     visibility = ["//visibility:private"],
 )
 
@@ -395,8 +395,8 @@ cc_library(
     name = "_SwiftSyntaxCShims",
     srcs = glob(["Sources/_SwiftSyntaxCShims/*.c"]),
     hdrs = glob(["Sources/_SwiftSyntaxCShims/include/*.h"]),
+    aspect_hints = ["@build_bazel_rules_swift//swift:auto_module"],
     includes = ["Sources/_SwiftSyntaxCShims/include"],
-    tags = ["swift_module=_SwiftSyntaxCShims"],
     visibility = ["//visibility:private"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,5 +17,10 @@ module(
 )
 
 bazel_dep(name = "apple_support", version = "1.13.0", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "rules_apple", version = "3.3.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "1.18.0", max_compatibility_level = 2, repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_apple", version = "4.0.1", repo_name = "build_bazel_rules_apple")
+bazel_dep(
+  name = "rules_swift",
+  version = "2.9.0",
+  max_compatibility_level = 3,
+  repo_name = "build_bazel_rules_swift",
+)


### PR DESCRIPTION
This is needed when using rules_swift 2.x+, otherwise inputs aren’t properly tracked and RBE doesn’t work.

Also includes some of the version bumps from https://github.com/bazelbuild/bazel-central-registry/pull/4879.