### PR TITLE
Fix missing imports when enabling MemberImportVisibility (back port)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -452,6 +452,14 @@ package.targets.append(
   )
 )
 
+// MARK: - Apply upcoming feature flags to all targets
+
+for target in package.targets {
+  var settings = target.swiftSettings ?? []
+  settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+  target.swiftSettings = settings
+}
+
 // MARK: - Parse build arguments
 
 func hasEnvironmentVariable(_ name: String) -> Bool {

--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -13,9 +13,11 @@
 #if compiler(>=6)
 internal import SwiftDiagnostics
 internal import SwiftSyntax
+internal import SwiftSyntaxMacros
 #else
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxMacros
 #endif
 
 /// Errors in macro handing.

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -13,6 +13,7 @@
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Evaluate the condition of an `#if`.
 /// - Parameters:

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -11,10 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
+internal import SwiftBasicFormat
 public import SwiftDiagnostics
 @_spi(Diagnostics) internal import SwiftParser
 @_spi(ExperimentalLanguageFeatures) public import SwiftSyntax
 #else
+import SwiftBasicFormat
 import SwiftDiagnostics
 @_spi(Diagnostics) import SwiftParser
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax

--- a/Sources/SwiftRefactor/ConvertComputedPropertyToStored.swift
+++ b/Sources/SwiftRefactor/ConvertComputedPropertyToStored.swift
@@ -12,8 +12,10 @@
 
 #if compiler(>=6)
 public import SwiftSyntax
+public import SwiftSyntaxBuilder
 #else
 import SwiftSyntax
+import SwiftSyntaxBuilder
 #endif
 
 public struct ConvertComputedPropertyToStored: SyntaxRefactoringProvider {

--- a/Sources/SwiftRefactor/ConvertStoredPropertyToComputed.swift
+++ b/Sources/SwiftRefactor/ConvertStoredPropertyToComputed.swift
@@ -12,8 +12,10 @@
 
 #if compiler(>=6)
 public import SwiftSyntax
+public import SwiftSyntaxBuilder
 #else
 import SwiftSyntax
+import SwiftSyntaxBuilder
 #endif
 
 public struct ConvertStoredPropertyToComputed: SyntaxRefactoringProvider {

--- a/Sources/SwiftRefactor/ConvertZeroParameterFunctionToComputedProperty.swift
+++ b/Sources/SwiftRefactor/ConvertZeroParameterFunctionToComputedProperty.swift
@@ -12,8 +12,12 @@
 
 #if compiler(>=6)
 public import SwiftSyntax
+import SwiftBasicFormat
+import SwiftSyntaxBuilder
 #else
 import SwiftSyntax
+import SwiftBasicFormat
+import SwiftSyntaxBuilder
 #endif
 
 public struct ConvertZeroParameterFunctionToComputedProperty: SyntaxRefactoringProvider {

--- a/Sources/SwiftRefactor/PackageManifest/ManifestSyntaxRepresentable.swift
+++ b/Sources/SwiftRefactor/PackageManifest/ManifestSyntaxRepresentable.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Describes an entity in the package model that can be represented as
 /// a syntax node.

--- a/Sources/SwiftRefactor/PackageManifest/PackageTarget.swift
+++ b/Sources/SwiftRefactor/PackageManifest/PackageTarget.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Syntactic wrapper type that describes a target for refactoring
 /// purposes but does not interpret its contents.

--- a/Sources/SwiftRefactor/PackageManifest/ProductDescription.swift
+++ b/Sources/SwiftRefactor/PackageManifest/ProductDescription.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Syntactic wrapper type that describes a product for refactoring
 /// purposes but does not interpret its contents.

--- a/Sources/SwiftRefactor/PackageManifest/SyntaxEditUtils.swift
+++ b/Sources/SwiftRefactor/PackageManifest/SyntaxEditUtils.swift
@@ -13,6 +13,7 @@
 import SwiftBasicFormat
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Default indent when we have to introduce indentation but have no context
 /// to get it right.

--- a/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/IndentationUtils.swift
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
+internal import SwiftBasicFormat
 internal import SwiftSyntax
 #else
+import SwiftBasicFormat
 import SwiftSyntax
 #endif
 

--- a/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroExpansion.swift
@@ -11,11 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
-import SwiftBasicFormat
+internal import SwiftBasicFormat
+internal import SwiftDiagnostics
+internal import SwiftIfConfig
 public import SwiftSyntax
 @_spi(MacroExpansion) @_spi(ExperimentalLanguageFeature) public import SwiftSyntaxMacros
 #else
 import SwiftBasicFormat
+import SwiftDiagnostics
+import SwiftIfConfig
 import SwiftSyntax
 @_spi(MacroExpansion) @_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
 #endif

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSpec.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSpec.swift
@@ -12,9 +12,11 @@
 
 #if compiler(>=6)
 public import SwiftSyntax
+internal import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 #else
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 #endif
 

--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
+internal import SwiftBasicFormat
 internal import SwiftDiagnostics
 internal import SwiftOperators
 @_spi(MacroExpansion) internal import SwiftParser
@@ -18,6 +19,7 @@ public import SwiftSyntax
 internal import SwiftSyntaxBuilder
 @_spi(MacroExpansion) @_spi(ExperimentalLanguageFeature) public import SwiftSyntaxMacros
 #else
+import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftOperators
 @_spi(MacroExpansion) import SwiftParser


### PR DESCRIPTION
Add missing imports when compiling with
`.enableUpcomingFeature("MemberImportVisibility")`

Backported to 6.3 release branch

Issue: #3301