### PR TITLE
[SwiftWarningControl] Specify control inputs to tree node in order

### DIFF
--- a/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
+++ b/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
@@ -27,7 +27,7 @@ extension SyntaxProtocol {
   @_spi(ExperimentalLanguageFeatures)
   public func warningGroupControl(
     for diagnosticGroupIdentifier: DiagnosticGroupIdentifier,
-    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl] = [:],
+    globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] = [],
     groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil
   ) -> WarningGroupControl? {
     let warningControlRegions = root.warningGroupControlRegionTreeImpl(

--- a/Sources/SwiftWarningControl/WarningControlDeclSyntax.swift
+++ b/Sources/SwiftWarningControl/WarningControlDeclSyntax.swift
@@ -15,8 +15,8 @@ import SwiftSyntax
 extension WithAttributesSyntax {
   /// Compute a dictionary of all `@warn` diagnostic group behavior controls
   /// specified on this warning control declaration scope.
-  var allWarningGroupControls: [DiagnosticGroupIdentifier: WarningGroupControl] {
-    attributes.reduce(into: [DiagnosticGroupIdentifier: WarningGroupControl]()) { result, attr in
+  var allWarningGroupControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] {
+    attributes.reduce(into: [(DiagnosticGroupIdentifier, WarningGroupControl)]()) { result, attr in
       // `@warn` attributes
       guard case .attribute(let attributeSyntax) = attr,
         attributeSyntax.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "warn"
@@ -50,7 +50,7 @@ extension WithAttributesSyntax {
       else {
         return
       }
-      result[DiagnosticGroupIdentifier(diagnosticGroupID)] = control
+      result.append((DiagnosticGroupIdentifier(diagnosticGroupID), control))
     }
   }
 }

--- a/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 extension SyntaxProtocol {
   @_spi(ExperimentalLanguageFeatures)
   public func warningGroupControlRegionTree(
-    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl] = [:],
+    globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] = [],
     groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil
   ) -> WarningControlRegionTree {
     return warningGroupControlRegionTreeImpl(
@@ -30,7 +30,7 @@ extension SyntaxProtocol {
   /// a specific absolute position - meant to speed up tree generation for individual
   /// queries.
   func warningGroupControlRegionTreeImpl(
-    globalControls: [DiagnosticGroupIdentifier: WarningGroupControl],
+    globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)],
     groupInheritanceTree: DiagnosticGroupInheritanceTree?,
     containing position: AbsolutePosition? = nil
   ) -> WarningControlRegionTree {

--- a/Sources/SwiftWarningControl/WarningControlRegions.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegions.swift
@@ -123,7 +123,7 @@ public struct WarningControlRegionTree {
   /// Add a warning control region to the tree
   mutating func addWarningGroupControls(
     range: Range<AbsolutePosition>,
-    controls: [DiagnosticGroupIdentifier: WarningGroupControl]
+    controls: [(DiagnosticGroupIdentifier, WarningGroupControl)]
   ) {
     guard !controls.isEmpty else { return }
     let newNode = WarningControlRegionNode(range: range)


### PR DESCRIPTION
Specifically for global controls, the ordering is important because later controls override earlier controls. Similarly, this will result in the same semantic for syntactic controls, with the first attribute being able to be overriden by subsequent attributes.

The control configuration logic as-is handles that correctly *except* for iterating over input controls which are supplied in an unordered dictionary. This refactors the API surface to accept an array of pairs '(groupIdentifier, groupControl)', instead of a dictionary.