### PR TITLE
Add support for Swift Testing in SwiftSyntaxMacrosTestsSupport

### DIFF
--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -37,6 +37,10 @@ public typealias DiagnosticSpec = SwiftSyntaxMacrosGenericTestSupport.Diagnostic
 /// Assert that expanding the given macros in the original source produces
 /// the given expanded source code.
 ///
+/// - Warning: If you call this function inside a Swift Testing test case,
+/// the test will report no assertion failures even if the test fails.
+/// Use ``expectMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:fileID:file:line:column:)`` instead.
+///
 /// - Parameters:
 ///   - originalSource: The original source code, which is expected to contain
 ///     macros in various places (e.g., `#stringify(x + y)`).
@@ -51,7 +55,7 @@ public typealias DiagnosticSpec = SwiftSyntaxMacrosGenericTestSupport.Diagnostic
 ///   - indentationWidth: The indentation width used in the expansion.
 ///   - buildConfiguration: a build configuration that will be made available
 ///     to the macro implementation
-/// - SeeAlso: ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:fileID:file:line:column:)``
+/// - SeeAlso: ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:file:line:)``
 ///   to also specify the list of conformances passed to the macro expansion.
 public func assertMacroExpansion(
   _ originalSource: String,
@@ -64,10 +68,8 @@ public func assertMacroExpansion(
   testFileName: String = "test.swift",
   indentationWidth: Trivia = .spaces(4),
   buildConfiguration: (any BuildConfiguration)? = nil,
-  fileID: StaticString = #fileID,
   file: StaticString = #filePath,
-  line: UInt = #line,
-  column: UInt = #column
+  line: UInt = #line
 ) {
   let specs = macros.mapValues { MacroSpec(type: $0) }
   assertMacroExpansion(
@@ -81,15 +83,17 @@ public func assertMacroExpansion(
     testFileName: testFileName,
     indentationWidth: indentationWidth,
     buildConfiguration: buildConfiguration,
-    fileID: fileID,
     file: file,
-    line: line,
-    column: column
+    line: line
   )
 }
 
 /// Assert that expanding the given macros in the original source produces
 /// the given expanded source code.
+///
+/// - Warning: If you call this function inside a Swift Testing test case,
+/// the test will report no assertion failures even if the test fails.
+/// Use ``expectMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:fileID:file:line:column:)`` instead.
 ///
 /// - Parameters:
 ///   - originalSource: The original source code, which is expected to contain
@@ -117,6 +121,60 @@ public func assertMacroExpansion(
   testFileName: String = "test.swift",
   indentationWidth: Trivia = .spaces(4),
   buildConfiguration: (any BuildConfiguration)? = nil,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  SwiftSyntaxMacrosGenericTestSupport.assertMacroExpansion(
+    originalSource,
+    expandedSource: expectedExpandedSource,
+    diagnostics: diagnostics,
+    macroSpecs: macroSpecs,
+    applyFixIts: applyFixIts,
+    fixedSource: expectedFixedSource,
+    testModuleName: testModuleName,
+    testFileName: testFileName,
+    indentationWidth: indentationWidth,
+    buildConfiguration: buildConfiguration,
+    failureHandler: {
+      XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
+    },
+    fileID: "",  // Not used in the failure handler
+    filePath: file,
+    line: line,
+    column: 0  // Not used in the failure handler
+  )
+}
+
+/// Expect that expanding the given macros in the original source produces
+/// the given expanded source code.
+/// This function is the Swift Testing equivalent of ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:file:line:)``
+///
+/// - Parameters:
+///   - originalSource: The original source code, which is expected to contain
+///     macros in various places (e.g., `#stringify(x + y)`).
+///   - expectedExpandedSource: The source code that we expect to see after
+///     performing macro expansion on the original source.
+///   - diagnostics: The diagnostics when expanding any macro
+///   - macroSpecs: The macros that should be expanded, provided as a dictionary
+///     mapping macro names (e.g., `"CodableMacro"`) to specification with macro type
+///     (e.g., `CodableMacro.self`) and a list of conformances macro provides
+///     (e.g., `["Decodable", "Encodable"]`).
+///   - applyFixIts: If specified, filters the Fix-Its that are applied to generate `fixedSource` to only those whose message occurs in this array. If `nil`, all Fix-Its from the diagnostics are applied.
+///   - fixedSource: If specified, asserts that the source code after applying Fix-Its matches this string.
+///   - testModuleName: The name of the test module to use.
+///   - testFileName: The name of the test file name to use.
+///   - indentationWidth: The indentation width used in the expansion.
+public func expectMacroExpansion(
+  _ originalSource: String,
+  expandedSource expectedExpandedSource: String,
+  diagnostics: [DiagnosticSpec] = [],
+  macroSpecs: [String: MacroSpec],
+  applyFixIts: [String]? = nil,
+  fixedSource expectedFixedSource: String? = nil,
+  testModuleName: String = "TestModule",
+  testFileName: String = "test.swift",
+  indentationWidth: Trivia = .spaces(4),
+  buildConfiguration: (any BuildConfiguration)? = nil,
   fileID: StaticString = #fileID,
   file: StaticString = #filePath,
   line: UInt = #line,
@@ -134,27 +192,72 @@ public func assertMacroExpansion(
     indentationWidth: indentationWidth,
     buildConfiguration: buildConfiguration,
     failureHandler: {
-      #if canImport(Testing)
-      if Test.current != nil {
-        Issue.record(
-          Comment(rawValue: $0.message),
-          sourceLocation: .init(
-            fileID: fileID.description,
-            filePath: file.description,
-            line: Int(line),
-            column: Int(column)
-          )
+      Issue.record(
+        Comment(rawValue: $0.message),
+        sourceLocation: .init(
+          fileID: fileID.description,
+          filePath: file.description,
+          line: Int(line),
+          column: Int(column)
         )
-      } else {
-        XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
-      }
-      #else
-      XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
-      #endif
+      )
     },
     fileID: "",  // Not used in the failure handler
     filePath: file,
     line: line,
     column: 0  // Not used in the failure handler
+  )
+}
+
+/// Expect that expanding the given macros in the original source produces
+/// the given expanded source code.
+/// This function is the Swift Testing equivalent of ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:file:line:)``
+///
+/// - Parameters:
+///   - originalSource: The original source code, which is expected to contain
+///     macros in various places (e.g., `#stringify(x + y)`).
+///   - expectedExpandedSource: The source code that we expect to see after
+///     performing macro expansion on the original source.
+///   - diagnostics: The diagnostics when expanding any macro
+///   - macros: The macros that should be expanded, provided as a dictionary
+///     mapping macro names (e.g., `"stringify"`) to implementation types
+///     (e.g., `StringifyMacro.self`).
+///   - applyFixIts: If specified, filters the Fix-Its that are applied to generate `fixedSource` to only those whose message occurs in this array. If `nil`, all Fix-Its from the diagnostics are applied.
+///   - fixedSource: If specified, asserts that the source code after applying Fix-Its matches this string.
+///   - testModuleName: The name of the test module to use.
+///   - testFileName: The name of the test file name to use.
+///   - indentationWidth: The indentation width used in the expansion.
+public func expectMacroExpansion(
+  _ originalSource: String,
+  expandedSource expectedExpandedSource: String,
+  diagnostics: [DiagnosticSpec] = [],
+  macros: [String: Macro.Type],
+  applyFixIts: [String]? = nil,
+  fixedSource expectedFixedSource: String? = nil,
+  testModuleName: String = "TestModule",
+  testFileName: String = "test.swift",
+  indentationWidth: Trivia = .spaces(4),
+  buildConfiguration: (any BuildConfiguration)? = nil,
+  fileID: StaticString = #fileID,
+  file: StaticString = #filePath,
+  line: UInt = #line,
+  column: UInt = #column
+) {
+  let specs = macros.mapValues { MacroSpec(type: $0) }
+  expectMacroExpansion(
+    originalSource,
+    expandedSource: expectedExpandedSource,
+    diagnostics: diagnostics,
+    macroSpecs: specs,
+    applyFixIts: applyFixIts,
+    fixedSource: expectedFixedSource,
+    testModuleName: testModuleName,
+    testFileName: testFileName,
+    indentationWidth: indentationWidth,
+    buildConfiguration: buildConfiguration,
+    fileID: fileID,
+    file: file,
+    line: line,
+    column: column
   )
 }

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -51,7 +51,7 @@ public typealias DiagnosticSpec = SwiftSyntaxMacrosGenericTestSupport.Diagnostic
 ///   - indentationWidth: The indentation width used in the expansion.
 ///   - buildConfiguration: a build configuration that will be made available
 ///     to the macro implementation
-/// - SeeAlso: ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:file:line:)``
+/// - SeeAlso: ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:fileID:file:line:column:)``
 ///   to also specify the list of conformances passed to the macro expansion.
 public func assertMacroExpansion(
   _ originalSource: String,

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -68,8 +68,10 @@ public func assertMacroExpansion(
   testFileName: String = "test.swift",
   indentationWidth: Trivia = .spaces(4),
   buildConfiguration: (any BuildConfiguration)? = nil,
+  fileID: StaticString = #fileID,
   file: StaticString = #filePath,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) {
   let specs = macros.mapValues { MacroSpec(type: $0) }
   assertMacroExpansion(
@@ -83,8 +85,10 @@ public func assertMacroExpansion(
     testFileName: testFileName,
     indentationWidth: indentationWidth,
     buildConfiguration: buildConfiguration,
+    fileID: fileID,
     file: file,
-    line: line
+    line: line,
+    column: column
   )
 }
 
@@ -121,8 +125,10 @@ public func assertMacroExpansion(
   testFileName: String = "test.swift",
   indentationWidth: Trivia = .spaces(4),
   buildConfiguration: (any BuildConfiguration)? = nil,
+  fileID: StaticString = #fileID,
   file: StaticString = #filePath,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) {
   SwiftSyntaxMacrosGenericTestSupport.assertMacroExpansion(
     originalSource,
@@ -137,62 +143,7 @@ public func assertMacroExpansion(
     buildConfiguration: buildConfiguration,
     failureHandler: {
       XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
-    },
-    fileID: "",  // Not used in the failure handler
-    filePath: file,
-    line: line,
-    column: 0  // Not used in the failure handler
-  )
-}
-
-#if canImport(Testing)
-/// Expect that expanding the given macros in the original source produces
-/// the given expanded source code.
-/// This function is the Swift Testing equivalent of ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:file:line:)``
-///
-/// - Parameters:
-///   - originalSource: The original source code, which is expected to contain
-///     macros in various places (e.g., `#stringify(x + y)`).
-///   - expectedExpandedSource: The source code that we expect to see after
-///     performing macro expansion on the original source.
-///   - diagnostics: The diagnostics when expanding any macro
-///   - macroSpecs: The macros that should be expanded, provided as a dictionary
-///     mapping macro names (e.g., `"CodableMacro"`) to specification with macro type
-///     (e.g., `CodableMacro.self`) and a list of conformances macro provides
-///     (e.g., `["Decodable", "Encodable"]`).
-///   - applyFixIts: If specified, filters the Fix-Its that are applied to generate `fixedSource` to only those whose message occurs in this array. If `nil`, all Fix-Its from the diagnostics are applied.
-///   - fixedSource: If specified, asserts that the source code after applying Fix-Its matches this string.
-///   - testModuleName: The name of the test module to use.
-///   - testFileName: The name of the test file name to use.
-///   - indentationWidth: The indentation width used in the expansion.
-public func expectMacroExpansion(
-  _ originalSource: String,
-  expandedSource expectedExpandedSource: String,
-  diagnostics: [DiagnosticSpec] = [],
-  macroSpecs: [String: MacroSpec],
-  applyFixIts: [String]? = nil,
-  fixedSource expectedFixedSource: String? = nil,
-  testModuleName: String = "TestModule",
-  testFileName: String = "test.swift",
-  indentationWidth: Trivia = .spaces(4),
-  buildConfiguration: (any BuildConfiguration)? = nil,
-  fileID: StaticString = #fileID,
-  file: StaticString = #filePath,
-  line: UInt = #line,
-  column: UInt = #column
-) {
-  SwiftSyntaxMacrosGenericTestSupport.assertMacroExpansion(
-    originalSource,
-    expandedSource: expectedExpandedSource,
-    diagnostics: diagnostics,
-    macroSpecs: macroSpecs,
-    applyFixIts: applyFixIts,
-    fixedSource: expectedFixedSource,
-    testModuleName: testModuleName,
-    testFileName: testFileName,
-    indentationWidth: indentationWidth,
-    buildConfiguration: buildConfiguration,
-    failureHandler: {
+      #if(canImport(Testing))
       Issue.record(
         Comment(rawValue: $0.message),
         sourceLocation: .init(
@@ -202,6 +153,7 @@ public func expectMacroExpansion(
           column: Int(column)
         )
       )
+      #endif
     },
     fileID: "",  // Not used in the failure handler
     filePath: file,
@@ -209,57 +161,3 @@ public func expectMacroExpansion(
     column: 0  // Not used in the failure handler
   )
 }
-
-/// Expect that expanding the given macros in the original source produces
-/// the given expanded source code.
-/// This function is the Swift Testing equivalent of ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:file:line:)``
-///
-/// - Parameters:
-///   - originalSource: The original source code, which is expected to contain
-///     macros in various places (e.g., `#stringify(x + y)`).
-///   - expectedExpandedSource: The source code that we expect to see after
-///     performing macro expansion on the original source.
-///   - diagnostics: The diagnostics when expanding any macro
-///   - macros: The macros that should be expanded, provided as a dictionary
-///     mapping macro names (e.g., `"stringify"`) to implementation types
-///     (e.g., `StringifyMacro.self`).
-///   - applyFixIts: If specified, filters the Fix-Its that are applied to generate `fixedSource` to only those whose message occurs in this array. If `nil`, all Fix-Its from the diagnostics are applied.
-///   - fixedSource: If specified, asserts that the source code after applying Fix-Its matches this string.
-///   - testModuleName: The name of the test module to use.
-///   - testFileName: The name of the test file name to use.
-///   - indentationWidth: The indentation width used in the expansion.
-public func expectMacroExpansion(
-  _ originalSource: String,
-  expandedSource expectedExpandedSource: String,
-  diagnostics: [DiagnosticSpec] = [],
-  macros: [String: Macro.Type],
-  applyFixIts: [String]? = nil,
-  fixedSource expectedFixedSource: String? = nil,
-  testModuleName: String = "TestModule",
-  testFileName: String = "test.swift",
-  indentationWidth: Trivia = .spaces(4),
-  buildConfiguration: (any BuildConfiguration)? = nil,
-  fileID: StaticString = #fileID,
-  file: StaticString = #filePath,
-  line: UInt = #line,
-  column: UInt = #column
-) {
-  let specs = macros.mapValues { MacroSpec(type: $0) }
-  expectMacroExpansion(
-    originalSource,
-    expandedSource: expectedExpandedSource,
-    diagnostics: diagnostics,
-    macroSpecs: specs,
-    applyFixIts: applyFixIts,
-    fixedSource: expectedFixedSource,
-    testModuleName: testModuleName,
-    testFileName: testFileName,
-    indentationWidth: indentationWidth,
-    buildConfiguration: buildConfiguration,
-    fileID: fileID,
-    file: file,
-    line: line,
-    column: column
-  )
-}
-#endif

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -145,6 +145,7 @@ public func assertMacroExpansion(
   )
 }
 
+#if canImport(Testing)
 /// Expect that expanding the given macros in the original source produces
 /// the given expanded source code.
 /// This function is the Swift Testing equivalent of ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:file:line:)``
@@ -261,3 +262,4 @@ public func expectMacroExpansion(
     column: column
   )
 }
+#endif

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -64,8 +64,10 @@ public func assertMacroExpansion(
   testFileName: String = "test.swift",
   indentationWidth: Trivia = .spaces(4),
   buildConfiguration: (any BuildConfiguration)? = nil,
+  fileID: StaticString = #fileID,
   file: StaticString = #filePath,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) {
   let specs = macros.mapValues { MacroSpec(type: $0) }
   assertMacroExpansion(
@@ -79,8 +81,10 @@ public func assertMacroExpansion(
     testFileName: testFileName,
     indentationWidth: indentationWidth,
     buildConfiguration: buildConfiguration,
+    fileID: fileID,
     file: file,
-    line: line
+    line: line,
+    column: column
   )
 }
 

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -136,7 +136,15 @@ public func assertMacroExpansion(
     failureHandler: {
       #if canImport(Testing)
       if Test.current != nil {
-        Issue.record(Comment(rawValue: $0.message), sourceLocation: .init(fileID: fileID.description, filePath: file.description, line: Int(line), column: Int(column)))
+        Issue.record(
+          Comment(rawValue: $0.message),
+          sourceLocation: .init(
+            fileID: fileID.description,
+            filePath: file.description,
+            line: Int(line),
+            column: Int(column)
+          )
+        )
       } else {
         XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
       }

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -18,7 +18,7 @@ public import SwiftSyntaxMacros
 @_spi(XCTestFailureLocation) public import SwiftSyntaxMacrosGenericTestSupport
 private import XCTest
 #if canImport(Testing)
-import Testing
+private import Testing
 #endif
 #else
 import SwiftIfConfig

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -142,18 +142,30 @@ public func assertMacroExpansion(
     indentationWidth: indentationWidth,
     buildConfiguration: buildConfiguration,
     failureHandler: {
-      XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
       #if(canImport(Testing))
+      // Record a Swift Testing issue.
+      //
+      // (Note: If/when Swift Testing gains interoperability with XCTest, this
+      // will be translated into an XCTest failure if called while an XCTest is
+      // running.)
       Issue.record(
         Comment(rawValue: $0.message),
         sourceLocation: .init(
-          fileID: fileID.description,
-          filePath: file.description,
-          line: Int(line),
-          column: Int(column)
+          fileID: $0.location.fileID,
+          filePath: $0.location.filePath,
+          line: $0.location.line,
+          column: $0.location.column
         )
       )
       #endif
+      // Record an XCTest failure.
+      //
+      // FIXME: If/when Swift Testing gains interoperability with XCTest, this
+      // will become redundant with the above -- at least, when this library is
+      // compiled and run using a Swift version which supports interoperability.
+      // At that point, this should be adjusted so that it's only called when
+      // using older Swift versions.
+      XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
     },
     fileID: "",  // Not used in the failure handler
     filePath: file,

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -51,7 +51,7 @@ public typealias DiagnosticSpec = SwiftSyntaxMacrosGenericTestSupport.Diagnostic
 ///   - indentationWidth: The indentation width used in the expansion.
 ///   - buildConfiguration: a build configuration that will be made available
 ///     to the macro implementation
-/// - SeeAlso: ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:file:line:)``
+/// - SeeAlso: ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:fileID:file:line:column:)``
 ///   to also specify the list of conformances passed to the macro expansion.
 public func assertMacroExpansion(
   _ originalSource: String,
@@ -134,7 +134,7 @@ public func assertMacroExpansion(
     indentationWidth: indentationWidth,
     buildConfiguration: buildConfiguration,
     failureHandler: {
-      #if(canImport(Testing))
+      #if canImport(Testing)
       // Record a Swift Testing issue.
       //
       // (Note: If/when Swift Testing gains interoperability with XCTest, this
@@ -159,9 +159,9 @@ public func assertMacroExpansion(
       // using older Swift versions.
       XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
     },
-    fileID: "",  // Not used in the failure handler
+    fileID: fileID,
     filePath: file,
     line: line,
-    column: 0  // Not used in the failure handler
+    column: column
   )
 }

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -136,10 +136,6 @@ public func assertMacroExpansion(
     failureHandler: {
       #if canImport(Testing)
       // Record a Swift Testing issue.
-      //
-      // (Note: If/when Swift Testing gains interoperability with XCTest, this
-      // will be translated into an XCTest failure if called while an XCTest is
-      // running.)
       Issue.record(
         Comment(rawValue: $0.message),
         sourceLocation: .init(
@@ -150,14 +146,16 @@ public func assertMacroExpansion(
         )
       )
       #endif
+
+#if compiler(<6.4)
       // Record an XCTest failure.
       //
-      // FIXME: If/when Swift Testing gains interoperability with XCTest, this
-      // will become redundant with the above -- at least, when this library is
-      // compiled and run using a Swift version which supports interoperability.
-      // At that point, this should be adjusted so that it's only called when
-      // using older Swift versions.
+      // Only do this in pre-6.4 toolchains. In 6.4 and later toolchains,
+      // ST-0021: Targeted Interoperability between Swift Testing and XCTest
+      // means that the call to `Issue.record()` above will be propagated to
+      // XCTest as well.
       XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
+#endif
     },
     fileID: fileID,
     filePath: file,

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -37,10 +37,6 @@ public typealias DiagnosticSpec = SwiftSyntaxMacrosGenericTestSupport.Diagnostic
 /// Assert that expanding the given macros in the original source produces
 /// the given expanded source code.
 ///
-/// - Warning: If you call this function inside a Swift Testing test case,
-/// the test will report no assertion failures even if the test fails.
-/// Use ``expectMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:fileID:file:line:column:)`` instead.
-///
 /// - Parameters:
 ///   - originalSource: The original source code, which is expected to contain
 ///     macros in various places (e.g., `#stringify(x + y)`).
@@ -94,10 +90,6 @@ public func assertMacroExpansion(
 
 /// Assert that expanding the given macros in the original source produces
 /// the given expanded source code.
-///
-/// - Warning: If you call this function inside a Swift Testing test case,
-/// the test will report no assertion failures even if the test fails.
-/// Use ``expectMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:fileID:file:line:column:)`` instead.
 ///
 /// - Parameters:
 ///   - originalSource: The original source code, which is expected to contain

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -147,7 +147,7 @@ public func assertMacroExpansion(
       )
       #endif
 
-#if compiler(<6.4)
+      #if compiler(<6.4)
       // Record an XCTest failure.
       //
       // Only do this in pre-6.4 toolchains. In 6.4 and later toolchains,
@@ -155,7 +155,7 @@ public func assertMacroExpansion(
       // means that the call to `Issue.record()` above will be propagated to
       // XCTest as well.
       XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
-#endif
+      #endif
     },
     fileID: fileID,
     filePath: file,

--- a/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
@@ -25,7 +25,7 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-private struct ConstantOneGetter: AccessorMacro {
+struct ConstantOneGetter: AccessorMacro {
   static func expansion(
     of node: AttributeSyntax,
     providingAccessorsOf declaration: some DeclSyntaxProtocol,

--- a/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
@@ -1,0 +1,49 @@
+#if canImport(Testing)
+import Testing
+import SwiftSyntaxMacrosTestSupport
+
+@Suite("Swift Testing Macro Expansion Tests")
+struct SwiftTestingMacroExpansionTests {
+  @Test("Test Happy Path")
+  func testHappyPathWorks() {
+    assertMacroExpansion(
+      """
+      @constantOne
+      var x: Int /*1*/ // hello
+      """,
+      expandedSource: """
+        var x: Int { /*1*/ // hello
+          get {
+            return 1
+          }
+        }
+        """,
+      macros: ["constantOne": ConstantOneGetter.self],
+      indentationWidth: .spaces(2)
+    )
+  }
+
+  @Test("Test Failure")
+  func failureReportedCorrectly() {
+    withKnownIssue {
+      assertMacroExpansion(
+        """
+        @constantOne
+        var x: Int /*1*/ // hello
+        """,
+        expandedSource: """
+          var x: Int { /*1*/ // hello
+            get {
+              return 1
+            }
+          }
+          """,
+        macros: ["constantOne": ConstantOneGetter.self],
+        indentationWidth: .spaces(4)
+      )
+    } matching: { issue in
+      issue.description.contains("Macro expansion did not produce the expected expanded source")
+    }
+  }
+}
+#endif

--- a/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
@@ -18,7 +18,7 @@ import SwiftSyntaxMacrosTestSupport
 struct SwiftTestingMacroExpansionTests {
   @Test("Test Happy Path")
   func testHappyPathWorks() {
-    expectMacroExpansion(
+    assertMacroExpansion(
       """
       @constantOne
       var x: Int /*1*/ // hello
@@ -38,7 +38,7 @@ struct SwiftTestingMacroExpansionTests {
   @Test("Test Failure")
   func failureReportedCorrectly() {
     withKnownIssue {
-      expectMacroExpansion(
+      assertMacroExpansion(
         """
         @constantOne
         var x: Int /*1*/ // hello

--- a/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
@@ -1,3 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
 #if canImport(Testing)
 import Testing
 import SwiftSyntaxMacrosTestSupport

--- a/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
@@ -18,7 +18,7 @@ import SwiftSyntaxMacrosTestSupport
 struct SwiftTestingMacroExpansionTests {
   @Test("Test Happy Path")
   func testHappyPathWorks() {
-    assertMacroExpansion(
+    expectMacroExpansion(
       """
       @constantOne
       var x: Int /*1*/ // hello
@@ -38,7 +38,7 @@ struct SwiftTestingMacroExpansionTests {
   @Test("Test Failure")
   func failureReportedCorrectly() {
     withKnownIssue {
-      assertMacroExpansion(
+      expectMacroExpansion(
         """
         @constantOne
         var x: Int /*1*/ // hello

--- a/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
@@ -51,10 +51,25 @@ struct SwiftTestingMacroExpansionTests {
           }
           """,
         macros: ["constantOne": ConstantOneGetter.self],
-        indentationWidth: .spaces(4)
+        indentationWidth: .spaces(4),
+        fileID: "ExampleModule/ExampleTest.swift",
+        file: "path/to/ExampleTest.swift",
+        line: 9999,
+        column: 8888
       )
     } matching: { issue in
-      issue.description.contains("Macro expansion did not produce the expected expanded source")
+      guard issue.description.contains("Macro expansion did not produce the expected expanded source") else {
+        return false
+      }
+
+      #expect(issue.sourceLocation == .init(
+        fileID: "ExampleModule/ExampleTest.swift",
+        filePath: "path/to/ExampleTest.swift",
+        line: 9999,
+        column: 8888
+      ))
+
+      return true
     }
   }
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
@@ -62,12 +62,15 @@ struct SwiftTestingMacroExpansionTests {
         return false
       }
 
-      #expect(issue.sourceLocation == .init(
-        fileID: "ExampleModule/ExampleTest.swift",
-        filePath: "path/to/ExampleTest.swift",
-        line: 9999,
-        column: 8888
-      ))
+      #expect(
+        issue.sourceLocation
+          == .init(
+            fileID: "ExampleModule/ExampleTest.swift",
+            filePath: "path/to/ExampleTest.swift",
+            line: 9999,
+            column: 8888
+          )
+      )
 
       return true
     }


### PR DESCRIPTION
- **Explanation**:
  As described in https://github.com/swiftlang/swift-syntax/issues/2720 `SwiftSyntaxMacrosTestsSupport` does not work with Swift Testing, which is an issue given Swift Testing is the way to test projects and XCTest is deprecated. If produces false positives (where tests pass even if they shouldn't) which is a major issue, especially as there are no warnings.

This PR adds support for Swift Testing so that tests fail correctly. This **does not** introduce an issue with a circular dependency on Swift Testing. There is a circular dependency at the package level, but this is allowed due to https://github.com/swiftlang/swift-package-manager/pull/7530. There is no circular dependency between targets.

- **Scope**: No changes to existing code unless tests are passing when they shouldn't be. Only affects `SwiftSyntaxMacrosTestsSupport`
- **Issues**: https://github.com/swiftlang/swift-syntax/issues/2720
- **Risk**: Low risk
- **Testing**: Tests written to ensure it fails as expected
- **Reviewers**:
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
