### PR TITLE
[NFC] Avoid use of unavailable range 'contains' method

### DIFF
--- a/Sources/SwiftWarningControl/WarningControlRegions.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegions.swift
@@ -254,7 +254,7 @@ private class WarningControlRegionNode {
 
   /// Add a child region that is directly nested within this region
   func addChild(_ node: WarningControlRegionNode) {
-    precondition(range.contains(node.range))
+    precondition(range.lowerBound <= node.range.lowerBound && node.range.upperBound <= range.upperBound)
     children.append(node)
     children.sort()
   }

--- a/Tests/SwiftWarningControlTest/WarningControlTests.swift
+++ b/Tests/SwiftWarningControlTest/WarningControlTests.swift
@@ -386,8 +386,6 @@ private func assertWarningGroupControl(
       groupInheritanceTree: groupInheritanceTree
     )
 
-    print(warningControlRegions.debugDescription)
-
     let groupControl = token.warningGroupControl(
       for: diagnosticGroupID,
       globalControls: globalControls,


### PR DESCRIPTION
This method appears to be missing in the host standard library on some CI platforms, as it is sufficiently new:
https://github.com/swiftlang/swift/pull/76891

e.g. https://ci.swift.org/job/swift-PR-macos/25670/, https://ci.swift.org/job/swift-PR-Linux/24824/