### PR TITLE
Prefer child name over type name in missing-node diagnostics

### DIFF
--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -152,8 +152,9 @@ func nodesDescriptionAndCommonParent(
     isOnlyTokenWithNonMissingText = false
   }
 
-  // If all tokens in the parent are missing, return the parent type name unless
-  // we are replacing by a single token that has explicit text, in which case we
+  // If all tokens in the common ancestor are missing, describe it by the name
+  // in the parent if available, otherwise by its type name. Unless we are
+  // replacing by a single token that has explicit text, in which case we
   // return that explicit text.
   if let commonAncestor = findCommonAncestor(missingSyntaxNodes),
     commonAncestor.isMissingAllTokens,
@@ -163,9 +164,9 @@ func nodesDescriptionAndCommonParent(
     missingSyntaxNodes.contains(Syntax(lastToken)),
     !isOnlyTokenWithNonMissingText
   {
-    if let nodeTypeName = commonAncestor.nodeTypeNameForDiagnostics(allowBlockNames: true) {
-      return (commonAncestor, nodeTypeName)
-    } else if let nodeTypeName = commonAncestor.childNameInParent {
+    if let childName = commonAncestor.childNameInParent {
+      return (commonAncestor, childName)
+    } else if let nodeTypeName = commonAncestor.nodeTypeNameForDiagnostics(allowBlockNames: true) {
       return (commonAncestor, nodeTypeName)
     }
   }

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2775,9 +2775,8 @@ final class StatementExpressionTests: ParserTestCase {
       diagnostics: [
         DiagnosticSpec(
           locationMarker: "1️⃣",
-          // FIXME: "expected attribute name after '@'". https://github.com/swiftlang/swift-syntax/issues/3159
-          message: "expected type in attribute",
-          fixIts: ["insert type"]
+          message: "expected name in attribute",
+          fixIts: ["insert name"]
         ),
         DiagnosticSpec(
           locationMarker: "2️⃣",


### PR DESCRIPTION
Closes #3159.

When parsing code such as this snippet:

```swift
switch expr {
  @ case foo: // expected type in attribute
}
```

`parseSwitchCase()` consumes `@` and calls `expectIdentifier()`, which produces a missing identifier token since `case` isn't an identifier. The `AttributeSyntax` ends up with an `IdentifierTypeSyntax` in its `attributeName` slot, whose only token is missing.

Later, `ParseDiagnosticsGenerator` encounters the missing syntax, calls `handleMissingSyntax()`, and adds a diagnostic with `MissingNodesError(missingNodes:)`, which calls `nodesDescriptionAndCommonParent()`. The early `isMissingAllTokens` return in that function fires, and previously preferred the node's type name over its child name in the parent, producing the misleading diagnostic.

This PR switches the order of the checks within that early return so the child name is preferred. This aligns its behavior with the `descriptionParts()` path, which already prefers the child name. Now, the example above produces an "expected name in attribute" diagnostic.

## Testing

Updated `ExpressionTests.testStandaloneAtCaseInSwitch()` to expect the correct diagnostic.

All tests pass when run locally.