### PR TITLE
[SwiftWarningControl] Add support for file-scoped 'using @warn'

### DIFF
--- a/Sources/SwiftWarningControl/WarningControlDeclSyntax.swift
+++ b/Sources/SwiftWarningControl/WarningControlDeclSyntax.swift
@@ -10,47 +10,68 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+
+extension AttributeSyntax {
+  var warningGroupControl: (DiagnosticGroupIdentifier, WarningGroupControl)? {
+    // `@warn` attributes
+    guard attributeName.as(IdentifierTypeSyntax.self)?.name.text == "warn"
+    else {
+      return nil
+    }
+
+    // First argument is the unquoted diagnostic group identifier
+    guard
+      let diagnosticGroupID = arguments?
+        .as(LabeledExprListSyntax.self)?.first?.expression
+        .as(DeclReferenceExprSyntax.self)?.baseName.text
+    else {
+      return nil
+    }
+
+    // Second argument is the `as: ` behavior control specifier
+    guard
+      let asParamExprSyntax = arguments?.as(LabeledExprListSyntax.self)?
+        .dropFirst().first
+    else {
+      return nil
+    }
+    guard
+      asParamExprSyntax.label?.text == "as",
+      let controlText = asParamExprSyntax
+        .expression.as(DeclReferenceExprSyntax.self)?
+        .baseName.text,
+      let control = WarningGroupControl(rawValue: controlText)
+    else {
+      return nil
+    }
+
+    return (DiagnosticGroupIdentifier(diagnosticGroupID), control)
+  }
+}
 
 extension WithAttributesSyntax {
   /// Compute a dictionary of all `@warn` diagnostic group behavior controls
   /// specified on this warning control declaration scope.
   var allWarningGroupControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] {
     attributes.reduce(into: [(DiagnosticGroupIdentifier, WarningGroupControl)]()) { result, attr in
-      // `@warn` attributes
       guard case .attribute(let attributeSyntax) = attr,
-        attributeSyntax.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "warn"
+        let warningGroupControl = attributeSyntax.warningGroupControl
       else {
         return
       }
-
-      // First argument is the unquoted diagnostic group identifier
-      guard
-        let diagnosticGroupID = attributeSyntax.arguments?
-          .as(LabeledExprListSyntax.self)?.first?.expression
-          .as(DeclReferenceExprSyntax.self)?.baseName.text
-      else {
-        return
-      }
-
-      // Second argument is the `as: ` behavior control specifier
-      guard
-        let asParamExprSyntax = attributeSyntax
-          .arguments?.as(LabeledExprListSyntax.self)?
-          .dropFirst().first
-      else {
-        return
-      }
-      guard
-        asParamExprSyntax.label?.text == "as",
-        let controlText = asParamExprSyntax
-          .expression.as(DeclReferenceExprSyntax.self)?
-          .baseName.text,
-        let control = WarningGroupControl(rawValue: controlText)
-      else {
-        return
-      }
-      result.append((DiagnosticGroupIdentifier(diagnosticGroupID), control))
+      result.append(warningGroupControl)
     }
+  }
+}
+
+extension UsingDeclSyntax {
+  var warningControl: (DiagnosticGroupIdentifier, WarningGroupControl)? {
+    guard case .attribute(let attributeSyntax) = self.specifier,
+      let warningGroupControl = attributeSyntax.warningGroupControl
+    else {
+      return nil
+    }
+    return warningGroupControl
   }
 }

--- a/Sources/SwiftWarningControl/WarningControlRegions.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegions.swift
@@ -149,6 +149,12 @@ public struct WarningControlRegionTree {
     insertIntoSubtree(newNode, parent: rootRegionNode)
   }
 
+  /// Add warning control regions to the tree root node.
+  /// For example, controls corresponding to a top-level `using @warn()` statement.
+  mutating func addRootWarningGroupControls(controls: [(DiagnosticGroupIdentifier, WarningGroupControl)]) {
+    addWarningGroupControls(range: rootRegionNode.range, controls: controls)
+  }
+
   /// Insert a region node into the appropriate position in a subtree.
   /// During top-down traversal of the syntax tree, nodes that are visited
   /// later should never contain any of the previously visited nodes,

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3694,6 +3694,39 @@ final class UsingDeclarationTests: ParserTestCase {
     )
 
     assertParse(
+      "using @warn(DiagGroupID, as: warning)",
+      substructure: UsingDeclSyntax(
+        usingKeyword: .keyword(.using),
+        specifier: .attribute(
+          AttributeSyntax(
+            attributeName: IdentifierTypeSyntax(
+              name: .identifier("warn")
+            ),
+            leftParen: .leftParenToken(),
+            arguments: .argumentList(
+              LabeledExprListSyntax([
+                LabeledExprSyntax(
+                  expression: DeclReferenceExprSyntax(
+                    baseName: .identifier("DiagGroupID")
+                  ),
+                  trailingComma: .commaToken()
+                ),
+                LabeledExprSyntax(
+                  label: .identifier("as"),
+                  colon: .colonToken(),
+                  expression: DeclReferenceExprSyntax(
+                    baseName: .identifier("warning")
+                  )
+                ),
+              ])
+            ),
+            rightParen: .rightParenToken()
+          )
+        )
+      )
+    )
+
+    assertParse(
       """
       nonisolated
       using


### PR DESCRIPTION
`using @warn(DiagGroupID, as: warning)` 
specifies a file-scoped diagnostic group control. This change adds detection of these controls and upon encountering one, adds a corresponding control to the file-scoped root of the warning control region tree. 

This change also removes the optimization on `warningGroupControlRegionTreeImpl` construction which only constructs a tree that considers nodes which contain a queried location because we now have a scenario where diagnostic group behavior at a specific location can be affected by an `using @warn` node elsewhere in the file. I expect clients to run queries against a once-built tree for the source file, so I do not think this will have a meaningful impact, in practice. 