### PR TITLE
Return `MissingPatternSyntax` for empty pattern positions

### DIFF
--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -245,6 +245,16 @@ extension Parser {
       break
     }
 
+    // If the current token can start neither a pattern nor an expression, this
+    // is a pattern position with no recoverable content. Return a missing
+    // pattern directly so diagnostics describe the missing node as a pattern
+    // rather than an expression wrapped in an expression-pattern.
+    if !self.atStartOfExpression()
+      && !self.withLookahead({ $0.canParsePattern() })
+    {
+      return RawPatternSyntax(RawMissingPatternSyntax(arena: self.arena))
+    }
+
     // Fall back to expression parsing for ambiguous forms. Name lookup will
     // disambiguate.
     let patternSyntax = self.parseSequenceExpression(flavor: .stmtCondition, pattern: context)

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -2781,14 +2781,13 @@ final class StatementExpressionTests: ParserTestCase {
         ),
         DiagnosticSpec(
           locationMarker: "2️⃣",
-          // FIXME: "expected pattern and ':' in switch case". https://github.com/swiftlang/swift-syntax/issues/3158
-          message: "expected expression and ':' in switch case",
-          fixIts: ["insert expression and ':'"]
+          message: "expected pattern and ':' in switch case",
+          fixIts: ["insert pattern and ':'"]
         ),
       ],
       fixedSource: """
         switch x {
-          @<#identifier#> case <#expression#>:
+          @<#identifier#> case <#pattern#>:
         }
         """
     )

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -78,13 +78,13 @@ final class StatementTests: ParserTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(
-          message: "expected expression, '=', and expression in pattern matching",
-          fixIts: ["insert expression, '=', and expression"]
+          message: "expected pattern, '=', and expression in pattern matching",
+          fixIts: ["insert pattern, '=', and expression"]
         ),
         DiagnosticSpec(message: "unexpected code '* ! = x' in 'if' statement"),
       ],
       fixedSource: """
-        if case <#expression#> = <#expression#> * ! = x {
+        if case <#pattern#> = <#expression#> * ! = x {
           bar()
         }
         """
@@ -94,6 +94,20 @@ final class StatementTests: ParserTestCase {
       """
       if includeSavedHints { a = a.flatMap{ $0 } ?? nil }
       """
+    )
+  }
+
+  func testIfCaseWithMissingPattern() {
+    assertParse(
+      """
+      if case 1️⃣= x {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected pattern in pattern matching", fixIts: ["insert pattern"])
+      ],
+      fixedSource: """
+        if case <#pattern#> = x {}
+        """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -3134,8 +3134,8 @@ final class RecoveryTests: ParserTestCase {
       diagnostics: [
         DiagnosticSpec(
           locationMarker: "1️⃣",
-          message: "expected expression, '=', and expression in pattern matching",
-          fixIts: ["insert expression, '=', and expression"]
+          message: "expected pattern, '=', and expression in pattern matching",
+          fixIts: ["insert pattern, '=', and expression"]
         ),
         DiagnosticSpec(
           locationMarker: "1️⃣",
@@ -3151,7 +3151,7 @@ final class RecoveryTests: ParserTestCase {
       ],
       fixedSource: """
         func testSkipToFindOpenBrace1() {
-          do { if case <#expression#> = <#expression#> {}
+          do { if case <#pattern#> = <#expression#> {}
         }
         }
         """

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -82,12 +82,36 @@ final class SwitchTests: ParserTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected expression and ':' in switch case", fixIts: ["insert expression and ':'"])
+        DiagnosticSpec(message: "expected pattern and ':' in switch case", fixIts: ["insert pattern and ':'"])
       ],
       fixedSource: """
         func parseError3(x: Int) {
           switch x {
-            case <#expression#>:
+            case <#pattern#>:
+          }
+        }
+        """
+    )
+  }
+
+  func testSwitch4b() {
+    assertParse(
+      """
+      func parseError3b(x: Int) {
+        switch x {
+          case 1️⃣:
+            break
+        }
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected pattern in switch case", fixIts: ["insert pattern"])
+      ],
+      fixedSource: """
+        func parseError3b(x: Int) {
+          switch x {
+            case <#pattern#>:
+              break
           }
         }
         """


### PR DESCRIPTION
Closes #3158.

When parsing code such as these snippets:

```swift
switch x {
  case // error: expected expression and ':' in switch case
}
```

```swift
switch expr {
  case : // error: expected expression in pattern
}
```

`parseMatchingPattern()` reaches its expression-fallback path, calls `parseSequenceExpression()`, and wraps the result in a `RawExpressionPatternSyntax`. If the current token starts neither a pattern nor an expression, this produces a missing expression wrapped in an expression-pattern, which the diagnostic engine describes as a missing expression rather than a missing pattern.

This PR adds an early return of `RawMissingPatternSyntax` before the expression fallback, which fires if the current token is neither an expression nor the start of a pattern. The fallback still fires for ambiguous forms. Now, the above examples produce "expected pattern..." diagnostics.

## Testing

Updated `ExpressionTests.testStandaloneAtCaseInSwitch()`, `StatementTests.testIf()`, `RecoveryTests.testRecovery180()`, and `SwitchTests.testSwitch4()` to expect the correct diagnostics.

Added `StatementTests.testIfCaseWithMissingPattern()` and `SwitchTests.testSwitch4b()` to cover `if case = x` and `case :`, respectively.

All tests pass when run locally.