### PR TITLE
Describe a missing decl with attributes or modifiers as "declaration"

### DIFF
--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -178,6 +178,28 @@ func nodesDescriptionAndCommonParent(
   return (nil, formatDescriptions(partDescriptions))
 }
 
+/// Like `nodesDescriptionAndCommonParent`, but applies special-case overrides
+/// for missing-node arrangements whose surrounding context would otherwise
+/// produce a misleading description.
+private func missingNodesDescriptionAndCommonParent(
+  _ missingNodes: [Syntax],
+  format: Bool
+) -> (commonAncestor: Syntax?, description: String) {
+  // When producing a description for a single `MissingDeclSyntax` that already
+  // carries attributes or modifiers, the parser has committed to "this should
+  // be a declaration"; describe it that way directly. The general climb logic
+  // in `nodesDescriptionAndCommonParent` would otherwise pick up the surrounding
+  // container's slot name (e.g. "statements" for a code block), which is accurate
+  // to the grammar but misleading as a description of the missing element.
+  if missingNodes.count == 1,
+    let missingDecl = missingNodes.first?.as(MissingDeclSyntax.self),
+    !missingDecl.attributes.isEmpty || !missingDecl.modifiers.isEmpty
+  {
+    return (nil, "declaration")
+  }
+  return nodesDescriptionAndCommonParent(missingNodes, format: format)
+}
+
 /// Formats an array of descriptions into a single string.
 ///
 /// This function takes an array of descriptions and formats them into a single string. Depending on the number
@@ -337,7 +359,7 @@ public struct MissingNodesError: ParserError {
   }
 
   public var message: String {
-    let (anchor, description) = nodesDescriptionAndCommonParent(missingNodes, format: true)
+    let (anchor, description) = missingNodesDescriptionAndCommonParent(missingNodes, format: true)
     var message = "expected \(description)"
     if let afterClause {
       message += " \(afterClause)"
@@ -367,7 +389,9 @@ public struct InsertTokenFixIt: ParserFixIt {
     self.missingNodes = missingNodes
   }
 
-  public var message: String { "insert \(nodesDescription(missingNodes, format: true))" }
+  public var message: String {
+    "insert \(missingNodesDescriptionAndCommonParent(missingNodes, format: true).description)"
+  }
 }
 
 // MARK: - Generate Error

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -3419,8 +3419,7 @@ final class RecoveryTests: ParserTestCase {
         ),
       ]),
       diagnostics: [
-        // FIXME: expected *declaration* after attribute
-        DiagnosticSpec(message: "expected statements after attribute", fixIts: ["insert statements"])
+        DiagnosticSpec(message: "expected declaration after attribute", fixIts: ["insert declaration"])
       ],
       fixedSource: """
         func foo() {


### PR DESCRIPTION
`MissingNodesError` already recognizes a `MissingDeclSyntax` carrying attributes or modifiers as a declaration, and `afterClause` uses that signal to produce tailored diagnostics. This PR extends the same recognition to the description half of the message, which is currently computed independently and can disagree.

For example:

```swift
func foo() {
  @attr1️⃣ // error: expected statements after attribute
          // fix-it: insert statements
}
struct S {}
```

The misleading description comes from the climb in the `.node` case of `NodesDescriptionPart.description(format:)`, which walks up through single-child parents looking for a `childNameInParent`. For a `MissingDeclSyntax` alone in a function body's code block, the chain `MissingDecl → CodeBlockItem → CodeBlockItemList` consists entirely of single-child parents, so the climb reaches `CodeBlockItemList` and returns its slot name `"statements"`. For the same `MissingDeclSyntax` at the top level alongside other statements, the surrounding `CodeBlockItemList` has more than one child, the climb terminates early, and the fallback `nodeTypeNameForDiagnostics(allowBlockNames:)` returns `"declaration"`. The diagnostic wording therefore depends on whether other items happen to sit alongside the missing one, which is structural noise unrelated to what the user wrote.

After this PR, the code above produces an `expected declaration` diagnostic and an `insert declaration` fix-it.

## Alternatives considered

### Fix the climb logic

A general fix to the climb logic may involve annotating each collection-typed child's `nameForDiagnostics` with information regarding whether it names the aggregate (e.g. `"statements"`, `"members"`) or an element (e.g. `"condition"` for `ConditionElementListSyntax` in a `guard`). This could be something like `enum NamingKind`, and would be plumbed into `childNameForDiagnostics(_:)` to be consulted during the climb. This is probably the principled solution, but it crosses into code-generation and substantially expands the PR's scope for currently just one FIXME.

### Never take a collection name

The `childNameInParent` of a `SyntaxCollection` names the collection slot (e.g. `"statements"`, `"elements"`, `"arguments"`), not any individual element inside it. When describing a single missing element that happens to be the only thing in such a collection, that name is sometimes misleading, since it would describe the missing thing as if it were the whole list. This change would treat collections as transparent in the climb, so we either find a more specific named slot above, or fall through to the node's own type name.

This is implemented with a one-line change in the `.node` case of `NodesDescriptionPart.description(format:)`:

```diff
      var walk: Syntax = node
      while true {
+       if !walk.kind.isSyntaxCollection, let childName = walk.childNameInParent {
-       if let childName = walk.childNameInParent {
          return childName
        }
        if let parent = walk.parent, parent.children(viewMode: .all).count == 1 {
          walk = parent
        } else {
          break
        }
      }
```

However, the `childNameInParent` of a `SyntaxCollection` isn't always an aggregate name. Some collections (e.g. `ConditionElementListSyntax` in a `guard` statement) carry an element-naming slot name like `"condition"`, which is the correct description for a missing element inside them. The climb has no way to tell these two kinds apart: both are simply `nameForDiagnostics: String` with nothing further to discriminate on, so a general "skip-collections" rule regresses the element-naming cases. Concretely, with this change applied, `GuardTests.testGuard2()` regresses from `expected condition` to `expected expression`, which is accurate but less useful, and inconsistent with the corresponding `guard`/`if`/`while`/`repeat` tests.