### PR TITLE
Implement ExpandTernaryExpr mirroring sourcekitd implementation

### DIFF
--- a/Sources/SwiftRefactor/CMakeLists.txt
+++ b/Sources/SwiftRefactor/CMakeLists.txt
@@ -16,6 +16,7 @@ add_swift_syntax_library(SwiftRefactor
   ConvertZeroParameterFunctionToComputedProperty.swift
   DeclModifierRemover.swift
   ExpandEditorPlaceholder.swift
+  ExpandTernaryExpr.swift
   FormatRawStringLiteral.swift
   IntegerLiteralUtilities.swift
   MigrateToNewIfLetSyntax.swift

--- a/Sources/SwiftRefactor/ExpandTernaryExpr.swift
+++ b/Sources/SwiftRefactor/ExpandTernaryExpr.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6)
+import SwiftBasicFormat
+public import SwiftSyntax
+#else
+import SwiftBasicFormat
+import SwiftSyntax
+#endif
+
+/// Converts a ternary conditional expression to an if-else expression using
+/// Swift 5.9's if-expression syntax.
+///
+/// ## Before
+///
+/// ```swift
+/// let x = condition ? trueValue : falseValue
+/// ```
+///
+/// ## After
+///
+/// ```swift
+/// let x = if condition {
+///     trueValue
+/// } else {
+///     falseValue
+/// }
+/// ```
+public struct ExpandTernaryExpr: SyntaxRefactoringProvider {
+  public static func refactor(syntax ternary: TernaryExprSyntax, in context: ()) -> IfExprSyntax {
+    // Extract components with cleaned trivia
+    let condition = ternary.condition
+      .with(\.leadingTrivia, [])
+      .with(\.trailingTrivia, [])
+    let thenExpr = ternary.thenExpression
+      .with(\.leadingTrivia, [])
+      .with(\.trailingTrivia, [])
+    let elseExpr = ternary.elseExpression
+      .with(\.leadingTrivia, [])
+      .with(\.trailingTrivia, [])
+
+    // Infer indentation from context, falling back to 4 spaces
+    let indentStep = BasicFormat.inferIndentation(of: ternary.root) ?? .spaces(4)
+
+    // Build the if-expression
+    return IfExprSyntax(
+      leadingTrivia: ternary.leadingTrivia,
+      ifKeyword: .keyword(.if, trailingTrivia: .space),
+      conditions: ConditionElementListSyntax {
+        ConditionElementSyntax(condition: .expression(ExprSyntax(condition)))
+      },
+      body: CodeBlockSyntax(
+        leftBrace: .leftBraceToken(leadingTrivia: .space),
+        statements: CodeBlockItemListSyntax {
+          CodeBlockItemSyntax(
+            leadingTrivia: .newline + indentStep,
+            item: .expr(thenExpr)
+          )
+        },
+        rightBrace: .rightBraceToken(leadingTrivia: .newline)
+      ),
+      elseKeyword: .keyword(.else, leadingTrivia: .space, trailingTrivia: .space),
+      elseBody: .codeBlock(
+        CodeBlockSyntax(
+          statements: CodeBlockItemListSyntax {
+            CodeBlockItemSyntax(
+              leadingTrivia: .newline + indentStep,
+              item: .expr(elseExpr)
+            )
+          },
+          rightBrace: .rightBraceToken(leadingTrivia: .newline)
+        )
+      ),
+      trailingTrivia: ternary.trailingTrivia
+    )
+  }
+}

--- a/Tests/SwiftRefactorTest/ExpandTernaryExprTests.swift
+++ b/Tests/SwiftRefactorTest/ExpandTernaryExprTests.swift
@@ -1,0 +1,163 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftRefactor
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import XCTest
+import _SwiftSyntaxTestSupport
+
+final class ExpandTernaryExprTests: XCTestCase {
+  func testSimpleTernary() throws {
+    let baseline = TernaryExprSyntax(
+      condition: ExprSyntax("a"),
+      thenExpression: ExprSyntax("b"),
+      elseExpression: ExprSyntax("c")
+    )
+
+    let expected: ExprSyntax = """
+      if a {
+          b
+      } else {
+          c
+      }
+      """
+
+    try assertRefactor(baseline, context: (), provider: ExpandTernaryExpr.self, expected: expected)
+  }
+
+  func testTernaryWithComplexCondition() throws {
+    let baseline = TernaryExprSyntax(
+      condition: ExprSyntax("(x > 0 && y < 10)"),
+      thenExpression: ExprSyntax("a"),
+      elseExpression: ExprSyntax("b")
+    )
+
+    let expected: ExprSyntax = """
+      if (x > 0 && y < 10) {
+          a
+      } else {
+          b
+      }
+      """
+
+    try assertRefactor(baseline, context: (), provider: ExpandTernaryExpr.self, expected: expected)
+  }
+
+  func testTernaryWithStringLiterals() throws {
+    let baseline = TernaryExprSyntax(
+      condition: ExprSyntax("flag"),
+      thenExpression: ExprSyntax("\"yes\""),
+      elseExpression: ExprSyntax("\"no\"")
+    )
+
+    let expected: ExprSyntax = """
+      if flag {
+          "yes"
+      } else {
+          "no"
+      }
+      """
+
+    try assertRefactor(baseline, context: (), provider: ExpandTernaryExpr.self, expected: expected)
+  }
+
+  func testTernaryWithFunctionCalls() throws {
+    let baseline = TernaryExprSyntax(
+      condition: ExprSyntax("isValid"),
+      thenExpression: ExprSyntax("doA()"),
+      elseExpression: ExprSyntax("doB()")
+    )
+
+    let expected: ExprSyntax = """
+      if isValid {
+          doA()
+      } else {
+          doB()
+      }
+      """
+
+    try assertRefactor(baseline, context: (), provider: ExpandTernaryExpr.self, expected: expected)
+  }
+
+  func testTernaryWithBooleanLiterals() throws {
+    let baseline = TernaryExprSyntax(
+      condition: ExprSyntax("condition"),
+      thenExpression: ExprSyntax("true"),
+      elseExpression: ExprSyntax("false")
+    )
+
+    let expected: ExprSyntax = """
+      if condition {
+          true
+      } else {
+          false
+      }
+      """
+
+    try assertRefactor(baseline, context: (), provider: ExpandTernaryExpr.self, expected: expected)
+  }
+
+  func testTernaryWithComparisonCondition() throws {
+    let baseline = TernaryExprSyntax(
+      condition: ExprSyntax("x == 5"),
+      thenExpression: ExprSyntax("result1"),
+      elseExpression: ExprSyntax("result2")
+    )
+
+    let expected: ExprSyntax = """
+      if x == 5 {
+          result1
+      } else {
+          result2
+      }
+      """
+
+    try assertRefactor(baseline, context: (), provider: ExpandTernaryExpr.self, expected: expected)
+  }
+
+  func testTernaryWithNilLiteral() throws {
+    let baseline = TernaryExprSyntax(
+      condition: ExprSyntax("hasValue"),
+      thenExpression: ExprSyntax("value"),
+      elseExpression: ExprSyntax("nil")
+    )
+
+    let expected: ExprSyntax = """
+      if hasValue {
+          value
+      } else {
+          nil
+      }
+      """
+
+    try assertRefactor(baseline, context: (), provider: ExpandTernaryExpr.self, expected: expected)
+  }
+
+  func testTernaryWithMemberAccess() throws {
+    let baseline = TernaryExprSyntax(
+      condition: ExprSyntax("obj.isEnabled"),
+      thenExpression: ExprSyntax("obj.enabledValue"),
+      elseExpression: ExprSyntax("obj.disabledValue")
+    )
+
+    let expected: ExprSyntax = """
+      if obj.isEnabled {
+          obj.enabledValue
+      } else {
+          obj.disabledValue
+      }
+      """
+
+    try assertRefactor(baseline, context: (), provider: ExpandTernaryExpr.self, expected: expected)
+  }
+}


### PR DESCRIPTION
# ExpandTernaryExpr

Part of [Sourcekit-LSP Issue#2424](https://github.com/swiftlang/sourcekit-lsp/issues/2424)

## Description

Implement ExpandTernaryExpr in Swift-Syntax to be used by lsp in place of current sourcekitd implementation. 
Updated sourcekitd implementation to use Swift 5.9+ if-expression syntax.

Support:
1. Variable assignment
2. return statements
3. bare ternary expression