### PR TITLE
[6.3] Implement BasicMacroExpansionContext.buildConfiguration

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/BasicMacroExpansionContext.swift
@@ -269,4 +269,8 @@ extension BasicMacroExpansionContext: MacroExpansionContext {
     let converter = SourceLocationConverter(fileName: fileName, tree: rootSourceFile)
     return AbstractSourceLocation(converter.location(for: rawPosition + offsetAdjustment))
   }
+
+  public var buildConfiguration: (any BuildConfiguration)? {
+    sharedState.buildConfiguration
+  }
 }


### PR DESCRIPTION
- **Explanation**: Adds an implementation of `BasicMacroExpansionContext.buildConfiguration` so that unit test-provided build configurations get passed through to generic callers in swift-syntax that use the expansion context
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Only impacts uses of `buildConfiguration` on a `BasicMacroExpansionContext` which are typically created for tests
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**:
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift-syntax/pull/3191
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low - the scope is small and the change size is minimal
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: I was not able to add a unit test for this, but the change is trivial and straightforward so I have high confidence it is correct and does not introduce a regression
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @DougGregor @ahoppen 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
