### PR TITLE
Add diagnostic metadata test for the StaticParserError

### DIFF
--- a/Tests/SwiftParserDiagnosticsTest/DiagnosticInfrastructureTests.swift
+++ b/Tests/SwiftParserDiagnosticsTest/DiagnosticInfrastructureTests.swift
@@ -1,15 +1,3 @@
-//===----------------------------------------------------------------------===//
-//
-// This source file is part of the Swift.org open source project
-//
-// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
-//
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-//
-//===----------------------------------------------------------------------===//
-
 import SwiftDiagnostics
 import SwiftParserDiagnostics
 import XCTest
@@ -35,5 +23,18 @@ class DiagnosticInfrastructureTests: XCTestCase {
       StaticParserFixIt.insertSemicolon.fixItID,
       MessageID(domain: "SwiftParser", id: "StaticParserFixIt.insertSemicolon")
     )
+  }
+  public func testCaseOutsideOfSwitchDiagnosticSeverityAndID() {
+    let diagnostic = StaticParserError.caseOutsideOfSwitchOrEnum
+
+    XCTAssertEqual(
+      diagnostic.diagnosticID,
+      MessageID(
+        domain: "SwiftParser",
+        id: "StaticParserError.caseOutsideOfSwitchOrEnum"
+      )
+    )
+
+    XCTAssertEqual(diagnostic.severity, DiagnosticSeverity.error)
   }
 }


### PR DESCRIPTION
This PR adds test coverage to verify the diagnostic ID and severity
for an existing StaticParserError.

No functional behavior is changed; this only improves test coverage
to help prevent regressions.