### PR TITLE
[PluginMessage] Bump protocol version to 8 for Syntax.Kind.accessor

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
@@ -84,7 +84,7 @@ public enum PluginToHostMessage: Codable {
 
 @_spi(PluginMessage)
 public enum PluginMessage {
-  public static var PROTOCOL_VERSION_NUMBER: Int { 7 }  // Pass extension protocol list
+  public static var PROTOCOL_VERSION_NUMBER: Int { 8 }  // Syntax.Kind.accessor
 
   public struct HostCapability: Codable {
     var protocolVersion: Int


### PR DESCRIPTION
Add `accessor` case to `PluginMessage.Syntax.Kind` and advance `PROTOCOL_VERSION_NUMBER` to 8. This allows the compiler host to identify `AccessorDeclSyntax` nodes distinctly from general declarations in plugin messages, so that plugins on version 8+ can parse them correctly via `AccessorDeclSyntax.parse(from:)` rather than `DeclSyntax.parse(from:)`.