### PR TITLE
Add explicit target dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -185,7 +185,7 @@ let package = Package(
 
     .target(
       name: "SwiftWarningControl",
-      dependencies: ["SwiftSyntax", "SwiftParser"],
+      dependencies: ["SwiftSyntax", "SwiftParser", "SwiftDiagnostics"],
       exclude: ["CMakeLists.txt", "SwiftWarningControl.md"]
     ),
 


### PR DESCRIPTION
Same as #3195 for the 6.3.1 release.

- **Explanation**: Adds an explicit dependency to `SwiftDiagnostics` to the `SwiftWarningControl` package to pass the `--explicit-target-dependency-import-check` build check.
- **Scope**: It only makes the dependency explicit and `--explicit-target-dependency-import-check` pass. There is no change in dependencies.
- **Issues**: Issue was reported in [a comment](https://github.com/swiftlang/swift-syntax/pull/3195#issuecomment-4160020636) on the same fix on `main`.
- **Original PRs**: #3195
- **Risk**: None.
- **Testing**: Not required.
- **Reviewers**: @ahoppen, @hamishknight