### PR TITLE
Minor cleanup from `if` to `guard` statement

### DIFF
--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -266,7 +266,7 @@ extension Parser.Lookahead {
     }
 
     // If we don't have attributes, then it cannot be an accessor block.
-    if nextToken.rawTokenKind != .atSign {
+    guard self.peek(isAt: .atSign) else {
       return false
     }
 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3831,4 +3831,16 @@ final class UsingDeclarationTests: ParserTestCase {
       )
     )
   }
+
+  func testAccessorBlockAfterPatternBindingDeclWithAttribute() {
+    assertParse(
+      """
+      var x: Int = foo()
+      {
+        @available(*, deprecated)
+        didSet {}
+      }
+      """
+    )
+  }
 }


### PR DESCRIPTION
I think the guard is a lot easier to read here, noticed while reviewing https://github.com/swiftlang/swift-syntax/pull/3171.