### PR TITLE
Allow trailing commas in macro role attribute arguments

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -406,7 +406,7 @@ extension Parser {
     let additionalArgs = self.parseArgumentListElements(
       pattern: .none,
       flavor: .attributeArguments,
-      allowTrailingComma: false
+      allowTrailingComma: true
     )
     return [roleElement] + additionalArgs
   }

--- a/Tests/SwiftParserTest/TrailingCommaTests.swift
+++ b/Tests/SwiftParserTest/TrailingCommaTests.swift
@@ -81,6 +81,12 @@ final class TrailingCommaTests: ParserTestCase {
     assertParse("f(_: @foo(1, 2,) Int)")
   }
 
+  func testMacroRoleAttributes() {
+    assertParse("@attached(member, names: named(foo),) struct S {}")
+
+    assertParse("@freestanding(expression, names: named(foo),) macro stringify<T>(_ value: T)")
+  }
+
   func testMacroExpansionExpressionArguments() {
     assertParse(
       """


### PR DESCRIPTION
Fixes #3306.

`parseMacroRoleArguments` parsed its argument list with `allowTrailingComma: false`, even though the equivalent custom-attribute path already uses `allowTrailingComma: true`. As the issue notes, SE-0439 generalized trailing commas to comma-separated lists like these, and to the user (and in the AST) macro role arguments are a regular `LabeledExprListSyntax`. The `false` looks like an oversight from when trailing-comma support was rolled out (enabled for custom attributes but not for macro role attributes).

### Change
- `Sources/SwiftParser/Attributes.swift`: `parseMacroRoleArguments` now passes `allowTrailingComma: true`, matching the custom-attribute argument path.

### Test
- `Tests/SwiftParserTest/TrailingCommaTests.swift`: added `testMacroRoleAttributes`, mirroring the existing `testCustomAttributes`, covering `@attached(...)` and `@freestanding(...)` with a trailing comma.

Verified the test fails before the change (`expected value in attribute`) and passes after. `TrailingCommaTests`, `AttributeTests`, and `DeclarationTests` all pass with no regressions.