### PR TITLE
[6.4][Tests] Prevent inlining of a test function

### DIFF
--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -110,11 +110,13 @@ final class StringInterpolationTests: XCTestCase {
     XCTAssertTrue(structNode.is(StructDeclSyntax.self))
   }
 
-  func testSourceFile() {
-    let _: SourceFileSyntax =
+  func testSourceFile() throws {
+    let sourceFile: SourceFileSyntax =
       """
       print("Hello, world!")
       """
+    let expr = try XCTUnwrap(sourceFile.statements.first?.item.as(ExprSyntax.self))
+    XCTAssertTrue(expr.is(FunctionCallExprSyntax.self))
   }
 
   func testInterpolationLiteralString() {


### PR DESCRIPTION
Cherry-pick #3354 into release/6.4

* **Explanation**: Workaround for an inliner issue where a test function is mistakingly inlined into the test runner object file, causing linker error (missing symbols). To workaround that, add non-trivial test assertions.
* **Scope**: Unit tests
* **Risk**: Low. This is test only changes.
* **Issues**: workaround for rdar://178757853
* **Testing**: Passes the test suite
* **Reviewer**: Hamish Knight (@hamishknight)