### PR TITLE
[Tests] Prevent inlining of a test function

### DIFF
--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -110,11 +110,13 @@ final class StringInterpolationTests: XCTestCase {
     XCTAssertTrue(structNode.is(StructDeclSyntax.self))
   }
 
-  func testSourceFile() {
-    let _: SourceFileSyntax =
+  func testSourceFile() throws {
+    let sourceFile: SourceFileSyntax =
       """
       print("Hello, world!")
       """
+    let expr = try XCTUnwrap(sourceFile.statements.first?.item.as(ExprSyntax.self))
+    XCTAssertTrue(expr.is(FunctionCallExprSyntax.self))
   }
 
   func testInterpolationLiteralString() {


### PR DESCRIPTION
Workaround for https://github.com/swiftlang/swift/issues/88199