### PR TITLE
[LexicalLookup] Make `GenericParameterScopeSyntax` public

### DIFF
--- a/Sources/SwiftLexicalLookup/Scopes/GenericParameterScopeSyntax.swift
+++ b/Sources/SwiftLexicalLookup/Scopes/GenericParameterScopeSyntax.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 /// futher lookup to its `WithGenericParametersScopeSyntax`
 /// parent scope's parent scope (i.e. on return, bypasses names
 /// introduced by its parent).
-protocol GenericParameterScopeSyntax: ScopeSyntax {}
+@_spi(Experimental) public protocol GenericParameterScopeSyntax: ScopeSyntax {}
 
 @_spi(Experimental) extension GenericParameterScopeSyntax {
   /// Returns names matching lookup and bypasses


### PR DESCRIPTION
Using a method in a extension of non-public protocol to witness a public protocol requirement is not allowed in future version of Swift and is diagnosed as a warning in the current main.

Make `GenericParameterScopeSyntax` a `@_spi(Experimetnal) public` the same accessibility as the concrete type.

Fixes build failures e.g. https://github.com/swiftlang/swift-syntax/actions/runs/20438687858/job/58726284454#step:14:31
since we're building it with `-warnings-as-errors`