### PR TITLE
Change default release version for GitHub action to 605.0.0 + add version marker module

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -14,7 +14,7 @@ on:
         required: true
       swift_syntax_version:
         type: string
-        default: 604.0.0
+        default: 605.0.0
         description: "swift-syntax version"
         # The version of swift-syntax to tag. If this is a prerelease, `-prerelease-<date>` is added to this version.
         required: true

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -226,6 +226,7 @@ swift_syntax_library(
         ":SwiftSyntax602",
         ":SwiftSyntax603",
         ":SwiftSyntax604",
+        ":SwiftSyntax605",
         ":_SwiftSyntaxCShims",
     ],
 )
@@ -275,6 +276,13 @@ swift_syntax_library(
 swift_syntax_library(
     name = "SwiftSyntax604",
     srcs = glob(["Sources/VersionMarkerModules/SwiftSyntax604/**/*.swift"]),
+    deps = [
+    ],
+)
+
+swift_syntax_library(
+    name = "SwiftSyntax605",
+    srcs = glob(["Sources/VersionMarkerModules/SwiftSyntax605/**/*.swift"]),
     deps = [
     ],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -231,7 +231,7 @@ let package = Package(
       name: "SwiftSyntax",
       dependencies: [
         "_SwiftSyntaxCShims", "SwiftSyntax509", "SwiftSyntax510", "SwiftSyntax600", "SwiftSyntax601", "SwiftSyntax602",
-        "SwiftSyntax603", "SwiftSyntax604",
+        "SwiftSyntax603", "SwiftSyntax604", "SwiftSyntax605",
       ],
       exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSyntaxSwiftSettings
@@ -278,6 +278,11 @@ let package = Package(
     .target(
       name: "SwiftSyntax604",
       path: "Sources/VersionMarkerModules/SwiftSyntax604"
+    ),
+
+    .target(
+      name: "SwiftSyntax605",
+      path: "Sources/VersionMarkerModules/SwiftSyntax605"
     ),
 
     // MARK: SwiftSyntaxBuilder

--- a/Sources/VersionMarkerModules/CMakeLists.txt
+++ b/Sources/VersionMarkerModules/CMakeLists.txt
@@ -22,3 +22,5 @@ add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax603 STATIC
   SwiftSyntax603/Empty.swift)
 add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax604 STATIC
   SwiftSyntax604/Empty.swift)
+add_library(${SWIFTSYNTAX_TARGET_NAMESPACE}SwiftSyntax605 STATIC
+  SwiftSyntax605/Empty.swift)

--- a/Sources/VersionMarkerModules/SwiftSyntax605/Empty.swift
+++ b/Sources/VersionMarkerModules/SwiftSyntax605/Empty.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// The SwiftSyntax605 module is intentionally empty.
+// It serves as an indicator which version of swift-syntax a package is building against.
+// See the 'Macro Versioning.md' document for more details.


### PR DESCRIPTION
Now that `release/6.4.x` is branched. Bump the default release version to 605.0.0