### PR TITLE
Allow up to five components in `#if compiler()` and `#if canImport()` versions

### DIFF
--- a/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
+++ b/Sources/SwiftIfConfig/IfConfigDiagnostic.swift
@@ -27,7 +27,6 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
   case emptyVersionComponent(syntax: ExprSyntax)
   case compilerVersionOutOfRange(value: Int, upperLimit: Int, syntax: ExprSyntax)
   case compilerVersionSecondComponentNotWildcard(syntax: ExprSyntax)
-  case compilerVersionTooManyComponents(syntax: ExprSyntax)
   case canImportMissingModule(syntax: ExprSyntax)
   case canImportLabel(syntax: ExprSyntax)
   case canImportTwoParameters(syntax: ExprSyntax)
@@ -67,9 +66,6 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
 
     case .compilerVersionSecondComponentNotWildcard(syntax: _):
       return "the second version component is not used for comparison in legacy compiler versions"
-
-    case .compilerVersionTooManyComponents(syntax: _):
-      return "compiler version must not have more than five components"
 
     case .canImportMissingModule(syntax: _):
       return "'canImport' requires a module name"
@@ -126,7 +122,6 @@ enum IfConfigDiagnostic: Error, CustomStringConvertible {
       .invalidVersionOperand(name: _, let syntax),
       .emptyVersionComponent(let syntax),
       .compilerVersionOutOfRange(value: _, upperLimit: _, let syntax),
-      .compilerVersionTooManyComponents(let syntax),
       .compilerVersionSecondComponentNotWildcard(let syntax),
       .canImportMissingModule(let syntax),
       .canImportLabel(let syntax),
@@ -158,7 +153,8 @@ extension IfConfigDiagnostic: DiagnosticMessage {
 
   var severity: SwiftDiagnostics.DiagnosticSeverity {
     switch self {
-    case .compilerVersionSecondComponentNotWildcard, .ignoredTrailingComponents,
+    case .compilerVersionSecondComponentNotWildcard,
+      .ignoredTrailingComponents,
       .likelySimulatorPlatform, .likelyTargetOS, .endiannessDoesNotMatch,
       .macabiIsMacCatalyst:
       return .warning

--- a/Sources/SwiftIfConfig/IfConfigEvaluation.swift
+++ b/Sources/SwiftIfConfig/IfConfigEvaluation.swift
@@ -269,8 +269,26 @@ func evaluateIfConfig(
 
       // Parse the version.
       let opToken = unaryArg.operator
-      guard let version = VersionTuple(parsing: unaryArg.expression.trimmedDescription) else {
+      guard var version = VersionTuple(parsing: unaryArg.expression.trimmedDescription) else {
         return recordError(.invalidVersionOperand(name: fnName, syntax: unaryArg.expression))
+      }
+
+      if version.components.count > 5 {
+        let trailingHighlights = trailingMemberAccessSyntaxes(
+          of: unaryArg.expression,
+          trailingCount: version.components.count - 5
+        )
+        version.components.removeSubrange(5...)
+        extraDiagnostics.append(
+          Diagnostic(
+            node: unaryArg.expression,
+            message: IfConfigDiagnostic.ignoredTrailingComponents(
+              version: version,
+              syntax: unaryArg.expression
+            ),
+            highlights: trailingHighlights
+          )
+        )
       }
 
       switch opToken.text {
@@ -479,16 +497,25 @@ func evaluateIfConfig(
         }
 
         // Remove excess components from the version,
-        if versionTuple.components.count > 4 {
+        if versionTuple.components.count > 5 {
+          let trailingHighlights = trailingMemberAccessSyntaxes(
+            of: secondArg.expression,
+            trailingCount: versionTuple.components.count - 5
+          )
+
           // Remove excess components.
-          versionTuple.components.removeSubrange(4...)
+          versionTuple.components.removeSubrange(5...)
 
           // Warn that we did this.
           extraDiagnostics.append(
-            IfConfigDiagnostic.ignoredTrailingComponents(
-              version: versionTuple,
-              syntax: secondArg.expression
-            ).asDiagnostic
+            Diagnostic(
+              node: secondArg.expression,
+              message: IfConfigDiagnostic.ignoredTrailingComponents(
+                version: versionTuple,
+                syntax: secondArg.expression
+              ),
+              highlights: trailingHighlights
+            )
           )
         }
 
@@ -675,6 +702,38 @@ private func diagnoseLikelyTargetOSTest(
   guard let replacement = targetOSNameMap[osName] else { return nil }
 
   return IfConfigDiagnostic.likelyTargetOS(syntax: ExprSyntax(reference), replacement: replacement).asDiagnostic
+}
+
+/// Returns the period and component-name tokens of the trailing
+/// `MemberAccessExprSyntax`es of a dotted version expression like
+/// `5.8.1.2.3.4`, suitable for use as ``Diagnostic`` highlights covering the
+/// trailing portion of the version. Returns an empty array when `expr` does
+/// not have at least `trailingCount` member accesses.
+private func trailingMemberAccessSyntaxes(
+  of expr: ExprSyntax,
+  trailingCount: Int
+) -> [Syntax] {
+  // Walk the chain of member accesses, outermost first. Each member access
+  // contributes one component to the version, with the outermost holding the
+  // last component.
+  var memberAccesses: [MemberAccessExprSyntax] = []
+  var current: ExprSyntax = expr
+  while let memberAccess = current.as(MemberAccessExprSyntax.self),
+    let base = memberAccess.base
+  {
+    memberAccesses.append(memberAccess)
+    current = base
+  }
+
+  guard trailingCount > 0, trailingCount <= memberAccesses.count else {
+    return []
+  }
+
+  // `memberAccesses` is outermost-first (last component first), so iterate in
+  // reverse to emit highlights in source order.
+  return memberAccesses.prefix(trailingCount).reversed().flatMap {
+    [Syntax($0.period), Syntax($0.declName)]
+  }
 }
 
 // TARGET_OS_* macros that don’t have a direct Swift equivalent

--- a/Sources/SwiftIfConfig/VersionTuple+Parsing.swift
+++ b/Sources/SwiftIfConfig/VersionTuple+Parsing.swift
@@ -92,7 +92,13 @@ extension VersionTuple {
 
     // Only allowed to specify up to 5 version components.
     if components.count > 5 {
-      throw IfConfigDiagnostic.compilerVersionTooManyComponents(syntax: versionSyntax)
+      components.removeSubrange(5...)
+      extraDiagnostics.append(
+        IfConfigDiagnostic.ignoredTrailingComponents(
+          version: VersionTuple(components: components),
+          syntax: versionSyntax
+        ).asDiagnostic
+      )
     }
 
     // In the beginning, '_compiler_version(string-literal)' was designed for a

--- a/Tests/SwiftIfConfigTest/EvaluateTests.swift
+++ b/Tests/SwiftIfConfigTest/EvaluateTests.swift
@@ -345,6 +345,33 @@ public class EvaluateTests: XCTestCase {
     assertIfConfig("compiler(>=5.8)", .active)
     assertIfConfig("compiler(>=5.9)", .active)
     assertIfConfig("compiler(>=5.10)", .unparsed)
+    assertIfConfig("compiler(>=5.8.0.0.0)", .active)
+    assertIfConfig(
+      "compiler(>=5.8.0.0.0.0)",
+      .active,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "trailing components of version '5.8.0.0.0' are ignored",
+          line: 1,
+          column: 12,
+          severity: .warning,
+          highlights: [".", "0"]
+        )
+      ]
+    )
+    assertIfConfig(
+      "compiler(>=5.10.0.0.0.0)",
+      .unparsed,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "trailing components of version '5.10.0.0.0' are ignored",
+          line: 1,
+          column: 12,
+          severity: .warning,
+          highlights: [".", "0"]
+        )
+      ]
+    )
     assertIfConfig(#"_compiler_version("5009.*.1")"#, .active)
     assertIfConfig(#"_compiler_version("5009.*.3.2.3")"#, .unparsed)
     assertIfConfig(#"_compiler_version("5010.*.0")"#, .unparsed)
@@ -440,10 +467,11 @@ public class EvaluateTests: XCTestCase {
       .inactive,
       diagnostics: [
         DiagnosticSpec(
-          message: "trailing components of version '5009.10.5.4' are ignored",
+          message: "trailing components of version '5009.10.5.4.2' are ignored",
           line: 1,
           column: 44,
-          severity: .warning
+          severity: .warning,
+          highlights: [".", "3", ".", "5"]
         )
       ]
     )


### PR DESCRIPTION
Match the Swift compiler's storage cap of five components instead of four for `canImport(_:_version:)`, and add the same five-component cap to the `compiler(>=...)` evaluation path, which previously enforced none.

When the cap is exceeded, emit a warning using the same `"trailing components of version '...' are ignored"` phrasing as the `canImport` variant, substituting the truncated version actually used for the comparison.

Resolves rdar://112954087.