### PR TITLE
[CODEOWNERS] Add `xedin` to code owners of `SwiftLexicalLookup`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,10 @@
 /Sources/SwiftOperators @DougGregor @ahoppen @hamishknight @rintaro @hborla
 /Tests/SwiftOperatorsTest @DougGregor @ahoppen @hamishknight @rintaro @hborla
 
+# SwiftLexicalLookup
+/Sources/SwiftLexicalLookup @xedin @ahoppen @hamishknight @rintaro @hborla
+/Tests/SwiftLexicalLookupTest @xedin @ahoppen @hamishknight @rintaro @hborla
+
 /utils/bazel @keith @ahoppen @hamishknight @rintaro @hborla
 *.bazel @keith @ahoppen @hamishknight @rintaro @hborla
 WORKSPACE @keith @ahoppen @hamishknight @rintaro @hborla


### PR DESCRIPTION
I'm helping with GSoC project that is building a new qualified lookup functionality.