### PR TITLE
[SwiftWarningControl] Honor `#if` directives in `@diagnose` attributes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -393,12 +393,14 @@ swift_syntax_library(
         ":SwiftDiagnostics",
         ":SwiftParser",
         ":SwiftSyntax",
+        ":SwiftIfConfig",
     ],
 )
 
 swift_syntax_test(
     name = "SwiftWarningControlTest",
     deps = [
+        ":SwiftIfConfig",
         ":SwiftParser",
         ":SwiftSyntaxMacrosGenericTestSupport",
         ":SwiftWarningControl",

--- a/Package.swift
+++ b/Package.swift
@@ -185,7 +185,7 @@ let package = Package(
 
     .target(
       name: "SwiftWarningControl",
-      dependencies: ["SwiftSyntax", "SwiftParser", "SwiftDiagnostics"],
+      dependencies: ["SwiftSyntax", "SwiftParser", "SwiftDiagnostics", "SwiftIfConfig"],
       exclude: ["CMakeLists.txt", "SwiftWarningControl.md"]
     ),
 
@@ -193,6 +193,7 @@ let package = Package(
       name: "SwiftWarningControlTest",
       dependencies: [
         "_SwiftSyntaxTestSupport",
+        "SwiftIfConfig",
         "SwiftWarningControl",
         "SwiftParser",
         "SwiftSyntaxMacrosGenericTestSupport",

--- a/Sources/SwiftIfConfig/ConfiguredRegions.swift
+++ b/Sources/SwiftIfConfig/ConfiguredRegions.swift
@@ -128,6 +128,13 @@ extension ConfiguredRegions: CustomDebugStringConvertible {
   }
 }
 
+extension ConfiguredRegions {
+  /// A `ConfiguredRegions` with no `#if` regions; every node is `.active`.
+  public static var empty: ConfiguredRegions {
+    ConfiguredRegions(regions: [], activeClauses: [:], diagnostics: [])
+  }
+}
+
 extension IfConfigClauseSyntax {
   /// The effective start of the region after which code is subject to its
   /// condition.

--- a/Sources/SwiftWarningControl/CMakeLists.txt
+++ b/Sources/SwiftWarningControl/CMakeLists.txt
@@ -17,4 +17,5 @@ add_swift_syntax_library(SwiftWarningControl
 
 target_link_swift_syntax_libraries(SwiftWarningControl PUBLIC
   SwiftSyntax
-  SwiftParser)
+  SwiftParser
+  SwiftIfConfig)

--- a/Sources/SwiftWarningControl/DiagnosticGroupInheritanceTree.swift
+++ b/Sources/SwiftWarningControl/DiagnosticGroupInheritanceTree.swift
@@ -13,7 +13,6 @@
 /// A struct wrapper for a diagnostic group inheritance tree
 /// represented with a dictionary of a group identifier to an array
 /// of its sub-group identifiers.
-@_spi(ExperimentalLanguageFeatures)
 public struct DiagnosticGroupInheritanceTree {
   private let subGroups: [DiagnosticGroupIdentifier: [DiagnosticGroupIdentifier]]
   public init(subGroups: [DiagnosticGroupIdentifier: [DiagnosticGroupIdentifier]]) throws {
@@ -63,7 +62,6 @@ extension DiagnosticGroupInheritanceTree {
 /// Describes the kinds of diagnostics that can occur when processing warning
 /// group control queries. This is an Error-conforming type so we can throw errors when
 /// needed.
-@_spi(ExperimentalLanguageFeatures)
 public enum WarningControlError: Error, CustomStringConvertible {
   case groupInheritanceCycle
 

--- a/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
+++ b/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
+import SwiftIfConfig
 import SwiftSyntax
 
 extension SyntaxProtocol {
@@ -20,6 +21,7 @@ extension SyntaxProtocol {
   /// there is not one.
   /// - Parameters:
   ///   - for diagnosticGroupIdentifier: The identifier of the diagnostic group.
+  ///   - configuredRegions: configured regions of the current syntax tree.
   ///   - globalControls: The global controls to consider, specified by the client (compiler)
   ///     representing module-wide diagnostic group emission configuration, for example
   ///     with `-Wwarning` and `-Werror` flags. These controls can be overriden at
@@ -27,14 +29,35 @@ extension SyntaxProtocol {
   @_spi(ExperimentalLanguageFeatures)
   public func warningGroupControl(
     for diagnosticGroupIdentifier: DiagnosticGroupIdentifier,
+    configuredRegions: ConfiguredRegions,
     globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] = [],
     groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil
   ) -> WarningGroupControl? {
     let warningControlRegions = root.warningGroupControlRegionTreeImpl(
+      configuredRegions: configuredRegions,
       globalControls: globalControls,
       groupInheritanceTree: groupInheritanceTree,
       containing: self.position
     )
     return warningControlRegions.warningGroupControl(at: self.position, for: diagnosticGroupIdentifier)
+  }
+
+  @_spi(ExperimentalLanguageFeatures)
+  @available(
+    *,
+    deprecated,
+    message: "Use warningGroupControl(for:configuredRegions:globalControls:groupInheritanceTree:) instead"
+  )
+  public func warningGroupControl(
+    for diagnosticGroupIdentifier: DiagnosticGroupIdentifier,
+    globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] = [],
+    groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil
+  ) -> WarningGroupControl? {
+    return warningGroupControl(
+      for: diagnosticGroupIdentifier,
+      configuredRegions: ConfiguredRegions.empty,
+      globalControls: globalControls,
+      groupInheritanceTree: groupInheritanceTree
+    )
   }
 }

--- a/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
+++ b/Sources/SwiftWarningControl/SyntaxProtocol+WarningControl.swift
@@ -26,7 +26,6 @@ extension SyntaxProtocol {
   ///     representing module-wide diagnostic group emission configuration, for example
   ///     with `-Wwarning` and `-Werror` flags. These controls can be overriden at
   ///     finer-grained scopes with the `@diagnose` attribute.
-  @_spi(ExperimentalLanguageFeatures)
   public func warningGroupControl(
     for diagnosticGroupIdentifier: DiagnosticGroupIdentifier,
     configuredRegions: ConfiguredRegions,

--- a/Sources/SwiftWarningControl/WarningControlDeclSyntax.swift
+++ b/Sources/SwiftWarningControl/WarningControlDeclSyntax.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftIfConfig
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 extension AttributeSyntax {
@@ -54,14 +55,31 @@ extension AttributeSyntax {
 extension WithAttributesSyntax {
   /// Compute a dictionary of all `@diagnose` diagnostic group behavior controls
   /// specified on this warning control declaration scope.
-  var allWarningGroupControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] {
-    attributes.reduce(into: [(DiagnosticGroupIdentifier, WarningGroupControl)]()) { result, attr in
-      guard case .attribute(let attributeSyntax) = attr,
-        let warningGroupControl = attributeSyntax.warningGroupControl
-      else {
-        return
+  func allWarningGroupControls(
+    in configuredRegions: ConfiguredRegions
+  ) -> [(DiagnosticGroupIdentifier, WarningGroupControl)] {
+    attributes.warningGroupControls(in: configuredRegions)
+  }
+}
+
+extension AttributeListSyntax {
+  fileprivate func warningGroupControls(
+    in configuredRegions: ConfiguredRegions
+  ) -> [(DiagnosticGroupIdentifier, WarningGroupControl)] {
+    reduce(into: []) { result, element in
+      switch element {
+      case .attribute(let attr):
+        if let control = attr.warningGroupControl {
+          result.append(control)
+        }
+      case .ifConfigDecl(let ifConfig):
+        guard let activeClause = configuredRegions.activeClause(for: ifConfig),
+          case .attributes(let nested) = activeClause.elements
+        else {
+          return
+        }
+        result.append(contentsOf: nested.warningGroupControls(in: configuredRegions))
       }
-      result.append(warningGroupControl)
     }
   }
 }

--- a/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
@@ -34,7 +34,6 @@ extension SyntaxProtocol {
   ///   - groupInheritanceTree: An optional inheritance tree describing parent/child
   ///     relationships between diagnostic groups. When provided, a control applied
   ///     to a parent group also applies to its descendants unless overridden.
-  @_spi(ExperimentalLanguageFeatures)
   public func warningGroupControlRegionTree(
     configuredRegions: ConfiguredRegions,
     globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] = [],

--- a/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegionBuilder.swift
@@ -10,16 +10,56 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftIfConfig
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 /// Compute the full set of warning control regions in this syntax node
 extension SyntaxProtocol {
+  /// Compute the tree of warning control regions for this syntax node, representing
+  /// the effect of every `@diagnose` attribute reachable through the active
+  /// branches of `#if` directives.
+  ///
+  /// The returned tree can be queried with `warningGroupControl(at:for:)` to
+  /// determine the effective `WarningGroupControl` for a given diagnostic group
+  /// at any position within this node.
+  ///
+  /// - Parameters:
+  ///   - configuredRegions: The configured regions of the current syntax tree.
+  ///     Used to resolve `#if` directives so that only `@diagnose` attributes
+  ///     in active clauses contribute to the resulting tree.
+  ///   - globalControls: The global controls to consider, specified by the client,
+  ///     representing module-wide diagnostic group emission configuration, for example
+  ///     with `-Wwarning` and `-Werror` flags. These controls can be overriden at
+  ///     finer-grained scopes with the `@diagnose` attribute.
+  ///   - groupInheritanceTree: An optional inheritance tree describing parent/child
+  ///     relationships between diagnostic groups. When provided, a control applied
+  ///     to a parent group also applies to its descendants unless overridden.
+  @_spi(ExperimentalLanguageFeatures)
+  public func warningGroupControlRegionTree(
+    configuredRegions: ConfiguredRegions,
+    globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] = [],
+    groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil
+  ) -> WarningControlRegionTree {
+    return warningGroupControlRegionTreeImpl(
+      configuredRegions: configuredRegions,
+      globalControls: globalControls,
+      groupInheritanceTree: groupInheritanceTree
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Use warningGroupControlRegionTree(configuredRegions:globalControls:groupInheritanceTree:) instead"
+  )
   @_spi(ExperimentalLanguageFeatures)
   public func warningGroupControlRegionTree(
     globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] = [],
     groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil
   ) -> WarningControlRegionTree {
+    let emptyRegions = ConfiguredRegions.empty
     return warningGroupControlRegionTreeImpl(
+      configuredRegions: emptyRegions,
       globalControls: globalControls,
       groupInheritanceTree: groupInheritanceTree
     )
@@ -30,6 +70,7 @@ extension SyntaxProtocol {
   /// a specific absolute position - meant to speed up tree generation for individual
   /// queries.
   func warningGroupControlRegionTreeImpl(
+    configuredRegions: ConfiguredRegions,
     globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)],
     groupInheritanceTree: DiagnosticGroupInheritanceTree?,
     containing position: AbsolutePosition? = nil
@@ -37,7 +78,8 @@ extension SyntaxProtocol {
     let visitor = WarningControlRegionVisitor(
       self.range,
       containing: position,
-      groupInheritanceTree: groupInheritanceTree
+      groupInheritanceTree: groupInheritanceTree,
+      configuredRegions: configuredRegions
     )
     visitor.tree.addWarningGroupControls(range: self.range, controls: globalControls)
     visitor.walk(self)
@@ -51,13 +93,13 @@ extension WarningControlRegionTree {
   mutating func addWarningControlRegions(for syntax: some WithAttributesSyntax) {
     addWarningGroupControls(
       range: syntax.range,
-      controls: syntax.allWarningGroupControls
+      controls: syntax.allWarningGroupControls(in: configuredRegions)
     )
   }
 }
 
 /// Helper class that walks a syntax tree looking for warning behavior control regions.
-private class WarningControlRegionVisitor: SyntaxAnyVisitor {
+private class WarningControlRegionVisitor: ActiveSyntaxAnyVisitor {
   /// The tree of warning control regions we have found so far
   var tree: WarningControlRegionTree
   let containingPosition: AbsolutePosition?
@@ -65,11 +107,16 @@ private class WarningControlRegionVisitor: SyntaxAnyVisitor {
   init(
     _ topLevelRange: Range<AbsolutePosition>,
     containing position: AbsolutePosition?,
-    groupInheritanceTree: DiagnosticGroupInheritanceTree?
+    groupInheritanceTree: DiagnosticGroupInheritanceTree?,
+    configuredRegions: ConfiguredRegions
   ) {
-    self.tree = WarningControlRegionTree(range: topLevelRange, groupInheritanceTree: groupInheritanceTree)
+    self.tree = WarningControlRegionTree(
+      range: topLevelRange,
+      configuredRegions: configuredRegions,
+      groupInheritanceTree: groupInheritanceTree
+    )
     containingPosition = position
-    super.init(viewMode: .fixedUp)
+    super.init(viewMode: .fixedUp, configuredRegions: configuredRegions)
   }
 
   override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftWarningControl/WarningControlRegions.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegions.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftIfConfig
 import SwiftSyntax
 
 /// A single warning control region, consisting of a start and end positions,
@@ -103,6 +104,9 @@ public struct WarningControlRegionTree {
   /// Root region representing top-level (file) scope
   private var rootRegionNode: WarningControlRegionNode
 
+  /// The configured regions for this tree
+  let configuredRegions: ConfiguredRegions
+
   /// All of the diagnostic group identifiers contained in this tree
   /// which have at least one occurence with a non-`ignored` behavior
   /// specifier
@@ -114,9 +118,11 @@ public struct WarningControlRegionTree {
 
   init(
     range: Range<AbsolutePosition>,
+    configuredRegions: ConfiguredRegions,
     groupInheritanceTree: DiagnosticGroupInheritanceTree?
   ) {
     self.rootRegionNode = WarningControlRegionNode(range: range)
+    self.configuredRegions = configuredRegions
     self.groupInheritanceTree = groupInheritanceTree ?? DiagnosticGroupInheritanceTree()
   }
 

--- a/Sources/SwiftWarningControl/WarningControlRegions.swift
+++ b/Sources/SwiftWarningControl/WarningControlRegions.swift
@@ -15,7 +15,6 @@ import SwiftSyntax
 
 /// A single warning control region, consisting of a start and end positions,
 /// a diagnostic group identifier, and an emission behavior control specifier.
-@_spi(ExperimentalLanguageFeatures)
 public struct WarningControlRegion {
   public let range: Range<AbsolutePosition>
   public let diagnosticGroupIdentifier: DiagnosticGroupIdentifier
@@ -33,7 +32,6 @@ public struct WarningControlRegion {
 }
 
 /// A struct representing a diagnostic group identifier string
-@_spi(ExperimentalLanguageFeatures)
 public struct DiagnosticGroupIdentifier: Hashable, Sendable, ExpressibleByStringLiteral {
   public init(stringLiteral value: String) {
     self.identifier = value
@@ -99,7 +97,6 @@ public struct DiagnosticGroupIdentifier: Hashable, Sendable, ExpressibleByString
 /// traversal until we find the first containing region which specifies warning
 /// behavior control for the given diagnostic group id.
 ///
-@_spi(ExperimentalLanguageFeatures)
 public struct WarningControlRegionTree {
   /// Root region representing top-level (file) scope
   private var rootRegionNode: WarningControlRegionNode
@@ -110,7 +107,6 @@ public struct WarningControlRegionTree {
   /// All of the diagnostic group identifiers contained in this tree
   /// which have at least one occurence with a non-`ignored` behavior
   /// specifier
-  @_spi(ExperimentalLanguageFeatures)
   public private(set) var enabledGroups: Set<DiagnosticGroupIdentifier> = []
 
   /// Inheritance tree among diagnostic group identifiers
@@ -214,7 +210,6 @@ extension WarningControlRegionTree: CustomDebugStringConvertible {
 extension WarningControlRegionTree {
   /// Determine the warning group behavior control at a specified position
   /// for a given diagnostic group.
-  @_spi(ExperimentalLanguageFeatures)
   public func warningGroupControl(
     at position: AbsolutePosition,
     for diagnosticGroupIdentifier: DiagnosticGroupIdentifier

--- a/Sources/SwiftWarningControl/WarningGroupControl.swift
+++ b/Sources/SwiftWarningControl/WarningGroupControl.swift
@@ -13,7 +13,6 @@
 import SwiftSyntax
 
 // Describes the emission behavior state of a particular warning diagnostic group.
-@_spi(ExperimentalLanguageFeatures)
 public enum WarningGroupControl: String {
   /// Emitted as a fatal error, halting compilation
   case error

--- a/Tests/SwiftWarningControlTest/WarningControlTests.swift
+++ b/Tests/SwiftWarningControlTest/WarningControlTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftIfConfig
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 @_spi(ExperimentalLanguageFeatures) import SwiftWarningControl
@@ -95,9 +96,16 @@ public class WarningGroupControlTests: XCTestCase {
         }
       }
       """
+    let buildConfig = StaticBuildConfiguration(
+      customConditions: [],
+      languageVersion: VersionTuple(5, 5),
+      compilerVersion: VersionTuple(6, 0)
+    )
+
     var parser = Parser(source)
     let parseTree = SourceFileSyntax.parse(from: &parser)
-    let warningControlTree = parseTree.warningGroupControlRegionTree()
+    let configuredRegions = parseTree.configuredRegions(in: buildConfig)
+    let warningControlTree = parseTree.warningGroupControlRegionTree(configuredRegions: configuredRegions)
     let enabledDiagnosticGroups = warningControlTree.enabledGroups
     XCTAssertTrue(enabledDiagnosticGroups.contains("Group1"))
     XCTAssertTrue(enabledDiagnosticGroups.contains("Group2"))
@@ -462,12 +470,282 @@ public class WarningGroupControlTests: XCTestCase {
       ]
     )
   }
+
+  /// `@diagnose` inside an active `#if` clause overrides the outer attribute.
+  func testIfConfigActiveAttributeOverridesOuter() throws {
+    try assertWarningGroupControl(
+      """
+      @diagnose(GroupID, as: warning)
+      #if STRICT
+      @diagnose(GroupID, as: error)
+      #endif
+      func foo() {
+        1️⃣let x = 1
+      }
+      """,
+      customConditions: ["STRICT"],
+      diagnosticGroupID: "GroupID",
+      states: [
+        "1️⃣": .error
+      ]
+    )
+  }
+
+  /// `@diagnose` inside an inactive `#if` clause does not contribute; the
+  /// outer attribute remains in effect.
+  func testIfConfigInactiveAttributeIgnored() throws {
+    try assertWarningGroupControl(
+      """
+      @diagnose(GroupID, as: warning)
+      #if STRICT
+      @diagnose(GroupID, as: error)
+      #endif
+      func foo() {
+        1️⃣let x = 1
+      }
+      """,
+      diagnosticGroupID: "GroupID",
+      states: [
+        "1️⃣": .warning
+      ]
+    )
+  }
+
+  /// `#if` with no outer `@diagnose`: when the condition is false, no control
+  /// applies; when true, the inner attribute applies.
+  func testIfConfigStandaloneInsideAttributes() throws {
+    try assertWarningGroupControl(
+      """
+      #if STRICT
+      @diagnose(GroupID, as: error)
+      #endif
+      func foo() {
+        1️⃣let x = 1
+      }
+      """,
+      diagnosticGroupID: "GroupID",
+      states: [
+        "1️⃣": nil
+      ]
+    )
+
+    try assertWarningGroupControl(
+      """
+      #if STRICT
+      @diagnose(GroupID, as: error)
+      #endif
+      func foo() {
+        1️⃣let x = 1
+      }
+      """,
+      customConditions: ["STRICT"],
+      diagnosticGroupID: "GroupID",
+      states: [
+        "1️⃣": .error
+      ]
+    )
+  }
+
+  /// `#else` clause is honored when the `#if` condition is false.
+  func testIfConfigElseClause() throws {
+    let source =
+      """
+      #if STRICT
+      @diagnose(GroupID, as: error)
+      #else
+      @diagnose(GroupID, as: ignored)
+      #endif
+      func foo() {
+        1️⃣let x = 1
+      }
+      """
+
+    try assertWarningGroupControl(
+      source,
+      customConditions: ["STRICT"],
+      diagnosticGroupID: "GroupID",
+      states: ["1️⃣": .error]
+    )
+
+    try assertWarningGroupControl(
+      source,
+      diagnosticGroupID: "GroupID",
+      states: ["1️⃣": .ignored]
+    )
+  }
+
+  /// `#elseif` chains pick the first matching active clause.
+  func testIfConfigElseifChain() throws {
+    let source =
+      """
+      #if STRICT
+      @diagnose(GroupID, as: error)
+      #elseif LENIENT
+      @diagnose(GroupID, as: ignored)
+      #else
+      @diagnose(GroupID, as: warning)
+      #endif
+      func foo() {
+        1️⃣let x = 1
+      }
+      """
+
+    // First clause active.
+    try assertWarningGroupControl(
+      source,
+      customConditions: ["STRICT"],
+      diagnosticGroupID: "GroupID",
+      states: ["1️⃣": .error]
+    )
+
+    // Second clause active.
+    try assertWarningGroupControl(
+      source,
+      customConditions: ["LENIENT"],
+      diagnosticGroupID: "GroupID",
+      states: ["1️⃣": .ignored]
+    )
+
+    // Both conditions present: first clause still wins.
+    try assertWarningGroupControl(
+      source,
+      customConditions: ["STRICT", "LENIENT"],
+      diagnosticGroupID: "GroupID",
+      states: ["1️⃣": .error]
+    )
+
+    // Neither: `#else` wins.
+    try assertWarningGroupControl(
+      source,
+      diagnosticGroupID: "GroupID",
+      states: ["1️⃣": .warning]
+    )
+  }
+
+  /// Nested `#if` directives: only attributes whose enclosing chain is
+  /// fully active are visible.
+  func testIfConfigNested() throws {
+    try assertWarningGroupControl(
+      """
+      #if OUTER
+      #if INNER
+      @diagnose(GroupID, as: error)
+      #endif
+      #endif
+      func foo() {
+        1️⃣let x = 1
+      }
+      """,
+      customConditions: ["OUTER", "INNER"],
+      diagnosticGroupID: "GroupID",
+      states: ["1️⃣": .error]
+    )
+
+    // INNER alone is not enough — the outer #if must also be active.
+    try assertWarningGroupControl(
+      """
+      #if OUTER
+      #if INNER
+      @diagnose(GroupID, as: error)
+      #endif
+      #endif
+      func foo() {
+        1️⃣let x = 1
+      }
+      """,
+      customConditions: ["INNER"],
+      diagnosticGroupID: "GroupID",
+      states: ["1️⃣": nil]
+    )
+  }
+
+  /// Multiple `@diagnose` for distinct groups inside a single `#if`.
+  func testIfConfigMultipleGroups() throws {
+    let source =
+      """
+      #if STRICT
+      @diagnose(GroupA, as: error)
+      @diagnose(GroupB, as: ignored)
+      #endif
+      func foo() {
+        1️⃣let x = 1
+      }
+      """
+
+    try assertWarningGroupControl(
+      source,
+      customConditions: ["STRICT"],
+      diagnosticGroupID: "GroupA",
+      states: ["1️⃣": .error]
+    )
+
+    try assertWarningGroupControl(
+      source,
+      customConditions: ["STRICT"],
+      diagnosticGroupID: "GroupB",
+      states: ["1️⃣": .ignored]
+    )
+  }
+
+  /// Whole-decl `#if`: `ActiveSyntaxAnyVisitor` walks the active branch only,
+  /// so the `@diagnose` on the active clone of `foo()` is recorded.
+  func testIfConfigWholeDeclActive() throws {
+    try assertWarningGroupControl(
+      """
+      #if STRICT
+      @diagnose(GroupID, as: error)
+      func foo() {
+        1️⃣let x = 1
+      }
+      #else
+      @diagnose(GroupID, as: ignored)
+      func foo() {
+        2️⃣let x = 1
+      }
+      #endif
+      """,
+      customConditions: ["STRICT"],
+      diagnosticGroupID: "GroupID",
+      states: [
+        "1️⃣": .error,
+        "2️⃣": nil,
+      ]
+    )
+  }
+
+  /// `#if` declares whole types; the visitor should descend into the active
+  /// clause and record per-member regions correctly.
+  func testIfConfigWholeTypeWithMemberAttributes() throws {
+    try assertWarningGroupControl(
+      """
+      #if STRICT
+      @diagnose(GroupID, as: error)
+      class Foo {
+        @diagnose(GroupID, as: ignored)
+        func bar() {
+          1️⃣let x = 1
+        }
+        func baz() {
+          2️⃣let x = 1
+        }
+      }
+      #endif
+      """,
+      customConditions: ["STRICT"],
+      diagnosticGroupID: "GroupID",
+      states: [
+        "1️⃣": .ignored,
+        "2️⃣": .error,
+      ]
+    )
+  }
 }
 
 /// Assert that the various marked positions in the source code have the
 /// expected warning behavior controls.
 private func assertWarningGroupControl(
   _ markedSource: String,
+  customConditions: Set<String> = [],
   globalControls: [(DiagnosticGroupIdentifier, WarningGroupControl)] = [],
   groupInheritanceTree: DiagnosticGroupInheritanceTree? = nil,
   experimentalFeatures: Parser.ExperimentalFeatures? = nil,
@@ -481,6 +759,13 @@ private func assertWarningGroupControl(
   let experimentalFeatures = experimentalFeatures ?? []
   var parser = Parser(source, experimentalFeatures: experimentalFeatures)
   let tree = SourceFileSyntax.parse(from: &parser)
+  let buildConfig = StaticBuildConfiguration(
+    customConditions: customConditions,
+    languageVersion: VersionTuple(5, 5),
+    compilerVersion: VersionTuple(6, 0)
+  )
+  let configuredRegions = tree.configuredRegions(in: buildConfig)
+
   for (marker, location) in markerLocations {
     guard let expectedState = states[marker] else {
       XCTFail("Missing marker \(marker) in expected states", file: file, line: line)
@@ -494,21 +779,23 @@ private func assertWarningGroupControl(
     }
 
     let warningControlRegions = tree.warningGroupControlRegionTree(
+      configuredRegions: configuredRegions,
       globalControls: globalControls,
       groupInheritanceTree: groupInheritanceTree
     )
 
     let groupControl = token.warningGroupControl(
       for: diagnosticGroupID,
+      configuredRegions: configuredRegions,
       globalControls: globalControls,
       groupInheritanceTree: groupInheritanceTree
     )
-    XCTAssertEqual(groupControl, expectedState)
+    XCTAssertEqual(groupControl, expectedState, "marker \(marker)", file: file, line: line)
 
     let groupControlViaRegions = warningControlRegions.warningGroupControl(
       at: absolutePosition,
       for: diagnosticGroupID
     )
-    XCTAssertEqual(groupControlViaRegions, expectedState)
+    XCTAssertEqual(groupControlViaRegions, expectedState, "marker \(marker) (via regions)", file: file, line: line)
   }
 }


### PR DESCRIPTION
`@diagnose` attributes wrapped in an `#if` directives within an attribute list were silently dropped because `WithAttributesSyntax.allWarningGroupControls` only matched the `.attribute` case, and `WarningControlRegionVisitor` walked the raw parsed syntax with no build-configuration awareness.

This change plumbs `ConfiguredRegions` through `warningGroupControlRegionTree(...)` and `SyntaxProtocol.warningGroupControl(for:...)`. The attribute list extraction now descends into `IfConfigDecl` elements via `ConfiguredRegions.activeClause` and recurses through nested `#if`s. `WarningControlRegionVisitor` now subclasses `ActiveSyntaxAnyVisitor` so whole-decl `#if` clauses contribute regions only when active.

For the time being, to ease transition with the compiler client code, the existing overloads without a `ConfiguredRegions` parameter are kept and marked deprecated, they forward to the new entry points using a new public `ConfiguredRegions.empty` constant, which matches today's behavior of dropping all `#if`-wrapped attributes.

Compile adoption PR: https://github.com/swiftlang/swift/pull/89077

Resolves rdar://176454319