### PR TITLE
Update pull request workflow to use the tagged github-workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,12 +16,12 @@ concurrency:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
     with:
       enable_wasm_sdk_build: true
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.2
     with:
       api_breakage_check_enabled: false  # https://github.com/swiftlang/swift-syntax/issues/3010
       docs_check_additional_arguments: "--disable-parameters-and-returns-validation"


### PR DESCRIPTION
Now that workflows is more stable, use the most recent tag instead of main to avoid changes to default jobs preventing merging.