### PR TITLE
Exclude documentation from build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -186,7 +186,7 @@ let package = Package(
     .target(
       name: "SwiftWarningControl",
       dependencies: ["SwiftSyntax", "SwiftParser"],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt", "SwiftWarningControl.md"]
     ),
 
     .testTarget(

--- a/Sources/SwiftWarningControl/SwiftWarningControl.md
+++ b/Sources/SwiftWarningControl/SwiftWarningControl.md
@@ -6,7 +6,7 @@ A library to evaluate `@warn` diagnostic group controls within a Swift syntax tr
 
 Swift provides a mechanism to control the behavior of specific diagnostic groups for a given declaration's lexical scope with the `@warn` attribute.
 
-The syntax tree and its parser do not reason about warning group controls. The syntax tree produced by the parser represents the `@warn` attribute in a generic fashion, as it would any other basic attribute on a declaration. The per-declaration nature of the attribute means that for any given lexical scope, the behavior of a given diagnostic group can be queried by checking for the presence of this attribute in its parent declaration scope. 
+The syntax tree and its parser do not reason about warning group controls. The syntax tree produced by the parser represents the `@warn` attribute in a generic fashion, as it would any other basic attribute on a declaration. The per-declaration nature of the attribute means that for any given lexical scope, the behavior of a given diagnostic group can be queried by checking for the presence of this attribute in its parent declaration scope.
 
 ```swift
 @warn(Deprecate, as: error)
@@ -23,7 +23,7 @@ func foo() {
 }
 ```
 
-The `SwiftWarningControl` library provides a utility to determine, for a given source location and diagnostic group identifier, whether or not its behavior is affected by an `@warn` attribute of any of its parent declaration scope. 
+The `SwiftWarningControl` library provides a utility to determine, for a given source location and diagnostic group identifier, whether or not its behavior is affected by an `@warn` attribute of any of its parent declaration scope.
 
 * `SyntaxProtocol.getWarningGroupControl(for diagnosticGroupIdentifier:)` produces the behavior specifier (`WarningGroupBehavior`: `error`, `warning`, `ignored`) which applies at this node.
 


### PR DESCRIPTION
This otherwise causes the warning

```
warning: 'swift-syntax': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/danny/Projects/swift-syntax/Sources/SwiftWarningControl/SwiftWarningControl.md
```