### PR TITLE
Remove spurious leading newline in `AttributeRemover`

### DIFF
--- a/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacroExpansion/MacroSystem.swift
@@ -527,6 +527,16 @@ public class AttributeRemover: SyntaxRewriter {
 
   var triviaToAttachToNextToken: Trivia = Trivia()
 
+  /// When `true`, the next call to `prependAndClearAccumulatedTrivia(to:)`
+  /// should also drop one leading newline (and any spaces/tabs that
+  /// immediately precede it) from the resulting trivia.
+  ///
+  /// This is set when we remove an attribute that occupies its own line but
+  /// whose own leading trivia does not contain the line-terminating newline
+  /// (e.g. the attribute is the first token of the file, so the newline
+  /// terminating its line lives on the following node).
+  var dropLeadingNewlineOnNextNode: Bool = false
+
   /// Initializes an attribute remover with a given predicate to determine which attributes to remove.
   ///
   /// - Parameter predicate: A closure that determines whether a given `AttributeSyntax` should be removed.
@@ -560,6 +570,16 @@ public class AttributeRemover: SyntaxRewriter {
           !nextToken.leadingTrivia.isEmpty
         {
           leadingTrivia = Trivia(pieces: leadingTrivia.pieces[..<lastNewline])
+        } else if leadingTrivia.isEmpty,
+          attribute.trailingTrivia.allSatisfy(\.isSpaceOrTab),
+          attribute.previousToken(viewMode: .sourceAccurate)
+            .map({ $0.trailingTrivia.pieces.last?.isNewline ?? false }) ?? true
+        {
+          // The attribute occupies its own line, but the newline terminating that
+          // line lives on a following node (either the next attribute or the next
+          // token on a following node) rather than on this attribute. Record that
+          // we need to drop that newline when we attach accumulated trivia.
+          dropLeadingNewlineOnNextNode = true
         }
 
         // Drop any spaces or tabs from the trailing trivia because there’s no
@@ -609,12 +629,30 @@ public class AttributeRemover: SyntaxRewriter {
   /// significant trivia accumulated from removed attributes to the provided subsequent node.
   /// Once attached, the accumulated trivia is cleared.
   ///
+  /// If `dropLeadingNewlineOnNextNode` is `true`, this function additionally
+  /// drops one leading newline (and any spaces or tabs that precede it) from
+  /// the combined trivia, removing the line vacated by a removed attribute
+  /// whose own leading trivia did not include that newline.
+  ///
   /// - Parameter node: The syntax node receiving the accumulated trivia.
   /// - Returns: The modified syntax node with the prepended trivia.
   private func prependAndClearAccumulatedTrivia<T: SyntaxProtocol>(to syntaxNode: T) -> T {
-    guard !triviaToAttachToNextToken.isEmpty else { return syntaxNode }
-    defer { triviaToAttachToNextToken = Trivia() }
-    return syntaxNode.with(\.leadingTrivia, triviaToAttachToNextToken + syntaxNode.leadingTrivia)
+    guard !triviaToAttachToNextToken.isEmpty || dropLeadingNewlineOnNextNode else {
+      return syntaxNode
+    }
+    defer {
+      triviaToAttachToNextToken = Trivia()
+      dropLeadingNewlineOnNextNode = false
+    }
+
+    var combined = triviaToAttachToNextToken + syntaxNode.leadingTrivia
+    if dropLeadingNewlineOnNextNode,
+      let firstNewline = combined.pieces.firstIndex(where: \.isNewline),
+      combined.pieces[..<firstNewline].allSatisfy(\.isSpaceOrTab)
+    {
+      combined = Trivia(pieces: combined.pieces[combined.index(after: firstNewline)...])
+    }
+    return syntaxNode.with(\.leadingTrivia, combined)
   }
 }
 

--- a/Tests/SwiftSyntaxMacroExpansionTest/AttributeRemoverTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AttributeRemoverTests.swift
@@ -59,25 +59,23 @@ final class AttributeRemoverTests: XCTestCase {
     )
   }
 
-  // FIXME: `AttributeRemover` should not leave a leading newline.
   func testEmptyOnOwnLineBeforeVariable() {
     assertSyntaxRemovingTestAttributes(
       """
       @Test
       var x: Int
       """,
-      reduction: "\nvar x: Int"
+      reduction: "var x: Int"
     )
   }
 
-  // FIXME: `AttributeRemover` should not leave a leading newline.
   func testEmptyTwiceOnOwnLineBeforeVariable() {
     assertSyntaxRemovingTestAttributes(
       """
       @Test @Test
       var x: Int
       """,
-      reduction: "\nvar x: Int"
+      reduction: "var x: Int"
     )
   }
 
@@ -166,7 +164,6 @@ final class AttributeRemoverTests: XCTestCase {
     )
   }
 
-  // FIXME: `AttributeRemover` should not leave a leading newline.
   func testEmptyNewlineBlockComment() {
     assertSyntaxRemovingTestAttributes(
       """
@@ -175,7 +172,7 @@ final class AttributeRemoverTests: XCTestCase {
       var value: Int
       """,
       reduction: """
-        \n/* comment */
+        /* comment */
         var value: Int
         """
     )
@@ -339,7 +336,6 @@ final class AttributeRemoverTests: XCTestCase {
     )
   }
 
-  // FIXME: `AttributeRemover` should not leave a leading newline.
   func testEmptyAndAttributeOnOwnLinesBeforeVariable() {
     assertSyntaxRemovingTestAttributes(
       """
@@ -348,7 +344,7 @@ final class AttributeRemoverTests: XCTestCase {
       var x: Int
       """,
       reduction: """
-        \n@State
+        @State
         var x: Int
         """
     )
@@ -367,14 +363,13 @@ final class AttributeRemoverTests: XCTestCase {
     )
   }
 
-  // FIXME: `AttributeRemover` should not leave a leading newline.
   func testEmptyOnOwnLineThenEmptyBeforeVariable() {
     assertSyntaxRemovingTestAttributes(
       """
       @Test
       @Test var x: Int
       """,
-      reduction: "\nvar x: Int"
+      reduction: "var x: Int"
     )
   }
 


### PR DESCRIPTION
Closes #2269.

`AttributeRemover` left behind a leading newline when the removed attribute had no leading trivia of its own. The existing cleanup logic trims back through the attribute's leading trivia up to its last newline, which works when the attribute carries the line-terminating newline (e.g. removing `@Test` from `@State\n@Test\nvar x`), but does nothing when the newline lives downstream on a following node (e.g. removing `@Test` from `@Test\nvar x`, where the newline lives on the leading trivia of `var`).

This PR adds a complementary forward-trim signal. When an attribute that occupies its own line is removed, but it contributes no line-terminating newline of its own, a flag is set that causes the next `prependAndClearAccumulatedTrivia(to:)` call to drop one leading newline from the combined `triviaToAttachToNextToken + node.leadingTrivia`. A kept attribute encountered before the next token consumes the flag, so the newline is dropped from whichever node the trivia attaches to.

## Testing

This PR updates 5 existing tests in `AttributeRemoverTests` to expect the correct reduction.