### PR TITLE
Remove stale `testBinOpDisambiguation28()` FIXME

### DIFF
--- a/Tests/SwiftParserTest/RegexLiteralTests.swift
+++ b/Tests/SwiftParserTest/RegexLiteralTests.swift
@@ -916,7 +916,6 @@ final class RegexLiteralTests: ParserTestCase {
   }
 
   func testBinOpDisambiguation28() {
-    // FIXME: The diagnostic should be one character back
     assertParse(
       #"""
       \1️⃣ /^ x/


### PR DESCRIPTION
`RegexLiteralTests.testBinOpDisambiguation28()` was added in ec2f3d3 with a FIXME noting the `expected root in key path` diagnostic was emitted one character too far forward. The diagnostic position was corrected in 30b891c as part of broader work on incorrect fix-it insertion locations. The marker location was updated, but the FIXME was left behind. This PR removes the FIXME.