### PR TITLE
Fix whitespace in convertStoredPropertyToComputed 

### DIFF
--- a/Sources/SwiftRefactor/ConvertStoredPropertyToComputed.swift
+++ b/Sources/SwiftRefactor/ConvertStoredPropertyToComputed.swift
@@ -70,12 +70,12 @@ public struct ConvertStoredPropertyToComputed: SyntaxRefactoringProvider {
       typeAnnotation = existingType
     } else if let providedType = context.type {
       typeAnnotation = TypeAnnotationSyntax(
-        colon: .colonToken(leadingTrivia: [], trailingTrivia: .space),
+        colon: .colonToken(trailingTrivia: .space),
         type: providedType
       )
     } else {
       typeAnnotation = TypeAnnotationSyntax(
-        colon: .colonToken(leadingTrivia: [], trailingTrivia: .space),
+        colon: .colonToken(trailingTrivia: .space),
         type: TypeSyntax(stringLiteral: "<#Type#>")
       )
     }

--- a/Sources/SwiftRefactor/ConvertStoredPropertyToComputed.swift
+++ b/Sources/SwiftRefactor/ConvertStoredPropertyToComputed.swift
@@ -69,15 +69,20 @@ public struct ConvertStoredPropertyToComputed: SyntaxRefactoringProvider {
     if let existingType = binding.typeAnnotation {
       typeAnnotation = existingType
     } else if let providedType = context.type {
-      typeAnnotation = TypeAnnotationSyntax(type: providedType)
+      typeAnnotation = TypeAnnotationSyntax(
+        colon: .colonToken(leadingTrivia: [], trailingTrivia: .space),
+        type: providedType
+      )
     } else {
       typeAnnotation = TypeAnnotationSyntax(
+        colon: .colonToken(leadingTrivia: [], trailingTrivia: .space),
         type: TypeSyntax(stringLiteral: "<#Type#>")
       )
     }
 
     let newBinding =
       binding
+      .with(\.pattern, binding.pattern.with(\.trailingTrivia, []))
       .with(\.initializer, nil)
       .with(\.typeAnnotation, typeAnnotation)
       .with(

--- a/Tests/SwiftRefactorTest/ConvertStoredPropertyToComputedTest.swift
+++ b/Tests/SwiftRefactorTest/ConvertStoredPropertyToComputedTest.swift
@@ -297,14 +297,14 @@ final class ConvertStoredPropertyToComputedTest: XCTestCase {
 
   func testRefactoringStoredPropertyMissingTypeAnnotation() throws {
     let baseline: DeclSyntax = "var foo = \"abc\""
-    let expected: DeclSyntax = "var foo :<#Type#>{ \"abc\" }"
+    let expected: DeclSyntax = "var foo: <#Type#>{ \"abc\" }"
 
     try assertRefactorConvert(baseline, expected: expected)
   }
 
   func testRefactoringStoredPropertyWithTypeAnnotation() throws {
     let baseline: DeclSyntax = "var foo = \"abc\""
-    let expected: DeclSyntax = "var foo :String{ \"abc\" }"
+    let expected: DeclSyntax = "var foo: String{ \"abc\" }"
 
     let context = ConvertStoredPropertyToComputed.Context(type: TypeSyntax(stringLiteral: "String"))
     try assertRefactorConvert(baseline, expected: expected, context: context)


### PR DESCRIPTION
## Description
This PR fixes formatting issue where the refactored computed property was generating a leading space before the type annotation colon (e.g., `var x :Int` instead of `var x: Int`).

The fix removes the `trailingTrivia` from the variable's pattern that was previously associated with the equals sign.

## Context
Related to https://github.com/swiftlang/swift-syntax/pull/3249. 
Addresses feedback from https://github.com/swiftlang/sourcekit-lsp/pull/2622