### PR TITLE
[Lexer] Close comment on //*/ instead of opening a nested one

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -765,6 +765,12 @@ extension Lexer.Cursor {
       case "/":
         // Check for a '/*'
         if self.advance(matching: "*") {
+          if self.advance(matching: "/") {
+              depth -= 1
+              if depth == 0 {
+                  break LOOP
+                }
+            }
           depth += 1
         }
 


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift/issues/44163. Paired with https://github.com/swiftlang/swift/pull/86239.