### PR TITLE
Add swiftLanguageModes to the set of labels that occur after package targets

### DIFF
--- a/Sources/SwiftRefactor/PackageManifest/AddPackageTarget.swift
+++ b/Sources/SwiftRefactor/PackageManifest/AddPackageTarget.swift
@@ -34,6 +34,7 @@ public struct AddPackageTarget: EditRefactoringProvider {
   /// argument in the Package initializers.
   private static let argumentLabelsAfterTargets: Set<String> = [
     "swiftLanguageVersions",
+    "swiftLanguageModes",
     "cLanguageStandard",
     "cxxLanguageStandard",
   ]


### PR DESCRIPTION
Add swiftLanguageModes to the set of labels that occur after package targets.

Fixes case where user adds a package dependency for the first time after previously including swiftLanguageMode, eg:

* Create an empty Package and include the swiftLanguagesModes label:
```
// swift-tools-version: 6.3
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "tmp",
    swiftLanguageModes: [.v6]
)
```
* swift package describe works as expected:
```
Name: tmp
Manifest display name: tmp
Path: /Users/rconnell/tmp
Tools version: 6.3
Dependencies:
Platforms:
Products:
Targets:
Swift languages versions:
    6

```
* Adding a dependency results in a malformed manifest:
```
 %swift package add dependency https://github.com/apple/swift-syntax.git

% swift package describe
error: 'tmp': Invalid manifest (compiled with: ["...
...
```