### PR TITLE
[SE-0521] Parse `some P?` and `any P?` as `(some P)?` and `(any P)?`.

### DIFF
--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -126,23 +126,134 @@ extension Parser {
 
     let someOrAny = self.consume(if: .keyword(.some), .keyword(.any))
 
-    var base = self.parseSimpleType()
-    guard self.atContextualPunctuator("&") else {
-      if let someOrAny {
-        return RawTypeSyntax(
-          RawSomeOrAnyTypeSyntax(
-            someOrAnySpecifier: someOrAny,
-            constraint: base,
+    // Consumes all trailing optional sugar (`?` or `!`), wrapping the base type
+    // in the correct optional or IUO syntax node types.
+    func wrapWhileConsumingOptionalSugar(_ base: RawTypeSyntax) -> RawTypeSyntax {
+      var base = base
+      var loopProgress = LoopProgressCondition()
+
+      while self.hasProgressed(&loopProgress) {
+        if self.at(.postfixQuestionMark) {
+          base = RawTypeSyntax(self.parseOptionalType(base))
+        } else if self.at(.exclamationMark) {
+          base = RawTypeSyntax(self.parseImplicitlyUnwrappedOptionalType(base))
+        } else {
+          break
+        }
+      }
+      return base
+    }
+
+    var base = self.parseSimpleType(allowTrailingOptional: someOrAny == nil)
+
+    // This is the happy path for compositions, such as `P & Q` or `some P & Q`.
+    // If we have a composition that is interrupted by trailing optional sugar
+    // (e.g., `some P? & Q`), this check fails and we fall through to the
+    // recovery path below.
+    if let firstAmpersand = self.consumeIfContextualPunctuator("&") {
+      var elements = [RawCompositionTypeElementSyntax]()
+      elements.append(
+        RawCompositionTypeElementSyntax(
+          type: base,
+          ampersand: firstAmpersand,
+          arena: self.arena
+        )
+      )
+
+      var keepGoing: RawTokenSyntax? = nil
+      var loopProgress = LoopProgressCondition()
+      repeat {
+        var elementType: RawTypeSyntax
+        if someOrAny == nil {
+          elementType = self.parseSimpleType()
+        } else {
+          // If trailing `?` or `!` is present, determine whether it should bind
+          // to the element type instead of the entire `some`/`any` type. This
+          // happens in two cases:
+          //
+          // 1.  The optional is the base of a member type construction, like
+          //     `some P?.Q`.
+          // 2.  The user wrote the invalid type construction `some P? & Q`,
+          //     which we still want to parse syntactically as a composition for
+          //     recovery purposes; the type checker will reject it.
+          elementType = self.parseSimpleType(allowTrailingOptional: false)
+          let shouldBindOptionalToElement = self.withLookahead {
+            var hasOptional = false
+            while $0.consume(if: .postfixQuestionMark, .exclamationMark) != nil {
+              hasOptional = true
+            }
+            return hasOptional && ($0.atContextualPunctuator("&") || $0.at(.period))
+          }
+          if shouldBindOptionalToElement {
+            elementType = wrapWhileConsumingOptionalSugar(elementType)
+          }
+        }
+
+        keepGoing = self.consumeIfContextualPunctuator("&")
+        elements.append(
+          RawCompositionTypeElementSyntax(
+            type: elementType,
+            ampersand: keepGoing,
             arena: self.arena
           )
         )
-      } else {
-        return base
-      }
+      } while keepGoing != nil && self.hasProgressed(&loopProgress)
+
+      base = RawTypeSyntax(
+        RawCompositionTypeSyntax(
+          elements: RawCompositionTypeElementListSyntax(elements: elements, arena: self.arena),
+          arena: self.arena
+        )
+      )
     }
 
-    var elements = [RawCompositionTypeElementSyntax]()
+    // If `some`/`any` was present, apply it to the base, and *then* apply any
+    // trailing optionals.
+    if let someOrAny {
+      // If the constraint was an unparenthesized composition, wrap it in a
+      // tuple with missing parentheses so that a diagnostic is emitted later.
+      if base.is(RawCompositionTypeSyntax.self)
+        && (self.at(.postfixQuestionMark) || self.at(.exclamationMark))
+      {
+        base = RawTypeSyntax(
+          RawTupleTypeSyntax(
+            leftParen: RawTokenSyntax(missing: .leftParen, arena: self.arena),
+            elements: RawTupleTypeElementListSyntax(
+              elements: [
+                RawTupleTypeElementSyntax(
+                  inoutKeyword: nil,
+                  firstName: nil,
+                  secondName: nil,
+                  colon: nil,
+                  type: base,
+                  ellipsis: nil,
+                  trailingComma: nil,
+                  arena: self.arena
+                )
+              ],
+              arena: self.arena
+            ),
+            rightParen: RawTokenSyntax(missing: .rightParen, arena: self.arena),
+            arena: self.arena
+          )
+        )
+      }
+      base = RawTypeSyntax(
+        RawSomeOrAnyTypeSyntax(
+          someOrAnySpecifier: someOrAny,
+          constraint: base,
+          arena: self.arena
+        )
+      )
+      base = wrapWhileConsumingOptionalSugar(base)
+    }
+
+    // Recovery path for broken compositions, like `some P? & Q ...`: consume
+    // the rest of the composition with the `some` already applied to the first
+    // element (`(some P)? & Q ...`). This ensures we produce a reasonable AST,
+    // and the type checker will reject it.
     if let firstAmpersand = self.consumeIfContextualPunctuator("&") {
+      var elements = [RawCompositionTypeElementSyntax]()
       elements.append(
         RawCompositionTypeElementSyntax(
           type: base,
@@ -173,33 +284,23 @@ extension Parser {
       )
     }
 
-    if let someOrAny {
-      return RawTypeSyntax(
-        RawSomeOrAnyTypeSyntax(
-          someOrAnySpecifier: someOrAny,
-          constraint: base,
-          arena: self.arena
-        )
-      )
-    } else {
-      return base
-    }
+    return base
   }
 
   /// Parse the subset of types that we allow in attribute names.
   mutating func parseAttributeName() -> RawTypeSyntax {
-    return parseSimpleType(forAttributeName: true)
+    return parseSimpleType(allowTrailingOptional: false)
   }
 
   mutating func parseSimpleType(
     allowMemberTypes: Bool = true,
-    forAttributeName: Bool = false
+    allowTrailingOptional: Bool = true
   ) -> RawTypeSyntax {
     let tilde = self.consumeIfContextualPunctuator("~", remapping: .prefixOperator)
 
     let baseType = self.parseUnsuppressedSimpleType(
       allowMemberTypes: allowMemberTypes,
-      forAttributeName: forAttributeName
+      allowTrailingOptional: allowTrailingOptional
     )
 
     guard let tilde else {
@@ -213,7 +314,7 @@ extension Parser {
 
   mutating func parseUnsuppressedSimpleType(
     allowMemberTypes: Bool = true,
-    forAttributeName: Bool = false
+    allowTrailingOptional: Bool = true
   ) -> RawTypeSyntax {
     enum TypeBaseStart: TokenSpecSet {
       case `Self`
@@ -319,18 +420,25 @@ extension Parser {
         continue
       }
 
-      // Do not allow ? or ! suffixes when parsing attribute names.
-      if forAttributeName {
-        break
-      }
-
-      if self.at(TokenSpec(.postfixQuestionMark, allowAtStartOfLine: false)) {
-        base = RawTypeSyntax(self.parseOptionalType(base))
-        continue
-      }
-      if self.at(TokenSpec(.exclamationMark, allowAtStartOfLine: false)) {
-        base = RawTypeSyntax(self.parseImplicitlyUnwrappedOptionalType(base))
-        continue
+      if self.at(.postfixQuestionMark, .exclamationMark) {
+        // Even if we're not generally allowing trailing optional sugar (e.g.,
+        // at the end of a `some` type), we still need to consume them if they
+        // are followed by a member access (`.`), because we need to support
+        // valid types like `some P?.Q`.
+        let shouldConsume =
+          allowTrailingOptional
+          || self.withLookahead {
+            $0.consumeAnyToken()
+            return $0.at(.period)
+          }
+        if shouldConsume {
+          if self.at(.postfixQuestionMark) {
+            base = RawTypeSyntax(self.parseOptionalType(base))
+          } else {
+            base = RawTypeSyntax(self.parseImplicitlyUnwrappedOptionalType(base))
+          }
+          continue
+        }
       }
 
       break

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -1450,6 +1450,72 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     return handleMissingSyntax(node, additionalHandledNodes: [node.placeholder.id])
   }
 
+  public override func visit(_ node: OptionalTypeSyntax) -> SyntaxVisitorContinueKind {
+    if handledNodes.contains(node.id) {
+      return .skipChildren
+    }
+
+    if let someOrAny = node.wrappedType.as(SomeOrAnyTypeSyntax.self),
+      let tupleType = someOrAny.constraint.as(TupleTypeSyntax.self),
+      tupleType.leftParen.isMissing,
+      tupleType.rightParen.isMissing,
+      let element = tupleType.elements.only,
+      element.type.is(CompositionTypeSyntax.self)
+    {
+      addDiagnostic(
+        node,
+        position: node.questionMark.positionAfterSkippingLeadingTrivia,
+        .ambiguousOptionalComposition,
+        fixIts: [
+          FixIt(
+            message: .parenthesizeComposition,
+            changes: [
+              .makePresent(tupleType.leftParen),
+              .makePresent(tupleType.rightParen),
+            ]
+          )
+        ],
+        handledNodes: [node.id, tupleType.id]
+      )
+    } else {
+      handledNodes.append(node.id)
+    }
+    return .visitChildren
+  }
+
+  public override func visit(_ node: ImplicitlyUnwrappedOptionalTypeSyntax) -> SyntaxVisitorContinueKind {
+    if handledNodes.contains(node.id) {
+      return .skipChildren
+    }
+
+    if let someOrAny = node.wrappedType.as(SomeOrAnyTypeSyntax.self),
+      let tupleType = someOrAny.constraint.as(TupleTypeSyntax.self),
+      tupleType.leftParen.isMissing,
+      tupleType.rightParen.isMissing,
+      let element = tupleType.elements.only,
+      element.type.is(CompositionTypeSyntax.self)
+    {
+      addDiagnostic(
+        node,
+        position: node.exclamationMark.positionAfterSkippingLeadingTrivia,
+        .ambiguousOptionalComposition,
+        fixIts: [
+          FixIt(
+            message: .parenthesizeComposition,
+            changes: [
+              .makePresent(tupleType.leftParen),
+              .makePresent(tupleType.rightParen),
+            ]
+          )
+        ],
+        handledNodes: [node.id, tupleType.id]
+      )
+    } else {
+      handledNodes.append(node.id)
+    }
+    return .visitChildren
+  }
+
   override open func visit(_ node: OriginallyDefinedInAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
     if shouldSkip(node) {
       return .skipChildren

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -101,6 +101,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var allStatementsInSwitchMustBeCoveredByCase: Self {
     .init("all statements inside a switch must be covered by a 'case' or 'default' label")
   }
+  public static var ambiguousOptionalComposition: Self {
+    .init("confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence")
+  }
   public static var associatedTypeCannotUsePack: Self {
     .init("associated types cannot be variadic")
   }
@@ -720,6 +723,9 @@ extension FixItMessage where Self == StaticParserFixIt {
   }
   public static var insertExtraClosingPounds: Self {
     .init("insert additional closing '#' delimiters")
+  }
+  public static var parenthesizeComposition: Self {
+    .init("parenthesize composition")
   }
   public static var removeExtraneousWhitespace: Self {
     .init("remove whitespace")

--- a/Tests/SwiftParserTest/SomeAnyTypeTests.swift
+++ b/Tests/SwiftParserTest/SomeAnyTypeTests.swift
@@ -1,0 +1,246 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftParser
+@_spi(RawSyntax) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+import XCTest
+
+final class SomeAnyTypeTests: ParserTestCase {
+  func testSomeType() {
+    // Basic some P
+    assertParse(
+      "let x: some P",
+      substructure: SomeOrAnyTypeSyntax(
+        someOrAnySpecifier: .keyword(.some),
+        constraint: IdentifierTypeSyntax(name: .identifier("P"))
+      )
+    )
+
+    // Basic any P
+    assertParse(
+      "let x: any P",
+      substructure: SomeOrAnyTypeSyntax(
+        someOrAnySpecifier: .keyword(.any),
+        constraint: IdentifierTypeSyntax(name: .identifier("P"))
+      )
+    )
+  }
+
+  func testSomeOptionalHoisting() {
+    // some P? -> (some P)?
+    assertParse(
+      "let x: some P?",
+      substructure: OptionalTypeSyntax(
+        wrappedType: SomeOrAnyTypeSyntax(
+          someOrAnySpecifier: .keyword(.some),
+          constraint: IdentifierTypeSyntax(name: .identifier("P"))
+        )
+      )
+    )
+
+    // any P? -> (any P)?
+    assertParse(
+      "let x: any P?",
+      substructure: OptionalTypeSyntax(
+        wrappedType: SomeOrAnyTypeSyntax(
+          someOrAnySpecifier: .keyword(.any),
+          constraint: IdentifierTypeSyntax(name: .identifier("P"))
+        )
+      )
+    )
+
+    // some P! -> (some P)!
+    assertParse(
+      "let x: some P!",
+      substructure: ImplicitlyUnwrappedOptionalTypeSyntax(
+        wrappedType: SomeOrAnyTypeSyntax(
+          someOrAnySpecifier: .keyword(.some),
+          constraint: IdentifierTypeSyntax(name: .identifier("P"))
+        )
+      )
+    )
+  }
+
+  func testSomeComposition() {
+    // some P & Q -> some (P & Q)
+    assertParse(
+      "let x: some P & Q",
+      substructure: SomeOrAnyTypeSyntax(
+        someOrAnySpecifier: .keyword(.some),
+        constraint: CompositionTypeSyntax(
+          elements: .init([
+            CompositionTypeElementSyntax(
+              type: IdentifierTypeSyntax(name: .identifier("P")),
+              ampersand: .binaryOperator("&")
+            ),
+            CompositionTypeElementSyntax(type: IdentifierTypeSyntax(name: .identifier("Q"))),
+          ])
+        )
+      )
+    )
+
+    // some P? & Q -> (some P)? & Q
+    assertParse(
+      "let x: some P? & Q",
+      substructure: CompositionTypeSyntax(
+        elements: .init([
+          CompositionTypeElementSyntax(
+            type: OptionalTypeSyntax(
+              wrappedType: SomeOrAnyTypeSyntax(
+                someOrAnySpecifier: .keyword(.some),
+                constraint: IdentifierTypeSyntax(name: .identifier("P"))
+              )
+            ),
+            ampersand: .binaryOperator("&")
+          ),
+          CompositionTypeElementSyntax(type: IdentifierTypeSyntax(name: .identifier("Q"))),
+        ])
+      )
+    )
+  }
+
+  func testOptionalSomeCompositionDiagnosed() {
+    // some P & Q? -> (some (P & Q))? (diagnosed)
+    assertParse(
+      "let x: some P & Q1️⃣?",
+      substructure: OptionalTypeSyntax(
+        wrappedType: SomeOrAnyTypeSyntax(
+          someOrAnySpecifier: .keyword(.some),
+          constraint: TupleTypeSyntax(
+            leftParen: .leftParenToken(presence: .missing),
+            elements: .init([
+              TupleTypeElementSyntax(
+                type: CompositionTypeSyntax(
+                  elements: .init([
+                    CompositionTypeElementSyntax(
+                      type: IdentifierTypeSyntax(name: .identifier("P")),
+                      ampersand: .binaryOperator("&")
+                    ),
+                    CompositionTypeElementSyntax(
+                      type: IdentifierTypeSyntax(name: .identifier("Q"))
+                    ),
+                  ])
+                )
+              )
+            ]),
+            rightParen: .rightParenToken(presence: .missing)
+          )
+        )
+      ),
+      diagnostics: [
+        DiagnosticSpec(
+          message:
+            "confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence",
+          fixIts: ["parenthesize composition"]
+        )
+      ],
+      fixedSource: "let x: some (P & Q)?"
+    )
+
+    // some P & Q! -> (some (P & Q))! (diagnosed)
+    assertParse(
+      "let x: some P & Q1️⃣!",
+      substructure: ImplicitlyUnwrappedOptionalTypeSyntax(
+        wrappedType: SomeOrAnyTypeSyntax(
+          someOrAnySpecifier: .keyword(.some),
+          constraint: TupleTypeSyntax(
+            leftParen: .leftParenToken(presence: .missing),
+            elements: .init([
+              TupleTypeElementSyntax(
+                type: CompositionTypeSyntax(
+                  elements: .init([
+                    CompositionTypeElementSyntax(
+                      type: IdentifierTypeSyntax(name: .identifier("P")),
+                      ampersand: .binaryOperator("&")
+                    ),
+                    CompositionTypeElementSyntax(
+                      type: IdentifierTypeSyntax(name: .identifier("Q"))
+                    ),
+                  ])
+                )
+              )
+            ]),
+            rightParen: .rightParenToken(presence: .missing)
+          )
+        )
+      ),
+      diagnostics: [
+        DiagnosticSpec(
+          message:
+            "confusing use of optional after a 'some' or 'any' composition; use parentheses to clarify precedence",
+          fixIts: ["parenthesize composition"]
+        )
+      ],
+      fixedSource: "let x: some (P & Q)!"
+    )
+  }
+
+  func testSomeMemberAccess() {
+    // some P?.Q -> some (P?.Q)
+    assertParse(
+      "let x: some P?.Q",
+      substructure: SomeOrAnyTypeSyntax(
+        someOrAnySpecifier: .keyword(.some),
+        constraint: MemberTypeSyntax(
+          baseType: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("P"))),
+          period: .periodToken(),
+          name: .identifier("Q")
+        )
+      )
+    )
+
+    // some P?.Q? -> (some (P?.Q))?
+    assertParse(
+      "let x: some P?.Q?",
+      substructure: OptionalTypeSyntax(
+        wrappedType: SomeOrAnyTypeSyntax(
+          someOrAnySpecifier: .keyword(.some),
+          constraint: MemberTypeSyntax(
+            baseType: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("P"))),
+            period: .periodToken(),
+            name: .identifier("Q")
+          )
+        )
+      )
+    )
+  }
+
+  func testSomeAnySuppression() {
+    // some ~Copyable? -> (some (~Copyable))?
+    assertParse(
+      "let x: some ~Copyable?",
+      substructure: OptionalTypeSyntax(
+        wrappedType: SomeOrAnyTypeSyntax(
+          someOrAnySpecifier: .keyword(.some),
+          constraint: SuppressedTypeSyntax(
+            withoutTilde: .prefixOperator("~"),
+            type: IdentifierTypeSyntax(name: .identifier("Copyable"))
+          )
+        )
+      )
+    )
+
+    // any ~Copyable? -> (any (~Copyable))?
+    assertParse(
+      "let x: any ~Copyable?",
+      substructure: OptionalTypeSyntax(
+        wrappedType: SomeOrAnyTypeSyntax(
+          someOrAnySpecifier: .keyword(.any),
+          constraint: SuppressedTypeSyntax(
+            withoutTilde: .prefixOperator("~"),
+            type: IdentifierTypeSyntax(name: .identifier("Copyable"))
+          )
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
swift-syntax parser implementation of SE-0521. Companion of https://github.com/swiftlang/swift/pull/87115.