### PR TITLE
Support the `package` access modifier in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ if(NOT DEFINED SWIFTSYNTAX_PACKAGE_NAME)
   set(SWIFTSYNTAX_PACKAGE_NAME "${SWIFT_MODULE_ABI_NAME_PREFIX}${PROJECT_NAME}")
 endif()
 
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-package-name ${SWIFTSYNTAX_PACKAGE_NAME}>")
+
 # Determine the module triple.
 if("${SWIFT_HOST_MODULE_TRIPLE}" STREQUAL "")
   set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)

--- a/Sources/SwiftSyntax/Trivia.swift
+++ b/Sources/SwiftSyntax/Trivia.swift
@@ -216,8 +216,7 @@ extension RawTriviaPiece: CustomDebugStringConvertible {
   }
 }
 
-@_spi(RawSyntax)
-public extension Trivia {
+package extension Trivia {
   func trimmingPrefix(
     while predicate: (TriviaPiece) -> Bool
   ) -> Trivia {

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -91,14 +91,12 @@ function(add_swift_syntax_library name)
     if(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "IMPLEMENTED")
       target_compile_options("${target}" PRIVATE
         $<$<COMPILE_LANGUAGE:Swift>:
-          "SHELL:-package-name ${SWIFTSYNTAX_PACKAGE_NAME}"
           "SHELL:-Xfrontend -package-cmo"
           "SHELL:-Xfrontend -allow-non-resilient-access"
       >)
     elseif(Swift_COMPILER_PACKAGE_CMO_SUPPORT STREQUAL "EXPERIMENTAL")
       target_compile_options("${target}" PRIVATE
         $<$<COMPILE_LANGUAGE:Swift>:
-          "SHELL:-package-name ${SWIFTSYNTAX_PACKAGE_NAME}"
           "SHELL:-Xfrontend -experimental-package-cmo"
           "SHELL:-Xfrontend -experimental-allow-non-resilient-access"
           "SHELL:-Xfrontend -experimental-package-bypass-resilience"


### PR DESCRIPTION
As far as I can tell, we weren’t passing `-package-name` if the host compiler does not support CMO at all. Since we require Swift 5.9 (indicated by the Package manifest), we can unconditionally set `-package-name`.