### PR TITLE
Add a 603 release note about Swift Testing support in SwiftSyntaxMacrosTestSupport

### DIFF
--- a/Release Notes/603.md
+++ b/Release Notes/603.md
@@ -12,6 +12,14 @@
 
 ## API Behavior Changes
 
+### 603.0.2
+
+- `SwiftSyntaxMacrosTestSupport` now supports Swift Testing in addition to XCTest
+  - Description: Macro implementations can now be tested using Swift Testing. Calling `assertMacroExpansion()` from a Swift Testing test will record failures as test issues automatically.
+  - Pull Request: https://github.com/swiftlang/swift-syntax/pull/3352
+  - Migration steps: None required. Existing tests using `SwiftSyntaxMacrosTestSupport` with XCTest continue to work unchanged, but you can convert such tests to Swift Testing if desired.
+  - Notes: If your project has an explicit dependency on the `swift-testing` package, rather than using a built-in copy of the `Testing` module, you may encounter build or runtime issues. This is a known limitation of using a non-built-in distribution of Swift Testing; the [Distributions documentation](https://github.com/swiftlang/swift-testing/blob/main/Documentation/Distributions.md) covers this topic in detail. There are two ways to resolve this: (1) remove the dependency on the `swift-testing` package and switch to using a built-in copy, as the [documentation](https://github.com/swiftlang/swift-testing/blob/main/Documentation/Distributions.md) recommends; or (2) import `SwiftSyntaxMacrosGenericTestSupport` instead of `SwiftSyntaxMacrosTestSupport` and supply your own `failureHandler:` closure that calls `Issue.record()` explicitly. (The latter works correctly even when using a package dependency.)
+
 ## Deprecations
 
 ## API-Incompatible Changes


### PR DESCRIPTION
Add a release note to the `603.md` release notes file about the changes originally landed in https://github.com/swiftlang/swift-syntax/pull/3192, which were later included in 6.3 and 6.4 as well:

- [main] https://github.com/swiftlang/swift-syntax/pull/3192
- [6.3] https://github.com/swiftlang/swift-syntax/pull/3352
- [6.4] https://github.com/swiftlang/swift-syntax/pull/3351