### PR TITLE
[6.3.3] Add support for Swift Testing in SwiftSyntaxMacrosTestSupport

### DIFF
--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -17,6 +17,9 @@ public import SwiftSyntaxMacroExpansion
 public import SwiftSyntaxMacros
 @_spi(XCTestFailureLocation) public import SwiftSyntaxMacrosGenericTestSupport
 private import XCTest
+#if canImport(Testing)
+private import Testing
+#endif
 #else
 import SwiftIfConfig
 import SwiftSyntax
@@ -48,7 +51,7 @@ public typealias DiagnosticSpec = SwiftSyntaxMacrosGenericTestSupport.Diagnostic
 ///   - indentationWidth: The indentation width used in the expansion.
 ///   - buildConfiguration: a build configuration that will be made available
 ///     to the macro implementation
-/// - SeeAlso: ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:file:line:)``
+/// - SeeAlso: ``assertMacroExpansion(_:expandedSource:diagnostics:macroSpecs:applyFixIts:fixedSource:testModuleName:testFileName:indentationWidth:buildConfiguration:fileID:file:line:column:)``
 ///   to also specify the list of conformances passed to the macro expansion.
 public func assertMacroExpansion(
   _ originalSource: String,
@@ -61,8 +64,10 @@ public func assertMacroExpansion(
   testFileName: String = "test.swift",
   indentationWidth: Trivia = .spaces(4),
   buildConfiguration: (any BuildConfiguration)? = nil,
+  fileID: StaticString = #fileID,
   file: StaticString = #filePath,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) {
   let specs = macros.mapValues { MacroSpec(type: $0) }
   assertMacroExpansion(
@@ -76,8 +81,10 @@ public func assertMacroExpansion(
     testFileName: testFileName,
     indentationWidth: indentationWidth,
     buildConfiguration: buildConfiguration,
+    fileID: fileID,
     file: file,
-    line: line
+    line: line,
+    column: column
   )
 }
 
@@ -110,8 +117,10 @@ public func assertMacroExpansion(
   testFileName: String = "test.swift",
   indentationWidth: Trivia = .spaces(4),
   buildConfiguration: (any BuildConfiguration)? = nil,
+  fileID: StaticString = #fileID,
   file: StaticString = #filePath,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) {
   SwiftSyntaxMacrosGenericTestSupport.assertMacroExpansion(
     originalSource,
@@ -125,11 +134,32 @@ public func assertMacroExpansion(
     indentationWidth: indentationWidth,
     buildConfiguration: buildConfiguration,
     failureHandler: {
+      #if canImport(Testing)
+      // Record a Swift Testing issue.
+      Issue.record(
+        Comment(rawValue: $0.message),
+        sourceLocation: .init(
+          fileID: $0.location.fileID,
+          filePath: $0.location.filePath,
+          line: $0.location.line,
+          column: $0.location.column
+        )
+      )
+      #endif
+
+      #if compiler(<6.4)
+      // Record an XCTest failure.
+      //
+      // Only do this in pre-6.4 toolchains. In 6.4 and later toolchains,
+      // ST-0021: Targeted Interoperability between Swift Testing and XCTest
+      // means that the call to `Issue.record()` above will be propagated to
+      // XCTest as well.
       XCTFail($0.message, file: $0.location.staticFilePath, line: $0.location.unsignedLine)
+      #endif
     },
-    fileID: "",  // Not used in the failure handler
+    fileID: fileID,
     filePath: file,
     line: line,
-    column: 0  // Not used in the failure handler
+    column: column
   )
 }

--- a/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/AccessorMacroTests.swift
@@ -25,7 +25,7 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-private struct ConstantOneGetter: AccessorMacro {
+struct ConstantOneGetter: AccessorMacro {
   static func expansion(
     of node: AttributeSyntax,
     providingAccessorsOf declaration: some DeclSyntaxProtocol,

--- a/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
+++ b/Tests/SwiftSyntaxMacroExpansionTest/SwiftTestingTests.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Testing)
+import Testing
+import SwiftSyntaxMacrosTestSupport
+
+@Suite("Swift Testing Macro Expansion Tests")
+struct SwiftTestingMacroExpansionTests {
+  @Test("Test Happy Path")
+  func testHappyPathWorks() {
+    assertMacroExpansion(
+      """
+      @constantOne
+      var x: Int /*1*/ // hello
+      """,
+      expandedSource: """
+        var x: Int { /*1*/ // hello
+          get {
+            return 1
+          }
+        }
+        """,
+      macros: ["constantOne": ConstantOneGetter.self],
+      indentationWidth: .spaces(2)
+    )
+  }
+
+  @Test("Test Failure")
+  func failureReportedCorrectly() {
+    withKnownIssue {
+      assertMacroExpansion(
+        """
+        @constantOne
+        var x: Int /*1*/ // hello
+        """,
+        expandedSource: """
+          var x: Int { /*1*/ // hello
+            get {
+              return 1
+            }
+          }
+          """,
+        macros: ["constantOne": ConstantOneGetter.self],
+        indentationWidth: .spaces(4),
+        fileID: "ExampleModule/ExampleTest.swift",
+        file: "path/to/ExampleTest.swift",
+        line: 9999,
+        column: 8888
+      )
+    } matching: { issue in
+      guard issue.description.contains("Macro expansion did not produce the expected expanded source") else {
+        return false
+      }
+
+      #expect(
+        issue.sourceLocation
+          == .init(
+            fileID: "ExampleModule/ExampleTest.swift",
+            filePath: "path/to/ExampleTest.swift",
+            line: 9999,
+            column: 8888
+          )
+      )
+
+      return true
+    }
+  }
+}
+#endif


### PR DESCRIPTION
- **Explanation**: This adds support for using the `assertMacroExpansion` API to test macro implementation logic from Swift Testing tests. Until now, it has only been supported from within XCTests, and attempting to use it from Swift Testing could give a false positive since it never reported failures.
- **Scope**: Affects `SwiftSyntaxMacrosTestSupport`, the module used to unit test macro implementations. There should be no change to the behavior of existing tests unless they're passing when they shouldn't be (such as if they're using this API from Swift Testing despite it being unsupported and there are legitimate failures).
- **Issues**: https://github.com/swiftlang/swift-syntax/issues/2720
- **Original PRs**: https://github.com/swiftlang/swift-syntax/pull/3192
- **Risk**: Low, and only affects test code. If clients use swift-syntax and also have a _package_ dependency on Swift Testing, they could encounter nondeterministic build problems. However, that practice is uncommon and [formally discouraged](https://github.com/swiftlang/swift-testing/blob/main/Documentation/Distributions.md) in favor of the toolchain copy.
- **Testing**: Includes new unit tests, and I performed manual testing against a sample package with macro tests.
- **Reviewers**: @rintaro, @0xTim 