### PR TITLE
Refactor `MoveMembersToExtension`

### DIFF
--- a/Sources/SwiftRefactor/CMakeLists.txt
+++ b/Sources/SwiftRefactor/CMakeLists.txt
@@ -19,6 +19,7 @@ add_swift_syntax_library(SwiftRefactor
   FormatRawStringLiteral.swift
   IntegerLiteralUtilities.swift
   MigrateToNewIfLetSyntax.swift
+  MoveMembersToExtension.swift
   OpaqueParameterToGeneric.swift
   RefactoringProvider.swift
   RemoveSeparatorsFromIntegerLiteral.swift

--- a/Sources/SwiftRefactor/MoveMembersToExtension.swift
+++ b/Sources/SwiftRefactor/MoveMembersToExtension.swift
@@ -12,10 +12,8 @@
 
 #if compiler(>=6)
 public import SwiftSyntax
-import SwiftParser
 #else
 import SwiftSyntax
-import SwiftParser
 #endif
 
 public struct MoveMembersToExtension: SyntaxRefactoringProvider {
@@ -32,12 +30,7 @@ public struct MoveMembersToExtension: SyntaxRefactoringProvider {
 
     guard
       let statement = syntax.statements.first(where: { $0.item.range.contains(context.range) }),
-      let decl = statement.item.asProtocol(NamedDeclSyntax.self)
-    else {
-      throw RefactoringNotApplicableError("Type declaration not found")
-    }
-
-    guard
+      let decl = statement.item.asProtocol(NamedDeclSyntax.self),
       let declGroup = statement.item.asProtocol(DeclGroupSyntax.self),
       let index = syntax.statements.index(of: statement)
     else {

--- a/Sources/SwiftRefactor/MoveMembersToExtension.swift
+++ b/Sources/SwiftRefactor/MoveMembersToExtension.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6)
+public import SwiftSyntax
+#else
+import SwiftSyntax
+#endif
+
+public struct MoveMembersToExtension: SyntaxRefactoringProvider {
+
+  public struct Context {
+    public let declName: TokenSyntax
+    public let selectedIdentifiers: [SyntaxIdentifier]
+
+    public init(declName: TokenSyntax, selectedIdentifiers: [SyntaxIdentifier]) {
+      self.declName = declName
+      self.selectedIdentifiers = selectedIdentifiers
+    }
+  }
+
+  public static func refactor(syntax: SourceFileSyntax, in context: Context) throws -> SourceFileSyntax {
+    guard
+      let decl = syntax.statements.first(where: {
+        $0.item.asProtocol(NamedDeclSyntax.self)?.name == context.declName
+      }),
+      let declGroup = decl.item.asProtocol(DeclGroupSyntax.self),
+      let index = syntax.statements.index(of: decl)
+    else {
+      throw RefactoringNotApplicableError("Type declaration not found")
+    }
+
+    let selectedMembers = declGroup.memberBlock.members.filter { context.selectedIdentifiers.contains($0.id) }
+
+    for member in selectedMembers {
+      try validateMember(member)
+    }
+
+    let remainingMembers = declGroup.memberBlock.members.filter { !context.selectedIdentifiers.contains($0.id) }
+
+    let updatedMemberBlock = declGroup.memberBlock.with(\.members, remainingMembers)
+    let updatedDeclGroup = declGroup.with(\.memberBlock, updatedMemberBlock)
+    let updatedItem = decl.with(\.item, .decl(DeclSyntax(updatedDeclGroup)))
+
+    let extensionMemberBlockSyntax = declGroup.memberBlock.with(\.members, selectedMembers)
+
+    let extensionDecl = ExtensionDeclSyntax(
+      leadingTrivia: .newlines(2),
+      extendedType: IdentifierTypeSyntax(
+        leadingTrivia: .space,
+        name: context.declName
+      ),
+      memberBlock: extensionMemberBlockSyntax
+    )
+
+    var updatedStatements = syntax.statements
+    updatedStatements.remove(at: index)
+    updatedStatements.insert(updatedItem, at: index)
+    updatedStatements.append(CodeBlockItemSyntax(item: .decl(DeclSyntax(extensionDecl))))
+
+    return syntax.with(\.statements, updatedStatements)
+  }
+
+  private static func validateMember(_ member: MemberBlockItemSyntax) throws {
+    if member.decl.is(AccessorDeclSyntax.self) || member.decl.is(DeinitializerDeclSyntax.self)
+      || member.decl.is(EnumCaseDeclSyntax.self)
+    {
+      throw RefactoringNotApplicableError("Cannot move this type of declaration")
+    }
+
+    if let varDecl = member.decl.as(VariableDeclSyntax.self),
+      varDecl.bindings.contains(where: { $0.initializer == nil })
+    {
+      throw RefactoringNotApplicableError("Cannot move stored properties to extension")
+    }
+  }
+}

--- a/Sources/SwiftRefactor/MoveMembersToExtension.swift
+++ b/Sources/SwiftRefactor/MoveMembersToExtension.swift
@@ -11,10 +11,47 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
-public import SwiftSyntax
+@_spi(RawSyntax) public import SwiftSyntax
 #else
-import SwiftSyntax
+@_spi(RawSyntax) import SwiftSyntax
 #endif
+
+private enum ValidationResult: CustomStringConvertible {
+  case accessor
+  case deinitializer
+  case enumCase
+  case storedProperty
+
+  var description: String {
+    switch self {
+    case .accessor: return "accessor"
+    case .deinitializer: return "deinitializer"
+    case .enumCase: return "enum case"
+    case .storedProperty: return "stored property"
+    }
+  }
+
+  /// Validates that `member` can be moved to an extension. If it can, return `nil`, otherwise return the reason why
+  /// `member` cannot be moved to an extension.
+  init?(_ member: MemberBlockItemSyntax) {
+    switch member.decl.kind {
+    case .accessorDecl:
+      self = .accessor
+    case .deinitializerDecl:
+      self = .deinitializer
+    case .enumCaseDecl:
+      self = .enumCase
+    default:
+      if let varDecl = member.decl.as(VariableDeclSyntax.self),
+         varDecl.bindings.contains(where: { $0.accessorBlock == nil || $0.initializer != nil })
+      {
+        self = .storedProperty
+      }
+      
+      return nil
+    }
+  }
+}
 
 public struct MoveMembersToExtension: SyntaxRefactoringProvider {
   public struct Context {
@@ -35,31 +72,23 @@ public struct MoveMembersToExtension: SyntaxRefactoringProvider {
       throw RefactoringNotApplicableError("Type declaration not found")
     }
 
-    var selectedMembers = [MemberBlockItemSyntax]()
-    var selectedIdentifiers = [SyntaxIdentifier]()
+    let selectedMembers = Array(declGroup.memberBlock.members).filter { context.range.overlaps($0.trimmedRange) }
+        .map { (member: $0, validationResult: ValidationResult($0)) }
 
-    var notMovedMembers: [MemberBlockItemSyntax] = []
+    var membersToMove = selectedMembers.filter({ $0.validationResult == nil }).map(\.member)
 
-    declGroup.memberBlock.members.forEach {
-      if context.range.overlaps($0.trimmedRange) {
-        if validateMember($0) {
-          selectedMembers.append($0)
-          selectedIdentifiers.append($0.id)
-        } else {
-          notMovedMembers.append($0)
-        }
-      }
-    }
-
-    guard !selectedMembers.isEmpty else {
-      throw RefactoringNotApplicableError("No members to move")
+    guard !membersToMove.isEmpty else {
+      throw RefactoringNotApplicableError(
+        "Cannot move \(Set(selectedMembers.compactMap(\.validationResult)).map(\.description).sorted()) to extension"
+      )
     }
 
     var updatedDeclGroup = declGroup
-    updatedDeclGroup.memberBlock.members = declGroup.memberBlock.members.filter { !selectedIdentifiers.contains($0.id) }
-    let updatedItem = statement.with(\.item, .decl(DeclSyntax(updatedDeclGroup)))
+    let remainingMembers = Array(declGroup.memberBlock.members).filter { !membersToMove.contains($0) }
+    membersToMove[0].decl.leadingTrivia = membersToMove[0].decl.leadingTrivia.trimmingPrefix(while: \.isSpaceOrTab)
 
-    let extensionMemberBlockSyntax = declGroup.memberBlock.with(\.members, MemberBlockItemListSyntax(selectedMembers))
+    updatedDeclGroup.memberBlock.members = MemberBlockItemListSyntax(remainingMembers)
+    let extensionMemberBlockSyntax = declGroup.memberBlock.with(\.members, MemberBlockItemListSyntax(membersToMove))
 
     var declName = decl.name
     declName.trailingTrivia = declName.trailingTrivia.merging(.space)
@@ -74,28 +103,12 @@ public struct MoveMembersToExtension: SyntaxRefactoringProvider {
     )
 
     var syntax = syntax
-    syntax.statements[statementIndex] = updatedItem
+    let updatedStatement = statement.with(\.item, .decl(DeclSyntax(updatedDeclGroup)))
+    syntax.statements[statementIndex] = updatedStatement
     syntax.statements.insert(
       CodeBlockItemSyntax(item: .decl(DeclSyntax(extensionDecl))),
       at: syntax.statements.index(after: statementIndex)
     )
     return syntax
-  }
-
-  private static func validateMember(_ member: MemberBlockItemSyntax) -> Bool {
-
-    if member.decl.is(AccessorDeclSyntax.self) || member.decl.is(DeinitializerDeclSyntax.self)
-      || member.decl.is(EnumCaseDeclSyntax.self)
-    {
-      return false
-    }
-
-    if let varDecl = member.decl.as(VariableDeclSyntax.self),
-      varDecl.bindings.contains(where: { $0.accessorBlock == nil || $0.initializer != nil })
-    {
-      return false
-    }
-
-    return true
   }
 }

--- a/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
+++ b/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
@@ -19,11 +19,11 @@ import _SwiftSyntaxTestSupport
 
 final class MoveMembersToExtensionTests: XCTestCase {
   func testMoveFunctionToExtension() throws {
-    let baseline: String = """
-      class Foo {1️⃣
+    let baseline: SourceFileSyntax = """
+      class Foo {
         func foo() {
           print("Hello world!")
-        }2️⃣
+        }
 
         func bar() {
           print("Hello world!")
@@ -46,30 +46,79 @@ final class MoveMembersToExtensionTests: XCTestCase {
       }
       """
 
-    let (markers, source) = extractMarkers(baseline)
-
-    var parser = Parser(source)
-    let tree = SourceFileSyntax.parse(from: &parser)
-    let context = makeContextFromClass(markers: markers, source: tree)
-    try assertRefactorConvert(tree, expected: expected, context: context)
+    let context = MoveMembersToExtension.Context(
+      range: AbsolutePosition(utf8Offset: 11)..<AbsolutePosition(utf8Offset: 56)
+    )
+    try assertRefactorConvert(baseline, expected: expected, context: context)
   }
-}
 
-private func makeContextFromClass(markers: [String: Int], source: SourceFileSyntax) -> MoveMembersToExtension.Context {
-  let classDecl = source.statements
-    .first(where: { $0.item.is(ClassDeclSyntax.self) })!
-    .item.cast(ClassDeclSyntax.self)
-  let members = classDecl.memberBlock.members
+  func testMoveFunctionToExtension2() throws {
+    let baseline: SourceFileSyntax = """
+      class Foo {
+        func foo() {
+          print("Hello world!")
+        }
 
-  let selectedMembersId: [SyntaxIdentifier] = members.compactMap({
-    let offset = $0.positionAfterSkippingLeadingTrivia.utf8Offset
-    if let start = markers["1️⃣"], let end = markers["2️⃣"], offset > start && offset < end {
-      return $0.id
-    }
-    return nil
-  })
+        func bar() {
+          print("Hello world!")
+        }
+      }
 
-  return MoveMembersToExtension.Context(declName: classDecl.name, selectedIdentifiers: selectedMembersId)
+      struct Bar {
+        func foo() {}
+      }
+      """
+
+    let expected: SourceFileSyntax = """
+      class Foo {
+
+        func bar() {
+          print("Hello world!")
+        }
+      }
+
+      extension Foo {
+        func foo() {
+          print("Hello world!")
+        }
+      }
+
+      struct Bar {
+        func foo() {}
+      }
+      """
+
+    let context = MoveMembersToExtension.Context(
+      range: AbsolutePosition(utf8Offset: 11)..<AbsolutePosition(utf8Offset: 56)
+    )
+    try assertRefactorConvert(baseline, expected: expected, context: context)
+  }
+
+  func testNested() throws {
+    let baseline: SourceFileSyntax = """
+      struct Outer {
+        struct Inner {
+          func moveThis() {}
+        }
+      }
+      """
+
+    let expected: SourceFileSyntax = """
+      struct Outer {
+      }
+
+      extension Outer {
+        struct Inner {
+          func moveThis() {}
+        }
+      }
+      """
+
+    let context = MoveMembersToExtension.Context(
+      range: AbsolutePosition(utf8Offset: 14)..<AbsolutePosition(utf8Offset: 58)
+    )
+    try assertRefactorConvert(baseline, expected: expected, context: context)
+  }
 }
 
 private func assertRefactorConvert(

--- a/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
+++ b/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
@@ -18,7 +18,7 @@ import XCTest
 import _SwiftSyntaxTestSupport
 
 final class MoveMembersToExtensionTests: XCTestCase {
-  func testMoveFunctionToExtension() throws {
+  func testMoveFunctionFromClass() throws {
     let baseline: SourceFileSyntax = """
       class Foo {
         func foo() {
@@ -52,7 +52,7 @@ final class MoveMembersToExtensionTests: XCTestCase {
     try assertRefactorConvert(baseline, expected: expected, context: context)
   }
 
-  func testMoveFunctionToExtension2() throws {
+  func testMoveFunctionFromClass2() throws {
     let baseline: SourceFileSyntax = """
       class Foo {
         func foo() {
@@ -94,7 +94,7 @@ final class MoveMembersToExtensionTests: XCTestCase {
     try assertRefactorConvert(baseline, expected: expected, context: context)
   }
 
-  func testNested() throws {
+  func testMoveNestedFromStruct() throws {
     let baseline: SourceFileSyntax = """
       struct Outer {
         struct Inner {
@@ -116,6 +116,74 @@ final class MoveMembersToExtensionTests: XCTestCase {
 
     let context = MoveMembersToExtension.Context(
       range: AbsolutePosition(utf8Offset: 14)..<AbsolutePosition(utf8Offset: 58)
+    )
+    try assertRefactorConvert(baseline, expected: expected, context: context)
+  }
+
+  func testMoveNestedFromStruct2() throws {
+    let baseline: SourceFileSyntax = """
+      struct Outer<T> {
+        struct Inner {
+          func moveThis() {}
+        }
+      }
+      """
+
+    let expected: SourceFileSyntax = """
+      struct Outer<T> {
+      }
+
+      extension Outer {
+        struct Inner {
+          func moveThis() {}
+        }
+      }
+      """
+
+    let context = MoveMembersToExtension.Context(
+      range: AbsolutePosition(utf8Offset: 17)..<AbsolutePosition(utf8Offset: 61)
+    )
+    try assertRefactorConvert(baseline, expected: expected, context: context)
+  }
+
+  func testMoveMembersFromEnum() throws {
+    let baseline: SourceFileSyntax = """
+      enum Foo {
+        func foo() {
+          print("Hello world!")
+        }
+
+        func bar() {
+          print("Hello world!")
+        }
+      }
+
+      struct Bar {
+        func foo() {}
+      }
+      """
+
+    let expected: SourceFileSyntax = """
+      enum Foo {
+
+        func bar() {
+          print("Hello world!")
+        }
+      }
+
+      extension Foo {
+        func foo() {
+          print("Hello world!")
+        }
+      }
+
+      struct Bar {
+        func foo() {}
+      }
+      """
+
+    let context = MoveMembersToExtension.Context(
+      range: AbsolutePosition(utf8Offset: 10)..<AbsolutePosition(utf8Offset: 55)
     )
     try assertRefactorConvert(baseline, expected: expected, context: context)
   }

--- a/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
+++ b/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
@@ -19,45 +19,42 @@ import _SwiftSyntaxTestSupport
 
 final class MoveMembersToExtensionTests: XCTestCase {
   func testMoveFunctionFromClass() throws {
-    let baseline: SourceFileSyntax = """
-      class Foo {
+    try assertMoveMembersToExtension(
+      """
+      class Foo {1️⃣
         func foo() {
           print("Hello world!")
-        }
+        }2️⃣
 
         func bar() {
           print("Hello world!")
         }
       }
-      """
+      """,
+      expected: """
+        class Foo {
 
-    let expected: SourceFileSyntax = """
-      class Foo {
-
-        func bar() {
-          print("Hello world!")
+          func bar() {
+            print("Hello world!")
+          }
         }
-      }
 
-      extension Foo {
-        func foo() {
-          print("Hello world!")
+        extension Foo {
+          func foo() {
+            print("Hello world!")
+          }
         }
-      }
-      """
-
-    let context = MoveMembersToExtension.Context(
-      range: AbsolutePosition(utf8Offset: 11)..<AbsolutePosition(utf8Offset: 56)
+        """
     )
-    try assertRefactorConvert(baseline, expected: expected, context: context)
   }
 
   func testMoveFunctionFromClass2() throws {
-    let baseline: SourceFileSyntax = """
-      class Foo {
+    try assertMoveMembersToExtension(
+      """
+      class Foo {1️⃣
         func foo() {
           print("Hello world!")
-        }
+        }2️⃣
 
         func bar() {
           print("Hello world!")
@@ -67,91 +64,199 @@ final class MoveMembersToExtensionTests: XCTestCase {
       struct Bar {
         func foo() {}
       }
-      """
+      """,
+      expected: """
+        class Foo {
 
-    let expected: SourceFileSyntax = """
-      class Foo {
-
-        func bar() {
-          print("Hello world!")
+          func bar() {
+            print("Hello world!")
+          }
         }
-      }
 
-      extension Foo {
-        func foo() {
-          print("Hello world!")
+        extension Foo {
+          func foo() {
+            print("Hello world!")
+          }
         }
-      }
 
-      struct Bar {
-        func foo() {}
-      }
-      """
-
-    let context = MoveMembersToExtension.Context(
-      range: AbsolutePosition(utf8Offset: 11)..<AbsolutePosition(utf8Offset: 56)
+        struct Bar {
+          func foo() {}
+        }
+        """
     )
-    try assertRefactorConvert(baseline, expected: expected, context: context)
+  }
+
+  func testMoveFunctionFromClassWithComment() throws {
+    try assertMoveMembersToExtension(
+      """
+      class Foo {
+        // Func foo prints "Hello world!"1️⃣
+        func foo() {
+          print("Hello world!")
+        }2️⃣
+
+        func bar() {
+          print("Hello world!")
+        }
+      }
+
+      struct Bar {
+        func foo() {}
+      }
+      """,
+      expected: """
+        class Foo {
+
+          func bar() {
+            print("Hello world!")
+          }
+        }
+
+        extension Foo {
+          // Func foo prints "Hello world!"
+          func foo() {
+            print("Hello world!")
+          }
+        }
+
+        struct Bar {
+          func foo() {}
+        }
+        """
+    )
+  }
+
+  func testMoveParticiallySelectedFunctionFromClass() throws {
+    try assertMoveMembersToExtension(
+      """
+      class Foo {
+        func foo() {
+          1️⃣print("Hello world!")
+        }2️⃣
+
+        func bar() {
+          print("Hello world!")
+        }
+      }
+
+      struct Bar {
+        func foo() {}
+      }
+      """,
+      expected: """
+        class Foo {
+
+          func bar() {
+            print("Hello world!")
+          }
+        }
+
+        extension Foo {
+          func foo() {
+            print("Hello world!")
+          }
+        }
+
+        struct Bar {
+          func foo() {}
+        }
+        """
+    )
+  }
+
+  func testMoveSelectedFromClass() throws {
+    try assertMoveMembersToExtension(
+      """
+      class Foo {1️⃣
+        func foo() {
+          print("Hello world!")
+        }
+
+        deinit() {}
+
+        func bar() {
+          print("Hello world!")
+        }2️⃣
+      }
+
+      struct Bar {
+        func foo() {}
+      }
+      """,
+      expected: """
+        class Foo {
+
+          deinit() {}
+        }
+
+        extension Foo {
+          func foo() {
+            print("Hello world!")
+          }
+
+          func bar() {
+            print("Hello world!")
+          }
+        }
+
+        struct Bar {
+          func foo() {}
+        }
+        """
+    )
   }
 
   func testMoveNestedFromStruct() throws {
-    let baseline: SourceFileSyntax = """
-      struct Outer {
+    try assertMoveMembersToExtension(
+      """
+      struct Outer {1️⃣
         struct Inner {
           func moveThis() {}
+        }2️⃣
+      }
+      """,
+      expected: """
+        struct Outer {
         }
-      }
-      """
 
-    let expected: SourceFileSyntax = """
-      struct Outer {
-      }
-
-      extension Outer {
-        struct Inner {
-          func moveThis() {}
+        extension Outer {
+          struct Inner {
+            func moveThis() {}
+          }
         }
-      }
-      """
-
-    let context = MoveMembersToExtension.Context(
-      range: AbsolutePosition(utf8Offset: 14)..<AbsolutePosition(utf8Offset: 58)
+        """
     )
-    try assertRefactorConvert(baseline, expected: expected, context: context)
   }
 
   func testMoveNestedFromStruct2() throws {
-    let baseline: SourceFileSyntax = """
-      struct Outer<T> {
+    try assertMoveMembersToExtension(
+      """
+      struct Outer<T> {1️⃣
         struct Inner {
           func moveThis() {}
+        }2️⃣
+      }
+      """,
+      expected: """
+        struct Outer<T> {
         }
-      }
-      """
 
-    let expected: SourceFileSyntax = """
-      struct Outer<T> {
-      }
-
-      extension Outer {
-        struct Inner {
-          func moveThis() {}
+        extension Outer {
+          struct Inner {
+            func moveThis() {}
+          }
         }
-      }
-      """
-
-    let context = MoveMembersToExtension.Context(
-      range: AbsolutePosition(utf8Offset: 17)..<AbsolutePosition(utf8Offset: 61)
+        """
     )
-    try assertRefactorConvert(baseline, expected: expected, context: context)
   }
 
   func testMoveMembersFromEnum() throws {
-    let baseline: SourceFileSyntax = """
-      enum Foo {
+    try assertMoveMembersToExtension(
+      """
+      enum Foo {1️⃣
         func foo() {
           print("Hello world!")
-        }
+        }2️⃣
 
         func bar() {
           print("Hello world!")
@@ -161,43 +266,45 @@ final class MoveMembersToExtensionTests: XCTestCase {
       struct Bar {
         func foo() {}
       }
-      """
+      """,
+      expected: """
+        enum Foo {
 
-    let expected: SourceFileSyntax = """
-      enum Foo {
-
-        func bar() {
-          print("Hello world!")
+          func bar() {
+            print("Hello world!")
+          }
         }
-      }
 
-      extension Foo {
-        func foo() {
-          print("Hello world!")
+        extension Foo {
+          func foo() {
+            print("Hello world!")
+          }
         }
-      }
 
-      struct Bar {
-        func foo() {}
-      }
-      """
-
-    let context = MoveMembersToExtension.Context(
-      range: AbsolutePosition(utf8Offset: 10)..<AbsolutePosition(utf8Offset: 55)
+        struct Bar {
+          func foo() {}
+        }
+        """
     )
-    try assertRefactorConvert(baseline, expected: expected, context: context)
   }
 }
 
-private func assertRefactorConvert(
-  _ callDecl: SourceFileSyntax,
-  expected: SourceFileSyntax?,
-  context: MoveMembersToExtension.Context,
+private func assertMoveMembersToExtension(
+  _ callDecl: String,
+  expected: SourceFileSyntax,
   file: StaticString = #filePath,
   line: UInt = #line
 ) throws {
+
+  let (markers, source) = extractMarkers(callDecl.description)
+  let positions = markers.mapValues { AbsolutePosition(utf8Offset: $0) }
+  var parser = Parser(source)
+  let tree = SourceFileSyntax.parse(from: &parser)
+
+  let context = MoveMembersToExtension.Context(range: positions["1️⃣"]!..<positions["2️⃣"]!)
+
   try assertRefactor(
-    callDecl,
+    tree,
     context: context,
     provider: MoveMembersToExtension.self,
     expected: expected,

--- a/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
+++ b/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftParser
+import SwiftRefactor
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import XCTest
+import _SwiftSyntaxTestSupport
+
+final class MoveMembersToExtensionTests: XCTestCase {
+  func testMoveFunctionToExtension() throws {
+    let baseline: String = """
+      class Foo {1️⃣
+        func foo() {
+          print("Hello world!")
+        }2️⃣
+
+        func bar() {
+          print("Hello world!")
+        }
+      }
+      """
+
+    let expected: SourceFileSyntax = """
+      class Foo {
+
+        func bar() {
+          print("Hello world!")
+        }
+      }
+
+      extension Foo {
+        func foo() {
+          print("Hello world!")
+        }
+      }
+      """
+
+    let (markers, source) = extractMarkers(baseline)
+
+    var parser = Parser(source)
+    let tree = SourceFileSyntax.parse(from: &parser)
+    let context = makeContextFromClass(markers: markers, source: tree)
+    try assertRefactorConvert(tree, expected: expected, context: context)
+  }
+}
+
+private func makeContextFromClass(markers: [String: Int], source: SourceFileSyntax) -> MoveMembersToExtension.Context {
+  let classDecl = source.statements
+    .first(where: { $0.item.is(ClassDeclSyntax.self) })!
+    .item.cast(ClassDeclSyntax.self)
+  let members = classDecl.memberBlock.members
+
+  let selectedMembersId: [SyntaxIdentifier] = members.compactMap({
+    let offset = $0.positionAfterSkippingLeadingTrivia.utf8Offset
+    if let start = markers["1️⃣"], let end = markers["2️⃣"], offset > start && offset < end {
+      return $0.id
+    }
+    return nil
+  })
+
+  return MoveMembersToExtension.Context(declName: classDecl.name, selectedIdentifiers: selectedMembersId)
+}
+
+private func assertRefactorConvert(
+  _ callDecl: SourceFileSyntax,
+  expected: SourceFileSyntax?,
+  context: MoveMembersToExtension.Context,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) throws {
+  try assertRefactor(
+    callDecl,
+    context: context,
+    provider: MoveMembersToExtension.self,
+    expected: expected,
+    file: file,
+    line: line
+  )
+}

--- a/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
+++ b/Tests/SwiftRefactorTest/MoveMembersToExtensionTests.swift
@@ -48,84 +48,6 @@ final class MoveMembersToExtensionTests: XCTestCase {
     )
   }
 
-  func testMoveFunctionFromClass2() throws {
-    try assertMoveMembersToExtension(
-      """
-      class Foo {1️⃣
-        func foo() {
-          print("Hello world!")
-        }2️⃣
-
-        func bar() {
-          print("Hello world!")
-        }
-      }
-
-      struct Bar {
-        func foo() {}
-      }
-      """,
-      expected: """
-        class Foo {
-
-          func bar() {
-            print("Hello world!")
-          }
-        }
-
-        extension Foo {
-          func foo() {
-            print("Hello world!")
-          }
-        }
-
-        struct Bar {
-          func foo() {}
-        }
-        """
-    )
-  }
-
-  func testMoveFunctionFromClassWithComment() throws {
-    try assertMoveMembersToExtension(
-      """
-      class Foo {
-        // Func foo prints "Hello world!"1️⃣
-        func foo() {
-          print("Hello world!")
-        }2️⃣
-
-        func bar() {
-          print("Hello world!")
-        }
-      }
-
-      struct Bar {
-        func foo() {}
-      }
-      """,
-      expected: """
-        class Foo {
-
-          func bar() {
-            print("Hello world!")
-          }
-        }
-
-        extension Foo {
-          // Func foo prints "Hello world!"
-          func foo() {
-            print("Hello world!")
-          }
-        }
-
-        struct Bar {
-          func foo() {}
-        }
-        """
-    )
-  }
-
   func testMoveParticiallySelectedFunctionFromClass() throws {
     try assertMoveMembersToExtension(
       """
@@ -249,59 +171,21 @@ final class MoveMembersToExtensionTests: XCTestCase {
         """
     )
   }
-
-  func testMoveMembersFromEnum() throws {
-    try assertMoveMembersToExtension(
-      """
-      enum Foo {1️⃣
-        func foo() {
-          print("Hello world!")
-        }2️⃣
-
-        func bar() {
-          print("Hello world!")
-        }
-      }
-
-      struct Bar {
-        func foo() {}
-      }
-      """,
-      expected: """
-        enum Foo {
-
-          func bar() {
-            print("Hello world!")
-          }
-        }
-
-        extension Foo {
-          func foo() {
-            print("Hello world!")
-          }
-        }
-
-        struct Bar {
-          func foo() {}
-        }
-        """
-    )
-  }
 }
 
 private func assertMoveMembersToExtension(
-  _ callDecl: String,
+  _ source: String,
   expected: SourceFileSyntax,
   file: StaticString = #filePath,
   line: UInt = #line
 ) throws {
-
-  let (markers, source) = extractMarkers(callDecl.description)
+  let (markers, source) = extractMarkers(source.description)
   let positions = markers.mapValues { AbsolutePosition(utf8Offset: $0) }
   var parser = Parser(source)
   let tree = SourceFileSyntax.parse(from: &parser)
 
-  let context = MoveMembersToExtension.Context(range: positions["1️⃣"]!..<positions["2️⃣"]!)
+  let range = try XCTUnwrap(positions["1️⃣"])..<XCTUnwrap(positions["2️⃣"])
+  let context = MoveMembersToExtension.Context(range: range)
 
   try assertRefactor(
     tree,


### PR DESCRIPTION
This PR implements the `MoveMembersToExtension` refactoring action as requested in [issue](https://github.com/swiftlang/sourcekit-lsp/issues/2424).
