### PR TITLE
[Parser] Consolidate recovery codepaths

### DIFF
--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -617,6 +617,23 @@ final class DeclarationTests: ParserTestCase {
         private(set) var get, didSet var a = 0
         """
     )
+
+    assertParse(
+      """
+      public 1️⃣{ {} }
+      open
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "expected declaration and ';' after 'public' modifier",
+          fixIts: ["insert declaration and ';'"]
+        )
+      ],
+      fixedSource: """
+        public <#declaration#>; { {} }
+        open
+        """
+    )
   }
 
   func testTypealias() {
@@ -1314,6 +1331,15 @@ final class DeclarationTests: ParserTestCase {
           get async { 0 }
         }
         """
+    )
+
+    assertParse(
+      """
+      public var foo: Swift.Int {
+        get
+        @inlinable set {}
+      }
+      """
     )
   }
 


### PR DESCRIPTION
We had two different codepaths for recovery, which could result in cases where we attempt to recover, but `expect` is then not able to do so. Consolidate them into a single function.