### PR TITLE
Replace key path with closure in _SwiftSyntaxGenericTestSupport for Embedded Swift

### DIFF
--- a/Sources/_SwiftSyntaxGenericTestSupport/String+TrimmingTrailingWhitespace.swift
+++ b/Sources/_SwiftSyntaxGenericTestSupport/String+TrimmingTrailingWhitespace.swift
@@ -15,7 +15,7 @@ extension String {
     return
       self
       .split(separator: "\n", omittingEmptySubsequences: false)
-      .map { $0.droppingLast(while: \.isWhitespace) }
+      .map { $0.droppingLast(while: { $0.isWhitespace }) }
       .joined(separator: "\n")
   }
 }


### PR DESCRIPTION
## Problem

`_SwiftSyntaxGenericTestSupport` uses a key path (`\.isWhitespace`) in `String.trimmingTrailingWhitespace()`. Key paths are unavailable in Embedded Swift, so the module fails to compile there, as reported in #3227.

## Change

Replace the key-path argument with an explicit closure:

```swift
.map { $0.droppingLast(while: { $0.isWhitespace }) }
```

This is semantically identical to `\.isWhitespace`, valid in both regular and Embedded Swift, and matches the suggested fix in the issue.

## Verification

`swift build` of `_SwiftSyntaxGenericTestSupport` succeeds. The change is behavior-preserving (the closure form evaluates the same predicate), so existing trailing-whitespace trimming behavior is unchanged.

Fixes #3227.
