### PR TITLE
Add new features to ConvertStoredPropertyToComputed

### DIFF
--- a/Sources/SwiftRefactor/CMakeLists.txt
+++ b/Sources/SwiftRefactor/CMakeLists.txt
@@ -14,6 +14,7 @@ add_swift_syntax_library(SwiftRefactor
   ConvertComputedPropertyToZeroParameterFunction.swift
   ConvertStoredPropertyToComputed.swift
   ConvertZeroParameterFunctionToComputedProperty.swift
+  DeclModifierRemover.swift
   ExpandEditorPlaceholder.swift
   FormatRawStringLiteral.swift
   IntegerLiteralUtilities.swift

--- a/Sources/SwiftRefactor/ConvertStoredPropertyToComputed.swift
+++ b/Sources/SwiftRefactor/ConvertStoredPropertyToComputed.swift
@@ -22,6 +22,14 @@ public struct ConvertStoredPropertyToComputed: SyntaxRefactoringProvider {
       throw RefactoringNotApplicableError("unsupported variable declaration")
     }
 
+    var syntax = syntax
+
+    if let lazyKeyword = syntax.modifiers.first(where: { $0.name.tokenKind == .keyword(.lazy) }) {
+      syntax = DeclModifierRemover { $0.id == lazyKeyword.id }
+        .rewrite(syntax)
+        .cast(VariableDeclSyntax.self)
+    }
+
     var codeBlockSyntax: CodeBlockItemListSyntax
 
     if let functionExpression = initializer.value.as(FunctionCallExprSyntax.self),

--- a/Sources/SwiftRefactor/DeclModifierRemover.swift
+++ b/Sources/SwiftRefactor/DeclModifierRemover.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+final class DeclModifierRemover: SyntaxRewriter {
+  private let predicate: (DeclModifierSyntax) -> Bool
+
+  private var triviaToAttachToNextToken: Trivia = Trivia()
+
+  /// Initializes a modifier remover with a given predicate to determine which modifiers to remove.
+  ///
+  /// - Parameter predicate: A closure that determines whether a given `AttributeSyntax` should be removed.
+  ///   If this closure returns `true` for an attribute, that attribute will be removed.
+  public init(removingWhere predicate: @escaping (DeclModifierSyntax) -> Bool) {
+    self.predicate = predicate
+    super.init()
+  }
+
+  public override func visit(_ node: DeclModifierListSyntax) -> DeclModifierListSyntax {
+    var filteredModifiers: [DeclModifierListSyntax.Element] = []
+
+    for modifier in node {
+      guard self.predicate(modifier) else {
+        filteredModifiers.append(prependAndClearAccumulatedTrivia(to: modifier))
+        continue
+      }
+
+      // Removing modifier before comment leaves space before comment intact — doesn’t merge with following trivia.
+      let trailingTrivia = modifier.trailingTrivia.trimmingPrefix(while: \.isSpaceOrTab)
+      triviaToAttachToNextToken += modifier.leadingTrivia.merging(trailingTrivia)
+    }
+
+    if !triviaToAttachToNextToken.isEmpty, !filteredModifiers.isEmpty {
+      filteredModifiers[filteredModifiers.count - 1].trailingTrivia = filteredModifiers[filteredModifiers.count - 1]
+        .trailingTrivia
+        .merging(triviaToAttachToNextToken)
+      triviaToAttachToNextToken = Trivia()
+    }
+
+    return DeclModifierListSyntax(filteredModifiers)
+  }
+
+  public override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    return prependAndClearAccumulatedTrivia(to: token)
+  }
+
+  /// Prepends the accumulated trivia to the given node's leading trivia.
+  ///
+  /// To preserve correct formatting after attribute removal, this function reassigns
+  /// significant trivia accumulated from removed attributes to the provided subsequent node.
+  /// Once attached, the accumulated trivia is cleared.
+  ///
+  /// - Parameter node: The syntax node receiving the accumulated trivia.
+  /// - Returns: The modified syntax node with the prepended trivia.
+  private func prependAndClearAccumulatedTrivia<T: SyntaxProtocol>(to syntaxNode: T) -> T {
+    guard !triviaToAttachToNextToken.isEmpty else { return syntaxNode }
+    defer { triviaToAttachToNextToken = Trivia() }
+    return syntaxNode.with(\.leadingTrivia, triviaToAttachToNextToken.merging(syntaxNode.leadingTrivia))
+  }
+}

--- a/Sources/SwiftSyntax/Trivia.swift
+++ b/Sources/SwiftSyntax/Trivia.swift
@@ -215,3 +215,27 @@ extension RawTriviaPiece: CustomDebugStringConvertible {
     TriviaPiece(raw: self).debugDescription
   }
 }
+
+@_spi(RawSyntax)
+public extension Trivia {
+  func trimmingPrefix(
+    while predicate: (TriviaPiece) -> Bool
+  ) -> Trivia {
+    Trivia(pieces: self.drop(while: predicate))
+  }
+
+  func trimmingSuffix(
+    while predicate: (TriviaPiece) -> Bool
+  ) -> Trivia {
+    Trivia(
+      pieces: self[...]
+        .reversed()
+        .drop(while: predicate)
+        .reversed()
+    )
+  }
+
+  var startsWithNewline: Bool {
+    self.first?.isNewline ?? false
+  }
+}


### PR DESCRIPTION
As part of https://github.com/swiftlang/sourcekit-lsp/issues/2424.
Add new functionality to the existing code action analogous to  [ConvertToComputedProperty.cpp](https://github.com/swiftlang/swift/blob/main/lib/Refactoring/ConvertToComputedProperty.cpp)  and [tryComputedPropertyFixIts](https://github.com/swiftlang/swift/blob/main/lib/Sema/CSDiagnostics.cpp#L3659).

- Support removing `lazy` attribute if present.
- Support removing the `=` sign if variable like `var foo: Int = { return 0 }()`.

I'm happy to make changes if needed