### PR TITLE
Implement BasicMacroExpansionContext.buildConfiguration

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
@@ -269,7 +269,7 @@ extension BasicMacroExpansionContext: MacroExpansionContext {
     let converter = SourceLocationConverter(fileName: fileName, tree: rootSourceFile)
     return AbstractSourceLocation(converter.location(for: rawPosition + offsetAdjustment))
   }
-  
+
   public var buildConfiguration: (any BuildConfiguration)? {
     sharedState.buildConfiguration
   }


### PR DESCRIPTION
While testing out the new `buildConfiguration` property on the macro expansion context, I noticed that when my macro was expanding in unit tests the macro was not receiving the build configuration. The root cause was that `BasicMacroExpansionContext` did not implement `var buildConfiguration` directly and was instead picking up the default implementation which always returns `nil`. This change implements the property by returning the value from the shared state.

I couldn't find existing tests that exercise the build configuration as part of an expansion context, but if there's a good place to add a unit test let me know and I can try to add that.