### PR TITLE
Build `AddCompletionHandler` body as `CodeBlockSyntax`

### DIFF
--- a/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/PeerMacroTests.swift
@@ -102,15 +102,13 @@ final class PeerMacroTests: XCTestCase {
       let call: ExprSyntax =
         "\(funcDecl.name)(\(raw: callArguments.joined(separator: ", ")))"
 
-      // FIXME: We should make CodeBlockSyntax ExpressibleByStringInterpolation,
-      // so that the full body could go here.
-      let newBody: ExprSyntax =
+      let newBody: CodeBlockSyntax =
         """
-
+        {
           Task {
             completionHandler(await \(call))
           }
-
+        }
         """
 
       // Drop the @addCompletionHandler attribute from the new declaration.
@@ -126,7 +124,7 @@ final class PeerMacroTests: XCTestCase {
       newFunc.signature.returnClause = nil  // drop result type
       newFunc.signature.parameterClause.parameters = newParameterList
       newFunc.signature.parameterClause.trailingTrivia = []
-      newFunc.body = CodeBlockSyntax { newBody }
+      newFunc.body = newBody
       newFunc.attributes = newAttributeList
 
       return [DeclSyntax(newFunc)]


### PR DESCRIPTION
The `AddCompletionHandler` peer macro in `PeerMacroTests` had a FIXME noting that `CodeBlockSyntax` should be made `ExpressibleByStringInterpolation` so the synthesized function body could be written directly. That conformance exists today, so this PR resolves the FIXME by building the body as a `CodeBlockSyntax` literal and assigning it directly, instead of parsing an `ExprSyntax` and wrapping it via `CodeBlockSyntax { newBody }`.