### PR TITLE
Add @unknown default to switch over RawSameTypeRequirementSyntax.LeftType

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -916,6 +916,10 @@ extension Parser {
               )
             )
           }
+        #if RESILIENT_LIBRARIES
+        @unknown default:
+          fatalError()
+        #endif
         }
 
         keepGoing = self.consume(if: .comma)


### PR DESCRIPTION
Hello!

The switch over `firstArgument` in `parseGenericWhereClauseRequirements` (around `Sources/SwiftParser/Declarations.swift:766`) only handles `.expr` and `.type`. `RawSameTypeRequirementSyntax.LeftType` is a public enum that isn't `@frozen`, so consumers building swift-syntax with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES` hit:

```
error: switch covers known cases, but 'RawSameTypeRequirementSyntax.LeftType' may have additional unknown values
```

The same situation was already addressed across the codebase in eee827f7 by wrapping such switches in `#if RESILIENT_LIBRARIES @unknown default: fatalError() #endif`. This switch was added later and is missing the clause, so the PR just brings it in line.

I ran into this while archiving an XCFramework that links a `.macro` target depending on swift-syntax.