### PR TITLE
[SwiftWarningControl] Add ability to specify diagnostic sub-group links

### DIFF
--- a/Sources/SwiftWarningControl/CMakeLists.txt
+++ b/Sources/SwiftWarningControl/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_syntax_library(SwiftWarningControl
+  DiagnosticGroupInheritanceTree.swift
   WarningGroupControl.swift
   WarningControlDeclSyntax.swift
   WarningControlRegionBuilder.swift

--- a/Sources/SwiftWarningControl/DiagnosticGroupInheritanceTree.swift
+++ b/Sources/SwiftWarningControl/DiagnosticGroupInheritanceTree.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A struct wrapper for a diagnostic group inheritance tree
+/// represented with a dictionary of a group identifier to an array
+/// of its sub-group identifiers.
+@_spi(ExperimentalLanguageFeatures)
+public struct DiagnosticGroupInheritanceTree {
+  private let subGroups: [DiagnosticGroupIdentifier: [DiagnosticGroupIdentifier]]
+  public init(subGroups: [DiagnosticGroupIdentifier: [DiagnosticGroupIdentifier]]) throws {
+    self.subGroups = subGroups
+    if hasCycle() {
+      throw WarningControlError.groupInheritanceCycle
+    }
+  }
+  init() {
+    self.subGroups = [:]
+  }
+
+  /// Diagnostic groups that inherit from `group`.
+  func subgroups(of group: DiagnosticGroupIdentifier) -> [DiagnosticGroupIdentifier] { subGroups[group] ?? [] }
+}
+
+extension DiagnosticGroupInheritanceTree {
+  // Check the subgroup tree for possible cycles
+  func hasCycle() -> Bool {
+    var visited: Set<DiagnosticGroupIdentifier> = []
+    var recursionStack: Set<DiagnosticGroupIdentifier> = []
+    func hasCycleFromGroup(_ group: DiagnosticGroupIdentifier) -> Bool {
+      if visited.insert(group).inserted {
+        recursionStack.insert(group)
+        let subgroups = self.subgroups(of: group)
+        for subGroup in subgroups {
+          if recursionStack.contains(subGroup) {
+            return true
+          } else if !visited.contains(subGroup), hasCycleFromGroup(subGroup) {
+            return true
+          }
+        }
+      }
+      recursionStack.remove(group)
+      return false
+    }
+
+    for group in subGroups.keys {
+      if !visited.contains(group), hasCycleFromGroup(group) {
+        return true
+      }
+    }
+    return false
+  }
+}
+
+/// Describes the kinds of diagnostics that can occur when processing warning
+/// group control queries. This is an Error-conforming type so we can throw errors when
+/// needed.
+@_spi(ExperimentalLanguageFeatures)
+public enum WarningControlError: Error, CustomStringConvertible {
+  case groupInheritanceCycle
+
+  public var description: String {
+    switch self {
+    case .groupInheritanceCycle:
+      return "cycle detected in the warning group inheritance hierarchy"
+    }
+  }
+}

--- a/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
+++ b/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
@@ -27,10 +27,12 @@ extension SyntaxProtocol {
   @_spi(ExperimentalLanguageFeatures)
   public func warningGroupControl(
     for diagnosticGroupIdentifier: DiagnosticGroupIdentifier,
-    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl] = [:]
+    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl] = [:],
+    groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil
   ) -> WarningGroupControl? {
     let warningControlRegions = root.warningGroupControlRegionTreeImpl(
       globalControls: globalControls,
+      groupInheritanceTree: groupInheritanceTree,
       containing: self.position
     )
     return warningControlRegions.warningGroupControl(at: self.position, for: diagnosticGroupIdentifier)

--- a/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
@@ -16,9 +16,13 @@ import SwiftSyntax
 extension SyntaxProtocol {
   @_spi(ExperimentalLanguageFeatures)
   public func warningGroupControlRegionTree(
-    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl] = [:]
+    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl] = [:],
+    groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil
   ) -> WarningControlRegionTree {
-    return warningGroupControlRegionTreeImpl(globalControls: globalControls)
+    return warningGroupControlRegionTreeImpl(
+      globalControls: globalControls,
+      groupInheritanceTree: groupInheritanceTree
+    )
   }
 
   /// Implementation of constructing a region tree with an optional parameter
@@ -27,9 +31,14 @@ extension SyntaxProtocol {
   /// queries.
   func warningGroupControlRegionTreeImpl(
     globalControls: [DiagnosticGroupIdentifier: WarningGroupControl],
+    groupInheritanceTree: DiagnosticGroupInheritanceTree?,
     containing position: AbsolutePosition? = nil
   ) -> WarningControlRegionTree {
-    let visitor = WarningControlRegionVisitor(self.range, containing: position)
+    let visitor = WarningControlRegionVisitor(
+      self.range,
+      containing: position,
+      groupInheritanceTree: groupInheritanceTree
+    )
     visitor.tree.addWarningGroupControls(range: self.range, controls: globalControls)
     visitor.walk(self)
     return visitor.tree
@@ -53,8 +62,12 @@ private class WarningControlRegionVisitor: SyntaxAnyVisitor {
   var tree: WarningControlRegionTree
   let containingPosition: AbsolutePosition?
 
-  init(_ topLevelRange: Range<AbsolutePosition>, containing position: AbsolutePosition? = nil) {
-    self.tree = WarningControlRegionTree(range: topLevelRange)
+  init(
+    _ topLevelRange: Range<AbsolutePosition>,
+    containing position: AbsolutePosition?,
+    groupInheritanceTree: DiagnosticGroupInheritanceTree?
+  ) {
+    self.tree = WarningControlRegionTree(range: topLevelRange, groupInheritanceTree: groupInheritanceTree)
     containingPosition = position
     super.init(viewMode: .fixedUp)
   }


### PR DESCRIPTION
These links establish group inheritance relationships amongst diagnostic groups. This takes form of a new parameter: `subGroupLinks: [DiagnosticGroupIdentifier: [DiagnosticGroupIdentifier]] = [:]` on both:
- `SyntaxProtocol.warningGroupBehavior`
- `SyntaxProtocol.warningGroupControlRegionTree` Where the dictionary key is a super-group and dictionary values are its sub-groups.

Upon encountering a warning group control (`@warn`), its corresponding region is populated with its identifier and behavior, as well as the same corresponding behavior for each of its sub-groups, direct and transitive.