### PR TITLE
[SwiftParse] Update for accessor block disambiguation marker

### DIFF
--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -274,6 +274,13 @@ extension Parser.Lookahead {
     var lookahead = self.lookahead()
     lookahead.eat(.leftBrace)
 
+    // '@_accessorBlock' is a builtin disambiguation marker.
+    if lookahead.peek(isAt: .identifier),
+      lookahead.peek().tokenText == "_accessorBlock"
+    {
+      return true
+    }
+
     // Eat attributes, if present.
     while lookahead.consume(if: .atSign) != nil {
       guard lookahead.consume(if: .identifier) != nil else {

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3768,4 +3768,41 @@ final class UsingDeclarationTests: ParserTestCase {
       """
     )
   }
+
+  func testAccessorBlockDisambiguationMarker() {
+    assertParse(
+      """
+      var value = initialValue { @_accessorBlock
+        get
+      }
+      """,
+      substructure: VariableDeclSyntax(
+        bindingSpecifier: .keyword(.var),
+        bindings: [
+          PatternBindingSyntax(
+            pattern: IdentifierPatternSyntax(identifier: .identifier("value")),
+            initializer: InitializerClauseSyntax(
+              value: DeclReferenceExprSyntax(baseName: .identifier("initialValue"))
+            ),
+            accessorBlock: AccessorBlockSyntax(
+              leftBrace: .leftBraceToken(),
+              accessors: .accessors([
+                AccessorDeclSyntax(
+                  attributes: [
+                    .attribute(
+                      AttributeSyntax(
+                        atSign: .atSignToken(),
+                        attributeName: IdentifierTypeSyntax(name: .identifier("_accessorBlock"))
+                      )
+                    )
+                  ],
+                  accessorSpecifier: .keyword(.get)
+                )
+              ])
+            )
+          )
+        ]
+      )
+    )
+  }
 }


### PR DESCRIPTION
Update for https://github.com/swiftlang/swift/pull/84972
If the block after a pattern binding initializer starts with `{ @_accessorBlock` it's an accessor block, not a trailing closure.

rdar://140943107