### PR TITLE
Preserve leading comments when converting functions to computed propetries #3236

### DIFF
--- a/Sources/SwiftRefactor/ConvertZeroParameterFunctionToComputedProperty.swift
+++ b/Sources/SwiftRefactor/ConvertZeroParameterFunctionToComputedProperty.swift
@@ -58,7 +58,7 @@ public struct ConvertZeroParameterFunctionToComputedProperty: SyntaxRefactoringP
       rightBrace: body.rightBrace
     )
 
-    let bindingSpecifier = syntax.funcKeyword.detached.with(\.tokenKind, .keyword(.var))
+    let bindingSpecifier = TokenSyntax.keyword(.var, leadingTrivia: syntax.funcKeyword.leadingTrivia)
 
     let patternBinding = PatternBindingSyntax(
       pattern: variableName,

--- a/Sources/SwiftRefactor/ConvertZeroParameterFunctionToComputedProperty.swift
+++ b/Sources/SwiftRefactor/ConvertZeroParameterFunctionToComputedProperty.swift
@@ -58,7 +58,7 @@ public struct ConvertZeroParameterFunctionToComputedProperty: SyntaxRefactoringP
       rightBrace: body.rightBrace
     )
 
-    let bindingSpecifier = TokenSyntax.keyword(.var, leadingTrivia: syntax.funcKeyword.leadingTrivia)
+    let bindingSpecifier = syntax.funcKeyword.detached.with(\.tokenKind, .keyword(.var)).with(\.leadingTrivia, syntax.funcKeyword.leadingTrivia).with(\.trailingTrivia, syntax.funcKeyword.trailingTrivia)
 
     let patternBinding = PatternBindingSyntax(
       pattern: variableName,

--- a/Tests/SwiftRefactorTest/ConvertZeroParameterFunctionToComputedPropertyTests.swift
+++ b/Tests/SwiftRefactorTest/ConvertZeroParameterFunctionToComputedPropertyTests.swift
@@ -191,6 +191,40 @@ final class ConvertZeroParameterFunctionToComputedPropertyTests: XCTestCase {
 
     try assertRefactorConvert(baseline, expected: expected)
   }
+
+  func testRefactoringFunctionToComputedPropertyPreservesComment() throws {
+    let baseline: DeclSyntax = """
+      // comment
+      public static func asJSON() -> String { "" }
+      // comment2
+      """
+
+    let expected: DeclSyntax = """
+      // comment
+      public static var asJSON: String { "" }
+      // comment2
+      """
+
+    try assertRefactorConvert(baseline, expected: expected)
+  }
+
+  func testSynchronousFunctionComment() throws {
+    let baseline: DeclSyntax = """
+      // comment
+      func qux() -> Int {
+        return 42
+      }
+      """
+    
+    let expected: DeclSyntax = """
+      // comment
+      var qux: Int {
+        return 42
+      }
+      """
+    
+    try assertRefactorConvert(baseline, expected: expected)
+  }
 }
 
 private func assertRefactorConvert(


### PR DESCRIPTION
Fixes #3236. 

Fixes an issue where documentation comments were dropped when converting zero-parameter functions to computed properties. The refactor now preserves leading comments during conversion. Tested locally. Please let me know if any changes needed or test cases need to be added.