### PR TITLE
Add regression test for comment preservation in func-to-computed-property refactoring

### DIFF
--- a/Tests/SwiftRefactorTest/ConvertZeroParameterFunctionToComputedPropertyTests.swift
+++ b/Tests/SwiftRefactorTest/ConvertZeroParameterFunctionToComputedPropertyTests.swift
@@ -29,6 +29,55 @@ final class ConvertZeroParameterFunctionToComputedPropertyTests: XCTestCase {
     try assertRefactorConvert(baseline, expected: expected)
   }
 
+  func testRefactoringFunctionToComputedPropertyPreservesLeadingComment() throws {
+    try assertRefactorConvert(
+      """
+      /// Some comment
+      func asJSON() -> String { "" }
+      """,
+      expected: """
+        /// Some comment
+        var asJSON: String { "" }
+        """
+    )
+
+    // With a modifier (comment is leading trivia of the modifier).
+    try assertRefactorConvert(
+      """
+      /// Some comment
+      public func asJSON() -> String { "" }
+      """,
+      expected: """
+        /// Some comment
+        public var asJSON: String { "" }
+        """
+    )
+
+    // With an attribute (comment is leading trivia of the attribute).
+    try assertRefactorConvert(
+      """
+      /// Some comment
+      @inlinable func asJSON() -> String { "" }
+      """,
+      expected: """
+        /// Some comment
+        @inlinable var asJSON: String { "" }
+        """
+    )
+
+    // Block doc comment.
+    try assertRefactorConvert(
+      """
+      /** Some comment */
+      func asJSON() -> String { "" }
+      """,
+      expected: """
+        /** Some comment */
+        var asJSON: String { "" }
+        """
+    )
+  }
+
   func testRefactoringFunctionToComputedPropertyWithVoidType() throws {
     let baseline: DeclSyntax = """
       func asJSON() { () }


### PR DESCRIPTION
Refs #3236.

#3236 reports that `ConvertZeroParameterFunctionToComputedProperty` drops a leading comment (e.g. a doc comment) when converting a zero-parameter function to a computed property.

I couldn't reproduce this on `main`: the refactoring already preserves the converted declaration's leading trivia. The binding specifier is derived from the detached `funcKeyword` (which keeps its leading trivia), and `attributes`/`modifiers` are carried over — so the comment survives whether it sits on the `func` keyword, a modifier, or an attribute.

This adds a regression test (`testRefactoringFunctionToComputedPropertyPreservesLeadingComment`) so the behavior stays correct, covering:
- a `///` doc comment with no modifiers,
- a `///` comment with a modifier (`public`),
- a `///` comment with an attribute (`@inlinable`),
- a `/** */` block comment.

All pass on `main`. Given this, #3236 looks resolved and could be closed once this lands (or if someone has a precise case that still drops the comment, the test is a good place to add it).