### PR TITLE
Allow `#warning` and `#error` directives in case position of a switch

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -1941,7 +1941,7 @@ public let EXPR_NODES: [Node] = [
     kind: .switchCaseList,
     base: .syntaxCollection,
     nameForDiagnostics: nil,
-    elementChoices: [.switchCase, .ifConfigDecl]
+    elementChoices: [.switchCase, .ifConfigDecl, .macroExpansionDecl]
   ),
 
   Node(

--- a/Release Notes/604.md
+++ b/Release Notes/604.md
@@ -13,6 +13,11 @@
 
 ## API-Incompatible Changes
 
+- `SwitchCaseListSyntax.Element` gained a new case `macroExpansionDecl`.
+  - Description: `#warning` and `#error` directives in `case` position of a `switch` are now parsed as elements of the switch's case list instead of being diagnosed.
+  - Issue: https://github.com/swiftlang/swift-syntax/issues/3251
+  - Migration steps: In exhaustive switches over `SwitchCaseListSyntax.Element`, cover the new case.
+
 ## Template
 
 - *Affected API or two word description*

--- a/Release Notes/605.md
+++ b/Release Notes/605.md
@@ -1,17 +1,18 @@
-# Swift Syntax 604 Release Notes
+# Swift Syntax 605 Release Notes
 
 ## New APIs
-
-- `Trivia` has a new `docCommentValue` property.
-  - Description: Extracts sanitized comment text from doc comment trivia pieces, omitting leading comment markers (`///`, `/**`).
-  - Pull Request: https://github.com/swiftlang/swift-syntax/pull/2966
-
 
 ## API Behavior Changes
 
 ## Deprecations
 
 ## API-Incompatible Changes
+
+- `SwitchCaseListSyntax.Element` gained a new case `macroExpansionDecl`.
+  - Description: `#warning` and `#error` directives in `case` position of a `switch` are now parsed as elements of the switch's case list instead of being diagnosed.
+  - Issue: https://github.com/swiftlang/swift-syntax/issues/3251
+  - Pull Request: https://github.com/swiftlang/swift-syntax/pull/3363
+  - Migration steps: In exhaustive switches over `SwitchCaseListSyntax.Element`, cover the new case.
 
 ## Template
 

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -2468,17 +2468,10 @@ extension Parser {
     while !self.at(.endOfFile, .rightBrace), !self.atEndOfIfConfigClauseBody(), self.hasProgressed(&elementsProgress) {
       if self.withLookahead({ $0.atStartOfSwitchCase() }) {
         elements.append(.switchCase(self.parseSwitchCase()))
-      } else if self.canRecoverTo(.poundIf) != nil {
-        // '#if' in 'case' position can enclose zero or more 'case' or 'default'
-        // clauses.
-        elements.append(
-          .ifConfigDecl(
-            self.parsePoundIfDirective({ parser in
-              .switchCases(parser.parseSwitchCases(allowStandaloneStmtRecovery: allowStandaloneStmtRecovery))
-            })
-          )
-        )
       } else if self.at(.pound), self.peek().tokenText == "warning" || self.peek().tokenText == "error" {
+        // Check for '#warning'/'#error' before '#if' recovery, otherwise a
+        // later '#if' in the source would cause the directive to be consumed as
+        // unexpected code before that '#if'.
         elements.append(
           .macroExpansionDecl(
             self.parseMacroExpansionDeclaration(
@@ -2488,6 +2481,16 @@ extension Parser {
               ),
               .constant(.pound)
             )
+          )
+        )
+      } else if self.canRecoverTo(.poundIf) != nil {
+        // '#if' in 'case' position can enclose zero or more 'case' or 'default'
+        // clauses.
+        elements.append(
+          .ifConfigDecl(
+            self.parsePoundIfDirective({ parser in
+              .switchCases(parser.parseSwitchCases(allowStandaloneStmtRecovery: allowStandaloneStmtRecovery))
+            })
           )
         )
       } else if allowStandaloneStmtRecovery {

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -2478,6 +2478,18 @@ extension Parser {
             })
           )
         )
+      } else if self.at(.pound), self.peek().tokenText == "warning" || self.peek().tokenText == "error" {
+        elements.append(
+          .macroExpansionDecl(
+            self.parseMacroExpansionDeclaration(
+              DeclAttributes(
+                attributes: self.emptyCollection(RawAttributeListSyntax.self),
+                modifiers: self.emptyCollection(RawDeclModifierListSyntax.self)
+              ),
+              .constant(.pound)
+            )
+          )
+        )
       } else if allowStandaloneStmtRecovery {
         // Synthesize a label for the statement or declaration that isn't covered by a case right now.
         let statements = parseSwitchCaseBody()

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -1751,7 +1751,7 @@ public struct SwitchCaseItemListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// ### Children
 /// 
-/// (``SwitchCaseSyntax`` | ``IfConfigDeclSyntax``) `*`
+/// (``SwitchCaseSyntax`` | ``IfConfigDeclSyntax`` | ``MacroExpansionDeclSyntax``) `*`
 ///
 /// ### Contained in
 /// 
@@ -1778,12 +1778,16 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     /// ```
     case switchCase(SwitchCaseSyntax)
     case ifConfigDecl(IfConfigDeclSyntax)
+    /// The expansion of a freestanding macro in a position that expects a declaration.
+    case macroExpansionDecl(MacroExpansionDeclSyntax)
 
     public var _syntaxNode: Syntax {
       switch self {
       case .switchCase(let node):
         return node._syntaxNode
       case .ifConfigDecl(let node):
+        return node._syntaxNode
+      case .macroExpansionDecl(let node):
         return node._syntaxNode
       }
     }
@@ -1796,18 +1800,24 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
       self = .ifConfigDecl(node)
     }
 
+    public init(_ node: MacroExpansionDeclSyntax) {
+      self = .macroExpansionDecl(node)
+    }
+
     public init?(_ node: __shared some SyntaxProtocol) {
       if let node = node.as(SwitchCaseSyntax.self) {
         self = .switchCase(node)
       } else if let node = node.as(IfConfigDeclSyntax.self) {
         self = .ifConfigDecl(node)
+      } else if let node = node.as(MacroExpansionDeclSyntax.self) {
+        self = .macroExpansionDecl(node)
       } else {
         return nil
       }
     }
 
     public static var structure: SyntaxNodeStructure {
-      return .choices([.node(SwitchCaseSyntax.self), .node(IfConfigDeclSyntax.self)])
+      return .choices([.node(SwitchCaseSyntax.self), .node(IfConfigDeclSyntax.self), .node(MacroExpansionDeclSyntax.self)])
     }
 
     /// Checks if the current syntax node can be cast to ``SwitchCaseSyntax``.
@@ -1852,6 +1862,28 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
     public func cast(_ syntaxType: IfConfigDeclSyntax.Type) -> IfConfigDeclSyntax {
       return self.as(IfConfigDeclSyntax.self)!
+    }
+
+    /// Checks if the current syntax node can be cast to ``MacroExpansionDeclSyntax``.
+    ///
+    /// - Returns: `true` if the node can be cast, `false` otherwise.
+    public func `is`(_ syntaxType: MacroExpansionDeclSyntax.Type) -> Bool {
+      return self.as(syntaxType) != nil
+    }
+
+    /// Attempts to cast the current syntax node to ``MacroExpansionDeclSyntax``.
+    ///
+    /// - Returns: An instance of ``MacroExpansionDeclSyntax``, or `nil` if the cast fails.
+    public func `as`(_ syntaxType: MacroExpansionDeclSyntax.Type) -> MacroExpansionDeclSyntax? {
+      return MacroExpansionDeclSyntax.init(self)
+    }
+
+    /// Force-casts the current syntax node to ``MacroExpansionDeclSyntax``.
+    ///
+    /// - Returns: An instance of ``MacroExpansionDeclSyntax``.
+    /// - Warning: This function will crash if the cast is not possible. Use `as` to safely attempt a cast.
+    public func cast(_ syntaxType: MacroExpansionDeclSyntax.Type) -> MacroExpansionDeclSyntax {
+      return self.as(MacroExpansionDeclSyntax.self)!
     }
   }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodesQRS.swift
@@ -2301,9 +2301,11 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
     /// ```
     case switchCase(RawSwitchCaseSyntax)
     case ifConfigDecl(RawIfConfigDeclSyntax)
+    /// The expansion of a freestanding macro in a position that expects a declaration.
+    case macroExpansionDecl(RawMacroExpansionDeclSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
-      RawSwitchCaseSyntax.isKindOf(raw) || RawIfConfigDeclSyntax.isKindOf(raw)
+      RawSwitchCaseSyntax.isKindOf(raw) || RawIfConfigDeclSyntax.isKindOf(raw) || RawMacroExpansionDeclSyntax.isKindOf(raw)
     }
 
     public var raw: RawSyntax {
@@ -2311,6 +2313,8 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
       case .switchCase(let node):
         return node.raw
       case .ifConfigDecl(let node):
+        return node.raw
+      case .macroExpansionDecl(let node):
         return node.raw
       }
     }
@@ -2320,6 +2324,8 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
         self = .switchCase(node)
       } else if let node = node.as(RawIfConfigDeclSyntax.self) {
         self = .ifConfigDecl(node)
+      } else if let node = node.as(RawMacroExpansionDeclSyntax.self) {
+        self = .macroExpansionDecl(node)
       } else {
         return nil
       }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -2793,7 +2793,8 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     for (index, element) in layout.enumerated() {
       assertAnyHasNoError(kind, index, [
         verify(element, as: RawSwitchCaseSyntax.self),
-        verify(element, as: RawIfConfigDeclSyntax.self)])
+        verify(element, as: RawIfConfigDeclSyntax.self),
+        verify(element, as: RawMacroExpansionDeclSyntax.self)])
     }
   }
   func validateSwitchCaseSyntax(kind: SyntaxKind, layout: RawSyntaxBuffer) {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodesJKLMN.swift
@@ -2661,6 +2661,10 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSynt
 ///  - `rightParen`: `)`?
 ///  - `trailingClosure`: ``ClosureExprSyntax``?
 ///  - `additionalTrailingClosures`: ``MultipleTrailingClosureElementListSyntax``
+///
+/// ### Contained in
+/// 
+///  - ``SwitchCaseListSyntax``
 public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable, _LeafDeclSyntaxNodeProtocol {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -649,6 +649,10 @@ public struct SwitchCaseListBuilder: ListBuilder {
   public static func buildExpression(_ expression: IfConfigDeclSyntax) -> Component {
     buildExpression(.init(expression))
   }
+
+  public static func buildExpression(_ expression: MacroExpansionDeclSyntax) -> Component {
+    buildExpression(.init(expression))
+  }
 }
 
 extension SwitchCaseListSyntax {

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -231,6 +231,39 @@ final class StatementTests: ParserTestCase {
     )
   }
 
+  func testSwitchWithPoundDiagnostic() {
+    assertParse(
+      """
+      switch x {
+      #warning("Something")
+      case "a":
+        break
+      default:
+        break
+      }
+      """,
+      substructure: MacroExpansionDeclSyntax(
+        pound: .poundToken(),
+        macroName: .identifier("warning"),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+          LabeledExprSyntax(expression: StringLiteralExprSyntax(content: "Something"))
+        ]),
+        rightParen: .rightParenToken()
+      )
+    )
+
+    assertParse(
+      """
+      switch x {
+      #error("Something")
+      default:
+        break
+      }
+      """
+    )
+  }
+
   func testCStyleForLoop() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -264,6 +264,66 @@ final class StatementTests: ParserTestCase {
     )
   }
 
+  func testSwitchWithPoundDiagnosticInIfConfig() {
+    assertParse(
+      """
+      switch x {
+      #if DEBUG
+      #warning("Something")
+      #else
+      #error("Something else")
+      #endif
+      case "a":
+        break
+      default:
+        break
+      }
+      """,
+      substructure: IfConfigDeclSyntax(
+        clauses: IfConfigClauseListSyntax([
+          IfConfigClauseSyntax(
+            poundKeyword: .poundIfToken(),
+            condition: DeclReferenceExprSyntax(baseName: .identifier("DEBUG")),
+            elements: .switchCases(
+              SwitchCaseListSyntax([
+                .macroExpansionDecl(
+                  MacroExpansionDeclSyntax(
+                    pound: .poundToken(),
+                    macroName: .identifier("warning"),
+                    leftParen: .leftParenToken(),
+                    arguments: LabeledExprListSyntax([
+                      LabeledExprSyntax(expression: StringLiteralExprSyntax(content: "Something"))
+                    ]),
+                    rightParen: .rightParenToken()
+                  )
+                )
+              ])
+            )
+          ),
+          IfConfigClauseSyntax(
+            poundKeyword: .poundElseToken(),
+            elements: .switchCases(
+              SwitchCaseListSyntax([
+                .macroExpansionDecl(
+                  MacroExpansionDeclSyntax(
+                    pound: .poundToken(),
+                    macroName: .identifier("error"),
+                    leftParen: .leftParenToken(),
+                    arguments: LabeledExprListSyntax([
+                      LabeledExprSyntax(expression: StringLiteralExprSyntax(content: "Something else"))
+                    ]),
+                    rightParen: .rightParenToken()
+                  )
+                )
+              ])
+            )
+          ),
+        ]),
+        poundEndif: .poundEndifToken()
+      )
+    )
+  }
+
   func testCStyleForLoop() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -324,6 +324,123 @@ final class StatementTests: ParserTestCase {
     )
   }
 
+  func testSwitchWithPoundDiagnosticInCaseBody() {
+    // A `#warning`/`#error` after a statement in a case body is parsed as a
+    // statement of that body, not as a new case-list element.
+    assertParse(
+      """
+      switch x {
+      case 1:
+        print()
+      #warning("Something")
+      }
+      """
+    )
+
+    assertParse(
+      """
+      switch x {
+      case 1:
+        print()
+      #warning("Something")
+      case 2:
+        break
+      }
+      """
+    )
+  }
+
+  func testSwitchWithCaseInPoundIfWhenFirstClauseStartsWithCase() {
+    // When the first clause of the `#if` starts with a `case`, the whole
+    // directive is parsed at case-list level, so a `#warning` in another
+    // clause is fine.
+    assertParse(
+      """
+      switch x {
+      case 1:
+        print()
+      #if COND
+      case 2: break
+      #else
+      #warning("Something")
+      #endif
+      }
+      """
+    )
+  }
+
+  func testSwitchWithCaseInPoundIfClauseAfterPoundDiagnostic() {
+    // When the first clause of the `#if` starts with a `#warning`/`#error`, the
+    // directive is parsed at statement level (matching the compiler), so a
+    // `case` in a later clause is diagnosed.
+    assertParse(
+      """
+      switch x {
+      case 1:
+        print()
+      #if COND
+      #warning("Something")
+      #else
+      1️⃣case 2: break
+      #endif
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "'case' can only appear inside a 'switch' statement or 'enum' declaration")
+      ]
+    )
+
+    assertParse(
+      """
+      switch x {
+      case 1:
+        print()
+      #if COND
+      #if COND2
+      #warning("Something")
+      #endif
+      #else
+      #if COND2
+      1️⃣case 2: break
+      #endif
+      #endif
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "'case' can only appear inside a 'switch' statement or 'enum' declaration")
+      ]
+    )
+  }
+
+  func testSwitchWithPoundDiagnosticAfterIfConfig() {
+    // A `#warning`/`#error` following a case-list-level `#if`…`#endif` is parsed
+    // as a `MacroExpansionDecl` sibling of the `IfConfigDecl`, not folded into a
+    // malformed case.
+    assertParse(
+      """
+      switch x {
+      case 1: break
+      #if COND
+      case 2: break
+      #else
+      case 3: break
+      #endif
+      #warning("Something")
+      default: break
+      }
+      """,
+      substructure: MacroExpansionDeclSyntax(
+        pound: .poundToken(),
+        macroName: .identifier("warning"),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+          LabeledExprSyntax(expression: StringLiteralExprSyntax(content: "Something"))
+        ]),
+        rightParen: .rightParenToken()
+      )
+    )
+  }
+
   func testCStyleForLoop() {
     assertParse(
       """

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -441,6 +441,32 @@ final class StatementTests: ParserTestCase {
     )
   }
 
+  func testSwitchWithPoundDiagnosticBeforeLaterIfConfig() {
+    // A '#warning'/'#error' at the start of a switch must be parsed as a
+    // case-list element and not be consumed as unexpected code before a '#if'
+    // that appears later in the source.
+    assertParse(
+      """
+      switch x {
+      #warning("Something")
+      case 1:
+        break
+      }
+      #if FOO
+      #endif
+      """,
+      substructure: MacroExpansionDeclSyntax(
+        pound: .poundToken(),
+        macroName: .identifier("warning"),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+          LabeledExprSyntax(expression: StringLiteralExprSyntax(content: "Something"))
+        ]),
+        rightParen: .rightParenToken()
+      )
+    )
+  }
+
   func testCStyleForLoop() {
     assertParse(
       """


### PR DESCRIPTION
Fixes #3251.

The C++ parser accepts `#warning` and `#error` between switch cases (`parseStmtCases` has a dedicated `pound_warning`/`pound_error` branch), but SwiftParser sent them through the missing-case-label recovery path. As a result, swiftc reported `error: new Swift parser generated errors for code that C++ parser accepted` for code like:

```swift
switch x {
#warning("Something")
case "a":
  break
}
```

Changes:
- Add `macroExpansionDecl` to the element choices of `SwitchCaseListSyntax`, since `#warning`/`#error` are represented as `MacroExpansionDeclSyntax` (there is no dedicated pound-diagnostic node).
- Parse `#warning`/`#error` in `parseSwitchCases` as `macroExpansionDecl` elements. Only these two directives are accepted, mirroring the C++ parser; other macro expansions in case position still go through case-label recovery.
- Add a 604 release note since the new `SwitchCaseListSyntax.Element` case is source-breaking for exhaustive switches.