### PR TITLE
[SwiftDiagnostics] Render attached notes in GroupedDiagnostics

### DIFF
--- a/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
+++ b/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
@@ -260,11 +260,16 @@ extension GroupedDiagnostics {
         ) + boxSuffix + "\n"
     }
 
-    // Render the buffer.
+    // Render the buffer, expanding each diagnostic's attached notes into
+    // note-severity diagnostics so the formatter lays them out too.
+    let diagnostics = sourceFile.diagnostics.flatMap { diagnostic in
+      [diagnostic] + diagnostic.notes.map(\.asDiagnostic)
+    }
+
     return prefixString
       + formatter.annotatedSource(
         tree: sourceFile.tree,
-        diags: sourceFile.diagnostics,
+        diags: diagnostics,
         indentString: diagnosticDecorator.decorateBufferOutline(indentString),
         suffixTexts: childSources,
         sourceLocationConverter: slc
@@ -287,5 +292,21 @@ extension DiagnosticsFormatter {
   ) -> String {
     let formatter = DiagnosticsFormatter(contextSize: contextSize, colorize: colorize)
     return formatter.annotateSources(in: group)
+  }
+}
+
+/// Renders a ``NoteMessage`` as a `.note`-severity ``DiagnosticMessage`` so that
+/// notes can be laid out by ``DiagnosticsFormatter`` alongside their diagnostic.
+private struct NoteAsDiagnosticMessage: DiagnosticMessage {
+  let noteMessage: NoteMessage
+  var message: String { noteMessage.message }
+  var diagnosticID: MessageID { noteMessage.noteID }
+  var severity: DiagnosticSeverity { .note }
+}
+
+extension Note {
+  /// This note expressed as a `.note`-severity diagnostic anchored at its own location.
+  fileprivate var asDiagnostic: Diagnostic {
+    Diagnostic(node: node, position: position, message: NoteAsDiagnosticMessage(noteMessage: noteMessage))
   }
 }

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -85,6 +85,43 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
     )
   }
 
+  func testAttachedNotesAreRendered() {
+    var group = GroupedDiagnostics()
+
+    _ = group.addTestFile(
+      """
+      let 1️⃣value = 2️⃣undefined
+      """,
+      displayName: "test.swift",
+      diagnosticDescriptors: [
+        DiagnosticDescriptor(
+          locationMarker: "2️⃣",
+          message: "cannot find 'undefined' in scope",
+          severity: .error,
+          noteDescriptors: [
+            NoteDescriptor(
+              locationMarker: "1️⃣",
+              id: MessageID(domain: "test", id: "note"),
+              message: "'value' declared here"
+            )
+          ]
+        )
+      ]
+    )
+
+    let annotated = DiagnosticsFormatter.annotateSources(in: group)
+    assertStringsEqualWithDiff(
+      annotated,
+      """
+      test.swift:1:13: error: cannot find 'undefined' in scope
+      1 | let value = undefined
+        |     |       `- error: cannot find 'undefined' in scope
+        |     `- note: 'value' declared here
+
+      """
+    )
+  }
+
   func testGroupingForMacroExpansion() {
     var group = GroupedDiagnostics()
 
@@ -147,7 +184,8 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
         |5 | }
         +---------------------------------------------------------------------
       6 | print("hello"
-        |              `- error: expected ')' to end function call
+        |      |       `- error: expected ')' to end function call
+        |      `- note: to match this opening '('
 
       """
     )


### PR DESCRIPTION
### Summary

`GroupedDiagnostics` only handed the top-level diagnostics to `DiagnosticsFormatter`, so any notes attached to a `Diagnostic` — which have their own `location` and `message` — were never rendered. This fixes #2166 by expanding each diagnostic's `notes` into `.note`-severity diagnostics before formatting, so they are laid out at their locations the same way top-level diagnostics are.

### Implementation

- Added a small `NoteAsDiagnosticMessage` adapter that presents a `NoteMessage` as a `.note`-severity `DiagnosticMessage`, plus a `Note.asDiagnostic` helper. Both are file-private; there is no public API change.
- `annotateSource` now flattens `[diagnostic] + diagnostic.notes` before passing the list to the formatter. Primary-diagnostic selection is unchanged, so the header still reports the error/warning rather than a note.

### Testing

- New `testAttachedNotesAreRendered`, covering a diagnostic with one attached note.
- `testGroupingForMacroExpansion`'s expected output is updated: the parser's real "to match this opening '('" note attached to the "expected ')'" error is now rendered (it was previously dropped), which doubles as evidence of the fix.

### Out of scope (noted in #2166)

- Fix-Its are still not rendered by `GroupedDiagnostics`.
- Notes that point into a different source buffer than their diagnostic are flattened as-is; refining cross-buffer note placement could be done separately.
