### PR TITLE
[6.4][PluginMessage] Bump protocol version to 8 for Syntax.Kind.accessor

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMessages.swift
@@ -84,7 +84,7 @@ public enum PluginToHostMessage: Codable {
 
 @_spi(PluginMessage)
 public enum PluginMessage {
-  public static var PROTOCOL_VERSION_NUMBER: Int { 7 }  // Pass extension protocol list
+  public static var PROTOCOL_VERSION_NUMBER: Int { 8 }  // Syntax.Kind.accessor
 
   public struct HostCapability: Codable {
     var protocolVersion: Int


### PR DESCRIPTION
Cherry-pick #3339 into release/6.4.x

- **Explanation**: When a macro plugin reports a protocol version less than 8 in its capability handshake, the compiler now sends `"kind":"declaration"` instead of `"kind":"accessor"` for `AccessorDeclSyntax` nodes in plugin messages (both in the `declSyntax` field and in `lexicalContext` entries). `Syntax.Kind.accessor` was introduced in swift-syntax protocol version 8; sending it to an older plugin causes a JSON decode failure because the case is absent from the plugin's decoder.
- **Scope**: Affects macro plugin messaging only. No user-visible language or API changes. Plugins built against swift-syntax ≥ version 8 are unaffected. Older plugins that encounter an `AccessorDeclSyntax` in a lexical context will now receive it as `"kind":"declaration"` and parse it via `DeclSyntax.parse(from:)` — a graceful degradation rather than a crash.
- **Issues**: rdar://177377637
- **Risk**: Low. The change is gated on a runtime protocol version check (`pluginProtocolVersion >= 8`) and only affects the wire representation sent to older plugins. Current plugins built against the latest swift-syntax are unaffected. 
- **Testing**: Added `test/Macros/macro_plugin_accessor_syntax_kind.swift`, which uses mock plugins responding with protocol versions 7 and 8 respectively. The test uses `SWIFT_DUMP_PLUGIN_MESSAGING=1` and `FileCheck` to verify that the accessor node appears as `"kind":"declaration"` in the lexical context for version 7, and `"kind":"accessor"` for version 8.