### PR TITLE
Recovery diagnostics for `repeat-while` (testRecovery28) 

### DIFF
--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -445,17 +445,17 @@ final class RecoveryTests: ParserTestCase {
         // TODO: Old parser expected error on line 2: consecutive statements on a line must be separated by ';', Fix-It replacements: 10 - 10 = ';'
         // TODO: Old parser expected warning on line 2: result of call to closure returning 'Bool' is unused
         DiagnosticSpec(
-          locationMarker:"1️⃣" ,
+          locationMarker: "1️⃣",
           message: "missing condition in 'while' statement"
-          ),
+        ),
         DiagnosticSpec(
-          locationMarker: "2️⃣", 
+          locationMarker: "2️⃣",
           message: "consecutive statements on a line must be separated by ';'",
           fixIts: ["seperate statements with ';"]
-          ),
+        ),
         DiagnosticSpec(
           message: "result of call to closure returning 'Bool' is unused"
-        )
+        ),
       ]
     )
   }


### PR DESCRIPTION
Issue : https://github.com/swiftlang/swift-syntax/issues/1373
I’ve added `DiagnosticSpec`s for `testRecovery28` following the pattern used in earlier recovery tests.

While doing this, I’m seeing test failures because the parser currently does not emit any diagnostics for this case, whereas the test expects three diagnostics and a fixed source (due to the presence of Fix-Its). This seems to stem from a difference between what the existing TODO comments describe and what the current parser behavior actually produces.

At this point, I’m unsure whether the test expectations should be updated to match the current parser behavior, or whether the parser is expected to be adjusted to emit the diagnostics described by the TODOs.

Could you please advise on the preferred approach here and whether I’m heading in the right direction before I continue further with the PR?

@ahoppen  @rintaro 