### PR TITLE
[CMake] Link swiftOnoneSupport in "Debug" build

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -56,6 +56,9 @@ function(add_swift_syntax_library name)
 
   # Create the library target.
   add_library(${target} ${ASHL_SOURCES})
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(${target} PUBLIC swiftSwiftOnoneSupport)
+  endif()
 
   if(SWIFTSYNTAX_EMIT_MODULE)
     # Determine where Swift modules will be built and installed.


### PR DESCRIPTION
When building the swift compler with "Debug" configuration, artifacts must be linked to swiftOnoneSupport. Explicitly link it as some linker doesn't auto-link it.

rdar://162631685