### PR TITLE
[SwiftWarningControl] Add ability to query warning group behavior including client-specified enclosing control rules

### DIFF
--- a/Sources/SwiftWarningControl/CMakeLists.txt
+++ b/Sources/SwiftWarningControl/CMakeLists.txt
@@ -7,7 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_syntax_library(SwiftWarningControl
-  WarningGroupBehavior.swift
+  WarningGroupControl.swift
   WarningControlDeclSyntax.swift
   WarningControlRegionBuilder.swift
   WarningControlRegions.swift

--- a/Sources/SwiftWarningControl/SwiftWarningControl.md
+++ b/Sources/SwiftWarningControl/SwiftWarningControl.md
@@ -25,6 +25,6 @@ func foo() {
 
 The `SwiftWarningControl` library provides a utility to determine, for a given source location and diagnostic group identifier, whether or not its behavior is affected by an `@warn` attribute of any of its parent declaration scope. 
 
-* `SyntaxProtocol.getWarningGroupControl(for diagnosticGroupIdentifier:)` produces the behavior specifier (`WarningGroupBehavior`: `error`, `warning`, `ignored`) which applies at this node.
+* `SyntaxProtocol.getWarningGroupControl(for diagnosticGroupIdentifier:)` produces the behavior control specifier (`WarningGroupControl`: `error`, `warning`, `ignored`) which applies at this node.
 
-* `SyntaxProtocol.warningGroupControlRegionTree` holds a computed `WarningControlRegionTree` data structure value that can be used to efficiently test for the specified `WarningGroupBehavior` at a given source location and a given diagnostic group.
+* `SyntaxProtocol.warningGroupControlRegionTree` holds a computed `WarningControlRegionTree` data structure value that can be used to efficiently test for the specified `WarningGroupControl` at a given source location and a given diagnostic group.

--- a/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
+++ b/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
@@ -14,13 +14,25 @@ import SwiftDiagnostics
 import SwiftSyntax
 
 extension SyntaxProtocol {
-  /// Get the warning emission behavior for the specified diagnostic group
+  /// Get the warning emission behavior control for the specified diagnostic group
   /// by determining its containing `WarningControlRegion`, if one is present.
+  /// Returns the syntactic control for the given diagnostic group, or `nil` if
+  /// there is not one.
+  /// - Parameters:
+  ///   - for diagnosticGroupIdentifier: The identifier of the diagnostic group.
+  ///   - globalControls: The global controls to consider, specified by the client (compiler)
+  ///     representing module-wide diagnostic group emission configuration, for example
+  ///     with `-Wwarning` and `-Werror` flags. These controls can be overriden at
+  ///     finer-grained scopes with the `@warn` attribute.
   @_spi(ExperimentalLanguageFeatures)
-  public func warningGroupBehavior(
-    for diagnosticGroupIdentifier: DiagnosticGroupIdentifier
-  ) -> WarningGroupBehavior? {
-    let warningControlRegions = root.warningGroupControlRegionTreeImpl(containing: self.position)
-    return warningControlRegions.warningGroupBehavior(at: self.position, for: diagnosticGroupIdentifier)
+  public func warningGroupControl(
+    for diagnosticGroupIdentifier: DiagnosticGroupIdentifier,
+    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl] = [:]
+  ) -> WarningGroupControl? {
+    let warningControlRegions = root.warningGroupControlRegionTreeImpl(
+      globalControls: globalControls,
+      containing: self.position
+    )
+    return warningControlRegions.warningGroupControl(at: self.position, for: diagnosticGroupIdentifier)
   }
 }

--- a/Sources/SwiftWarningControl/WarningControlDeclSyntax.swift
+++ b/Sources/SwiftWarningControl/WarningControlDeclSyntax.swift
@@ -13,10 +13,10 @@
 import SwiftSyntax
 
 extension WithAttributesSyntax {
-  /// Compute a dictionary of all `@warn` diagnostic group behaviors
+  /// Compute a dictionary of all `@warn` diagnostic group behavior controls
   /// specified on this warning control declaration scope.
-  var allWarningGroupControls: [DiagnosticGroupIdentifier: WarningGroupBehavior] {
-    attributes.reduce(into: [DiagnosticGroupIdentifier: WarningGroupBehavior]()) { result, attr in
+  var allWarningGroupControls: [DiagnosticGroupIdentifier: WarningGroupControl] {
+    attributes.reduce(into: [DiagnosticGroupIdentifier: WarningGroupControl]()) { result, attr in
       // `@warn` attributes
       guard case .attribute(let attributeSyntax) = attr,
         attributeSyntax.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "warn"
@@ -33,7 +33,7 @@ extension WithAttributesSyntax {
         return
       }
 
-      // Second argument is the `as: ` behavior specifier
+      // Second argument is the `as: ` behavior control specifier
       guard
         let asParamExprSyntax = attributeSyntax
           .arguments?.as(LabeledExprListSyntax.self)?
@@ -43,14 +43,14 @@ extension WithAttributesSyntax {
       }
       guard
         asParamExprSyntax.label?.text == "as",
-        let behaviorText = asParamExprSyntax
+        let controlText = asParamExprSyntax
           .expression.as(DeclReferenceExprSyntax.self)?
           .baseName.text,
-        let behavior = WarningGroupBehavior(rawValue: behaviorText)
+        let control = WarningGroupControl(rawValue: controlText)
       else {
         return
       }
-      result[DiagnosticGroupIdentifier(diagnosticGroupID)] = behavior
+      result[DiagnosticGroupIdentifier(diagnosticGroupID)] = control
     }
   }
 }

--- a/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
@@ -15,16 +15,22 @@ import SwiftSyntax
 /// Compute the full set of warning control regions in this syntax node
 extension SyntaxProtocol {
   @_spi(ExperimentalLanguageFeatures)
-  public func warningGroupControlRegionTree() -> WarningControlRegionTree {
-    return warningGroupControlRegionTreeImpl()
+  public func warningGroupControlRegionTree(
+    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl] = [:]
+  ) -> WarningControlRegionTree {
+    return warningGroupControlRegionTreeImpl(globalControls: globalControls)
   }
 
   /// Implementation of constructing a region tree with an optional parameter
   /// to specify that the constructed tree must only contain nodes which contain
   /// a specific absolute position - meant to speed up tree generation for individual
   /// queries.
-  func warningGroupControlRegionTreeImpl(containing position: AbsolutePosition? = nil) -> WarningControlRegionTree {
+  func warningGroupControlRegionTreeImpl(
+    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl],
+    containing position: AbsolutePosition? = nil
+  ) -> WarningControlRegionTree {
     let visitor = WarningControlRegionVisitor(self.range, containing: position)
+    visitor.tree.addWarningGroupControls(range: self.range, controls: globalControls)
     visitor.walk(self)
     return visitor.tree
   }

--- a/Sources/SwiftWarningControl/WarningGroupControl.swift
+++ b/Sources/SwiftWarningControl/WarningGroupControl.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 
 // Describes the emission behavior state of a particular warning diagnostic group.
 @_spi(ExperimentalLanguageFeatures)
-public enum WarningGroupBehavior: String {
+public enum WarningGroupControl: String {
   /// Emitted as a fatal error, halting compilation
   case error
   /// Emitted as a warning


### PR DESCRIPTION
Adds an optional parameter `with enclosingControls: [DiagnosticGroupIdentifier: WarningGroupBehavior] = [:]` to both:
- `SyntaxProtocol.warningGroupControlRegionTree`
- `SyntaxProtocol.warningGroupBehavior` to specify enclosing global warning group behavior controls which span the entire syntax node.

This mechanism will be used by the compiler to specify global controls over certain diagnostic groups from the compilation configuration. For example, a command-line-specified `-Werror Group` will become an input to this mechanism to be used as *the* behavior control at source positions where no syntactic control (`@warn`) is specified.

With this in place, the `SwiftWarningControl` API can be used as a single query which captures both syntactic and command-line configuration of warning diagnostic group behavior.