### PR TITLE
[6.2][Macros] Termination signal for executable plugin

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/StandardIOMessageConnection.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/StandardIOMessageConnection.swift
@@ -152,6 +152,10 @@ public struct StandardIOMessageConnection: MessageConnection {
 
     // Read the JSON payload.
     let count = Int(UInt64(littleEndian: header))
+    // Empty message is a termination signal.
+    if count == 0 {
+      return nil
+    }
     let data = UnsafeMutableRawBufferPointer.allocate(byteCount: count, alignment: 1)
     defer { data.deallocate() }
     try _read(into: data)


### PR DESCRIPTION
Cherry-pick #3164 into `release/6.2`

* **Explanation**: When the compiler shuts down a plugin, it sends SIGTERM to the plugin process and then wait(2) to ensure it exits. However, we've observed cases where the compiler waits for the plugin process to terminate for an unexpectedly long time. This change introduces a special macro plugin message - an empty string - used as a signal for the plugin to shut down itself gracefully. The compiler now sends it before delivering SIGTERM, ensuring that even if the signal is not handled, the plugin still shuts down.
* **Scope**: Macro plugins
* **Risk**: Low, The change is simple and straightforward. 
* **Testing**: Updated the existing test cases. Manually tested with locally built toolchain and verified the issue is not reproduced with this change.
* **Issues**: rdar://160820381
* **Reviewers**: Hamish Knight
