### PR TITLE
Classify 'Any' and 'Sendable' as Identifiers

### DIFF
--- a/Sources/SwiftSyntax/Identifier.swift
+++ b/Sources/SwiftSyntax/Identifier.swift
@@ -28,7 +28,7 @@ public struct Identifier: Equatable, Hashable, Sendable {
 
   public init?(_ token: TokenSyntax) {
     switch token.tokenKind {
-    case .identifier, .keyword(.self), .keyword(.Self):
+    case .identifier, .keyword(.Any), .keyword(.self), .keyword(.Self), .keyword(.Sendable):
       self.raw = RawIdentifier(token.tokenView.rawText)
       self.arena = token.raw.arenaReference
     case .dollarIdentifier(let dollarIdentifierStr):


### PR DESCRIPTION
I believe `Any` and `Sendable` should be treated as Identifiers because both can be used as type names in Swift.
Currently, parsing `Any` or `Sendable` doesn't treat them as Identifiers, which is somewhat inconvenient.